### PR TITLE
Update Italian translations

### DIFF
--- a/rocky/rocky/locale/it/LC_MESSAGES/django.po
+++ b/rocky/rocky/locale/it/LC_MESSAGES/django.po
@@ -3,10 +3,10 @@
 #: reports/forms.py
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: OpenKAT\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-20 07:38+0000\n"
-"PO-Revision-Date: 2025-08-22 09:39+0000\n"
+"POT-Creation-Date: 2026-03-28 14:22+0000\n"
+"PO-Revision-Date: 2026-07-14 16:48+0200\n"
 "Last-Translator: Luca Racchetti <razzo1987@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/openkat/nl-kat-"
 "coordination/it/>\n"
@@ -46,11 +46,11 @@ msgstr "Nome"
 
 #: account/forms/account_setup.py
 msgid "The name that will be used in order to communicate."
-msgstr ""
+msgstr "Il nome che verrà usato per comunicare."
 
 #: account/forms/account_setup.py
 msgid "Please provide username"
-msgstr ""
+msgstr "Inserisci un nome utente"
 
 #: account/forms/account_setup.py
 #: rocky/templates/organizations/organization_member_list.html
@@ -59,7 +59,7 @@ msgstr "E-mail"
 
 #: account/forms/account_setup.py
 msgid "Enter an email address."
-msgstr ""
+msgstr "Inserisci un indirizzo e-mail."
 
 #: account/forms/account_setup.py
 msgid "Password"
@@ -67,7 +67,7 @@ msgstr "Password"
 
 #: account/forms/account_setup.py
 msgid "Choose a super secret password"
-msgstr ""
+msgstr "Scegli una password super segreta"
 
 #: account/forms/account_setup.py
 msgid "Choose another email."
@@ -79,7 +79,7 @@ msgstr "--- Seleziona una delle opzioni disponibili ----"
 
 #: account/forms/account_setup.py
 msgid "Account type"
-msgstr ""
+msgstr "Tipo di account"
 
 #: account/forms/account_setup.py
 msgid "Please select an account type to proceed."
@@ -111,7 +111,7 @@ msgstr "spiegazione-nome-organizzazione"
 #: account/forms/account_setup.py
 #, python-brace-format
 msgid "A unique code of maximum {code_length} characters in length."
-msgstr ""
+msgstr "Un codice univoco con una lunghezza massima di {code_length} caratteri."
 
 #: account/forms/account_setup.py
 msgid "explanation-organization-code"
@@ -139,6 +139,10 @@ msgid ""
 "have permission to scan these assets. I am aware of the implications a scan "
 "(with a higher scan level) brings on my systems."
 msgstr ""
+"Dichiaro che OpenKAT può eseguire la scansione degli asset della mia "
+"organizzazione e che ho il permesso di scansionare tali asset. Sono "
+"consapevole delle implicazioni che una scansione, soprattutto con un livello "
+"più alto, può avere sui miei sistemi."
 
 #: account/forms/account_setup.py
 msgid ""
@@ -146,6 +150,9 @@ msgid ""
 "organization. I have the experience and knowledge to know what the "
 "consequences might be and can be held responsible for them."
 msgstr ""
+"Dichiaro di essere autorizzato a rilasciare questo indennizzo per conto "
+"della mia organizzazione. Ho l'esperienza e le conoscenze necessarie per "
+"comprendere le possibili conseguenze e posso esserne ritenuto responsabile."
 
 #: account/forms/account_setup.py
 msgid "Trusted to change Clearance Levels."
@@ -188,7 +195,7 @@ msgstr "Nuova password"
 
 #: account/forms/account_setup.py
 msgid "Enter a new password"
-msgstr ""
+msgstr "Inserisci una nuova password"
 
 #: account/forms/account_setup.py
 msgid "New password confirmation"
@@ -196,11 +203,11 @@ msgstr "Conferma nuova password"
 
 #: account/forms/account_setup.py
 msgid "Repeat the new password"
-msgstr ""
+msgstr "Ripeti la nuova password"
 
 #: account/forms/account_setup.py
 msgid "Confirm the new password"
-msgstr ""
+msgstr "Conferma la nuova password"
 
 #: account/forms/login.py
 msgid "Please enter a correct email address and password."
@@ -261,7 +268,7 @@ msgstr "Token di backup"
 
 #: account/mixins.py
 msgid "Clearance level has been set."
-msgstr ""
+msgstr "Il livello di autorizzazione è stato impostato."
 
 #: account/mixins.py
 #, python-format
@@ -269,6 +276,8 @@ msgid ""
 "Could not raise clearance level of %s to L%s. Indemnification not present at "
 "organization %s."
 msgstr ""
+"Impossibile aumentare il livello di autorizzazione di %s a L%s. Indennizzo "
+"non presente per l'organizzazione %s."
 
 #: account/mixins.py
 #, python-format
@@ -293,7 +302,7 @@ msgstr ""
 
 #: account/models.py
 msgid "The email must be set"
-msgstr ""
+msgstr "L'e-mail deve essere impostata"
 
 #: account/models.py
 msgid "Superuser must have is_staff=True."
@@ -338,11 +347,11 @@ msgstr "data di registrazione"
 
 #: account/models.py
 msgid "The clearance level of the user for all organizations."
-msgstr ""
+msgstr "Il livello di autorizzazione dell'utente per tutte le organizzazioni."
 
 #: account/models.py
 msgid "name"
-msgstr ""
+msgstr "nome"
 
 #: account/templates/account_detail.html account/views/account.py
 msgid "Account details"
@@ -369,7 +378,7 @@ msgstr "Organizzazione"
 
 #: account/templates/account_detail.html
 msgid "Permission to set OOI clearance levels"
-msgstr ""
+msgstr "Autorizzazione a impostare i livelli di autorizzazione degli OOI"
 
 #: account/templates/account_detail.html
 msgid "OOI clearance"
@@ -377,16 +386,18 @@ msgstr "Autorizzazione OOI"
 
 #: account/templates/account_detail.html
 msgid "You don't have any clearance to scan objects."
-msgstr ""
+msgstr "Non hai alcuna autorizzazione per scansionare oggetti."
 
 #: account/templates/account_detail.html
 msgid ""
 "Get in contact with the admin to give you the necessary clearance level."
 msgstr ""
+"Contatta l'amministratore per ricevere il livello di autorizzazione "
+"necessario."
 
 #: account/templates/account_detail.html
 msgid "You have currently accepted clearance up to level"
-msgstr ""
+msgstr "Attualmente hai accettato l'autorizzazione fino al livello"
 
 #: account/templates/account_detail.html
 msgid "Explanation OOI Clearance"
@@ -403,7 +414,7 @@ msgstr ""
 #: account/templates/account_detail.html
 #, python-format
 msgid "Withdraw L%(acl)s clearance and responsibility"
-msgstr ""
+msgstr "Ritira l'autorizzazione L%(acl)s e la relativa responsabilità"
 
 #: account/templates/account_detail.html
 msgid "Explanation OOI clearance"
@@ -426,7 +437,7 @@ msgstr ""
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 #, python-format
 msgid "Accept level L%(tcl)s clearance and responsibility"
-msgstr ""
+msgstr "Accetta l'autorizzazione di livello L%(tcl)s e la responsabilità"
 
 #: account/templates/password_reset.html
 msgid "Use the form below to reset your password."
@@ -511,7 +522,7 @@ msgstr "Indirizzo email dimenticato?"
 #: account/templates/recover_email.html
 msgid ""
 "If you don’t remember the email address connected to your account, contact:"
-msgstr ""
+msgstr "Se non ricordi l'indirizzo e-mail collegato al tuo account, contatta:"
 
 #: account/templates/recover_email.html
 msgid "Please contact the system administrator."
@@ -544,6 +555,8 @@ msgid ""
 "Your password must contain at least the following but longer passwords are "
 "recommended:"
 msgstr ""
+"La password deve contenere almeno quanto segue, ma sono consigliate password "
+"più lunghe:"
 
 #: account/validators.py
 msgid " characters"
@@ -561,6 +574,7 @@ msgstr " lettere"
 msgid ""
 " special characters such as: {str(validators.get('special_characters',''))}"
 msgstr ""
+" caratteri speciali come: {str(validators.get('special_characters',''))}"
 
 #: account/validators.py
 msgid " lower case letters"
@@ -602,7 +616,7 @@ msgstr ""
 
 #: components/modal/template.html
 msgid "Close modal"
-msgstr ""
+msgstr "Chiudi finestra modale"
 
 #: components/modal/template.html
 #: crisis_room/templates/partials/delete_dashboard_item_modal.html
@@ -629,114 +643,118 @@ msgstr "Annulla"
 
 #: crisis_room/forms.py
 msgid "Title on dashboard"
-msgstr ""
+msgstr "Titolo sulla dashboard"
 
 #: crisis_room/forms.py
 msgid "Dashboard item size"
-msgstr ""
+msgstr "Dimensione dell'elemento della dashboard"
 
 #: crisis_room/forms.py
 msgid "Full width"
-msgstr ""
+msgstr "Larghezza intera"
 
 #: crisis_room/forms.py
 msgid "Half width"
-msgstr ""
+msgstr "Mezza larghezza"
 
 #: crisis_room/forms.py
 msgid "An item with that name already exists. Try a different title."
-msgstr ""
+msgstr "Esiste già un elemento con questo nome. Prova un titolo diverso."
 
 #: crisis_room/forms.py
 msgid "An error occurred while adding dashboard item."
-msgstr ""
+msgstr "Si è verificato un errore durante l'aggiunta dell'elemento alla dashboard."
 
 #: crisis_room/forms.py
 msgid "Number of rows in list"
-msgstr ""
+msgstr "Numero di righe nell'elenco"
 
 #: crisis_room/forms.py
 msgid "List sorting by"
-msgstr ""
+msgstr "Ordinamento dell'elenco per"
 
 #: crisis_room/forms.py
 msgid "Type (A-Z)"
-msgstr ""
+msgstr "Tipo (A-Z)"
 
 #: crisis_room/forms.py
 msgid "Type (Z-A)"
-msgstr ""
+msgstr "Tipo (Z-A)"
 
 #: crisis_room/forms.py
 msgid "Clearance level (Low-High)"
-msgstr ""
+msgstr "Livello di autorizzazione (basso-alto)"
 
 #: crisis_room/forms.py
 msgid "Clearance level (High-Low)"
-msgstr ""
+msgstr "Livello di autorizzazione (alto-basso)"
 
 #: crisis_room/forms.py
 msgid "Show table columns"
-msgstr ""
+msgstr "Mostra colonne della tabella"
 
 #: crisis_room/forms.py
 msgid "Severity (Low-High)"
-msgstr ""
+msgstr "Gravità (bassa-alta)"
 
 #: crisis_room/forms.py
 msgid "Severity (High-Low)"
-msgstr ""
+msgstr "Gravità (alta-bassa)"
 
 #: crisis_room/forms.py
 msgid "Finding (A-Z)"
-msgstr ""
+msgstr "Rilevamento (A-Z)"
 
 #: crisis_room/forms.py
 msgid "Finding (Z-A)"
-msgstr ""
+msgstr "Rilevamento (Z-A)"
 
 #: crisis_room/models.py
 msgid "Findings Dashboard"
-msgstr ""
+msgstr "Dashboard dei rilevamenti"
 
 #: crisis_room/models.py
 msgid ""
 "Where on the dashboard do you want to show the data? Position {} is the most "
 "top level and the max position is {}."
 msgstr ""
+"Dove vuoi mostrare i dati sulla dashboard? La posizione {} è il livello più "
+"alto e la posizione massima è {}."
 
 #: crisis_room/models.py
 msgid "Will be displayed on the general crisis room, for all organizations."
-msgstr ""
+msgstr "Verrà mostrato nella sala di crisi generale, per tutte le organizzazioni."
 
 #: crisis_room/models.py
 msgid "Will be displayed on a single organization dashboard"
-msgstr ""
+msgstr "Verrà mostrato sulla dashboard di una singola organizzazione"
 
 #: crisis_room/models.py
 msgid "Will be displayed on the findings dashboard for all organizations"
-msgstr ""
+msgstr "Verrà mostrato sulla dashboard dei rilevamenti per tutte le organizzazioni"
 
 #: crisis_room/models.py
 msgid "Can change position up or down of a dashboard item."
-msgstr ""
+msgstr "Può spostare in alto o in basso un elemento della dashboard."
 
 #: crisis_room/models.py
 msgid "You have to choose between a recipe or a query, but not both."
-msgstr ""
+msgstr "Devi scegliere tra una ricetta o una query, ma non entrambe."
 
 #: crisis_room/models.py
 msgid "You have set a query and not where it is from. Also set the source."
-msgstr ""
+msgstr "Hai impostato una query, ma non la sua origine. Imposta anche la fonte."
 
 #: crisis_room/models.py
 msgid ""
 "DashboardItem must contain at least a 'recipe' or a 'source' with a 'query'."
 msgstr ""
+"DashboardItem deve contenere almeno una 'recipe' oppure una 'source' con una "
+"'query'."
 
 #: crisis_room/models.py
 msgid "Max dashboard items reached."
-msgstr ""
+msgstr "Numero massimo di elementi della dashboard raggiunto."
 
 #: crisis_room/templates/crisis_room.html
 #: crisis_room/templates/organization_crisis_room.html
@@ -746,25 +764,27 @@ msgstr "Sala di crisi"
 
 #: crisis_room/templates/crisis_room.html
 msgid "Crisis room overview for all organizations."
-msgstr ""
+msgstr "Panoramica della sala di crisi per tutte le organizzazioni."
 
 #: crisis_room/templates/crisis_room_dashboards.html
 msgid "Dashboards"
-msgstr ""
+msgstr "Dashboard"
 
 #: crisis_room/templates/crisis_room_dashboards.html
 msgid ""
 "On this page you can see an overview of the dashboards for all "
 "organizations. **More context can be written here**"
 msgstr ""
+"In questa pagina puoi vedere una panoramica delle dashboard per tutte le "
+"organizzazioni. **Qui è possibile aggiungere ulteriore contesto**"
 
 #: crisis_room/templates/crisis_room_dashboards.html
 msgid "dashboards"
-msgstr ""
+msgstr "dashboard"
 
 #: crisis_room/templates/crisis_room_dashboards.html
 msgid "There are no dashboards to display."
-msgstr ""
+msgstr "Non ci sono dashboard da mostrare."
 
 #: crisis_room/templates/crisis_room_findings.html
 #: crisis_room/templates/partials/crisis_room_findings_table.html
@@ -772,7 +792,7 @@ msgstr ""
 #: reports/templates/partials/report_findings_table.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Findings overview"
-msgstr ""
+msgstr "Panoramica dei rilevamenti"
 
 #: crisis_room/templates/crisis_room_findings.html
 msgid ""
@@ -786,10 +806,19 @@ msgid ""
 "                            of each organization.\n"
 "                        "
 msgstr ""
+"\n"
+"                            Questa panoramica mostra il numero totale di "
+"rilevamenti per\n"
+"                            gravità identificati per tutte le "
+"organizzazioni.\n"
+"                            Questi dati si basano sull'ultimo Report dei "
+"rilevamenti della sala di crisi\n"
+"                            di ciascuna organizzazione.\n"
+"                        "
 
 #: crisis_room/templates/crisis_room_findings.html
 msgid "Findings per organization"
-msgstr ""
+msgstr "Rilevamenti per organizzazione"
 
 #: crisis_room/templates/crisis_room_findings.html
 msgid ""
@@ -797,6 +826,10 @@ msgid ""
 "organization, sorted by the finding types and grouped by organizations. This "
 "data is based on the latest Crisis Room Findings Report of each organization."
 msgstr ""
+"Questa tabella mostra i rilevamenti identificati per ciascuna organizzazione, "
+"ordinati per tipo di rilevamento e raggruppati per organizzazione. Questi "
+"dati si basano sull'ultimo Report dei rilevamenti della sala di crisi di "
+"ciascuna organizzazione."
 
 #: crisis_room/templates/crisis_room_findings.html
 #: reports/report_types/findings_report/report.html
@@ -804,17 +837,21 @@ msgid ""
 "No findings have been identified yet. As soon as they have been identified, "
 "they will be shown on this page."
 msgstr ""
+"Non è stato ancora identificato alcun rilevamento. Appena saranno "
+"identificati, verranno mostrati in questa pagina."
 
 #: crisis_room/templates/crisis_room_findings.html
 msgid ""
 "There are no organizations yet. After creating an organization, the "
 "identified findings will be shown here."
 msgstr ""
+"Non ci sono ancora organizzazioni. Dopo aver creato un'organizzazione, i "
+"rilevamenti identificati verranno mostrati qui."
 
 #: crisis_room/templates/crisis_room_header.html
 #: crisis_room/templates/organization_crisis_room_header.html
 msgid "Crisis room navigation"
-msgstr ""
+msgstr "Navigazione della sala di crisi"
 
 #: crisis_room/templates/crisis_room_header.html
 #: crisis_room/templates/partials/new_dashboard_item_action_button.html
@@ -844,26 +881,28 @@ msgstr "Rilevamenti"
 
 #: crisis_room/templates/organization_crisis_room.html
 msgid "Options for dashboard"
-msgstr ""
+msgstr "Opzioni per la dashboard"
 
 #: crisis_room/templates/organization_crisis_room.html
 msgid "Show all descriptions"
-msgstr ""
+msgstr "Mostra tutte le descrizioni"
 
 #: crisis_room/templates/organization_crisis_room.html
 msgid "Hide all descriptions"
-msgstr ""
+msgstr "Nascondi tutte le descrizioni"
 
 #: crisis_room/templates/organization_crisis_room.html
 #: crisis_room/templates/partials/delete_dashboard_modal.html
 msgid "Delete dashboard"
-msgstr ""
+msgstr "Elimina dashboard"
 
 #: crisis_room/templates/organization_crisis_room.html
 msgid ""
 "There are no dashboards yet. Click on \"Add dashboard\" to create a new "
 "dashboard."
 msgstr ""
+"Non ci sono ancora dashboard. Fai clic su \"Aggiungi dashboard\" per creare "
+"una nuova dashboard."
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 #: katalogus/templates/partials/objects_to_scan.html
@@ -874,43 +913,45 @@ msgstr "Elenco oggetti"
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid "Finding list"
-msgstr ""
+msgstr "Elenco dei rilevamenti"
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 #: crisis_room/templates/partials/new_dashboard_item_action_button.html
 msgid "Report section"
-msgstr ""
+msgstr "Sezione del report"
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid "There are no dashboard items added yet."
-msgstr ""
+msgstr "Non sono ancora stati aggiunti elementi alla dashboard."
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid ""
 "You can add dashboard items via the filters on the objects and findings page "
 "or you can add a report section."
 msgstr ""
+"Puoi aggiungere elementi alla dashboard tramite i filtri nelle pagine degli "
+"oggetti e dei rilevamenti, oppure puoi aggiungere una sezione del report."
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid "Add objects"
-msgstr ""
+msgstr "Aggiungi oggetti"
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid "Add findings"
-msgstr ""
+msgstr "Aggiungi rilevamenti"
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid "Add report section"
-msgstr ""
+msgstr "Aggiungi sezione del report"
 
 #: crisis_room/templates/organization_crisis_room_header.html
 #: crisis_room/templates/partials/new_dashboard_modal.html
 msgid "Add dashboard"
-msgstr ""
+msgstr "Aggiungi dashboard"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid "Findings per organization overview"
-msgstr ""
+msgstr "Panoramica dei rilevamenti per organizzazione"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: reports/templates/partials/report_findings_table.html
@@ -932,11 +973,11 @@ msgstr "Occorrenze"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid "Highest risk level"
-msgstr ""
+msgstr "Livello di rischio più alto"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid "Critical finding types"
-msgstr ""
+msgstr "Tipi di rilevamento critici"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
@@ -987,11 +1028,13 @@ msgid ""
 "This overview shows the total number of findings per severity that have been "
 "identified for this organization."
 msgstr ""
+"Questa panoramica mostra il numero totale di rilevamenti per gravità "
+"identificati per questa organizzazione."
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: reports/report_types/findings_report/report.html
 msgid "Critical and high findings"
-msgstr ""
+msgstr "Rilevamenti critici e alti"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: reports/report_types/findings_report/report.html
@@ -1000,41 +1043,44 @@ msgid ""
 "identified for this organization, grouped by finding types. A table with all "
 "the identified findings can be found in the Findings Report."
 msgstr ""
+"Questa tabella mostra i primi 25 rilevamenti critici e alti identificati per "
+"questa organizzazione, raggruppati per tipo di rilevamento. Una tabella con "
+"tutti i rilevamenti identificati è disponibile nel Report dei rilevamenti."
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid "No findings have been identified. Check report for more details."
-msgstr ""
+msgstr "Non è stato identificato alcun rilevamento. Controlla il report per maggiori dettagli."
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid "View findings report"
-msgstr ""
+msgstr "Visualizza report dei rilevamenti"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Edit report recipe"
-msgstr ""
+msgstr "Modifica ricetta del report"
 
 #: crisis_room/templates/partials/dashboard_finding_list.html
 #, python-format
 msgid "Showing %(length)s findings"
-msgstr ""
+msgstr "Visualizzazione di %(length)s rilevamenti"
 
 #: crisis_room/templates/partials/dashboard_finding_list.html
 msgid "Go to findings"
-msgstr ""
+msgstr "Vai ai rilevamenti"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
 msgid "Findings table "
-msgstr ""
+msgstr "Tabella dei rilevamenti "
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: crisis_room/templates/partials/dashboard_ooi_list_table.html
 #: rocky/templates/findings/finding_list.html
 #: rocky/templates/oois/ooi_list.html
 msgid "column headers with buttons are sortable"
-msgstr ""
+msgstr "le intestazioni di colonna con pulsanti sono ordinabili"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
@@ -1101,7 +1147,7 @@ msgstr "Mostra oggetti %(ooi_type)s"
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/views/mixins.py
 msgid "Location"
-msgstr ""
+msgstr "Posizione"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #, python-format
@@ -1111,7 +1157,7 @@ msgstr "Mostra dettagli per %(ooi)s"
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
 msgid "Risk score"
-msgstr ""
+msgstr "Punteggio di rischio"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: katalogus/templates/normalizer_detail.html
@@ -1132,7 +1178,7 @@ msgstr "Descrizione"
 #: reports/templates/partials/report_severity_totals_table.html
 #: rocky/templates/findings/finding_list.html
 msgid "Recommendation"
-msgstr ""
+msgstr "Raccomandazione"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: reports/report_types/vulnerability_report/report.py
@@ -1148,55 +1194,55 @@ msgstr "Fonte"
 #: reports/templates/partials/report_findings_table.html
 #: rocky/templates/findings/finding_list.html
 msgid "Impact"
-msgstr ""
+msgstr "Impatto"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Options for dashboard items"
-msgstr ""
+msgstr "Opzioni per gli elementi della dashboard"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Show description"
-msgstr ""
+msgstr "Mostra descrizione"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Hide description"
-msgstr ""
+msgstr "Nascondi descrizione"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Position up"
-msgstr ""
+msgstr "Sposta in alto"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Position down"
-msgstr ""
+msgstr "Sposta in basso"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Rerun report"
-msgstr ""
+msgstr "Riesegui report"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 #: crisis_room/templates/partials/delete_dashboard_item_modal.html
 msgid "Delete item"
-msgstr ""
+msgstr "Elimina elemento"
 
 #: crisis_room/templates/partials/dashboard_ooi_list.html
 #, python-format
 msgid "Showing %(length)s objects"
-msgstr ""
+msgstr "Visualizzazione di %(length)s oggetti"
 
 #: crisis_room/templates/partials/dashboard_ooi_list.html
 msgid "Go to objects"
-msgstr ""
+msgstr "Vai agli oggetti"
 
 #: crisis_room/templates/partials/dashboard_ooi_list_table.html
 #: rocky/templates/oois/ooi_list.html
 msgid "Objects "
-msgstr ""
+msgstr "Oggetti "
 
 #: crisis_room/templates/partials/delete_dashboard_item_modal.html
 #, python-format
 msgid "Are you sure you want to delete '%(name)s' from this dashboard?"
-msgstr ""
+msgstr "Vuoi davvero eliminare '%(name)s' da questa dashboard?"
 
 #: crisis_room/templates/partials/delete_dashboard_item_modal.html
 #: crisis_room/templates/partials/delete_dashboard_modal.html
@@ -1217,14 +1263,16 @@ msgid ""
 "Are you sure you want to delete dashboard '%(dashboard)s'? All the items on "
 "the dashboard will be deleted as well."
 msgstr ""
+"Vuoi davvero eliminare la dashboard '%(dashboard)s'? Verranno eliminati "
+"anche tutti gli elementi della dashboard."
 
 #: crisis_room/templates/partials/new_dashboard_item_action_button.html
 msgid "Actions for adding dashboard items"
-msgstr ""
+msgstr "Azioni per aggiungere elementi alla dashboard"
 
 #: crisis_room/templates/partials/new_dashboard_item_action_button.html
 msgid "Add item"
-msgstr ""
+msgstr "Aggiungi elemento"
 
 #: crisis_room/templates/partials/new_dashboard_item_action_button.html
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
@@ -1241,7 +1289,7 @@ msgstr "Oggetti"
 
 #: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
 msgid "Add dashboard item"
-msgstr ""
+msgstr "Aggiungi elemento alla dashboard"
 
 #: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
 msgid ""
@@ -1249,10 +1297,14 @@ msgid ""
 "report. Then go to the section that you want to add to your dashboard and "
 "press the options button next to the section name to create a dashboard item."
 msgstr ""
+"Per aggiungere una <strong>sezione del report</strong>, vai alla pagina "
+"della cronologia e apri un report. Poi vai alla sezione che vuoi aggiungere "
+"alla dashboard e premi il pulsante delle opzioni accanto al nome della "
+"sezione per creare un elemento della dashboard."
 
 #: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
 msgid "Go to report history"
-msgstr ""
+msgstr "Vai alla cronologia dei report"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #, python-format
@@ -1260,6 +1312,8 @@ msgid ""
 "\n"
 "    Add %(item_type)s to dashboard\n"
 msgstr ""
+"\n"
+"    Aggiungi %(item_type)s alla dashboard\n"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #, python-format
@@ -1267,6 +1321,8 @@ msgid ""
 "Add these %(item_type)s with the selected filters to the dashboard of your "
 "choice."
 msgstr ""
+"Aggiungi questi %(item_type)s con i filtri selezionati alla dashboard che "
+"preferisci."
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
@@ -1282,7 +1338,7 @@ msgstr "spiegazione"
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid "You do not have a custom dashboard yet"
-msgstr ""
+msgstr "Non hai ancora una dashboard personalizzata"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #, python-format
@@ -1290,22 +1346,25 @@ msgid ""
 "In order to add these %(item_type)s to a dashboard, you first need to create "
 "a dashboard. Please add a dashboard in the crisis room of your organization."
 msgstr ""
+"Per aggiungere questi %(item_type)s a una dashboard, devi prima creare una "
+"dashboard. Aggiungi una dashboard nella sala di crisi della tua "
+"organizzazione."
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 #: rocky/templates/findings/finding_list.html
 #: rocky/templates/oois/ooi_list.html
 msgid "Add to dashboard"
-msgstr ""
+msgstr "Aggiungi alla dashboard"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid "Go to crisis room"
-msgstr ""
+msgstr "Vai alla sala di crisi"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid "Add report section to dashboard"
-msgstr ""
+msgstr "Aggiungi sezione del report alla dashboard"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid ""
@@ -1313,10 +1372,13 @@ msgid ""
 "a dashboard. Please create a dashboard in the crisis room of your "
 "organization."
 msgstr ""
+"Per aggiungere questa sezione del report a una dashboard, devi prima creare "
+"una dashboard. Crea una dashboard nella sala di crisi della tua "
+"organizzazione."
 
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid "Report must be scheduled for dashboard items"
-msgstr ""
+msgstr "Il report deve essere pianificato per gli elementi della dashboard"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid ""
@@ -1324,14 +1386,18 @@ msgid ""
 "of showing static data, the report should be scheduled. The frequency of the "
 "schedules recurrence determines how fresh the data on the dashboard will be."
 msgstr ""
+"Affinché le informazioni della dashboard vengano aggiornate regolarmente "
+"invece di mostrare dati statici, il report deve essere pianificato. La "
+"frequenza della ricorrenza determina quanto saranno aggiornati i dati sulla "
+"dashboard."
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 msgid "Applied filters"
-msgstr ""
+msgstr "Filtri applicati"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 msgid "Object types"
-msgstr ""
+msgstr "Tipi di oggetto"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 #: katalogus/templates/change_clearance_level.html onboarding/forms.py
@@ -1348,7 +1414,7 @@ msgstr "Livello di autorizzazione"
 #: reports/templates/summary/ooi_selection.html tools/forms/ooi.py
 #: rocky/views/mixins.py
 msgid "Clearance type"
-msgstr ""
+msgstr "Tipo di autorizzazione"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 #: reports/templates/report_overview/modal_partials/delete_modal.html
@@ -1356,82 +1422,84 @@ msgstr ""
 #: reports/templates/report_overview/report_history_table.html
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Input objects"
-msgstr ""
+msgstr "Oggetti di input"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 msgid "Show all objects"
-msgstr ""
+msgstr "Mostra tutti gli oggetti"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 #: reports/templates/partials/report_types_selection.html
 msgid "No filters applied"
-msgstr ""
+msgstr "Nessun filtro applicato"
 
 #: crisis_room/templates/partials/report_section_action_button.html
 msgid "Add section to dashboard"
-msgstr ""
+msgstr "Aggiungi sezione alla dashboard"
 
 #: katalogus/client.py
 msgid ""
 "The KATalogus has an unexpected error. Check the logs for further details."
 msgstr ""
+"KAT-alogus ha riscontrato un errore imprevisto. Controlla i log per "
+"ulteriori dettagli."
 
 #: katalogus/client.py
 #, python-format
 msgid "An HTTP %d error occurred. Check logs for more info."
-msgstr ""
+msgstr "Si è verificato un errore HTTP %d. Controlla i log per maggiori informazioni."
 
 #: katalogus/client.py
 msgid "An HTTP error occurred. Check logs for more info."
-msgstr ""
+msgstr "Si è verificato un errore HTTP. Controlla i log per maggiori informazioni."
 
 #: katalogus/client.py
 msgid "Boefje with this name already exists."
-msgstr ""
+msgstr "Esiste già un Boefje con questo nome."
 
 #: katalogus/client.py
 msgid "Boefje with this ID already exists."
-msgstr ""
+msgstr "Esiste già un Boefje con questo ID."
 
 #: katalogus/client.py
 msgid "Access to resource not allowed"
-msgstr ""
+msgstr "Accesso alla risorsa non consentito"
 
 #: katalogus/client.py
 msgid "User is not allowed to see plugin settings"
-msgstr ""
+msgstr "L'utente non è autorizzato a vedere le impostazioni del plugin"
 
 #: katalogus/client.py
 msgid "User is not allowed to set plugin settings"
-msgstr ""
+msgstr "L'utente non è autorizzato a impostare le impostazioni del plugin"
 
 #: katalogus/client.py
 msgid "User is not allowed to delete plugin settings"
-msgstr ""
+msgstr "L'utente non è autorizzato a eliminare le impostazioni del plugin"
 
 #: katalogus/client.py
 msgid "User is not allowed to view plugin settings"
-msgstr ""
+msgstr "L'utente non è autorizzato a visualizzare le impostazioni del plugin"
 
 #: katalogus/client.py
 msgid "User is not allowed to access the other organization"
-msgstr ""
+msgstr "L'utente non è autorizzato ad accedere all'altra organizzazione"
 
 #: katalogus/client.py
 msgid "User is not allowed to enable plugins"
-msgstr ""
+msgstr "L'utente non è autorizzato ad abilitare plugin"
 
 #: katalogus/client.py
 msgid "User is not allowed to disable plugins"
-msgstr ""
+msgstr "L'utente non è autorizzato a disabilitare plugin"
 
 #: katalogus/client.py
 msgid "User is not allowed to create plugins"
-msgstr ""
+msgstr "L'utente non è autorizzato a creare plugin"
 
 #: katalogus/client.py
 msgid "User is not allowed to edit plugins"
-msgstr ""
+msgstr "L'utente non è autorizzato a modificare plugin"
 
 #: katalogus/forms/katalogus_filter.py
 msgid "Show all"
@@ -1496,6 +1564,9 @@ msgid ""
 "issues, and give insight. Each boefje is a separate scan that can run on a "
 "selection of objects."
 msgstr ""
+"I Boefjes vengono usati per scansionare oggetti. Rilevano vulnerabilità, "
+"problemi di sicurezza e forniscono informazioni. Ogni boefje è una scansione "
+"separata che può essere eseguita su una selezione di oggetti."
 
 #: katalogus/templates/about_plugins.html katalogus/templates/normalizers.html
 msgid ""
@@ -1541,7 +1612,7 @@ msgstr "%(plugin_name)s non ha bisogno di oggetti di input."
 #: katalogus/templates/normalizer_detail.html
 #: katalogus/templates/partials/plugin_tile_modal.html
 msgid "Produces"
-msgstr "Produzione"
+msgstr "Produce"
 
 #: katalogus/templates/boefje_detail.html
 #: katalogus/templates/normalizer_detail.html
@@ -1553,11 +1624,11 @@ msgstr "%(plugin_name)s può produrre il seguente output:"
 #: katalogus/templates/boefje_detail.html
 #, python-format
 msgid "%(plugin_name)s doesn't produce any output mime types."
-msgstr ""
+msgstr "%(plugin_name)s non produce alcun tipo MIME di output."
 
 #: katalogus/templates/boefje_setup.html
 msgid "Boefje variant setup"
-msgstr ""
+msgstr "Configurazione variante Boefje"
 
 #: katalogus/templates/boefje_setup.html
 #: rocky/templates/organizations/organization_member_list.html
@@ -1568,7 +1639,7 @@ msgstr "Modifica"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Boefje setup"
-msgstr ""
+msgstr "Configurazione Boefje"
 
 #: katalogus/templates/boefje_setup.html
 msgid ""
@@ -1576,35 +1647,38 @@ msgid ""
 "check out the <a href=\"https://docs.openkat.nl/developer_documentation/"
 "development_tutorial/creating_a_boefje.html\">documentation</a>."
 msgstr ""
+"Puoi creare un nuovo Boefje. Per maggiori informazioni, consulta la "
+"<a href=\"https://docs.openkat.nl/developer_documentation/"
+"development_tutorial/creating_a_boefje.html\">documentazione</a>."
 
 #: katalogus/templates/boefje_setup.html
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 msgid "Save changes"
-msgstr ""
+msgstr "Salva modifiche"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Discard changes"
-msgstr ""
+msgstr "Scarta modifiche"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Create variant"
-msgstr ""
+msgstr "Crea variante"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Discard variant"
-msgstr ""
+msgstr "Scarta variante"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Create new Boefje"
-msgstr ""
+msgstr "Crea nuovo Boefje"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Discard new Boefje"
-msgstr ""
+msgstr "Scarta nuovo Boefje"
 
 #: katalogus/templates/boefjes.html
 msgid "Add Boefje"
-msgstr ""
+msgstr "Aggiungi Boefje"
 
 #: katalogus/templates/boefjes.html katalogus/templates/katalogus.html
 #: katalogus/templates/normalizers.html
@@ -1628,7 +1702,7 @@ msgstr ""
 
 #: katalogus/templates/change_clearance_level.html
 msgid "Scan object"
-msgstr ""
+msgstr "Scansiona oggetto"
 
 #: katalogus/templates/change_clearance_level.html
 #, python-format
@@ -1645,7 +1719,7 @@ msgstr ""
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/summary/report_asset_overview.html
 msgid "Selected objects"
-msgstr ""
+msgstr "Oggetti selezionati"
 
 #: katalogus/templates/change_clearance_level.html
 #: reports/templates/report_overview/report_history_table.html
@@ -1675,25 +1749,30 @@ msgid ""
 "includes both the KAT-alogus settings as well as enabled and disabled "
 "plugins."
 msgstr ""
+"Usa il modulo qui sotto per clonare le impostazioni da "
+"<strong>%(current_organization)s</strong> all'organizzazione selezionata. "
+"Sono incluse sia le impostazioni di KAT-alogus sia i plugin abilitati e "
+"disabilitati."
 
 #: katalogus/templates/confirmation_clone_settings.html
 msgid "Clone"
 msgstr "Clona"
 
 #: katalogus/templates/katalogus.html
-#, fuzzy
 msgid "All plugins"
-msgstr "Plugin disponibili"
+msgstr "Tutti i plugin"
 
 #: katalogus/templates/katalogus_settings.html
 msgid "KAT-alogus settings"
-msgstr ""
+msgstr "Impostazioni KAT-alogus"
 
 #: katalogus/templates/katalogus_settings.html
 msgid ""
 "There are currently no settings defined. Add settings at the plugin detail "
 "page."
 msgstr ""
+"Al momento non sono definite impostazioni. Aggiungi le impostazioni nella "
+"pagina dei dettagli del plugin."
 
 #: katalogus/templates/katalogus_settings.html
 #: rocky/templates/two_factor/core/otp_required.html
@@ -1706,7 +1785,7 @@ msgstr "Questa è una panoramica delle ultime impostazioni di tutti i plugin."
 
 #: katalogus/templates/katalogus_settings.html
 msgid "Latest plugin settings"
-msgstr ""
+msgstr "Ultime impostazioni del plugin"
 
 #: katalogus/templates/katalogus_settings.html
 #: rocky/templates/tasks/ooi_detail_task_list.html
@@ -1722,11 +1801,11 @@ msgstr "Valore"
 #: katalogus/templates/normalizer_detail.html
 #, python-format
 msgid "%(plugin_name)s is able to process the following mime types:"
-msgstr ""
+msgstr "%(plugin_name)s è in grado di elaborare i seguenti tipi MIME:"
 
 #: katalogus/templates/partials/boefje_tile.html
 msgid "This object type is required"
-msgstr ""
+msgstr "Questo tipo di oggetto è obbligatorio"
 
 #: katalogus/templates/partials/boefje_tile.html
 msgid "Scan level:"
@@ -1734,7 +1813,7 @@ msgstr "Livello di scansione:"
 
 #: katalogus/templates/partials/boefje_tile.html
 msgid "Publisher:"
-msgstr ""
+msgstr "Editore:"
 
 #: katalogus/templates/partials/boefje_tile.html
 #: katalogus/templates/partials/plugin_tile.html
@@ -1743,9 +1822,8 @@ msgid "See details"
 msgstr "Vedi dettagli"
 
 #: katalogus/templates/partials/enable_disable_plugin.html
-#, fuzzy
 msgid "Enable"
-msgstr "Abilitato"
+msgstr "Abilita"
 
 #: katalogus/templates/partials/enable_disable_plugin.html
 #: rocky/templates/two_factor/profile/disable.html
@@ -1774,17 +1852,15 @@ msgstr "Mostra filtri"
 #: rocky/templates/partials/organization_member_list_filters.html
 #: rocky/templates/tasks/partials/task_filter.html
 msgid "applied"
-msgstr ""
+msgstr "applicati"
 
 #: katalogus/templates/partials/katalogus_filter.html
-#, fuzzy
 msgid "Filter plugins"
-msgstr "Opzioni di filtro"
+msgstr "Filtra plugin"
 
 #: katalogus/templates/partials/katalogus_filter.html
-#, fuzzy
 msgid "Clear filter"
-msgstr "Cancella filtri"
+msgstr "Cancella filtro"
 
 #: katalogus/templates/partials/katalogus_header.html
 #: katalogus/views/change_clearance_level.py katalogus/views/katalogus.py
@@ -1797,9 +1873,8 @@ msgid "KAT-alogus"
 msgstr "KAT-alogus"
 
 #: katalogus/templates/partials/katalogus_header.html
-#, fuzzy
 msgid "An overview of all available plugins."
-msgstr "Plugin disponibili"
+msgstr "Una panoramica di tutti i plugin disponibili."
 
 #: katalogus/templates/partials/katalogus_header.html
 #: katalogus/templates/plugin_settings_list.html
@@ -1820,23 +1895,23 @@ msgstr "Vista tabella"
 
 #: katalogus/templates/partials/modal_report_types.html
 msgid "Required for"
-msgstr ""
+msgstr "Richiesto per"
 
 #: katalogus/templates/partials/modal_report_types.html
 msgid "report types"
-msgstr ""
+msgstr "tipi di report"
 
 #: katalogus/templates/partials/modal_report_types.html
 msgid "Report types for "
-msgstr ""
+msgstr "Tipi di report per "
 
 #: katalogus/templates/partials/no_enabling_permission_message.html
 msgid "No permission to enable/disable plugins"
-msgstr ""
+msgstr "Nessuna autorizzazione per abilitare/disabilitare plugin"
 
 #: katalogus/templates/partials/no_enabling_permission_message.html
 msgid "Contact your administrator to request permission."
-msgstr ""
+msgstr "Contatta il tuo amministratore per richiedere l'autorizzazione."
 
 #: katalogus/templates/partials/objects_to_scan.html
 #, python-format
@@ -1849,14 +1924,14 @@ msgid ""
 msgstr ""
 "Questo boefje effettuerà la scansione solo degli oggetti con un livello di "
 "autorizzazione corrispondente di <strong>L%(scan_level)s</strong> o "
-"superiore. Non c'è alcuna indennità per questo boefje per la scansione di un "
+"superiore. Non c'è alcun indennizzo per questo boefje per la scansione di un "
 "OOI con un livello di autorizzazione inferiore a <strong>L%(scan_level)s</"
 "strong>. Usa il filtro per mostrare gli OOI con un livello di autorizzazione "
 "inferiore."
 
 #: katalogus/templates/partials/objects_to_scan.html
 msgid "Warning scan level:"
-msgstr ""
+msgstr "Avviso livello di scansione:"
 
 #: katalogus/templates/partials/objects_to_scan.html
 msgid ""
@@ -1865,6 +1940,11 @@ msgid ""
 "now on out, until it manually gets set to something else again. This means "
 "that all other enabled Boefjes will use this higher clearance level aswel."
 msgstr ""
+"La scansione di OOI con un livello di autorizzazione inferiore farà sì che "
+"OpenKAT aumenti il livello di autorizzazione di quell'OOI, non solo per "
+"questa scansione ma da ora in poi, finché non verrà impostato manualmente su "
+"qualcos'altro. Questo significa che anche tutti gli altri Boefjes abilitati "
+"useranno questo livello di autorizzazione più alto."
 
 #: katalogus/templates/partials/objects_to_scan.html
 #, python-format
@@ -1903,47 +1983,43 @@ msgstr "Aggiungi"
 
 #: katalogus/templates/partials/plugin_tile.html
 msgid "Required for:"
-msgstr ""
+msgstr "Richiesto per:"
 
 #: katalogus/templates/partials/plugin_tile_modal.html
 msgid "Boefje details"
-msgstr ""
+msgstr "Dettagli del Boefje"
 
 #: katalogus/templates/partials/plugin_tile_modal.html reports/forms.py
 #: reports/templates/report_overview/report_history_table.html
 msgid "Report types"
-msgstr ""
+msgstr "Tipi di report"
 
 #: katalogus/templates/partials/plugin_tile_modal.html
 msgid "This boefje is required by the following report types."
-msgstr ""
+msgstr "Questo boefje è richiesto dai seguenti tipi di report."
 
 #: katalogus/templates/partials/plugin_tile_modal.html
 msgid "Go to boefje detail page"
-msgstr ""
+msgstr "Vai alla pagina dei dettagli del boefje"
 
 #: katalogus/templates/partials/plugins.html
-#, fuzzy
 msgid "Plugins overview:"
-msgstr "Panoramica utente:"
+msgstr "Panoramica dei plugin:"
 
 #: katalogus/templates/partials/plugins.html
 #: reports/templates/summary/selected_plugins.html
-#, fuzzy
 msgid "Plugin name"
-msgstr "Plugin"
+msgstr "Nome del plugin"
 
 #: katalogus/templates/partials/plugins.html
 #: reports/templates/summary/selected_plugins.html
-#, fuzzy
 msgid "Plugin type"
-msgstr "Plugin"
+msgstr "Tipo di plugin"
 
 #: katalogus/templates/partials/plugins.html
 #: reports/templates/summary/selected_plugins.html
-#, fuzzy
 msgid "Plugin description"
-msgstr "Descrizione"
+msgstr "Descrizione del plugin"
 
 #: katalogus/templates/partials/plugins.html
 #: reports/templates/partials/report_header.html
@@ -1955,13 +2031,12 @@ msgstr "Azioni"
 
 #: katalogus/templates/partials/plugins.html
 msgid "Detail page"
-msgstr ""
+msgstr "Pagina dei dettagli"
 
 #: katalogus/templates/partials/plugins_navigation.html
 #: reports/templates/report_overview/report_overview_navigation.html
-#, fuzzy
 msgid "Plugins Navigation"
-msgstr "Navigazione principale"
+msgstr "Navigazione dei plugin"
 
 #: katalogus/templates/partials/plugins_navigation.html
 #: rocky/templates/scan.html rocky/templates/tasks/boefjes.html
@@ -1982,25 +2057,27 @@ msgstr "Tutto"
 
 #: katalogus/templates/plugin_container_image.html tools/forms/boefje.py
 msgid "Container image"
-msgstr ""
+msgstr "Immagine container"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "The container image for this Boefje is:"
-msgstr ""
+msgstr "L'immagine container per questo Boefje è:"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Variants"
-msgstr ""
+msgstr "Varianti"
 
 #: katalogus/templates/plugin_container_image.html
 msgid ""
 "Boefje variants that use the same container image. For more information "
 "about Boefje variants you can read the documentation."
 msgstr ""
+"Varianti Boefje che usano la stessa immagine container. Per maggiori "
+"informazioni sulle varianti Boefje puoi leggere la documentazione."
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Add variant"
-msgstr ""
+msgstr "Aggiungi variante"
 
 #: katalogus/templates/plugin_container_image.html
 #: rocky/templates/partials/notifications_block.html
@@ -2010,15 +2087,15 @@ msgstr "conferma"
 #: katalogus/templates/plugin_container_image.html
 #, python-format
 msgid "Variant %(plugin.name)s created."
-msgstr ""
+msgstr "Variante %(plugin.name)s creata."
 
 #: katalogus/templates/plugin_container_image.html
 msgid "The Boefje variant is successfully created and can now be used."
-msgstr ""
+msgstr "La variante Boefje è stata creata con successo e ora può essere usata."
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Overview of variants"
-msgstr ""
+msgstr "Panoramica delle varianti"
 
 #: katalogus/templates/plugin_container_image.html
 #: reports/report_types/tls_report/report.html
@@ -2033,32 +2110,32 @@ msgstr "Stato"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Age"
-msgstr ""
+msgstr "Età"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Scan interval"
-msgstr ""
+msgstr "Intervallo di scansione"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Run on"
-msgstr ""
+msgstr "Esegui su"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "current"
-msgstr ""
+msgstr "corrente"
 
 #: katalogus/templates/plugin_container_image.html
 #: reports/report_types/dns_report/report.html
 msgid "minutes"
-msgstr ""
+msgstr "minuti"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Default system scan frequency"
-msgstr ""
+msgstr "Frequenza predefinita di scansione del sistema"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Boefje ID"
-msgstr ""
+msgstr "ID Boefje"
 
 #: katalogus/templates/plugin_container_image.html
 #: reports/templates/report_overview/modal_partials/delete_modal.html
@@ -2067,51 +2144,53 @@ msgstr ""
 #: reports/templates/report_overview/subreports_table.html
 #: rocky/templates/tasks/reports.html
 msgid "Creation date"
-msgstr ""
+msgstr "Data di creazione"
 
 #: katalogus/templates/plugin_container_image.html tools/forms/boefje.py
 msgid "Arguments"
-msgstr ""
+msgstr "Argomenti"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "The following arguments are used for this Boefje variant:"
-msgstr ""
+msgstr "Per questa variante Boefje vengono usati i seguenti argomenti:"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "There are no arguments used for this Boefje variant."
-msgstr ""
+msgstr "Non vengono usati argomenti per questa variante Boefje."
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Edit variant"
-msgstr ""
+msgstr "Modifica variante"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "This Boefje has no variants yet."
-msgstr ""
+msgstr "Questo Boefje non ha ancora varianti."
 
 #: katalogus/templates/plugin_container_image.html
 msgid ""
 "You can make a variant and change the arguments and JSON Schema to customize "
 "it to fit your needs."
 msgstr ""
+"Puoi creare una variante e modificare gli argomenti e lo schema JSON per "
+"personalizzarla in base alle tue esigenze."
 
 #: katalogus/templates/plugin_settings_add.html
 msgid "Add setting"
 msgid_plural "Add settings"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Aggiungi impostazione"
+msgstr[1] "Aggiungi impostazioni"
 
 #: katalogus/templates/plugin_settings_add.html
 msgid "Setting"
 msgid_plural "Settings"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Impostazione"
+msgstr[1] "Impostazioni"
 
 #: katalogus/templates/plugin_settings_add.html
 msgid "Add setting and enable boefje"
 msgid_plural "Add settings and enable boefje"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Aggiungi impostazione e abilita boefje"
+msgstr[1] "Aggiungi impostazioni e abilita boefje"
 
 #: katalogus/templates/plugin_settings_delete.html
 msgid "Delete settings"
@@ -2130,22 +2209,25 @@ msgid ""
 "In the table below the settings for this specific Boefje can be seen. Set or "
 "change the value of the variables by editing the settings."
 msgstr ""
+"Nella tabella seguente sono visibili le impostazioni per questo specifico "
+"Boefje. Imposta o modifica il valore delle variabili modificando le "
+"impostazioni."
 
 #: katalogus/templates/plugin_settings_list.html
 msgid "Configure Settings"
-msgstr ""
+msgstr "Configura impostazioni"
 
 #: katalogus/templates/plugin_settings_list.html
 msgid "Overview of settings"
-msgstr ""
+msgstr "Panoramica delle impostazioni"
 
 #: katalogus/templates/plugin_settings_list.html
 msgid "Variable"
-msgstr ""
+msgstr "Variabile"
 
 #: katalogus/views/change_clearance_level.py
 msgid "Session has terminated, please select objects again."
-msgstr ""
+msgstr "La sessione è terminata, seleziona nuovamente gli oggetti."
 
 #: katalogus/views/change_clearance_level.py
 msgid "Change clearance level"
@@ -2164,8 +2246,8 @@ msgstr "Errore nel recupero delle impostazioni per il boefje {}"
 msgid ""
 "Getting information for plugin {} failed. Please check the KATalogus logs."
 msgstr ""
-"Recuperare le informazioni per il plugin {} è fallito. Controlla i log di "
-"KATalogus."
+"Recupero delle informazioni per il plugin {} non riuscito. Controlla i log "
+"di KAT-alogus."
 
 #: katalogus/views/plugin_detail.py
 msgid ""
@@ -2177,42 +2259,41 @@ msgstr ""
 "livello di autorizzazione."
 
 #: katalogus/views/plugin_enable_disable.py
-#, fuzzy
 msgid "{} '{}' disabled."
-msgstr ""
-"Recupero delle impostazioni del boefje {boefje_name} non riuscito. Katalogus "
-"è attivo?"
+msgstr "{} '{}' disabilitato."
 
 #: katalogus/views/plugin_enable_disable.py
 msgid "{} '{}' enabled."
-msgstr ""
-"Recupero delle impostazioni del boefje {boefje_name} non riuscito. Katalogus "
-"è attivo?"
+msgstr "{} '{}' abilitato."
 
 #: katalogus/views/plugin_enable_disable.py
 msgid ""
 "You have not acknowledged your clearance level. Go to your profile page to "
 "acknowledge your clearance level."
 msgstr ""
+"Non hai ancora confermato il tuo livello di autorizzazione. Vai alla pagina "
+"del tuo profilo per confermarlo."
 
 #: katalogus/views/plugin_enable_disable.py
 msgid ""
 "Your clearance level is not set. Go to your profile page to see your "
 "clearance or contact the administrator to set a clearance level."
 msgstr ""
-"Prima di abilitare, impostare le impostazioni richieste per il boefje "
-"'{boefje_name}'."
+"Il tuo livello di autorizzazione non è impostato. Vai alla pagina del tuo "
+"profilo per vedere la tua autorizzazione o contatta l'amministratore per "
+"impostare un livello di autorizzazione."
 
 #: katalogus/views/plugin_enable_disable.py
 msgid ""
 "Your clearance level is L{}. Contact your administrator to get a higher "
 "clearance level."
 msgstr ""
+"Il tuo livello di autorizzazione è L{}. Contatta l'amministratore per "
+"ottenere un livello di autorizzazione più alto."
 
 #: katalogus/views/plugin_enable_disable.py
-#, fuzzy
 msgid "To enable {} you need at least a clearance level of L{}. "
-msgstr "Stai per impostare il livello di autorizzazione da \\"
+msgstr "Per abilitare {} è necessario almeno un livello di autorizzazione L{}. "
 
 #: katalogus/views/plugin_settings_add.py
 msgid "Trying to add settings to boefje without schema"
@@ -2257,13 +2338,16 @@ msgid ""
 "info."
 msgstr ""
 "Eliminazione delle impostazioni del plugin {} non riuscita. Controlla i log "
-"di Katalogus per ulteriori informazioni."
+"di KAT-alogus per ulteriori informazioni."
 
 #: onboarding/forms.py
 msgid ""
 "The clearance level determines how aggressive the object can be scanned by "
 "plugins. A higher clearance level means more aggressive scans are allowed."
 msgstr ""
+"Il livello di autorizzazione determina quanto aggressivamente l'oggetto può "
+"essere scansionato dai plugin. Un livello di autorizzazione più alto consente "
+"scansioni più aggressive."
 
 #: onboarding/forms.py tools/forms/ooi.py
 msgid "explanation-clearance-level"
@@ -2271,31 +2355,35 @@ msgstr "Spiegazione del livello di autorizzazione"
 
 #: onboarding/forms.py
 msgid "Please enter a valid URL starting with 'http://' or 'https://'."
-msgstr ""
+msgstr "Inserisci un URL valido che inizi con 'http://' o 'https://'."
 
 #: onboarding/templates/partials/onboarding_header.html
 msgid "Onboarding"
-msgstr ""
+msgstr "Onboarding"
 
 #: onboarding/templates/partials/step_1_introduction_text.html
 msgid "Welcome to OpenKAT!"
-msgstr ""
+msgstr "Benvenuto in OpenKAT!"
 
 #: onboarding/templates/partials/step_1_introduction_text.html
 msgid ""
 "Welcome to the onboarding of OpenKAT. We will walk you through some steps to "
 "set everything up."
 msgstr ""
+"Benvenuto nell'onboarding di OpenKAT. Ti guideremo attraverso alcuni "
+"passaggi per configurare tutto."
 
 #: onboarding/templates/partials/step_1_introduction_text.html
 msgid ""
 "At the end of this onboarding you have added your first object, created your "
 "first DNS report and learned about some basic concepts used within OpenKAT."
 msgstr ""
+"Alla fine di questo onboarding avrai aggiunto il tuo primo oggetto, creato "
+"il tuo primo report DNS e imparato alcuni concetti di base usati in OpenKAT."
 
 #: onboarding/templates/partials/step_1_introduction_text.html
 msgid "The full documentation for OpenKAT can be found at:"
-msgstr ""
+msgstr "La documentazione completa di OpenKAT è disponibile su:"
 
 #: onboarding/templates/partials/step_2_organization_text.html
 #: rocky/templates/organizations/organization_add.html
@@ -2308,6 +2396,10 @@ msgid ""
 "be changed later in the interface. The organization code cannot be changed "
 "as this is used by the database."
 msgstr ""
+"Inserisci i seguenti dettagli dell'organizzazione. Il nome "
+"dell'organizzazione può essere modificato successivamente nell'interfaccia. "
+"Il codice dell'organizzazione non può essere modificato perché viene usato "
+"dal database."
 
 #: onboarding/templates/step_10_report.html
 #: reports/report_types/concatenated_report/report.py
@@ -2323,16 +2415,20 @@ msgid ""
 "The enabled Boefjes are running in the background to gather the data for "
 "your DNS Report. This may take a few minutes."
 msgstr ""
+"I Boefjes abilitati sono in esecuzione in background per raccogliere i dati "
+"per il tuo report DNS. Potrebbero volerci alcuni minuti."
 
 #: onboarding/templates/step_10_report.html
 msgid ""
 "In the meantime you can explore OpenKAT and view your DNS Report on the "
 "Reports page once it has been generated."
 msgstr ""
+"Nel frattempo puoi esplorare OpenKAT e visualizzare il tuo report DNS nella "
+"pagina dei report una volta generato."
 
 #: onboarding/templates/step_10_report.html
 msgid "Continue to OpenKAT"
-msgstr ""
+msgstr "Continua su OpenKAT"
 
 #: onboarding/templates/step_1_introduction_registration.html
 #: onboarding/templates/step_1a_introduction.html
@@ -2380,19 +2476,25 @@ msgstr "L'indennizzo sull'organizzazione è già presente."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 msgid "User clearance level"
-msgstr ""
+msgstr "Livello di autorizzazione dell'utente"
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 msgid ""
 "The user clearance level specifies the maximum scan level for security scans "
 "and the maximum clearance level you can assign to objects (e.g. a URL)."
 msgstr ""
+"Il livello di autorizzazione dell'utente specifica il livello massimo per le "
+"scansioni di sicurezza e il livello massimo di autorizzazione che puoi "
+"assegnare agli oggetti, ad esempio a un URL."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 msgid ""
 "The administrator assigns a maximum user clearance level to each user. This "
 "will make sure that only trusted users can start more aggressive scans."
 msgstr ""
+"L'amministratore assegna a ciascun utente un livello massimo di "
+"autorizzazione. Questo garantisce che solo utenti fidati possano avviare "
+"scansioni più aggressive."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 msgid ""
@@ -2401,6 +2503,11 @@ msgid ""
 "assigned by your administrator. On your user settings page you can choose to "
 "lower your accepted clearance level after completing the onboarding."
 msgstr ""
+"Un utente deve accettare un livello di autorizzazione prima di eseguire "
+"azioni in OpenKAT. Qui puoi accettare il livello massimo di autorizzazione "
+"fidato assegnato dal tuo amministratore. Nella pagina delle impostazioni "
+"utente puoi scegliere di abbassare il livello accettato dopo aver completato "
+"l'onboarding."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 msgid "What is my clearance level?"
@@ -2416,6 +2523,12 @@ msgid ""
 "<strong>%(ooi)s</strong> </br> Contact your administrator to receive a "
 "higher clearance."
 msgstr ""
+"Purtroppo non puoi continuare l'onboarding. </br> Il tuo amministratore ti "
+"ha assegnato un livello di autorizzazione fidato di <strong>L%(tcl)s</"
+"strong>. </br> Hai bisogno almeno di un livello di autorizzazione "
+"<strong>L%(dns_report_least_clearance_level)s</strong> per scansionare "
+"<strong>%(ooi)s</strong> </br> Contatta il tuo amministratore per ricevere "
+"un'autorizzazione più alta."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 #: onboarding/templates/step_5_add_scan_ooi.html
@@ -2434,6 +2547,9 @@ msgid ""
 "<strong>L%(tcl)s</strong>. </br> You must first accept this clearance level "
 "to continue."
 msgstr ""
+"Il tuo amministratore ti ha assegnato un livello di autorizzazione fidato di "
+"<strong>L%(tcl)s</strong>. </br> Devi prima accettare questo livello di "
+"autorizzazione per continuare."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 #, python-format
@@ -2441,10 +2557,12 @@ msgid ""
 "Your administrator has <strong>trusted</strong> you with a clearance level "
 "of <strong>L%(tcl)s</strong>."
 msgstr ""
+"Il tuo amministratore ti ha <strong>affidato</strong> un livello di "
+"autorizzazione di <strong>L%(tcl)s</strong>."
 
 #: onboarding/templates/step_5_add_scan_ooi.html
 msgid "Add an object"
-msgstr ""
+msgstr "Aggiungi un oggetto"
 
 #: onboarding/templates/step_5_add_scan_ooi.html
 msgid ""
@@ -2452,6 +2570,9 @@ msgid ""
 "URLs. In the onboarding we will add an URL object, such as our vulnerable "
 "OpenKAT website: https://mispo.es."
 msgstr ""
+"OpenKAT usa vari tipi di oggetti, come indirizzi IP, hostname e URL. "
+"Nell'onboarding aggiungeremo un oggetto URL, come il nostro sito OpenKAT "
+"vulnerabile: https://mispo.es."
 
 #: onboarding/templates/step_5_add_scan_ooi.html
 #: rocky/templates/partials/ooi_detail_related_object.html
@@ -2466,6 +2587,11 @@ msgid ""
 "collects and adds these related objects by running scans. Objects can also "
 "be manually added."
 msgstr ""
+"La maggior parte degli oggetti dipende dall'esistenza di oggetti correlati. "
+"Per esempio, un URL deve essere collegato a una rete, a un hostname, a un "
+"FQDN (fully qualified domain name) e a un indirizzo IP. Quando possibile, "
+"OpenKAT raccoglie e aggiunge automaticamente questi oggetti correlati "
+"eseguendo scansioni. Gli oggetti possono anche essere aggiunti manualmente."
 
 #: onboarding/templates/step_5_add_scan_ooi.html
 msgid "Create object"
@@ -2473,7 +2599,7 @@ msgstr "Crea oggetto"
 
 #: onboarding/templates/step_6_set_clearance_level.html
 msgid "Set object clearance level"
-msgstr ""
+msgstr "Imposta il livello di autorizzazione dell'oggetto"
 
 #: onboarding/templates/step_6_set_clearance_level.html
 msgid ""
@@ -2482,6 +2608,11 @@ msgid ""
 "higher clearance level, means that more aggressive scans are allowed. "
 "Clearance levels can always be adjusted later on."
 msgstr ""
+"Dopo aver creato un nuovo oggetto puoi impostare un livello di "
+"autorizzazione per quell'oggetto. Il livello di autorizzazione determina "
+"quanto aggressivamente l'oggetto può essere scansionato. Un livello più alto "
+"significa che sono consentite scansioni più aggressive. I livelli di "
+"autorizzazione possono sempre essere modificati in seguito."
 
 #: onboarding/templates/step_6_set_clearance_level.html
 #, python-format
@@ -2490,6 +2621,9 @@ msgid ""
 "L%(dns_report_least_clearance_level)s, meaning only informational scans are "
 "allowed."
 msgstr ""
+"Per l'onboarding usiamo un livello di autorizzazione "
+"L%(dns_report_least_clearance_level)s, il che significa che sono consentite "
+"solo scansioni informative."
 
 #: onboarding/templates/step_6_set_clearance_level.html
 msgid "Set clearance level"
@@ -2497,7 +2631,7 @@ msgstr "Imposta il livello di autorizzazione"
 
 #: onboarding/templates/step_7_clearance_level_introduction.html
 msgid "Plugin introduction"
-msgstr ""
+msgstr "Introduzione ai plugin"
 
 #: onboarding/templates/step_7_clearance_level_introduction.html
 msgid ""
@@ -2506,6 +2640,11 @@ msgid ""
 "a clearance level that is equal to, or higher than the scan level of the "
 "plugin. Plugin scan level are indicated by the number of cat paws."
 msgstr ""
+"OpenKAT usa plugin per scansionare i tuoi oggetti. Ogni plugin ha un livello "
+"di scansione che indica quanto è aggressiva la scansione. I plugin possono "
+"scansionare solo oggetti con un livello di autorizzazione uguale o superiore "
+"al livello di scansione del plugin. I livelli di scansione dei plugin sono "
+"indicati dal numero di zampe di gatto."
 
 #: onboarding/templates/step_7_clearance_level_introduction.html
 msgid ""
@@ -2513,6 +2652,10 @@ msgid ""
 "performs non-intrusive scans which look for publicly available information. "
 "It scans objects with a clearance level of 1 or higher."
 msgstr ""
+"Il plugin <strong>DNS Zone</strong> ha un livello di scansione 1, il che "
+"significa che esegue scansioni non intrusive alla ricerca di informazioni "
+"pubblicamente disponibili. Scansiona oggetti con un livello di "
+"autorizzazione 1 o superiore."
 
 #: onboarding/templates/step_7_clearance_level_introduction.html
 msgid ""
@@ -2520,22 +2663,30 @@ msgid ""
 "more aggressive and could potentially break things. It scans objects with a "
 "clearance level of 3 or higher."
 msgstr ""
+"Il plugin <strong>Fierce</strong> ha un livello di scansione 3, il che "
+"significa che è più aggressivo e potrebbe potenzialmente causare problemi. "
+"Scansiona oggetti con un livello di autorizzazione 3 o superiore."
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid "Enabling plugins and start scanning"
-msgstr ""
+msgstr "Abilitare i plugin e avviare la scansione"
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid ""
 "OpenKAT uses plugins to scan, check and analyze. There are three types of "
 "plugins."
 msgstr ""
+"OpenKAT usa plugin per scansionare, controllare e analizzare. Esistono tre "
+"tipi di plugin."
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid ""
 "The first plugin are <b>Boefjes</b>, which scan objects for data. These are "
 "security tools like nmap, LeakIX and WPscan. </p>"
 msgstr ""
+"Il primo tipo di plugin sono i <b>Boefjes</b>, che scansionano gli oggetti "
+"alla ricerca di dati. Si tratta di strumenti di sicurezza come nmap, LeakIX "
+"e WPscan. </p>"
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid ""
@@ -2544,6 +2695,10 @@ msgid ""
 "objects. Bits are also used to create organization specific findings, based "
 "on policy requirements. </p>"
 msgstr ""
+"Gli altri due tipi di plugin sono <b>Normalizers</b> e <b>Bits</b>, usati "
+"per elaborare l'output dei Boefjes. Possono creare rilevamenti e oggetti "
+"correlati. I Bits vengono usati anche per creare rilevamenti specifici per "
+"l'organizzazione, basati sui requisiti delle policy. </p>"
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid ""
@@ -2552,14 +2707,18 @@ msgid ""
 "a clearance level of 1 or higher. Normalizers and Bits are enabled by "
 "default."
 msgstr ""
+"Per l'onboarding abiliteremo i Boefjes mostrati qui sotto. Una volta "
+"abilitati, questi Boefjes raccolgono informazioni pubblicamente disponibili "
+"su oggetti idonei con un livello di autorizzazione 1 o superiore. "
+"Normalizers e Bits sono abilitati per impostazione predefinita."
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid "Enable and continue"
-msgstr ""
+msgstr "Abilita e continua"
 
 #: onboarding/templates/step_9_choose_report_type.html
 msgid "Generate a report"
-msgstr ""
+msgstr "Genera un report"
 
 #: onboarding/templates/step_9_choose_report_type.html
 msgid ""
@@ -2567,20 +2726,26 @@ msgid ""
 "can generate different types of reports in OpenKAT. Each report may require "
 "one or more plugins that provide the input for the report."
 msgstr ""
+"I report possono essere usati per ottenere maggiori informazioni sugli asset "
+"della tua organizzazione. In OpenKAT puoi generare diversi tipi di report. "
+"Ogni report può richiedere uno o più plugin che forniscano l'input per il "
+"report."
 
 #: onboarding/templates/step_9_choose_report_type.html
 msgid ""
 "For the onboarding we will generate a DNS report for your added URL. In the "
 "previous step you enabled the required plugins for this report."
 msgstr ""
+"Per l'onboarding genereremo un report DNS per l'URL che hai aggiunto. Nel "
+"passaggio precedente hai abilitato i plugin richiesti per questo report."
 
 #: onboarding/templates/step_9_choose_report_type.html
 msgid "Generate DNS Report"
-msgstr ""
+msgstr "Genera report DNS"
 
 #: onboarding/view_helpers.py
 msgid "1: Welcome"
-msgstr ""
+msgstr "1: Benvenuto"
 
 #: onboarding/view_helpers.py
 msgid "2: Organization setup"
@@ -2588,15 +2753,15 @@ msgstr "2: Impostazione dell'organizzazione"
 
 #: onboarding/view_helpers.py
 msgid "3: Add object"
-msgstr ""
+msgstr "3: Aggiungi oggetto"
 
 #: onboarding/view_helpers.py
 msgid "4: Plugins"
-msgstr ""
+msgstr "4: Plugin"
 
 #: onboarding/view_helpers.py
 msgid "5: Generating report"
-msgstr ""
+msgstr "5: Generazione del report"
 
 #: onboarding/views.py
 #, python-brace-format
@@ -2614,32 +2779,32 @@ msgstr "Creazione di un oggetto"
 
 #: onboarding/views.py
 msgid "Fetch the parent DNS zone of a hostname"
-msgstr ""
+msgstr "Recupera la zona DNS padre di un hostname"
 
 #: onboarding/views.py
 msgid "Finds subdomains by brute force"
-msgstr ""
+msgstr "Trova sottodomini tramite brute force"
 
 #: onboarding/views.py
 msgid "Please select a plugin to proceed."
-msgstr ""
+msgstr "Seleziona un plugin per procedere."
 
 #: onboarding/views.py
 msgid "Please select all required plugins to proceed."
-msgstr ""
+msgstr "Seleziona tutti i plugin richiesti per procedere."
 
 #: onboarding/views.py reports/views/aggregate_report.py
 #: reports/views/generate_report.py
 msgid "An error occurred while enabling {}. The plugin is not available."
-msgstr ""
+msgstr "Si è verificato un errore durante l'abilitazione di {}. Il plugin non è disponibile."
 
 #: onboarding/views.py
 msgid "Plugins successfully enabled."
-msgstr ""
+msgstr "Plugin abilitati con successo."
 
 #: onboarding/views.py
 msgid "Web URL not found."
-msgstr ""
+msgstr "URL web non trovato."
 
 #: onboarding/views.py
 msgid ""
@@ -2647,6 +2812,9 @@ msgid ""
 "waiting for Boefjes to complete. In the meantime get familiar with OpenKAT "
 "and visit the Reports History tab later."
 msgstr ""
+"La generazione del report è pianificata tra circa 3 minuti, perché stiamo "
+"aspettando il completamento dei Boefjes. Nel frattempo familiarizza con "
+"OpenKAT e visita più tardi la scheda Cronologia report."
 
 #: reports/forms.py tools/forms/ooi_form.py
 msgid "Filter by OOI types"
@@ -2654,104 +2822,104 @@ msgstr "Filtra per tipi di OOI"
 
 #: reports/forms.py
 msgid "Today"
-msgstr ""
+msgstr "Oggi"
 
 #: reports/forms.py
 msgid "Different date"
-msgstr ""
+msgstr "Data diversa"
 
 #: reports/forms.py
 msgid "No, just once"
-msgstr ""
+msgstr "No, solo una volta"
 
 #: reports/forms.py
 msgid "Yes, repeat"
-msgstr ""
+msgstr "Sì, ripeti"
 
 #: reports/forms.py
 msgid "Start date"
-msgstr ""
+msgstr "Data di inizio"
 
 #: reports/forms.py
 msgid "Start time (UTC)"
-msgstr ""
+msgstr "Ora di inizio (UTC)"
 
 #: reports/forms.py
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Recurrence"
-msgstr ""
+msgstr "Ricorrenza"
 
 #: reports/forms.py
 msgid "No recurrence, just once"
-msgstr ""
+msgstr "Nessuna ricorrenza, solo una volta"
 
 #: reports/forms.py
 msgid "Daily"
-msgstr ""
+msgstr "Giornaliera"
 
 #: reports/forms.py
 msgid "Weekly"
-msgstr ""
+msgstr "Settimanale"
 
 #: reports/forms.py
 msgid "Monthly"
-msgstr ""
+msgstr "Mensile"
 
 #: reports/forms.py
 msgid "Yearly"
-msgstr ""
+msgstr "Annuale"
 
 #: reports/forms.py
 msgid "day"
-msgstr ""
+msgstr "giorno"
 
 #: reports/forms.py
 msgid "week"
-msgstr ""
+msgstr "settimana"
 
 #: reports/forms.py
 msgid "month"
-msgstr ""
+msgstr "mese"
 
 #: reports/forms.py
 msgid "year"
-msgstr ""
+msgstr "anno"
 
 #: reports/forms.py
 msgid "Never"
-msgstr ""
+msgstr "Mai"
 
 #: reports/forms.py
 msgid "On"
-msgstr ""
+msgstr "Il"
 
 #: reports/forms.py
 msgid "After"
-msgstr ""
+msgstr "Dopo"
 
 #: reports/forms.py
 msgid "Report name format"
-msgstr ""
+msgstr "Formato del nome del report"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/report_types/multi_organization_report/appendix.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Appendix"
-msgstr ""
+msgstr "Appendice"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Currently filtered on"
-msgstr ""
+msgstr "Attualmente filtrato su"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/partials/report_sidemenu.html
 #: reports/templates/summary/report_asset_overview.html
 msgid "Selected Report Types"
-msgstr ""
+msgstr "Tipi di report selezionati"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Selected report types"
-msgstr ""
+msgstr "Tipi di report selezionati"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/partials/plugin_overview_table.html
@@ -2761,16 +2929,16 @@ msgstr ""
 #: reports/templates/report_overview/subreports_table.html
 #: reports/templates/summary/report_asset_overview.html
 msgid "Report type"
-msgstr ""
+msgstr "Tipo di report"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Service Versions and Health"
-msgstr ""
+msgstr "Versioni e stato dei servizi"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Service, version and health"
-msgstr ""
+msgstr "Servizio, versione e stato"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/summary/service_health.html rocky/templates/footer.html
@@ -2795,31 +2963,31 @@ msgstr "Sano"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Unhealthy"
-msgstr ""
+msgstr "Non sano"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Used Config objects"
-msgstr ""
+msgstr "Oggetti di configurazione usati"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Used config objects"
-msgstr ""
+msgstr "Oggetti di configurazione usati"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Primary Key"
-msgstr ""
+msgstr "Chiave primaria"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Bit ID"
-msgstr ""
+msgstr "ID Bit"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Config"
-msgstr ""
+msgstr "Configurazione"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "No config objects found."
-msgstr ""
+msgstr "Nessun oggetto di configurazione trovato."
 
 #: reports/report_types/aggregate_organisation_report/asset_overview.html
 #: reports/report_types/multi_organization_report/asset_overview.html
@@ -2827,7 +2995,7 @@ msgstr ""
 #: reports/templates/partials/report_sidemenu.html
 #: reports/templates/summary/report_asset_overview.html
 msgid "Asset overview"
-msgstr ""
+msgstr "Panoramica degli asset"
 
 #: reports/report_types/aggregate_organisation_report/asset_overview.html
 #: reports/report_types/multi_organization_report/asset_overview.html
@@ -2836,11 +3004,14 @@ msgid ""
 "strong> are taken as a starting point, assets that are not in bold were "
 "found by OpenKAT itself."
 msgstr ""
+"Una panoramica degli asset scansionati rilasciati manualmente. Gli asset in "
+"<strong>grassetto</strong> sono usati come punto di partenza; gli asset non "
+"in grassetto sono stati trovati da OpenKAT."
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 #: reports/report_types/aggregate_organisation_report/report.html
 msgid "Overview of the basic security status"
-msgstr ""
+msgstr "Panoramica dello stato della sicurezza di base"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 msgid ""
@@ -2848,39 +3019,42 @@ msgid ""
 "assets. Basic security in order. In principle, all values in this table "
 "should be checked off."
 msgstr ""
+"Questa tabella fornisce una panoramica dello stato della sicurezza di base "
+"degli asset conosciuti. Sicurezza di base in ordine. In linea di principio, "
+"tutti i valori in questa tabella dovrebbero essere spuntati."
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 msgid "Basic security status"
-msgstr ""
+msgstr "Stato della sicurezza di base"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 #: reports/report_types/ipv6_report/report.html
 #: reports/report_types/multi_organization_report/ipv6.html
 #: reports/report_types/systems_report/report.html
 msgid "System type"
-msgstr ""
+msgstr "Tipo di sistema"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Safe connections"
-msgstr ""
+msgstr "Connessioni sicure"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 msgid "System Specific"
-msgstr ""
+msgstr "Specifico del sistema"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 msgid "RPKI"
-msgstr ""
+msgstr "RPKI"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/rpki_report/report.html
 #: reports/report_types/safe_connections_report/report.html
 msgid "server"
-msgstr ""
+msgstr "server"
 
 #: reports/report_types/aggregate_organisation_report/findings.html
 #: reports/report_types/aggregate_organisation_report/report.html
@@ -2888,53 +3062,58 @@ msgid ""
 "This chapter contains information about the findings that have been "
 "identified for this organization."
 msgstr ""
+"Questo capitolo contiene informazioni sui rilevamenti identificati per "
+"questa organizzazione."
 
 #: reports/report_types/aggregate_organisation_report/recommendations.html
 #: reports/report_types/multi_organization_report/recommendations.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Recommendations"
-msgstr ""
+msgstr "Raccomandazioni"
 
 #: reports/report_types/aggregate_organisation_report/recommendations.html
 #, python-format
 msgid "There is <i>%(total_findings)s</i> vulnerability"
 msgid_plural "There are <i>%(total_findings)s</i> vulnerabilities"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "C'è <i>%(total_findings)s</i> vulnerabilità"
+msgstr[1] "Ci sono <i>%(total_findings)s</i> vulnerabilità"
 
 #: reports/report_types/aggregate_organisation_report/recommendations.html
 #, python-format
 msgid "found on <i>%(total_systems)s</i> system."
 msgid_plural "found on <i>%(total_systems)s</i> systems."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "trovata su <i>%(total_systems)s</i> sistema."
+msgstr[1] "trovate su <i>%(total_systems)s</i> sistemi."
 
 #: reports/report_types/aggregate_organisation_report/recommendations.html
 #: reports/report_types/multi_organization_report/recommendations.html
 msgid "There are no recommendations."
-msgstr ""
+msgstr "Non ci sono raccomandazioni."
 
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Basic security"
-msgstr ""
+msgstr "Sicurezza di base"
 
 #: reports/report_types/aggregate_organisation_report/report.html
 msgid ""
 "In this chapter, first a table of compliance checks is displayed, followed "
 "by a detailed examination of compliance issues for each component."
 msgstr ""
+"In questo capitolo viene prima mostrata una tabella dei controlli di "
+"conformità, seguita da un'analisi dettagliata dei problemi di conformità per "
+"ciascun componente."
 
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "System specific"
-msgstr ""
+msgstr "Specifico del sistema"
 
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Resource Public Key Infrastructure"
-msgstr ""
+msgstr "Resource Public Key Infrastructure"
 
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/report_types/aggregate_organisation_report/vulnerabilities.html
@@ -2942,16 +3121,16 @@ msgstr ""
 #: reports/report_types/vulnerability_report/report.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Vulnerabilities"
-msgstr ""
+msgstr "Vulnerabilità"
 
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/report_types/aggregate_organisation_report/vulnerabilities.html
 msgid "Vulnerabilities found are grouped per system."
-msgstr ""
+msgstr "Le vulnerabilità trovate sono raggruppate per sistema."
 
 #: reports/report_types/aggregate_organisation_report/report.py
 msgid "Aggregate Organisation Report"
-msgstr ""
+msgstr "Report aggregato dell'organizzazione"
 
 #: reports/report_types/aggregate_organisation_report/rpki.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
@@ -2962,6 +3141,12 @@ msgid ""
 "misconfigurations and malicious route intercepts through verified route "
 "announcements, ensuring reliable server access and secure internet traffic."
 msgstr ""
+"Questa sezione contiene informazioni di sicurezza di base sulla Resource "
+"Public Key Infrastructure. Se il tuo web server utilizza RPKI per i suoi "
+"indirizzi IP e nameserver associati, migliora la protezione dei visitatori "
+"contro configurazioni errate e intercettazioni malevole delle rotte tramite "
+"annunci di rotta verificati, garantendo un accesso affidabile al server e "
+"traffico internet sicuro."
 
 #: reports/report_types/aggregate_organisation_report/safe_connections.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
@@ -2972,6 +3157,11 @@ msgid ""
 "strong encryption which protects the data from interception during "
 "communiction."
 msgstr ""
+"In questo capitolo verifichiamo se le connessioni di tutte le porte IP del "
+"sistema sono sicure. Le connessioni sicure sono importanti per prevenire "
+"accessi non autorizzati e violazioni dei dati. Cifrari forti sono "
+"fondamentali perché garantiscono una crittografia robusta che protegge i "
+"dati dall'intercettazione durante la comunicazione."
 
 #: reports/report_types/aggregate_organisation_report/summary.html
 #: reports/report_types/multi_organization_report/summary.html
@@ -2981,19 +3171,19 @@ msgstr "Sommario"
 
 #: reports/report_types/aggregate_organisation_report/summary.html
 msgid "Critical Vulnerabilities"
-msgstr ""
+msgstr "Vulnerabilità critiche"
 
 #: reports/report_types/aggregate_organisation_report/summary.html
 msgid "IPs scanned"
-msgstr ""
+msgstr "IP scansionati"
 
 #: reports/report_types/aggregate_organisation_report/summary.html
 msgid "Hostnames scanned"
-msgstr ""
+msgstr "Hostname scansionati"
 
 #: reports/report_types/aggregate_organisation_report/summary.html
 msgid "Terms in report"
-msgstr ""
+msgstr "Termini nel report"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/rpki_report/report.html
@@ -3003,10 +3193,12 @@ msgid ""
 "This table shows which checks were performed. Following that, the compliance "
 "issues, if any, are shown for each %(type)s Server."
 msgstr ""
+"Questa tabella mostra quali controlli sono stati eseguiti. Successivamente "
+"vengono mostrati eventuali problemi di conformità per ogni server %(type)s."
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 msgid "Check overview"
-msgstr ""
+msgstr "Panoramica dei controlli"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/mail_report/report.html
@@ -3016,7 +3208,7 @@ msgstr ""
 #: reports/report_types/safe_connections_report/report.html
 #: reports/report_types/web_system_report/report.html
 msgid "Check"
-msgstr ""
+msgstr "Controllo"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/mail_report/report.html
@@ -3025,18 +3217,18 @@ msgstr ""
 #: reports/report_types/safe_connections_report/report.html
 #: reports/report_types/web_system_report/report.html
 msgid "Compliance"
-msgstr ""
+msgstr "Conformità"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/rpki_report/report.html
 msgid "IPs are compliant"
-msgstr ""
+msgstr "Gli IP sono conformi"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/safe_connections_report/report.html
 #: reports/report_types/vulnerability_report/report.html
 msgid "Host:"
-msgstr ""
+msgstr "Host:"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/mail_report/report.html
@@ -3045,7 +3237,7 @@ msgstr ""
 #: reports/report_types/safe_connections_report/report.html
 #: reports/report_types/web_system_report/report.html
 msgid "Compliance issue"
-msgstr ""
+msgstr "Problema di conformità"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/mail_report/report.html
@@ -3068,15 +3260,18 @@ msgid ""
 "security and compliance issues come into play for different systems. They "
 "are listed here under each other."
 msgstr ""
+"Qui vengono eseguiti i controlli specifici per tipo di sistema. Sistemi "
+"diversi comportano problemi di sicurezza e conformità diversi, elencati qui "
+"uno sotto l'altro."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Term Overview"
-msgstr ""
+msgstr "Panoramica dei termini"
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid "For definitions of terms used in this chapter, see the glossary below."
-msgstr ""
+msgstr "Per le definizioni dei termini usati in questo capitolo, consulta il glossario qui sotto."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
@@ -3090,6 +3285,15 @@ msgid ""
 "against threats and ensure the overall security and functionality of an "
 "organization's IT environment."
 msgstr ""
+"Web server e domini sono esempi di asset digitali all'interno di questo "
+"framework. I web server sono essenziali per ospitare e servire siti web o "
+"applicazioni web, mentre i domini rappresentano gli indirizzi online usati "
+"per accedere a queste risorse. Altri esempi di asset in ambito IT includono "
+"database, account utente, applicazioni software e infrastruttura di rete. La "
+"gestione degli asset è un aspetto critico della cybersecurity e comprende "
+"identificazione, classificazione e protezione di questi asset per difendersi "
+"dalle minacce e garantire la sicurezza e il funzionamento complessivo "
+"dell'ambiente IT di un'organizzazione."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
@@ -3097,6 +3301,10 @@ msgid ""
 "hostnames or the IP address has a declared scan level that is at least L1. "
 "Type systems are web servers, mail servers and name servers (DNS)."
 msgstr ""
+"Più hostname che risolvono verso un unico indirizzo IP, dove almeno uno "
+"degli hostname o l'indirizzo IP ha un livello di scansione dichiarato di "
+"almeno L1. I tipi di sistema sono web server, mail server e name server "
+"(DNS)."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
@@ -3104,6 +3312,9 @@ msgid ""
 "protocols like HTTP or HTTPS to facilitate communication between clients and "
 "the server."
 msgstr ""
+"Un componente fondamentale del modello client-server. Un web server usa "
+"protocolli come HTTP o HTTPS per facilitare la comunicazione tra client e "
+"server."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
@@ -3117,6 +3328,15 @@ msgid ""
 "emails, handling tasks such as authentication, spam filtering, and message "
 "storage."
 msgstr ""
+"Un mail server è un'applicazione software specializzata o un dispositivo "
+"hardware che facilita l'invio, la ricezione e l'archiviazione delle e-mail "
+"all'interno di una rete informatica. Operando con il Simple Mail Transfer "
+"Protocol (SMTP) per i messaggi in uscita e con Internet Message Access "
+"Protocol (IMAP) o Post Office Protocol (POP) per i messaggi in arrivo, un "
+"mail server gestisce la comunicazione e-mail instradando i messaggi tra gli "
+"utenti e conservandoli finché non vengono recuperati. Il server garantisce "
+"il trasferimento efficiente e sicuro delle e-mail, gestendo attività come "
+"autenticazione, filtro antispam e archiviazione dei messaggi."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
@@ -3127,6 +3347,12 @@ msgid ""
 "to obtain the corresponding IP address of the server hosting the associated "
 "website or service."
 msgstr ""
+"Un nameserver, o server Domain Name System (DNS), è un componente critico "
+"dell'infrastruttura internet responsabile della traduzione dei nomi di "
+"dominio leggibili dall'uomo in indirizzi IP, consentendo una navigazione web "
+"fluida. Quando un utente inserisce un nome di dominio in un browser, il "
+"nameserver viene interrogato per ottenere l'indirizzo IP corrispondente del "
+"server che ospita il sito web o il servizio associato."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
@@ -3141,15 +3367,25 @@ msgid ""
 "medical images, like X-rays, CT scans, and MRIs, utilizing a standardized "
 "format."
 msgstr ""
+"Un server DICOM, acronimo di Digital Imaging and Communications in Medicine, "
+"è un server specializzato progettato per l'archiviazione, il recupero e lo "
+"scambio di immagini mediche e informazioni correlate nel settore sanitario. "
+"DICOM è uno standard ampiamente adottato che garantisce interoperabilità e "
+"coerenza nella comunicazione di immagini mediche e dati associati tra "
+"dispositivi e sistemi diversi, come apparecchiature di imaging medicale, "
+"sistemi PACS (Picture Archiving and Communication Systems) e sistemi RIS "
+"(Radiology Information Systems). I server DICOM archiviano e gestiscono "
+"immagini mediche specifiche del paziente, come radiografie, TAC e risonanze "
+"magnetiche, usando un formato standardizzato."
 
 #: reports/report_types/aggregate_organisation_report/vulnerabilities.html
 #: reports/report_types/multi_organization_report/vulnerabilities.html
 msgid "No CVEs have been found."
-msgstr ""
+msgstr "Non sono stati trovati CVE."
 
 #: reports/report_types/dns_report/report.html
 msgid "Records found"
-msgstr ""
+msgstr "Record trovati"
 
 #: reports/report_types/dns_report/report.html
 msgid ""
@@ -3157,24 +3393,30 @@ msgid ""
 "DNSZone. Additionally the security measures table shows whether or not DNS "
 "relating security measures are enabled."
 msgstr ""
+"Il report DNS fornisce una panoramica dei record DNS trovati per la DNSZone. "
+"Inoltre, la tabella delle misure di sicurezza mostra se le misure di "
+"sicurezza relative al DNS sono abilitate o meno."
 
 #: reports/report_types/dns_report/report.html
 msgid ""
 "<strong>Disclaimer:</strong> Not all DNSRecords are parsed in OpenKAT. DNS "
 "record types that are parsed and could be displayed in the table are:"
 msgstr ""
+"<strong>Disclaimer:</strong> non tutti i DNSRecords vengono analizzati in "
+"OpenKAT. I tipi di record DNS analizzati e che potrebbero essere mostrati "
+"nella tabella sono:"
 
 #: reports/report_types/dns_report/report.html
 msgid "All existing DNS record types can be found here:"
-msgstr ""
+msgstr "Tutti i tipi di record DNS esistenti sono disponibili qui:"
 
 #: reports/report_types/dns_report/report.html
 msgid "Record"
-msgstr ""
+msgstr "Record"
 
 #: reports/report_types/dns_report/report.html
 msgid "TTL"
-msgstr ""
+msgstr "TTL"
 
 #: reports/report_types/dns_report/report.html
 msgid "Data"
@@ -3182,17 +3424,19 @@ msgstr "Dati"
 
 #: reports/report_types/dns_report/report.html
 msgid "No records have been found."
-msgstr ""
+msgstr "Non è stato trovato alcun record."
 
 #: reports/report_types/dns_report/report.html
 msgid "Security measures"
-msgstr ""
+msgstr "Misure di sicurezza"
 
 #: reports/report_types/dns_report/report.html
 msgid ""
 "The security measures table below shows which DNS relating security measures "
 "are enabled based on the contents of the DNS records."
 msgstr ""
+"La tabella delle misure di sicurezza qui sotto mostra quali misure relative "
+"al DNS sono abilitate in base al contenuto dei record DNS."
 
 #: reports/report_types/dns_report/report.html
 #: reports/templates/partials/report_ooi_list.html
@@ -3218,11 +3462,11 @@ msgstr "No"
 #: reports/report_types/dns_report/report.html
 #: reports/templates/partials/report_findings_table.html
 msgid "Other findings found"
-msgstr ""
+msgstr "Altri rilevamenti trovati"
 
 #: reports/report_types/dns_report/report.html
 msgid "Findings information"
-msgstr ""
+msgstr "Informazioni sui rilevamenti"
 
 #: reports/report_types/dns_report/report.py
 msgid "DNS Report"
@@ -3233,20 +3477,24 @@ msgid ""
 "DNS reports focus on domain name system configuration and potential "
 "weaknesses."
 msgstr ""
+"I report DNS si concentrano sulla configurazione del Domain Name System e "
+"sulle potenziali debolezze."
 
 #: reports/report_types/findings_report/report.html
 msgid ""
 "The Findings Report contains information about the findings that have been "
 "identified for the selected asset and organization."
 msgstr ""
+"Il Report dei rilevamenti contiene informazioni sui rilevamenti identificati "
+"per l'asset e l'organizzazione selezionati."
 
 #: reports/report_types/findings_report/report.py
 msgid "Findings Report"
-msgstr ""
+msgstr "Report dei rilevamenti"
 
 #: reports/report_types/findings_report/report.py
 msgid "Shows all the finding types and their occurrences."
-msgstr ""
+msgstr "Mostra tutti i tipi di rilevamento e le relative occorrenze."
 
 #: reports/report_types/ipv6_report/report.html
 msgid ""
@@ -3255,23 +3503,27 @@ msgid ""
 "over IPv6 or not. A green compliance check is shown if this is the case. A "
 "grey compliance cross is shown if no IPv6 address was detected."
 msgstr ""
+"Il report IPv6 fornisce una panoramica dello stato IPv6 attuale del sistema "
+"identificato. La tabella seguente mostra se il dominio è raggiungibile via "
+"IPv6. In tal caso viene mostrato un controllo di conformità verde. Se non è "
+"stato rilevato alcun indirizzo IPv6 viene mostrata una croce grigia."
 
 #: reports/report_types/ipv6_report/report.html
 msgid "IPv6 overview"
-msgstr ""
+msgstr "Panoramica IPv6"
 
 #: reports/report_types/ipv6_report/report.html
 #: reports/report_types/systems_report/report.html
 msgid "Domain"
-msgstr ""
+msgstr "Dominio"
 
 #: reports/report_types/ipv6_report/report.py
 msgid "IPv6 Report"
-msgstr ""
+msgstr "Report IPv6"
 
 #: reports/report_types/ipv6_report/report.py
 msgid "Check whether hostnames point to IPv6 addresses."
-msgstr ""
+msgstr "Controlla se gli hostname puntano a indirizzi IPv6."
 
 #: reports/report_types/mail_report/report.html
 msgid ""
@@ -3282,86 +3534,93 @@ msgid ""
 "issue description and risk level. The risk level may be different for your "
 "specific environment."
 msgstr ""
+"Il Report Mail fornisce una panoramica dei controlli di conformità associati "
+"ai server e-mail. La conformità attuale verifica la presenza di record SPF, "
+"DKIM e DMARC. La tabella seguente mostra, per ciascuno di questi controlli, "
+"quanti dei server mail identificati sono conformi e, se applicabile, una "
+"descrizione del problema di conformità e il livello di rischio. Il livello di "
+"rischio può essere diverso nel tuo ambiente specifico."
 
 #: reports/report_types/mail_report/report.html
 msgid "Mailserver compliance"
-msgstr ""
+msgstr "Conformità dei mailserver"
 
 #: reports/report_types/mail_report/report.html
 msgid "mailservers compliant"
-msgstr ""
+msgstr "mailserver conformi"
 
 #: reports/report_types/mail_report/report.html
 msgid "No mailservers have been found on this system."
-msgstr ""
+msgstr "Non sono stati trovati mailserver su questo sistema."
 
 #: reports/report_types/mail_report/report.py
 msgid "Mail Report"
-msgstr ""
+msgstr "Report Mail"
 
 #: reports/report_types/mail_report/report.py
 msgid ""
 "System specific Mail Report that focusses on IP addresses and hostnames."
 msgstr ""
+"Report Mail specifico del sistema, focalizzato su indirizzi IP e hostname."
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Overview of included assets"
-msgstr ""
+msgstr "Panoramica degli asset inclusi"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Asset"
-msgstr ""
+msgstr "Asset"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
 msgid "Amount"
-msgstr ""
+msgstr "Quantità"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "IP addresses"
-msgstr ""
+msgstr "Indirizzi IP"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Domain names"
-msgstr ""
+msgstr "Nomi di dominio"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Assets with most critical vulnerabilities"
-msgstr ""
+msgstr "Asset con il maggior numero di vulnerabilità critiche"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Vulnerability"
-msgstr ""
+msgstr "Vulnerabilità"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Organisation"
-msgstr ""
+msgstr "Organizzazione"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "No vulnerabilities found."
-msgstr ""
+msgstr "Nessuna vulnerabilità trovata."
 
 #: reports/report_types/multi_organization_report/basic_security_details.html
 msgid "Overview of safe connections"
-msgstr ""
+msgstr "Panoramica delle connessioni sicure"
 
 #: reports/report_types/multi_organization_report/basic_security_details.html
 #: reports/report_types/safe_connections_report/report.html
 msgid "Only Safe Ciphers"
-msgstr ""
+msgstr "Solo cifrari sicuri"
 
 #: reports/report_types/multi_organization_report/basic_security_details.html
 #: reports/report_types/safe_connections_report/report.html
 msgid "services are compliant"
-msgstr ""
+msgstr "servizi sono conformi"
 
 #: reports/report_types/multi_organization_report/basic_security_details.html
 msgid "System specific checks"
-msgstr ""
+msgstr "Controlli specifici del sistema"
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid "IPv6"
-msgstr ""
+msgstr "IPv6"
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid ""
@@ -3369,55 +3628,61 @@ msgid ""
 "can implement security measures, IPv6 was designed with security in mind, "
 "and its adoption can contribute to a more secure internet."
 msgstr ""
+"IPv6 include miglioramenti nelle funzionalità di sicurezza rispetto a IPv4. "
+"Sebbene IPv4 possa implementare misure di sicurezza, IPv6 è stato progettato "
+"tenendo conto della sicurezza e la sua adozione può contribuire a un "
+"internet più sicuro."
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid "In total "
-msgstr ""
+msgstr "In totale "
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid " out of "
-msgstr ""
+msgstr " su "
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid " systems have an IPv6 connection."
-msgstr ""
+msgstr " sistemi hanno una connessione IPv6."
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid "Overview of IP version compliance"
-msgstr ""
+msgstr "Panoramica della conformità della versione IP"
 
 #: reports/report_types/multi_organization_report/open_ports.html
 msgid ""
 "See an overview of open ports found over all systems and the services these "
 "systems provide."
 msgstr ""
+"Visualizza una panoramica delle porte aperte trovate su tutti i sistemi e "
+"dei servizi forniti da questi sistemi."
 
 #: reports/report_types/multi_organization_report/open_ports.html
 msgid "Overview of detected open ports"
-msgstr ""
+msgstr "Panoramica delle porte aperte rilevate"
 
 #: reports/report_types/multi_organization_report/open_ports.html
 #: reports/report_types/open_ports_report/report.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Open ports"
-msgstr ""
+msgstr "Porte aperte"
 
 #: reports/report_types/multi_organization_report/open_ports.html
 msgid "Occurrences (IP addresses)"
-msgstr ""
+msgstr "Occorrenze (indirizzi IP)"
 
 #: reports/report_types/multi_organization_report/open_ports.html
 #: reports/templates/summary/service_health.html
 msgid "Services"
-msgstr ""
+msgstr "Servizi"
 
 #: reports/report_types/multi_organization_report/open_ports.html
 msgid "No open ports found."
-msgstr ""
+msgstr "Nessuna porta aperta trovata."
 
 #: reports/report_types/multi_organization_report/recommendations.html
 msgid "Overview of recommendations"
-msgstr ""
+msgstr "Panoramica delle raccomandazioni"
 
 #: reports/report_types/multi_organization_report/recommendations.html
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
@@ -3426,33 +3691,35 @@ msgstr "Occorrenza"
 
 #: reports/report_types/multi_organization_report/report.html
 msgid "No findings have been identified yet."
-msgstr ""
+msgstr "Non è stato ancora identificato alcun rilevamento."
 
 #: reports/report_types/multi_organization_report/report.py
 msgid "Multi Organization Report"
-msgstr ""
+msgstr "Report multi-organizzazione"
 
 #: reports/report_types/multi_organization_report/summary.html
 msgid "Best scoring security check"
-msgstr ""
+msgstr "Controllo di sicurezza con il punteggio migliore"
 
 #: reports/report_types/multi_organization_report/summary.html
 msgid "Worst scoring security check"
-msgstr ""
+msgstr "Controllo di sicurezza con il punteggio peggiore"
 
 #: reports/report_types/multi_organization_report/vulnerabilities.html
 msgid ""
 "Vulnerabilities found are grouped per system. Here, we only consider CVE "
 "vulnerabilities."
 msgstr ""
+"Le vulnerabilità trovate sono raggruppate per sistema. Qui consideriamo solo "
+"le vulnerabilità CVE."
 
 #: reports/report_types/multi_organization_report/vulnerabilities.html
 msgid "Vulnerabilities grouped per system"
-msgstr ""
+msgstr "Vulnerabilità raggruppate per sistema"
 
 #: reports/report_types/multi_organization_report/vulnerabilities.html
 msgid "total"
-msgstr ""
+msgstr "totale"
 
 #: reports/report_types/name_server_report/report.html
 msgid ""
@@ -3465,39 +3732,47 @@ msgid ""
 "identified are shown too. The risk level may be different for your specific "
 "environment."
 msgstr ""
+"Il Report Name Server fornisce una panoramica dei controlli di conformità "
+"eseguiti sui Domain Name Server (DNS) identificati. I controlli verificano "
+"la presenza e la validità di DNSSEC e se non sono state identificate porte "
+"non necessarie aperte. La tabella seguente offre una panoramica dei "
+"controlli disponibili, incluso se il sistema ha superato i controlli "
+"eseguiti. Sono mostrati anche il livello di rischio e il motivo per cui è "
+"stato identificato un problema. Il livello di rischio può essere diverso nel "
+"tuo ambiente specifico."
 
 #: reports/report_types/name_server_report/report.html
 msgid "Name server compliance"
-msgstr ""
+msgstr "Conformità dei name server"
 
 #: reports/report_types/name_server_report/report.html
 msgid "DNSSEC Present"
-msgstr ""
+msgstr "DNSSEC presente"
 
 #: reports/report_types/name_server_report/report.html
 msgid "name servers compliant"
-msgstr ""
+msgstr "name server conformi"
 
 #: reports/report_types/name_server_report/report.html
 msgid "Valid DNSSEC"
-msgstr ""
+msgstr "DNSSEC valido"
 
 #: reports/report_types/name_server_report/report.html
 #: reports/report_types/web_system_report/report.html
 msgid "No unnecessary ports open"
-msgstr ""
+msgstr "Nessuna porta non necessaria aperta"
 
 #: reports/report_types/name_server_report/report.html
 msgid "No nameservers have been found on this system."
-msgstr ""
+msgstr "Non sono stati trovati nameserver su questo sistema."
 
 #: reports/report_types/name_server_report/report.py
 msgid "Name Server Report"
-msgstr ""
+msgstr "Report Name Server"
 
 #: reports/report_types/name_server_report/report.py
 msgid "Name Server Report checks name servers on basic security standards."
-msgstr ""
+msgstr "Il Report Name Server controlla i name server rispetto agli standard di sicurezza di base."
 
 #: reports/report_types/open_ports_report/report.html
 msgid ""
@@ -3507,31 +3782,37 @@ msgid ""
 "were identified through external services and/or scans (such as Shodan). "
 "Scans with the same hostnames, ports and IPs are merged."
 msgstr ""
+"Il Report Porte Aperte fornisce una panoramica delle porte aperte "
+"identificate su un sistema. Le porte contrassegnate in <b>grassetto</b> sono "
+"state identificate da scansioni dirette eseguite da OpenKAT, come nmap. Le "
+"porte non in grassetto sono state identificate tramite servizi esterni e/o "
+"scansioni, come Shodan. Le scansioni con gli stessi hostname, porte e IP "
+"vengono unite."
 
 #: reports/report_types/open_ports_report/report.html
 msgid "Overview of open ports found for the scanned assets"
-msgstr ""
+msgstr "Panoramica delle porte aperte trovate per gli asset scansionati"
 
 #: reports/report_types/open_ports_report/report.html
 #: reports/report_types/systems_report/report.html
 msgid "IP address"
-msgstr ""
+msgstr "Indirizzo IP"
 
 #: reports/report_types/open_ports_report/report.html
 msgid "Hostnames"
-msgstr ""
+msgstr "Hostname"
 
 #: reports/report_types/open_ports_report/report.html
 msgid "Direct scan"
-msgstr ""
+msgstr "Scansione diretta"
 
 #: reports/report_types/open_ports_report/report.py
 msgid "Open Ports Report"
-msgstr ""
+msgstr "Report Porte Aperte"
 
 #: reports/report_types/open_ports_report/report.py
 msgid "Find open ports of IP addresses"
-msgstr ""
+msgstr "Trova porte aperte degli indirizzi IP"
 
 #: reports/report_types/rpki_report/report.html
 msgid ""
@@ -3541,47 +3822,57 @@ msgid ""
 "misconfigurations and malicious route intercepts through verified route "
 "announcements, ensuring reliable server access and secure internet traffic."
 msgstr ""
+"Questa sezione contiene informazioni di sicurezza di base sulla Resource "
+"Public Key Infrastructure (RPKI). Se il tuo web server utilizza RPKI per i "
+"suoi indirizzi IP e nameserver associati, migliora la protezione dei "
+"visitatori contro configurazioni errate e intercettazioni malevole delle "
+"rotte tramite annunci di rotta verificati, garantendo un accesso affidabile "
+"al server e traffico internet sicuro."
 
 #: reports/report_types/rpki_report/report.html
 msgid ""
 "The RPKI Report shows if an RPKI route announcement was available for the "
 "system and if this announcement is not expired."
 msgstr ""
+"Il Report RPKI mostra se era disponibile un annuncio di rotta RPKI per il "
+"sistema e se tale annuncio non è scaduto."
 
 #: reports/report_types/rpki_report/report.html
 msgid "RPKI compliance"
-msgstr ""
+msgstr "Conformità RPKI"
 
 #: reports/report_types/rpki_report/report.html
 msgid "RPKI Available"
-msgstr ""
+msgstr "RPKI disponibile"
 
 #: reports/report_types/rpki_report/report.html
 msgid "RPKI valid"
-msgstr ""
+msgstr "RPKI valido"
 
 #: reports/report_types/rpki_report/report.html
 msgid "RPKI record is not valid."
-msgstr ""
+msgstr "Il record RPKI non è valido."
 
 #: reports/report_types/rpki_report/report.html
 msgid "RPKI record does not exist."
-msgstr ""
+msgstr "Il record RPKI non esiste."
 
 #: reports/report_types/rpki_report/report.html
 #: reports/report_types/safe_connections_report/report.html
 msgid "No IPs have been found on this system."
-msgstr ""
+msgstr "Non sono stati trovati IP su questo sistema."
 
 #: reports/report_types/rpki_report/report.py
 msgid "RPKI Report"
-msgstr ""
+msgstr "Report RPKI"
 
 #: reports/report_types/rpki_report/report.py
 msgid ""
 "Shows whether the IP is covered by a valid RPKI ROA. For a hostname it shows "
 "the IP addresses and whether they are covered by a valid RPKI ROA."
 msgstr ""
+"Mostra se l'IP è coperto da una ROA RPKI valida. Per un hostname mostra gli "
+"indirizzi IP e se sono coperti da una ROA RPKI valida."
 
 #: reports/report_types/safe_connections_report/report.html
 msgid ""
@@ -3592,18 +3883,24 @@ msgid ""
 "was identified are shown too. The risk level may be different for your "
 "specific environment."
 msgstr ""
+"Il report Connessioni sicure fornisce una panoramica dei controlli eseguiti "
+"sui canali di comunicazione cifrati, come HTTPS. La tabella seguente offre "
+"una panoramica dei controlli disponibili, incluso se il sistema ha superato i "
+"controlli eseguiti. Sono mostrati anche il livello di rischio e il motivo "
+"per cui è stato identificato un problema. Il livello di rischio può essere "
+"diverso nel tuo ambiente specifico."
 
 #: reports/report_types/safe_connections_report/report.html
 msgid "Safe connections compliance"
-msgstr ""
+msgstr "Conformità delle connessioni sicure"
 
 #: reports/report_types/safe_connections_report/report.py
 msgid "Safe Connections Report"
-msgstr ""
+msgstr "Report Connessioni Sicure"
 
 #: reports/report_types/safe_connections_report/report.py
 msgid "Shows whether the IPService contains safe ciphers."
-msgstr ""
+msgstr "Mostra se l'IPService contiene cifrari sicuri."
 
 #: reports/report_types/systems_report/report.html
 msgid ""
@@ -3614,46 +3911,56 @@ msgid ""
 "or more system types depending on the identified ports and services. The "
 "table below gives an overview of these results."
 msgstr ""
+"Il Report Sistema fornisce una panoramica dei tipi di sistema (tipi di "
+"servizi simili) identificati per ciascun sistema. Possono essere identificati "
+"i seguenti tipi di sistema: server DNS, web server, mail server e server "
+"classificati come 'Altro'. A ogni hostname e/o indirizzo IP vengono assegnati "
+"uno o più tipi di sistema in base alle porte e ai servizi identificati. La "
+"tabella seguente offre una panoramica di questi risultati."
 
 #: reports/report_types/systems_report/report.html
 msgid "Selected assets"
-msgstr ""
+msgstr "Asset selezionati"
 
 #: reports/report_types/systems_report/report.html
 msgid "No system types have been identified on this system."
-msgstr ""
+msgstr "Non sono stati identificati tipi di sistema su questo sistema."
 
 #: reports/report_types/systems_report/report.py
 msgid "System Report"
-msgstr ""
+msgstr "Report Sistema"
 
 #: reports/report_types/systems_report/report.py
 msgid "Combine IP addresses, hostnames and services into systems."
-msgstr ""
+msgstr "Combina indirizzi IP, hostname e servizi in sistemi."
 
 #: reports/report_types/tls_report/report.html
 msgid ""
 "The TLS Report shows which TLS protocols and ciphers were identified on the "
 "host for the provided port."
 msgstr ""
+"Il Report TLS mostra quali protocolli TLS e cifrari sono stati identificati "
+"sull'host per la porta fornita."
 
 #: reports/report_types/tls_report/report.html
 msgid ""
 "The table below provides an overview of the identified TLS protocols and "
 "ciphers, including a status suggestion."
 msgstr ""
+"La tabella seguente fornisce una panoramica dei protocolli TLS e dei cifrari "
+"identificati, inclusa una proposta di stato."
 
 #: reports/report_types/tls_report/report.html
 msgid "Ciphers"
-msgstr ""
+msgstr "Cifrari"
 
 #: reports/report_types/tls_report/report.html
 msgid "Protocol"
-msgstr ""
+msgstr "Protocollo"
 
 #: reports/report_types/tls_report/report.html
 msgid "Encryption Algorithm"
-msgstr ""
+msgstr "Algoritmo di cifratura"
 
 #: reports/report_types/tls_report/report.html
 msgid "Bits"
@@ -3661,7 +3968,7 @@ msgstr "Bit"
 
 #: reports/report_types/tls_report/report.html
 msgid "Key Size"
-msgstr ""
+msgstr "Dimensione della chiave"
 
 #: reports/report_types/tls_report/report.html
 #: rocky/templates/organizations/organization_list.html
@@ -3671,16 +3978,18 @@ msgstr "Codice"
 
 #: reports/report_types/tls_report/report.html
 msgid "Phase out"
-msgstr ""
+msgstr "Dismettere"
 
 #: reports/report_types/tls_report/report.html
 msgid "Good"
-msgstr ""
+msgstr "Buono"
 
 #: reports/report_types/tls_report/report.html
 msgid ""
 "No ciphers were found for this combination of IP address, port and service."
 msgstr ""
+"Non sono stati trovati cifrari per questa combinazione di indirizzo IP, "
+"porta e servizio."
 
 #: reports/report_types/tls_report/report.html
 msgid ""
@@ -3688,20 +3997,25 @@ msgid ""
 "protocols and ciphers. This includes the reasoning why the cipher or "
 "protocol is marked as a finding."
 msgstr ""
+"L'elenco seguente fornisce una panoramica dei rilevamenti basati sui "
+"protocolli TLS e sui cifrari identificati. Include il motivo per cui il "
+"cifrario o il protocollo è contrassegnato come rilevamento."
 
 #: reports/report_types/tls_report/report.py
 msgid "TLS Report"
-msgstr ""
+msgstr "Report TLS"
 
 #: reports/report_types/tls_report/report.py
 msgid ""
 "TLS Report assesses the security of data encryption and transmission "
 "protocols."
 msgstr ""
+"Il Report TLS valuta la sicurezza della cifratura dei dati e dei protocolli "
+"di trasmissione."
 
 #: reports/report_types/vulnerability_report/report.html
 msgid "No vulnerabilities have been found on this system."
-msgstr ""
+msgstr "Non sono state trovate vulnerabilità su questo sistema."
 
 #: reports/report_types/vulnerability_report/report.html
 msgid ""
@@ -3710,34 +4024,37 @@ msgid ""
 "the table shows the CVE scoring, the number of occurrences, and the CVE "
 "details."
 msgstr ""
+"Il Report Vulnerabilità fornisce una panoramica di tutte le vulnerabilità CVE "
+"identificate sui sistemi selezionati. Per ogni CVE la tabella mostra il "
+"punteggio CVE, il numero di occorrenze e i dettagli della CVE."
 
 #: reports/report_types/vulnerability_report/report.html
 msgid "vulnerabilities on this system"
-msgstr ""
+msgstr "vulnerabilità su questo sistema"
 
 #: reports/report_types/vulnerability_report/report.html
 msgid "Advice"
-msgstr ""
+msgstr "Consiglio"
 
 #: reports/report_types/vulnerability_report/report.py
 msgid "Vulnerability Report"
-msgstr ""
+msgstr "Report Vulnerabilità"
 
 #: reports/report_types/vulnerability_report/report.py
 msgid "Vulnerabilities found are grouped for each system."
-msgstr ""
+msgstr "Le vulnerabilità trovate sono raggruppate per ciascun sistema."
 
 #: reports/report_types/vulnerability_report/report.py
 msgid "First seen"
-msgstr ""
+msgstr "Visto per la prima volta"
 
 #: reports/report_types/vulnerability_report/report.py
 msgid "Last seen"
-msgstr ""
+msgstr "Visto l'ultima volta"
 
 #: reports/report_types/vulnerability_report/report.py
 msgid "Evidence"
-msgstr ""
+msgstr "Evidenza"
 
 #: reports/report_types/web_system_report/report.html
 msgid ""
@@ -3748,62 +4065,68 @@ msgid ""
 "general risk level. The risk level may be different for your specific "
 "environment."
 msgstr ""
+"Il Report Sistema Web fornisce una panoramica dei vari controlli web server "
+"eseguiti sui sistemi scansionati. Per ogni controllo eseguito, la tabella "
+"seguente mostra se il server è conforme o meno. Viene mostrata anche una "
+"descrizione del motivo per cui il controllo di conformità non è riuscito, "
+"incluso un livello di rischio generale. Il livello di rischio può essere "
+"diverso nel tuo ambiente specifico."
 
 #: reports/report_types/web_system_report/report.html
 msgid "Web system compliance"
-msgstr ""
+msgstr "Conformità del sistema web"
 
 #: reports/report_types/web_system_report/report.html
 msgid "CSP Present"
-msgstr ""
+msgstr "CSP presente"
 
 #: reports/report_types/web_system_report/report.html
 msgid "webservers compliant"
-msgstr ""
+msgstr "webserver conformi"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Secure CSP Header"
-msgstr ""
+msgstr "Header CSP sicuro"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Redirects HTTP to HTTPS"
-msgstr ""
+msgstr "Reindirizza HTTP a HTTPS"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Offers HTTPS"
-msgstr ""
+msgstr "Offre HTTPS"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Has a Security.txt"
-msgstr ""
+msgstr "Ha un Security.txt"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Has a certificate"
-msgstr ""
+msgstr "Ha un certificato"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Certificate is valid"
-msgstr ""
+msgstr "Il certificato è valido"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Certificate is not expiring soon"
-msgstr ""
+msgstr "Il certificato non scade a breve"
 
 #: reports/report_types/web_system_report/report.html
 msgid "No webservers have been found on this system."
-msgstr ""
+msgstr "Non sono stati trovati webserver su questo sistema."
 
 #: reports/report_types/web_system_report/report.py
 msgid "Web System Report"
-msgstr ""
+msgstr "Report Sistema Web"
 
 #: reports/report_types/web_system_report/report.py
 msgid "Web System Reports check web systems on basic security standards."
-msgstr ""
+msgstr "I Report Sistema Web controllano i sistemi web rispetto agli standard di sicurezza di base."
 
 #: reports/templates/partials/export_report_settings.html
 msgid "Report schedule"
-msgstr ""
+msgstr "Pianificazione del report"
 
 #: reports/templates/partials/export_report_settings.html
 msgid ""
@@ -3812,11 +4135,15 @@ msgid ""
 "intervals, like daily, weekly, or monthly. If you need the report just for a "
 "single occasion, select the one-time option."
 msgstr ""
+"Quando pianifichi il report hai due opzioni: puoi scegliere di generarlo una "
+"sola volta ora, oppure impostarlo perché venga eseguito automaticamente a "
+"intervalli regolari, ad esempio ogni giorno, settimana o mese. Se ti serve "
+"solo per una singola occasione, seleziona l'opzione una tantum."
 
 #: reports/templates/partials/export_report_settings.html
 #: reports/templates/report_overview/report_history_table.html
 msgid "Report name"
-msgstr ""
+msgstr "Nome del report"
 
 #: reports/templates/partials/export_report_settings.html
 #, python-format, python-brace-format
@@ -3831,6 +4158,16 @@ msgid ""
 "for the week number, using options from <a href=\"https://strftime.org/\" "
 "target=\"_blank\" rel=\"noopener\">Python strftime code</a>."
 msgstr ""
+"Quando si generano report, è possibile assegnare un nome al report. Il nome "
+"può essere statico o dinamico. Il formato predefinito per un report è "
+"'${report_type} for ${oois_count} objects'. Questi placeholder si adattano "
+"automaticamente in base ai dettagli del report. Ad esempio, questo formato "
+"potrebbe restituire 'Aggregate Report for 15 objects'. Un altro placeholder "
+"utilizzabile è '${ooi}', che mostra il nome dell'oggetto quando è presente "
+"un solo oggetto. Puoi anche personalizzare il nome aggiungendo prefissi, "
+"suffissi o altri formati come '%%W' per il numero della settimana, usando le "
+"opzioni del <a href=\"https://strftime.org/\" target=\"_blank\" "
+"rel=\"noopener\">codice Python strftime</a>."
 
 #: reports/templates/partials/export_report_settings.html
 #: reports/templates/partials/generate_report_header.html
@@ -3841,38 +4178,38 @@ msgstr "Genera rapporto"
 
 #: reports/templates/partials/generate_report_header.html
 msgid "To generate an aggregate report, complete the following steps."
-msgstr ""
+msgstr "Per generare un report aggregato, completa i seguenti passaggi."
 
 #: reports/templates/partials/generate_report_header.html
 msgid "To generate a multi report, complete the following steps."
-msgstr ""
+msgstr "Per generare un multi-report, completa i seguenti passaggi."
 
 #: reports/templates/partials/generate_report_header.html
 msgid "To generate separate report(s), complete the following steps."
-msgstr ""
+msgstr "Per generare report separati, completa i seguenti passaggi."
 
 #: reports/templates/partials/generate_report_sidemenu.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Table of contents"
-msgstr ""
+msgstr "Indice"
 
 #: reports/templates/partials/new_report_action_button.html
 msgid "Actions for creating a new report"
-msgstr ""
+msgstr "Azioni per creare un nuovo report"
 
 #: reports/templates/partials/new_report_action_button.html
 msgid "Separate report(s)"
-msgstr ""
+msgstr "Report separati"
 
 #: reports/templates/partials/new_report_action_button.html
 #: reports/views/aggregate_report.py
 msgid "Aggregate report"
-msgstr ""
+msgstr "Report aggregato"
 
 #: reports/templates/partials/new_report_action_button.html
 #: reports/views/multi_report.py
 msgid "Multi report"
-msgstr ""
+msgstr "Multi-report"
 
 #: reports/templates/partials/plugin_overview_table.html
 #: reports/templates/partials/report_sidemenu.html
@@ -3882,12 +4219,12 @@ msgstr "Panoramica"
 
 #: reports/templates/partials/plugin_overview_table.html
 msgid "Plugin overview table"
-msgstr ""
+msgstr "Tabella panoramica dei plugin"
 
 #: reports/templates/partials/plugin_overview_table.html
 #: reports/templates/partials/report_setup_scan.html
 msgid "Required plugins"
-msgstr ""
+msgstr "Plugin richiesti"
 
 #: reports/templates/partials/plugin_overview_table.html
 #: reports/templates/partials/report_setup_scan.html
@@ -3896,11 +4233,11 @@ msgstr "Plugin suggeriti"
 
 #: reports/templates/partials/plugin_overview_table.html
 msgid "Action required"
-msgstr ""
+msgstr "Azione richiesta"
 
 #: reports/templates/partials/plugin_overview_table.html
 msgid "Ready"
-msgstr ""
+msgstr "Pronto"
 
 #: reports/templates/partials/report_findings_table.html
 msgid ""
@@ -3912,27 +4249,34 @@ msgid ""
 "finding can be found here. It also shows in which findings the finding type "
 "occurred."
 msgstr ""
+"Questa tabella fornisce una panoramica dei rilevamenti identificati sui "
+"sistemi scansionati. Per ogni tipo di rilevamento mostra il livello di "
+"rischio, il numero di occorrenze e la prima occorrenza nota del rilevamento. "
+"Il livello di rischio può essere diverso nel tuo ambiente specifico. I "
+"dettagli sono visibili espandendo una riga. Qui sono disponibili la "
+"descrizione, la fonte, l'impatto e la raccomandazione del rilevamento. Viene "
+"inoltre mostrato in quali rilevamenti si è verificato il tipo di rilevamento."
 
 #: reports/templates/partials/report_findings_table.html
 msgid "First known occurrence"
-msgstr ""
+msgstr "Prima occorrenza nota"
 
 #: reports/templates/partials/report_findings_table.html
 msgid "Open in report"
-msgstr ""
+msgstr "Apri nel report"
 
 #: reports/templates/partials/report_findings_table.html
 msgid ""
 "No critical and high findings have been identified for this organization."
-msgstr ""
+msgstr "Non sono stati identificati rilevamenti critici o alti per questa organizzazione."
 
 #: reports/templates/partials/report_findings_table.html
 msgid "No findings have been identified for this organization."
-msgstr ""
+msgstr "Non sono stati identificati rilevamenti per questa organizzazione."
 
 #: reports/templates/partials/report_header.html
 msgid "Download as PDF"
-msgstr ""
+msgstr "Scarica come PDF"
 
 #: reports/templates/partials/report_header.html
 #: rocky/templates/partials/ooi_list_toolbar.html
@@ -3941,55 +4285,57 @@ msgstr "Scarica come JSON"
 
 #: reports/templates/partials/report_header.html
 msgid "Open asset reports"
-msgstr ""
+msgstr "Apri report degli asset"
 
 #: reports/templates/partials/report_header.html
 msgid "This is the OpenKAT report for organization"
-msgstr ""
+msgstr "Questo è il report OpenKAT per l'organizzazione"
 
 #: reports/templates/partials/report_header.html
 msgid ""
 "All selected report types for the selected objects are displayed one below "
 "the other."
 msgstr ""
+"Tutti i tipi di report selezionati per gli oggetti selezionati sono mostrati "
+"uno sotto l'altro."
 
 #: reports/templates/partials/report_header.html
 msgid "Created with data from:"
-msgstr ""
+msgstr "Creato con dati da:"
 
 #: reports/templates/partials/report_header.html
 msgid "Created on:"
-msgstr ""
+msgstr "Creato il:"
 
 #: reports/templates/partials/report_header.html
 msgid "Created from recipe:"
-msgstr ""
+msgstr "Creato dalla ricetta:"
 
 #: reports/templates/partials/report_header.html
 msgid "Recipe created by:"
-msgstr ""
+msgstr "Ricetta creata da:"
 
 #: reports/templates/partials/report_header.html
 #, python-format
 msgid "This sector contains %(length)s scanned organizations."
-msgstr ""
+msgstr "Questo settore contiene %(length)s organizzazioni scansionate."
 
 #: reports/templates/partials/report_header.html
 msgid "Of these organizations"
-msgstr ""
+msgstr "Di queste organizzazioni"
 
 #: reports/templates/partials/report_header.html
 msgid "organizations have tag"
-msgstr ""
+msgstr "organizzazioni hanno il tag"
 
 #: reports/templates/partials/report_header.html
 msgid "The basic security scores are around "
-msgstr ""
+msgstr "I punteggi di sicurezza di base sono intorno a "
 
 #: reports/templates/partials/report_header.html
 #, python-format
 msgid "A total of %(total)s critical vulnerabilities have been identified."
-msgstr ""
+msgstr "Sono state identificate in totale %(total)s vulnerabilità critiche."
 
 #: reports/templates/partials/report_introduction.html
 msgid "Introduction"
@@ -4002,10 +4348,14 @@ msgid ""
 "of the selected systems (objects), plugins and reports. This is followed "
 "with the findings for each report."
 msgstr ""
+"Questo report fornisce una panoramica dello stato attuale della sicurezza "
+"della tua organizzazione per la data selezionata. La sezione di riepilogo "
+"offre una panoramica dei sistemi (oggetti), dei plugin e dei report "
+"selezionati. Seguono i rilevamenti per ciascun report."
 
 #: reports/templates/partials/report_names_form.html
 msgid "Report names:"
-msgstr ""
+msgstr "Nomi dei report:"
 
 #: reports/templates/partials/report_names_form.html
 #: rocky/templates/forms/widgets/checkbox_group_table.html
@@ -4020,7 +4370,7 @@ msgstr "Richiesto"
 
 #: reports/templates/partials/report_names_form.html
 msgid "Add reference date"
-msgstr ""
+msgstr "Aggiungi data di riferimento"
 
 #: reports/templates/partials/report_names_form.html
 #: reports/templates/report_overview/modal_partials/rename_modal.html
@@ -4029,27 +4379,27 @@ msgstr "Reimposta"
 
 #: reports/templates/partials/report_names_form.html
 msgid "No reference date"
-msgstr ""
+msgstr "Nessuna data di riferimento"
 
 #: reports/templates/partials/report_names_form.html
 msgid "Day"
-msgstr ""
+msgstr "Giorno"
 
 #: reports/templates/partials/report_names_form.html
 msgid "Week"
-msgstr ""
+msgstr "Settimana"
 
 #: reports/templates/partials/report_names_form.html
 msgid "Month"
-msgstr ""
+msgstr "Mese"
 
 #: reports/templates/partials/report_names_form.html
 msgid "Year"
-msgstr ""
+msgstr "Anno"
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "Object selection"
-msgstr ""
+msgstr "Selezione degli oggetti"
 
 #: reports/templates/partials/report_ooi_list.html
 msgid ""
@@ -4057,6 +4407,8 @@ msgid ""
 "continue with a live set or you can select the objects manually from the "
 "table below."
 msgstr ""
+"Seleziona quali oggetti vuoi includere nel report. Puoi continuare con un "
+"set live oppure selezionare manualmente gli oggetti dalla tabella qui sotto."
 
 #: reports/templates/partials/report_ooi_list.html
 msgid ""
@@ -4068,20 +4420,30 @@ msgid ""
 "more hostnames tomorrow (with the same filter criteria), your next scheduled "
 "report will contain 5 hostnames. Your live set will update as you go."
 msgstr ""
+"Un set live è un insieme di oggetti basato sui filtri applicati. Qualsiasi "
+"oggetto che corrisponde a questo filtro applicato, ora o in futuro, verrà "
+"usato come input per il report pianificato. Se il filtro del set live, ad "
+"esempio 'hostnames' con autorizzazione 'L2' che sono 'declared', mostra oggi "
+"2 hostname che corrispondono al filtro, il report pianificato verrà eseguito "
+"per quei 2 hostname. Se domani aggiungi altri 3 hostname con gli stessi "
+"criteri di filtro, il prossimo report pianificato conterrà 5 hostname. Il "
+"tuo set live si aggiornerà man mano."
 
 #: reports/templates/partials/report_ooi_list.html
 msgid ""
 "Based on the current dataset, your selected filters result in the following "
 "objects."
 msgstr ""
+"In base al dataset corrente, i filtri selezionati restituiscono i seguenti "
+"oggetti."
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "objects selected"
-msgstr ""
+msgstr "oggetti selezionati"
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "Deselect all objects"
-msgstr ""
+msgstr "Deseleziona tutti gli oggetti"
 
 #: reports/templates/partials/report_ooi_list.html
 #: rocky/templates/oois/ooi_list.html
@@ -4093,16 +4455,16 @@ msgstr "Mostrando %(length)s di %(total)s oggetti"
 #, python-format
 msgid "Select all %(total_oois)s object"
 msgid_plural "Select all %(total_oois)s objects"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Seleziona %(total_oois)s oggetto"
+msgstr[1] "Seleziona tutti i %(total_oois)s oggetti"
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "Object name"
-msgstr ""
+msgstr "Nome dell'oggetto"
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "Report(s) may be empty due to no objects in the selected filters."
-msgstr ""
+msgstr "I report potrebbero essere vuoti perché non ci sono oggetti nei filtri selezionati."
 
 #: reports/templates/partials/report_ooi_list.html
 msgid ""
@@ -4110,36 +4472,41 @@ msgid ""
 "Future reports may contain data. It is still possible to generate the "
 "(potentially empty) report."
 msgstr ""
+"I report che corrispondono ai filtri selezionati saranno vuoti in questo "
+"momento. I report futuri potrebbero contenere dati. È comunque possibile "
+"generare il report, anche se potenzialmente vuoto."
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "Continue with live set"
-msgstr ""
+msgstr "Continua con il set live"
 
 #: reports/templates/partials/report_ooi_list.html
 #: reports/templates/partials/report_types_selection.html
 msgid "Continue with selection"
-msgstr ""
+msgstr "Continua con la selezione"
 
 #: reports/templates/partials/report_setup_scan.html
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 #: reports/views/multi_report.py
 msgid "Configuration"
-msgstr ""
+msgstr "Configurazione"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Set up the required plugins for this report."
-msgstr ""
+msgstr "Configura i plugin richiesti per questo report."
 
 #: reports/templates/partials/report_setup_scan.html
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugins"
-msgstr ""
+msgstr "Plugin"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid ""
 "KAT will be able to generate a full report when all the required and "
 "suggested boefjes are enabled."
 msgstr ""
+"KAT potrà generare un report completo quando tutti i boefjes richiesti e "
+"suggeriti saranno abilitati."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid ""
@@ -4147,16 +4514,21 @@ msgid ""
 "produce will be left out of the report which will then be generated based on "
 "the available data collected by the enabled plugins."
 msgstr ""
+"Se scegli di non abilitare un plugin, i dati che quel plugin raccoglierebbe "
+"o produrrebbe verranno esclusi dal report, che sarà quindi generato in base "
+"ai dati disponibili raccolti dai plugin abilitati."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid ""
 "Some plugins are mandatory as they are crucial for a report type. Reports "
 "that don't have their requirements met will be skipped."
 msgstr ""
+"Alcuni plugin sono obbligatori perché sono cruciali per un tipo di report. I "
+"report i cui requisiti non sono soddisfatti verranno saltati."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Warning! Before you proceed read the following points:"
-msgstr ""
+msgstr "Attenzione! Prima di procedere leggi i seguenti punti:"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid ""
@@ -4167,54 +4539,61 @@ msgid ""
 "likely result in inaccurate reports, as plugins have not finished collecting "
 "data."
 msgstr ""
+"OpenKAT è progettato per scansionare regolarmente tutti gli oggetti noti "
+"usando i plugin abilitati e i livelli di autorizzazione impostati. Questo "
+"significa che le scansioni verranno eseguite automaticamente. Abbi pazienza: "
+"i plugin possono impiegare del tempo prima di raccogliere tutti i dati. "
+"Abilitarli appena prima della generazione del report probabilmente produrrà "
+"report imprecisi, perché i plugin non avranno ancora terminato la raccolta "
+"dei dati."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Good job! All required plugins are enabled."
-msgstr ""
+msgstr "Ottimo lavoro! Tutti i plugin richiesti sono abilitati."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "This report type requires the following plugins to be enabled:"
-msgstr ""
+msgstr "Questo tipo di report richiede l'abilitazione dei seguenti plugin:"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Toggle all required plugins"
-msgstr ""
+msgstr "Attiva/disattiva tutti i plugin richiesti"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Show enabled plugins"
-msgstr ""
+msgstr "Mostra plugin abilitati"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "There are no required plugins."
-msgstr ""
+msgstr "Non ci sono plugin richiesti."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Good job! All suggested plugins are enabled."
-msgstr ""
+msgstr "Ottimo lavoro! Tutti i plugin suggeriti sono abilitati."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "The following plugins are optional to generate the report:"
-msgstr ""
+msgstr "I seguenti plugin sono opzionali per generare il report:"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Toggle all optional plugins"
-msgstr ""
+msgstr "Attiva/disattiva tutti i plugin opzionali"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Hide suggested plugins"
-msgstr ""
+msgstr "Nascondi plugin suggeriti"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Show more suggested plugins"
-msgstr ""
+msgstr "Mostra altri plugin suggeriti"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "There are no optional plugins."
-msgstr ""
+msgstr "Non ci sono plugin opzionali."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Enable selected plugins and continue"
-msgstr ""
+msgstr "Abilita i plugin selezionati e continua"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid ""
@@ -4223,26 +4602,30 @@ msgid ""
 "            severity that have been identified for this organization.\n"
 "        "
 msgstr ""
+"\n"
+"            Questa panoramica mostra il numero totale di rilevamenti per\n"
+"            gravità identificati per questa organizzazione.\n"
+"        "
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Total per severity overview"
-msgstr ""
+msgstr "Panoramica totale per gravità"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Critical"
-msgstr ""
+msgstr "Critico"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "High"
-msgstr ""
+msgstr "Alto"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Medium"
-msgstr ""
+msgstr "Medio"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Low"
-msgstr ""
+msgstr "Basso"
 
 #: reports/templates/partials/report_severity_totals_table.html
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
@@ -4251,27 +4634,27 @@ msgstr "In attesa"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Unknown"
-msgstr ""
+msgstr "Sconosciuto"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Total"
-msgstr ""
+msgstr "Totale"
 
 #: reports/templates/partials/report_sidemenu.html
 msgid "Selected Objects"
-msgstr ""
+msgstr "Oggetti selezionati"
 
 #: reports/templates/partials/report_sidemenu.html
 msgid "Selected Plugins"
-msgstr ""
+msgstr "Plugin selezionati"
 
 #: reports/templates/partials/report_sidemenu.html
 msgid "Used Config Objects"
-msgstr ""
+msgstr "Oggetti di configurazione usati"
 
 #: reports/templates/partials/report_types_selection.html
 msgid "Choose report types"
-msgstr ""
+msgstr "Scegli i tipi di report"
 
 #: reports/templates/partials/report_types_selection.html
 msgid ""
@@ -4282,13 +4665,20 @@ msgid ""
 "transmission protocols, helping organizations pinpoint areas where security "
 "improvements are needed."
 msgstr ""
+"Vari tipi di report, come i report DNS e TLS, sono essenziali per "
+"identificare vulnerabilità in diversi aspetti della sicurezza di un sistema. "
+"I report DNS si concentrano sulla configurazione del Domain Name System e "
+"sulle potenziali debolezze, mentre i report TLS valutano la sicurezza della "
+"cifratura dei dati e dei protocolli di trasmissione, aiutando le "
+"organizzazioni a individuare le aree in cui sono necessari miglioramenti di "
+"sicurezza."
 
 #: reports/templates/partials/report_types_selection.html
 #, python-format
 msgid "Selected object (%(total_oois)s)"
 msgid_plural "Selected objects (%(total_oois)s)"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Oggetto selezionato (%(total_oois)s)"
+msgstr[1] "Oggetti selezionati (%(total_oois)s)"
 
 #: reports/templates/partials/report_types_selection.html
 #, python-format
@@ -4296,43 +4686,45 @@ msgid ""
 "You have selected a live set in the previous step. Based on the current "
 "dataset, this live set results in %(total_oois)s objects."
 msgstr ""
+"Nel passaggio precedente hai selezionato un set live. In base al dataset "
+"corrente, questo set live restituisce %(total_oois)s oggetti."
 
 #: reports/templates/partials/report_types_selection.html
 msgid "Applied filters:"
-msgstr ""
+msgstr "Filtri applicati:"
 
 #: reports/templates/partials/report_types_selection.html
 #, python-format
 msgid "You have selected %(total_oois)s object in the previous step."
 msgid_plural "You have selected %(total_oois)s objects in the previous step."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Hai selezionato %(total_oois)s oggetto nel passaggio precedente."
+msgstr[1] "Hai selezionato %(total_oois)s oggetti nel passaggio precedente."
 
 #: reports/templates/partials/report_types_selection.html
 msgid "Change selection"
-msgstr ""
+msgstr "Modifica selezione"
 
 #: reports/templates/partials/report_types_selection.html
 msgid "Available report types"
-msgstr ""
+msgstr "Tipi di report disponibili"
 
 #: reports/templates/partials/report_types_selection.html
 msgid "All report types that are available for your selection."
-msgstr ""
+msgstr "Tutti i tipi di report disponibili per la tua selezione."
 
 #: reports/templates/partials/report_types_selection.html
 msgid "Toggle all report types"
-msgstr ""
+msgstr "Attiva/disattiva tutti i tipi di report"
 
 #: reports/templates/partials/return_button.html
 #, python-format
 msgid "%(btn_text)s"
-msgstr ""
+msgstr "%(btn_text)s"
 
 #: reports/templates/report_overview/modal_partials/delete_modal.html
 #: reports/templates/report_overview/modal_partials/share_modal.html
 msgid "Delete the following report(s):"
-msgstr ""
+msgstr "Elimina i seguenti report:"
 
 #: reports/templates/report_overview/modal_partials/delete_modal.html
 #: reports/templates/report_overview/modal_partials/share_modal.html
@@ -4341,6 +4733,9 @@ msgid ""
 "report can still be accessed on timestamps before the deletion. Only the "
 "report is removed from the view, not the data it is based on."
 msgstr ""
+"I report eliminati vengono rimossi dalla vista dal momento dell'eliminazione. "
+"Il report resta accessibile per timestamp precedenti all'eliminazione. Viene "
+"rimosso dalla vista solo il report, non i dati su cui si basa."
 
 #: reports/templates/report_overview/modal_partials/delete_modal.html
 #: reports/templates/report_overview/modal_partials/share_modal.html
@@ -4349,6 +4744,8 @@ msgid ""
 "is part of a combined report, it will remain available in the combined "
 "report."
 msgstr ""
+"È ancora possibile generare un nuovo report per la stessa data. Se il report "
+"fa parte di un report combinato, resterà disponibile nel report combinato."
 
 #: reports/templates/report_overview/modal_partials/delete_modal.html
 #: reports/templates/report_overview/modal_partials/rerun_modal.html
@@ -4356,12 +4753,12 @@ msgstr ""
 #: reports/templates/report_overview/scheduled_reports_table.html
 #: reports/templates/report_overview/subreports_table.html
 msgid "Reference date"
-msgstr ""
+msgstr "Data di riferimento"
 
 #: reports/templates/report_overview/modal_partials/enable_disable_schedule_modal.html
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Disable schedule"
-msgstr ""
+msgstr "Disabilita pianificazione"
 
 #: reports/templates/report_overview/modal_partials/enable_disable_schedule_modal.html
 #, python-format
@@ -4370,67 +4767,73 @@ msgid ""
 "strong>? The recipe will still exist and the schedule can be enabled later "
 "on."
 msgstr ""
+"Vuoi davvero disabilitare la pianificazione per <strong>%(report_name)s</"
+"strong>? La ricetta continuerà a esistere e la pianificazione potrà essere "
+"riabilitata in seguito."
 
 #: reports/templates/report_overview/modal_partials/rename_modal.html
 msgid "Rename the following report(s):"
-msgstr ""
+msgstr "Rinomina i seguenti report:"
 
 #: reports/templates/report_overview/modal_partials/rename_modal.html
 #: reports/templates/report_overview/report_history_table.html
 msgid "Rename"
-msgstr ""
+msgstr "Rinomina"
 
 #: reports/templates/report_overview/modal_partials/rerun_modal.html
 msgid "Rerun the following report(s):"
-msgstr ""
+msgstr "Riesegui i seguenti report:"
 
 #: reports/templates/report_overview/modal_partials/rerun_modal.html
 msgid ""
 "By submitting you're generating the selected reports again, using the "
 "current data."
 msgstr ""
+"Inviando, genererai nuovamente i report selezionati usando i dati correnti."
 
 #: reports/templates/report_overview/modal_partials/rerun_modal.html
 #: reports/templates/report_overview/report_history_table.html
 msgid "Rerun"
-msgstr ""
+msgstr "Riesegui"
 
 #: reports/templates/report_overview/report_history.html
 msgid "Reports history"
-msgstr ""
+msgstr "Cronologia report"
 
 #: reports/templates/report_overview/report_history.html
 msgid ""
 "On this page you can see all the reports that have been generated in the "
 "past. To create a new report, click the 'Generate Report' button."
 msgstr ""
+"In questa pagina puoi vedere tutti i report generati in passato. Per creare "
+"un nuovo report, fai clic sul pulsante 'Genera report'."
 
 #: reports/templates/report_overview/report_history_table.html
 #: reports/templates/report_overview/subreports.html
 #, python-format
 msgid "Showing %(length)s of %(total)s reports"
-msgstr ""
+msgstr "Visualizzazione di %(length)s di %(total)s report"
 
 #: reports/templates/report_overview/report_history_table.html
 #: rocky/templates/tasks/reports.html
 msgid "Reports:"
-msgstr ""
+msgstr "Report:"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "Shows parent report details"
-msgstr ""
+msgstr "Mostra dettagli del report padre"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "Close asset report object details"
-msgstr ""
+msgstr "Chiudi dettagli dell'oggetto del report asset"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "Open asset report object details"
-msgstr ""
+msgstr "Apri dettagli dell'oggetto del report asset"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "Asset reports details"
-msgstr ""
+msgstr "Dettagli dei report asset"
 
 #: reports/templates/report_overview/report_history_table.html
 #, python-format
@@ -4441,26 +4844,30 @@ msgid_plural ""
 "This report consists of %(counter)s asset reports with the following report "
 "types and objects:"
 msgstr[0] ""
+"Questo report è composto da %(counter)s report asset con il seguente tipo di "
+"report e oggetto:"
 msgstr[1] ""
+"Questo report è composto da %(counter)s report asset con i seguenti tipi di "
+"report e oggetti:"
 
 #: reports/templates/report_overview/report_history_table.html
 #: reports/templates/report_overview/subreports_header.html
 #: reports/templates/report_overview/subreports_table.html
 #: reports/views/report_overview.py
 msgid "Asset reports"
-msgstr ""
+msgstr "Report asset"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "Shows asset report details"
-msgstr ""
+msgstr "Mostra dettagli del report asset"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "View all asset reports"
-msgstr ""
+msgstr "Visualizza tutti i report asset"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "No reports have been generated yet."
-msgstr ""
+msgstr "Non è stato ancora generato alcun report."
 
 #: reports/templates/report_overview/report_overview_header.html
 #: reports/views/base.py rocky/templates/header.html
@@ -4471,19 +4878,19 @@ msgstr "Report"
 
 #: reports/templates/report_overview/report_overview_header.html
 msgid "An overview of reports that are scheduled or have been generated."
-msgstr ""
+msgstr "Una panoramica dei report pianificati o già generati."
 
 #: reports/templates/report_overview/report_overview_navigation.html
 msgid "Scheduled"
-msgstr ""
+msgstr "Pianificati"
 
 #: reports/templates/report_overview/report_overview_navigation.html
 msgid "History"
-msgstr ""
+msgstr "Cronologia"
 
 #: reports/templates/report_overview/scheduled_reports.html
 msgid "Scheduled reports"
-msgstr ""
+msgstr "Report pianificati"
 
 #: reports/templates/report_overview/scheduled_reports.html
 msgid ""
@@ -4491,64 +4898,67 @@ msgid ""
 "schedule a report, select a start date and recurrence while generating a "
 "report."
 msgstr ""
+"In questa pagina puoi vedere tutti i report pianificati o già pianificati in "
+"passato. Per pianificare un report, seleziona una data di inizio e una "
+"ricorrenza durante la generazione del report."
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 #, python-format
 msgid "Showing %(length)s of %(total)s schedules"
-msgstr ""
+msgstr "Visualizzazione di %(length)s di %(total)s pianificazioni"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Scheduled reports:"
-msgstr ""
+msgstr "Report pianificati:"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Scheduled for"
-msgstr ""
+msgstr "Pianificato per"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Schedule status"
-msgstr ""
+msgstr "Stato della pianificazione"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Once"
-msgstr ""
+msgstr "Una volta"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Recent reports"
-msgstr ""
+msgstr "Report recenti"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Scheduled Reports:"
-msgstr ""
+msgstr "Report pianificati:"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Show report details"
-msgstr ""
+msgstr "Mostra dettagli del report"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "objects"
-msgstr ""
+msgstr "oggetti"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Enable schedule"
-msgstr ""
+msgstr "Abilita pianificazione"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "No scheduled reports have been generated yet."
-msgstr ""
+msgstr "Non è stato ancora generato alcun report pianificato."
 
 #: reports/templates/report_overview/subreports_header.html
 msgid "Back to Reports History"
-msgstr ""
+msgstr "Torna alla cronologia report"
 
 #: reports/templates/report_overview/subreports_header.html
 msgid "An overview of all underlying reports of"
-msgstr ""
+msgstr "Una panoramica di tutti i report sottostanti di"
 
 #: reports/templates/report_overview/subreports_header.html
 #: reports/templates/report_overview/subreports_table.html
 msgid "Shows report details"
-msgstr ""
+msgstr "Mostra dettagli del report"
 
 #: reports/templates/report_overview/subreports_table.html
 #: rocky/templates/tasks/boefjes.html
@@ -4558,12 +4968,12 @@ msgstr "Oggetto di Input"
 
 #: reports/templates/report_schedules/delete_recipe_modal.html
 msgid "Delete report recipe"
-msgstr ""
+msgstr "Elimina ricetta del report"
 
 #: reports/templates/report_schedules/delete_recipe_modal.html
 #, python-format
 msgid "Are you sure you want to delete report recipe \"%(name)s\"?"
-msgstr ""
+msgstr "Vuoi davvero eliminare la ricetta del report \"%(name)s\"?"
 
 #: reports/templates/report_schedules/delete_recipe_modal.html
 msgid ""
@@ -4571,6 +4981,9 @@ msgid ""
 "not be possible anymore to see or enable the schedule. You will find "
 "previously generated reports in the report history tab."
 msgstr ""
+"Eliminare questa ricetta del report significa eliminarla definitivamente. Non "
+"sarà più possibile vedere o abilitare la pianificazione. Troverai i report "
+"generati in precedenza nella scheda Cronologia report."
 
 #: reports/templates/summary/report_asset_overview.html
 msgid ""
@@ -4579,156 +4992,175 @@ msgid ""
 "whether or not the object was added by a user ('Declared') or indirectly "
 "identified through another service or system ('Inherited')."
 msgstr ""
+"Gli oggetti elencati nella tabella seguente sono stati usati per generare "
+"questo report. Per ogni oggetto la tabella mostra inoltre il livello di "
+"autorizzazione e se l'oggetto è stato aggiunto da un utente ('Dichiarato') o "
+"identificato indirettamente tramite un altro servizio o sistema ('Ereditato')."
 
 #: reports/templates/summary/report_asset_overview.html
 msgid "No objects found."
-msgstr ""
+msgstr "Nessun oggetto trovato."
 
 #: reports/templates/summary/report_asset_overview.html
 msgid ""
 "The table below shows which reports were chosen to generate this report, "
 "including a report description."
 msgstr ""
+"La tabella seguente mostra quali report sono stati scelti per generare "
+"questo report, inclusa una descrizione del report."
 
 #: reports/templates/summary/report_asset_overview.html
 msgid "No report types found."
-msgstr ""
+msgstr "Nessun tipo di report trovato."
 
 #: reports/templates/summary/selected_plugins.html
 msgid ""
 "The table below shows all required or optional plugins for the selected "
 "reports."
 msgstr ""
+"La tabella seguente mostra tutti i plugin richiesti o opzionali per i report "
+"selezionati."
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Required and optional plugins"
-msgstr ""
+msgstr "Plugin richiesti e opzionali"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugin enabled"
-msgstr ""
+msgstr "Plugin abilitato"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugin options"
-msgstr ""
+msgstr "Opzioni del plugin"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugin scan level"
-msgstr ""
+msgstr "Livello di scansione del plugin"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Enabled."
-msgstr ""
+msgstr "Abilitato."
 
 #: reports/templates/summary/selected_plugins.html
 msgid "required"
-msgstr ""
+msgstr "richiesto"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "optional"
-msgstr ""
+msgstr "opzionale"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugin extra info"
-msgstr ""
+msgstr "Informazioni extra del plugin"
 
 #: reports/templates/summary/selected_plugins.html
 msgid ""
 "There are no required or optional plugins needed for the selected report "
 "types."
 msgstr ""
+"Non sono necessari plugin richiesti o opzionali per i tipi di report "
+"selezionati."
 
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 #: reports/views/multi_report.py
 msgid "Select objects"
-msgstr ""
+msgstr "Seleziona oggetti"
 
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 #: reports/views/multi_report.py
 msgid "Select report types"
-msgstr ""
+msgstr "Seleziona tipi di report"
 
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 #: reports/views/multi_report.py
 msgid "Export setup"
-msgstr ""
+msgstr "Configurazione esportazione"
 
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 msgid "Save report"
-msgstr ""
+msgstr "Salva report"
 
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 msgid "You do not have the required permissions to enable plugins."
-msgstr ""
+msgstr "Non hai le autorizzazioni necessarie per abilitare plugin."
 
 #: reports/views/base.py
 msgid "Select at least one OOI to proceed."
-msgstr ""
+msgstr "Seleziona almeno un OOI per procedere."
 
 #: reports/views/base.py
 msgid "Select at least one report type to proceed."
-msgstr ""
+msgstr "Seleziona almeno un tipo di report per procedere."
 
 #: reports/views/mixins.py
 msgid ""
-"No data could be found for %(report_types). Object(s) did not exist on "
-"%(date)s."
+"No data could be found for %(report_types). Object(s) did not exist on %"
+"(date)s."
 msgstr ""
+"Non è stato possibile trovare dati per %(report_types). Gli oggetti non "
+"esistevano il %(date)s."
 
 #: reports/views/multi_report.py
 msgid "View report"
-msgstr ""
+msgstr "Visualizza report"
 
 #: reports/views/report_overview.py
 msgid "Not enough permissions"
-msgstr ""
+msgstr "Autorizzazioni insufficienti"
 
 #: reports/views/report_overview.py
 msgid "Recipe '{}' deleted successfully"
-msgstr ""
+msgstr "Ricetta '{}' eliminata con successo"
 
 #: reports/views/report_overview.py
 msgid "Recipe not found."
-msgstr ""
+msgstr "Ricetta non trovata."
 
 #: reports/views/report_overview.py
 msgid "No schedule or recipe selected"
-msgstr ""
+msgstr "Nessuna pianificazione o ricetta selezionata"
 
 #: reports/views/report_overview.py
 msgid ""
 "Schedule disabled successfully. '{}' will not be generated automatically "
 "until the schedule is enabled again."
 msgstr ""
+"Pianificazione disabilitata con successo. '{}' non verrà generato "
+"automaticamente finché la pianificazione non sarà riabilitata."
 
 #: reports/views/report_overview.py
 msgid ""
 "Schedule enabled successfully. '{}' will be generated according to schedule."
-msgstr ""
+msgstr "Pianificazione abilitata con successo. '{}' verrà generato secondo la pianificazione."
 
 #: reports/views/report_overview.py
 msgid "An unexpected error occurred, please check logs for more info."
-msgstr ""
+msgstr "Si è verificato un errore imprevisto, controlla i log per maggiori informazioni."
 
 #: reports/views/report_overview.py
 msgid "Other OOI type selected than Report"
-msgstr ""
+msgstr "È stato selezionato un tipo OOI diverso da Report"
 
 #: reports/views/report_overview.py
 msgid "Deletion successful."
-msgstr ""
+msgstr "Eliminazione riuscita."
 
 #: reports/views/report_overview.py
 msgid ""
 "Multi organization reports cannot be rescheduled. It consists of imported "
 "data from different organizations and is not based on newly generated data."
 msgstr ""
+"I report multi-organizzazione non possono essere ripianificati. Sono composti "
+"da dati importati da organizzazioni diverse e non si basano su dati appena "
+"generati."
 
 #: reports/views/report_overview.py
 msgid ""
 "Rerun successful. It may take a moment before the new report has been "
 "generated."
 msgstr ""
+"Riesecuzione riuscita. Potrebbe volerci un momento prima che il nuovo report "
+"venga generato."
 
 #: reports/views/report_overview.py
 #, python-format
@@ -4736,94 +5168,97 @@ msgid ""
 "Couldn't rerun %s, since the recipe for this report has been disabled or "
 "deleted."
 msgstr ""
+"Impossibile rieseguire %s, perché la ricetta di questo report è stata "
+"disabilitata o eliminata."
 
 #: reports/views/report_overview.py
 msgid "Renaming failed. Empty report name found."
-msgstr ""
+msgstr "Rinomina non riuscita. È stato trovato un nome report vuoto."
 
 #: reports/views/report_overview.py
 msgid "Report names and reports does not match."
-msgstr ""
+msgstr "I nomi dei report e i report non corrispondono."
 
 #: reports/views/report_overview.py
 msgid "Reports successfully renamed."
-msgstr ""
+msgstr "Report rinominati con successo."
 
 #: reports/views/report_overview.py
 msgid "Report {} could not be renamed."
-msgstr ""
+msgstr "Il report {} non può essere rinominato."
 
 #: reports/views/view_helpers.py
 msgid "1: Select objects"
-msgstr ""
+msgstr "1: Seleziona oggetti"
 
 #: reports/views/view_helpers.py
 msgid "2: Choose report types"
-msgstr ""
+msgstr "2: Scegli tipi di report"
 
 #: reports/views/view_helpers.py
 msgid "3: Configuration"
-msgstr ""
+msgstr "3: Configurazione"
 
 #: reports/views/view_helpers.py
 msgid "4: Export setup"
-msgstr ""
+msgstr "4: Configurazione esportazione"
 
 #: reports/views/view_helpers.py
 msgid "3: Export setup"
-msgstr ""
+msgstr "3: Configurazione esportazione"
 
 #: tools/forms/base.py
 msgid "Date"
 msgstr "Data"
 
-#: tools/forms/base.py tools/forms/scheduler.py
-msgid "The selected date is in the future. Please select a different date."
-msgstr ""
-
 #: tools/forms/boefje.py
 msgid "For example: -sTU --top-ports 1000"
-msgstr ""
+msgstr "Ad esempio: -sTU --top-ports 1000"
 
 #: tools/forms/boefje.py
 msgid "JSON Schema"
-msgstr ""
+msgstr "Schema JSON"
 
 #: tools/forms/boefje.py
 msgid "Input object type"
-msgstr ""
+msgstr "Tipo di oggetto di input"
 
 #: tools/forms/boefje.py
 msgid "Output mime types"
-msgstr ""
+msgstr "Tipi MIME di output"
 
 #: tools/forms/boefje.py
 msgid "Scan type"
-msgstr ""
+msgstr "Tipo di scansione"
 
 #: tools/forms/boefje.py
 msgid "Interval amount"
-msgstr ""
+msgstr "Quantità dell'intervallo"
 
 #: tools/forms/boefje.py
 msgid ""
 "Specify the scanning interval for this Boefje. The default is 24 hours. For "
 "example: 5 minutes will let the Boefje scan every 5 minutes."
 msgstr ""
+"Specifica l'intervallo di scansione per questo Boefje. Il valore predefinito "
+"è 24 ore. Ad esempio: 5 minuti farà eseguire la scansione al Boefje ogni 5 "
+"minuti."
 
 #: tools/forms/boefje.py
 msgid "Interval frequency"
-msgstr ""
+msgstr "Frequenza dell'intervallo"
 
 #: tools/forms/boefje.py
 msgid "Object creation/change"
-msgstr ""
+msgstr "Creazione/modifica dell'oggetto"
 
 #: tools/forms/boefje.py
 msgid ""
 "Choose weather the Boefje should run after creating and/or changing an "
 "object. "
 msgstr ""
+"Scegli se il Boefje deve essere eseguito dopo la creazione e/o la modifica "
+"di un oggetto. "
 
 #: tools/forms/finding_type.py
 msgid "KAT-ID"
@@ -4940,15 +5375,15 @@ msgstr "L'OOI non esiste"
 
 #: tools/forms/findings.py
 msgid "Show non-muted findings"
-msgstr "Mostra i rilevamenti non mutati"
+msgstr "Mostra i rilevamenti non silenziati"
 
 #: tools/forms/findings.py
 msgid "Show muted findings"
-msgstr "Mostra i rilevamenti mutati"
+msgstr "Mostra i rilevamenti silenziati"
 
 #: tools/forms/findings.py
 msgid "Show muted and non-muted findings"
-msgstr "Mostra i rilevamenti mutati e non mutati"
+msgstr "Mostra i rilevamenti silenziati e non silenziati"
 
 #: tools/forms/findings.py
 msgid "Filter by severity"
@@ -4956,7 +5391,7 @@ msgstr "Filtra per gravità"
 
 #: tools/forms/findings.py
 msgid "Filter by muted findings"
-msgstr "Filtra per rilevamenti mutati"
+msgstr "Filtra per rilevamenti silenziati"
 
 #: tools/forms/findings.py tools/forms/ooi_form.py tools/forms/scheduler.py
 msgid "Search"
@@ -4964,7 +5399,7 @@ msgstr "Ricerca"
 
 #: tools/forms/findings.py
 msgid "Object ID contains (case sensitive)"
-msgstr ""
+msgstr "L'ID oggetto contiene (sensibile alle maiuscole/minuscole)"
 
 #: tools/forms/ooi.py
 msgid "Filter types"
@@ -4976,12 +5411,11 @@ msgstr "Livello di autorizzazione"
 
 #: tools/forms/ooi.py
 msgid "Next scan"
-msgstr ""
+msgstr "Prossima scansione"
 
 #: tools/forms/ooi.py
-#, fuzzy
 msgid "Show objects that don't meet the Boefjes scan level."
-msgstr "Mostra gli oggetti che non soddisfano il livello di scansione Boefjes"
+msgstr "Mostra gli oggetti che non soddisfano il livello di scansione dei Boefjes."
 
 #: tools/forms/ooi.py
 msgid "Show Boefjes that exceed the objects clearance level."
@@ -4993,10 +5427,12 @@ msgid ""
 "All the boefjes with a scan level below or equal to the clearance level will "
 "be allowed to scan this object."
 msgstr ""
+"Tutti i boefjes con un livello di scansione inferiore o uguale al livello di "
+"autorizzazione potranno scansionare questo oggetto."
 
 #: tools/forms/ooi.py
 msgid "Expires by (UTC)"
-msgstr ""
+msgstr "Scade entro (UTC)"
 
 #: tools/forms/ooi_form.py
 msgid "option"
@@ -5013,14 +5449,12 @@ msgid "Please choose a {option_label}"
 msgstr "Scegli un {option_label}"
 
 #: tools/forms/ooi_form.py
-#, fuzzy
 msgid "Filter by clearance level"
-msgstr "Imposta il livello di autorizzazione"
+msgstr "Filtra per livello di autorizzazione"
 
 #: tools/forms/ooi_form.py
-#, fuzzy
 msgid "Filter by clearance type"
-msgstr "Filtra per tipi di OOI"
+msgstr "Filtra per tipo di autorizzazione"
 
 #: tools/forms/scheduler.py
 msgid "From"
@@ -5032,7 +5466,7 @@ msgstr "A"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Cancelled"
-msgstr ""
+msgstr "Annullato"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Completed"
@@ -5044,7 +5478,7 @@ msgstr "Spedito"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Failed"
-msgstr ""
+msgstr "Non riuscito"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Queued"
@@ -5052,11 +5486,15 @@ msgstr "In coda"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Running"
-msgstr ""
+msgstr "In esecuzione"
 
 #: tools/forms/scheduler.py
 msgid "Search by object name"
 msgstr "Cerca per nome oggetto"
+
+#: tools/forms/scheduler.py
+msgid "The selected date is in the future. Please select a different date."
+msgstr "La data selezionata è nel futuro. Seleziona una data diversa."
 
 #: tools/forms/settings.py
 msgid "--- Show all ----"
@@ -5112,7 +5550,7 @@ msgstr "Aggiungi data e ora del tuo rilevamento (UTC)"
 
 #: tools/forms/settings.py
 msgid "Add the date and time of when the raw file was generated (UTC)"
-msgstr ""
+msgstr "Aggiungi la data e l'ora in cui il file raw è stato generato (UTC)"
 
 #: tools/forms/settings.py
 msgid ""
@@ -5131,12 +5569,18 @@ msgid ""
 "seen as 'variants' and will be shown together on the Boefje detail page. </"
 "p> "
 msgstr ""
+"<p>Il nome dell'immagine Docker. Ad esempio: <i>'ghcr.io/minvws/openkat/"
+"nmap'</i>. In OpenKAT, tutti i Boefjes con la stessa immagine container "
+"saranno considerati 'varianti' e mostrati insieme nella pagina dei dettagli "
+"del Boefje. </p> "
 
 #: tools/forms/settings.py
 msgid ""
 "A description of the Boefje explaining in short what it can do. This will "
 "both be displayed inside the KAT-alogus and on the Boefje details page."
 msgstr ""
+"Una descrizione del Boefje che spiega brevemente cosa può fare. Verrà "
+"mostrata sia nel KAT-alogus sia nella pagina dei dettagli del Boefje."
 
 #: tools/forms/settings.py
 msgid ""
@@ -5144,6 +5588,9 @@ msgid ""
 "objects, press and hold the 'ctrl'/'command' key and then click the items "
 "you want to select. "
 msgstr ""
+"Seleziona i tipi di oggetto consumati dal tuo Boefje. Per selezionare più "
+"oggetti, tieni premuto il tasto 'ctrl'/'command' e fai clic sugli elementi "
+"che vuoi selezionare. "
 
 #: tools/forms/settings.py
 msgid ""
@@ -5152,10 +5599,18 @@ msgid ""
 "used as the basis for a form for the user. When the user enables this Boefje "
 "they can get the option to give extra information. For example, it can "
 "contain an API key that the script requires.</p> <p>More information about "
-"what the schema.json file looks like can be found <a href='https://docs."
-"openkat.nl/developer_documentation/development_tutorial/creating_a_boefje."
-"html'> here</a>.</p> "
+"what the schema.json file looks like can be found <a href='https://"
+"docs.openkat.nl/developer_documentation/development_tutorial/"
+"creating_a_boefje.html'> here</a>.</p> "
 msgstr ""
+"<p>Se sono necessarie altre impostazioni per il tuo Boefje, aggiungile come "
+"Schema JSON; altrimenti lascia il campo vuoto o 'null'.</p> <p>Questo JSON "
+"viene usato come base per un modulo per l'utente. Quando l'utente abilita "
+"questo Boefje, può avere la possibilità di fornire informazioni aggiuntive. "
+"Ad esempio, può contenere una chiave API richiesta dallo script.</p> "
+"<p>Maggiori informazioni sull'aspetto del file schema.json sono disponibili "
+"<a href='https://docs.openkat.nl/developer_documentation/development_tutorial/"
+"creating_a_boefje.html'>qui</a>.</p> "
 
 #: tools/forms/settings.py
 msgid ""
@@ -5164,6 +5619,10 @@ msgid ""
 "{boefje-id}'</i></p> <p>These output mime types will be shown on the Boefje "
 "detail page as information for other users. </p> "
 msgstr ""
+"<p>Aggiungi un insieme di tipi MIME prodotti da questo Boefje, separati da "
+"virgole. Ad esempio: <i>'text/html'</i>, <i>'image/jpeg'</i> o <i>'boefje/"
+"{boefje-id}'</i></p> <p>Questi tipi MIME di output saranno mostrati nella "
+"pagina dei dettagli del Boefje come informazione per altri utenti. </p> "
 
 #: tools/forms/settings.py
 msgid ""
@@ -5172,12 +5631,19 @@ msgid ""
 "manual/usermanual.html#scan-levels-clearance-indemnities'> documentation</a>."
 "</p> "
 msgstr ""
+"<p>Seleziona un livello di autorizzazione per il tuo Boefje. Per maggiori "
+"informazioni sui diversi livelli di autorizzazione consulta la "
+"<a href='https://docs.openkat.nl/manual/usermanual.html#scan-levels-"
+"clearance-indemnities'>documentazione</a>.</p> "
 
 #: tools/forms/settings.py
 msgid ""
 "Choose when this Boefje will scan objects. It can run on a given interval or "
 "it can run every time an object has been created or changed. "
 msgstr ""
+"Scegli quando questo Boefje deve scansionare gli oggetti. Può essere "
+"eseguito a un intervallo specifico oppure ogni volta che un oggetto viene "
+"creato o modificato. "
 
 #: tools/forms/settings.py
 msgid "Depth of the tree."
@@ -5253,21 +5719,23 @@ msgstr "Carica file raw"
 
 #: tools/forms/upload_raw.py
 msgid "Input or Scan OOI"
-msgstr ""
+msgstr "OOI di input o scansione"
 
 #: tools/forms/upload_raw.py
 msgid "Click to select one of the available options, or type one yourself"
-msgstr ""
+msgstr "Fai clic per selezionare una delle opzioni disponibili oppure digitane una"
 
 #: tools/forms/upload_raw.py
 msgid "OOI doesn't exist, try another valid time"
-msgstr ""
+msgstr "L'OOI non esiste, prova un altro valid time"
 
 #: tools/models.py
 msgid ""
 "A short code containing only lower-case unicode letters, numbers, hyphens or "
 "underscores that will be used in URLs and paths."
 msgstr ""
+"Un codice breve contenente solo lettere Unicode minuscole, numeri, trattini o "
+"underscore, che verrà usato negli URL e nei percorsi."
 
 #: tools/models.py
 msgid ""
@@ -5283,7 +5751,7 @@ msgstr "nuovo"
 
 #: tools/templatetags/ooi_extra.py
 msgid "Unknown user"
-msgstr ""
+msgstr "Utente sconosciuto"
 
 #: tools/view_helpers.py rocky/templates/header.html
 #: rocky/templates/organizations/organization_member_list.html
@@ -5293,7 +5761,7 @@ msgstr "Membri"
 
 #: rocky/forms.py
 msgid "Current status"
-msgstr ""
+msgstr "Stato attuale"
 
 #: rocky/forms.py rocky/templates/organizations/organization_member_list.html
 msgid "Active"
@@ -5305,7 +5773,7 @@ msgstr "Nuovo"
 
 #: rocky/forms.py
 msgid "Account status"
-msgstr ""
+msgstr "Stato dell'account"
 
 #: rocky/forms.py
 msgid "Not blocked"
@@ -5324,59 +5792,63 @@ msgstr ""
 
 #: rocky/paginator.py
 msgid "That page number is not an integer"
-msgstr ""
+msgstr "Quel numero di pagina non è un intero"
 
 #: rocky/paginator.py
 msgid "That page number is less than 1"
-msgstr ""
+msgstr "Quel numero di pagina è inferiore a 1"
 
 #: rocky/paginator.py
 msgid "That page contains no results"
-msgstr ""
+msgstr "Quella pagina non contiene risultati"
 
 #: rocky/scheduler.py
 msgid ""
 "The Scheduler has an unexpected error. Check the Scheduler logs for further "
 "details."
 msgstr ""
+"Lo Scheduler ha riscontrato un errore imprevisto. Controlla i log dello "
+"Scheduler per ulteriori dettagli."
 
 #: rocky/scheduler.py
 msgid "Could not connect to Scheduler. Service is possibly down."
-msgstr ""
+msgstr "Impossibile connettersi allo Scheduler. Il servizio potrebbe essere inattivo."
 
 #: rocky/scheduler.py
 msgid "Your request could not be validated."
-msgstr ""
+msgstr "La tua richiesta non può essere validata."
 
 #: rocky/scheduler.py
 msgid "Task could not be found."
-msgstr ""
+msgstr "Task non trovato."
 
 #: rocky/scheduler.py
 msgid ""
 "Scheduler is receiving too many requests. Increase SCHEDULER_PQ_MAXSIZE or "
 "wait for task to finish."
 msgstr ""
+"Lo Scheduler sta ricevendo troppe richieste. Aumenta SCHEDULER_PQ_MAXSIZE "
+"oppure attendi il completamento del task."
 
 #: rocky/scheduler.py
 msgid "Bad request. Your request could not be interpreted by the Scheduler."
-msgstr ""
+msgstr "Richiesta non valida. La tua richiesta non può essere interpretata dallo Scheduler."
 
 #: rocky/scheduler.py
 msgid "The Scheduler has received a conflict. Your task is already in queue."
-msgstr ""
+msgstr "Lo Scheduler ha ricevuto un conflitto. Il tuo task è già in coda."
 
 #: rocky/scheduler.py
 msgid "A HTTPError occurred. See Scheduler logs for more info."
-msgstr ""
+msgstr "Si è verificato un HTTPError. Consulta i log dello Scheduler per maggiori informazioni."
 
 #: rocky/scheduler.py
 msgid "Schedule list: "
-msgstr ""
+msgstr "Elenco pianificazioni: "
 
 #: rocky/scheduler.py
 msgid "Task list: "
-msgstr ""
+msgstr "Elenco task: "
 
 #: rocky/settings.py
 msgid "Blue light"
@@ -5501,27 +5973,27 @@ msgstr ""
 
 #: rocky/templates/admin/base.html
 msgid "Skip to main content"
-msgstr ""
+msgstr "Vai al contenuto principale"
 
 #: rocky/templates/admin/base.html
 msgid "Welcome,"
-msgstr ""
+msgstr "Benvenuto,"
 
 #: rocky/templates/admin/base.html
 msgid "View site"
-msgstr ""
+msgstr "Visualizza sito"
 
 #: rocky/templates/admin/base.html
 msgid "Documentation"
-msgstr ""
+msgstr "Documentazione"
 
 #: rocky/templates/admin/base.html
 msgid "Change password"
-msgstr ""
+msgstr "Cambia password"
 
 #: rocky/templates/admin/base.html
 msgid "Log out"
-msgstr ""
+msgstr "Esci"
 
 #: rocky/templates/admin/base.html rocky/templates/header.html
 msgid "Breadcrumbs"
@@ -5532,19 +6004,19 @@ msgstr "Breadcrumb"
 #: rocky/templates/admin/delete_confirmation.html
 #: rocky/templates/admin/delete_selected_confirmation.html
 msgid "Home"
-msgstr ""
+msgstr "Home"
 
 #: rocky/templates/admin/change_form.html
 #, python-format
 msgid "Add %(name)s"
-msgstr ""
+msgstr "Aggiungi %(name)s"
 
 #: rocky/templates/admin/change_form.html
 #: rocky/templates/admin/change_list.html
 msgid "Please correct the error below."
 msgid_plural "Please correct the errors below."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Correggi l'errore qui sotto."
+msgstr[1] "Correggi gli errori qui sotto."
 
 #: rocky/templates/admin/change_list.html
 msgid "Filter"
@@ -5552,15 +6024,15 @@ msgstr "Filtro"
 
 #: rocky/templates/admin/change_list.html
 msgid "Hide counts"
-msgstr ""
+msgstr "Nascondi conteggi"
 
 #: rocky/templates/admin/change_list.html
 msgid "Show counts"
-msgstr ""
+msgstr "Mostra conteggi"
 
 #: rocky/templates/admin/change_list.html
 msgid "Clear all filters"
-msgstr ""
+msgstr "Cancella tutti i filtri"
 
 #: rocky/templates/admin/delete_confirmation.html
 #, python-format
@@ -5569,6 +6041,9 @@ msgid ""
 "related objects, but your account doesn't have permission to delete the "
 "following types of objects"
 msgstr ""
+"L'eliminazione di %(object_name)s '%(escaped_object)s' comporterebbe "
+"l'eliminazione di oggetti correlati, ma il tuo account non ha il permesso di "
+"eliminare i seguenti tipi di oggetti"
 
 #: rocky/templates/admin/delete_confirmation.html
 #, python-format
@@ -5576,6 +6051,8 @@ msgid ""
 "Deleting the %(object_name)s '%(escaped_object)s' would require deleting the "
 "following protected related objects"
 msgstr ""
+"L'eliminazione di %(object_name)s '%(escaped_object)s' richiederebbe "
+"l'eliminazione dei seguenti oggetti correlati protetti"
 
 #: rocky/templates/admin/delete_confirmation.html
 #, python-format
@@ -5583,20 +6060,22 @@ msgid ""
 "Are you sure you want to delete the %(object_name)s \"%(escaped_object)s\"? "
 "All of the following related items will be deleted"
 msgstr ""
+"Vuoi davvero eliminare %(object_name)s \"%(escaped_object)s\"? Tutti i "
+"seguenti elementi correlati verranno eliminati"
 
 #: rocky/templates/admin/delete_confirmation.html
 #: rocky/templates/admin/delete_selected_confirmation.html
 msgid "Yes, I’m sure"
-msgstr ""
+msgstr "Sì, sono sicuro"
 
 #: rocky/templates/admin/delete_confirmation.html
 #: rocky/templates/admin/delete_selected_confirmation.html
 msgid "No, take me back"
-msgstr ""
+msgstr "No, torna indietro"
 
 #: rocky/templates/admin/delete_selected_confirmation.html
 msgid "Delete multiple objects"
-msgstr ""
+msgstr "Elimina più oggetti"
 
 #: rocky/templates/admin/delete_selected_confirmation.html
 #, python-format
@@ -5605,6 +6084,9 @@ msgid ""
 "objects, but your account doesn't have permission to delete the following "
 "types of objects"
 msgstr ""
+"L'eliminazione dei %(objects_name)s selezionati comporterebbe l'eliminazione "
+"di oggetti correlati, ma il tuo account non ha il permesso di eliminare i "
+"seguenti tipi di oggetti"
 
 #: rocky/templates/admin/delete_selected_confirmation.html
 #, python-format
@@ -5612,6 +6094,8 @@ msgid ""
 "Deleting the selected %(objects_name)s would require deleting the following "
 "protected related objects"
 msgstr ""
+"L'eliminazione dei %(objects_name)s selezionati richiederebbe l'eliminazione "
+"dei seguenti oggetti correlati protetti"
 
 #: rocky/templates/admin/delete_selected_confirmation.html
 #, python-format
@@ -5619,10 +6103,12 @@ msgid ""
 "Are you sure you want to delete the selected %(objects_name)s? All of the "
 "following objects and their related items will be deleted"
 msgstr ""
+"Vuoi davvero eliminare i %(objects_name)s selezionati? Tutti i seguenti "
+"oggetti e i relativi elementi correlati verranno eliminati"
 
 #: rocky/templates/admin/popup_response.html
 msgid "Popup closing…"
-msgstr ""
+msgstr "Chiusura popup…"
 
 #: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
 #: rocky/templates/header.html
@@ -5649,7 +6135,7 @@ msgstr "Benvenuto"
 
 #: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
 msgid "User overview"
-msgstr ""
+msgstr "Panoramica utente"
 
 #: rocky/templates/dashboard_redteam.html
 #: rocky/templates/partials/notifications_block.html
@@ -5662,7 +6148,7 @@ msgstr "avviso"
 #: rocky/templates/partials/notifications_block.html
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "Warning:"
-msgstr ""
+msgstr "Avviso:"
 
 #: rocky/templates/dashboard_redteam.html
 msgid "Organization code missing"
@@ -5687,8 +6173,8 @@ msgid "Add finding"
 msgstr "Aggiungi rilevamento"
 
 #: rocky/templates/findings/finding_list.html
-msgid "Findings @ "
-msgstr "Risultati @ "
+msgid "Findings "
+msgstr "Rilevamenti "
 
 #: rocky/templates/findings/finding_list.html
 #, python-format
@@ -5704,7 +6190,7 @@ msgstr ""
 #: rocky/templates/findings/finding_list.html
 #, python-format
 msgid "Showing %(length)s of %(total)s findings"
-msgstr ""
+msgstr "Visualizzazione di %(length)s di %(total)s rilevamenti"
 
 #: rocky/templates/findings/finding_list.html
 #: rocky/templates/partials/mute_findings_modal.html
@@ -5713,7 +6199,7 @@ msgstr "Silenzia rilevamenti"
 
 #: rocky/templates/findings/finding_list.html
 msgid "Unmute findings"
-msgstr ""
+msgstr "Riattiva rilevamenti"
 
 #: rocky/templates/findings/findings_filter.html
 #: rocky/templates/partials/elements/ooi_list_settings_form.html
@@ -5733,7 +6219,7 @@ msgstr "Informativa sulla Privacy"
 
 #: rocky/templates/forms/json_schema_form.html
 msgid "Fill out this form to answer the Question (again):"
-msgstr ""
+msgstr "Compila questo modulo per rispondere (di nuovo) alla domanda:"
 
 #: rocky/templates/graph-d3.html
 msgid ""
@@ -5769,7 +6255,7 @@ msgstr "Controlli di Salute"
 
 #: rocky/templates/health.html
 msgid "Health checks"
-msgstr ""
+msgstr "Controlli di salute"
 
 #: rocky/templates/health.html
 msgid "Additional"
@@ -5789,7 +6275,7 @@ msgstr ""
 
 #: rocky/templates/indemnification_present.html
 msgid "Go to Objects"
-msgstr ""
+msgstr "Vai agli oggetti"
 
 #: rocky/templates/indemnification_present.html
 msgid "Go to"
@@ -5826,10 +6312,12 @@ msgid ""
 "Dozens of tools are integrated in OpenKAT to view the world (digital and "
 "analog)."
 msgstr ""
+"Decine di strumenti sono integrati in OpenKAT per osservare il mondo "
+"digitale e analogico."
 
 #: rocky/templates/landing_page.html
 msgid "Our motto is therefore: I see, I see, what you do not see."
-msgstr ""
+msgstr "Il nostro motto quindi è: vedo, vedo, ciò che tu non vedi."
 
 #: rocky/templates/landing_page.html
 msgid "OpenKAT knows"
@@ -5956,7 +6444,7 @@ msgstr "Qui puoi eliminare il %(display_type)s."
 
 #: rocky/templates/oois/ooi_delete.html
 msgid "To be deleted object(s)"
-msgstr ""
+msgstr "Oggetti da eliminare"
 
 #: rocky/templates/oois/ooi_delete.html
 #: rocky/templates/partials/elements/ooi_tree_condensed_table.html
@@ -5989,21 +6477,26 @@ msgid ""
 "Go to the <a href=\"%(organization_settings)s\">organization settings page</"
 "a> to add one."
 msgstr ""
+"<strong>Avviso:</strong> non c'è alcun indennizzo per questa organizzazione. "
+"Vai alla <a href=\"%(organization_settings)s\">pagina delle impostazioni "
+"dell'organizzazione</a> per aggiungerne uno."
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "Permission warning"
-msgstr ""
+msgstr "Avviso autorizzazione"
 
 #: rocky/templates/oois/ooi_detail.html
 msgid ""
 "<strong>Warning:</strong> You don't have the proper permission at the "
 "organizational level to scan objects. Contact your administrator."
 msgstr ""
+"<strong>Avviso:</strong> non hai l'autorizzazione corretta a livello di "
+"organizzazione per scansionare oggetti. Contatta il tuo amministratore."
 
 #: rocky/templates/oois/ooi_detail.html
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Scan warning"
-msgstr ""
+msgstr "Avviso scansione"
 
 #: rocky/templates/oois/ooi_detail.html
 #, python-format
@@ -6013,10 +6506,15 @@ msgid ""
 "%(boefje_scan_level)s. Go to your <a href=\"%(account_details)s\">account "
 "details</a> to manage your clearance level."
 msgstr ""
+"<strong>Avviso:</strong> non sei autorizzato a scansionare questo OOI. Il "
+"tuo livello massimo di autorizzazione è %(member_clearance_level)s e questo "
+"OOI ha livello %(boefje_scan_level)s. Vai ai tuoi "
+"<a href=\"%(account_details)s\">dettagli account</a> per gestire il tuo "
+"livello di autorizzazione."
 
 #: rocky/templates/oois/ooi_detail.html rocky/templates/scan.html
 msgid "Boefjes overview"
-msgstr ""
+msgstr "Panoramica Boefjes"
 
 #: rocky/templates/oois/ooi_detail.html
 #: rocky/templates/oois/ooi_detail_origins_observations.html
@@ -6031,11 +6529,11 @@ msgstr "Profilo di scansione"
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "Unable to start scan. See the warning for more details."
-msgstr ""
+msgstr "Impossibile avviare la scansione. Vedi l'avviso per maggiori dettagli."
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "Start scan"
-msgstr ""
+msgstr "Avvia scansione"
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "There are no boefjes enabled to scan an OOI of type"
@@ -6079,7 +6577,7 @@ msgstr "Seleziona un tipo di oggetto da aggiungere."
 
 #: rocky/templates/oois/ooi_detail_findings_list.html
 msgid "Overview of findings for"
-msgstr ""
+msgstr "Panoramica dei rilevamenti per"
 
 #: rocky/templates/oois/ooi_detail_findings_list.html
 msgid "Score"
@@ -6115,7 +6613,7 @@ msgstr "Totale dei rilevamenti"
 #: rocky/templates/oois/ooi_detail_object.html
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Inactive"
-msgstr ""
+msgstr "Inattivo"
 
 #: rocky/templates/oois/ooi_detail_origins_declarations.html
 msgid "Declarations"
@@ -6135,7 +6633,7 @@ msgstr "Parametri"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "Last observed by"
-msgstr ""
+msgstr "Ultima osservazione da"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "Task ID"
@@ -6143,7 +6641,7 @@ msgstr "ID Attività"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "When"
-msgstr ""
+msgstr "Quando"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 #: rocky/templates/tasks/normalizers.html
@@ -6152,15 +6650,15 @@ msgstr "Normalizer"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "This scan was manually created."
-msgstr ""
+msgstr "Questa scansione è stata creata manualmente."
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "The boefje has since been deleted or disabled."
-msgstr ""
+msgstr "Da allora il boefje è stato eliminato o disabilitato."
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "No Raw file could be found, this might point to an error in OpenKAT"
-msgstr ""
+msgstr "Nessun file raw trovato; questo potrebbe indicare un errore in OpenKAT"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 #: rocky/templates/scan_profiles/scan_profile_detail.html
@@ -6183,7 +6681,7 @@ msgstr "Salva %(display_type)s"
 
 #: rocky/templates/oois/ooi_findings.html
 msgid "Currently no findings have been identified for OOI"
-msgstr ""
+msgstr "Al momento non sono stati identificati rilevamenti per l'OOI"
 
 #: rocky/templates/oois/ooi_list.html
 #, python-format
@@ -6200,11 +6698,11 @@ msgstr ""
 #: rocky/templates/oois/ooi_list.html
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Edit clearance level"
-msgstr ""
+msgstr "Modifica livello di autorizzazione"
 
 #: rocky/templates/oois/ooi_mute_finding.html
 msgid "Mute finding:"
-msgstr ""
+msgstr "Silenzia rilevamento:"
 
 #: rocky/templates/oois/ooi_mute_finding.html
 msgid "Give a reason below why you want to mute this finding."
@@ -6313,7 +6811,7 @@ msgstr "Salva organizzazione"
 
 #: rocky/templates/organizations/organization_list.html
 msgid "An overview of all organizations you are a member of."
-msgstr ""
+msgstr "Una panoramica di tutte le organizzazioni di cui sei membro."
 
 #: rocky/templates/organizations/organization_list.html
 msgid "Add new organization"
@@ -6326,6 +6824,9 @@ msgid ""
 "                            Showing %(total)s organizations\n"
 "                        "
 msgstr ""
+"\n"
+"                            Visualizzazione di %(total)s organizzazioni\n"
+"                        "
 
 #: rocky/templates/organizations/organization_list.html
 msgid "Organization overview:"
@@ -6342,7 +6843,7 @@ msgstr "Non sono state trovate organizzazioni per il tuo account utente"
 
 #: rocky/templates/organizations/organization_list.html
 msgid "Actions to perform for all of your organizations."
-msgstr ""
+msgstr "Azioni da eseguire per tutte le tue organizzazioni."
 
 #: rocky/templates/organizations/organization_list.html
 #: rocky/templates/organizations/organization_settings.html
@@ -6351,12 +6852,12 @@ msgstr "Riavvia tutti i bit"
 
 #: rocky/templates/organizations/organization_member_add.html
 msgid "Change account type"
-msgstr ""
+msgstr "Cambia tipo di account"
 
 #: rocky/templates/organizations/organization_member_add_header.html
 #: rocky/views/organization_member_add.py
 msgid "Add member"
-msgstr ""
+msgstr "Aggiungi membro"
 
 #: rocky/templates/organizations/organization_member_add_header.html
 #, python-format
@@ -6366,6 +6867,10 @@ msgid ""
 "href=\"https://docs.openkat.nl/basics/users-and-organisations.html#users\" "
 "target=\"_blank\" rel=\"noopener\">documentation</a>."
 msgstr ""
+"Creazione di un nuovo membro dell'organizzazione <strong>%(organization)s</"
+"strong>. Per informazioni dettagliate sui diversi tipi di account, consulta "
+"la <a href=\"https://docs.openkat.nl/basics/users-and-organisations.html#users\" "
+"target=\"_blank\" rel=\"noopener\">documentazione</a>."
 
 #: rocky/templates/organizations/organization_member_edit.html
 #: rocky/views/organization_member_edit.py
@@ -6379,7 +6884,7 @@ msgstr "Salva membro"
 #: rocky/templates/organizations/organization_member_list.html
 #, python-format
 msgid "An overview of members of <strong>%(organization_name)s</strong>."
-msgstr ""
+msgstr "Una panoramica dei membri di <strong>%(organization_name)s</strong>."
 
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Add member(s)"
@@ -6400,6 +6905,9 @@ msgid ""
 "                        Showing %(total)s members\n"
 "                    "
 msgstr ""
+"\n"
+"                        Visualizzazione di %(total)s membri\n"
+"                    "
 
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Member overview:"
@@ -6420,7 +6928,7 @@ msgstr "Super utente"
 #: rocky/templates/organizations/organization_member_upload.html
 #: rocky/views/organization_member_add.py
 msgid "Add members"
-msgstr ""
+msgstr "Aggiungi membri"
 
 #: rocky/templates/organizations/organization_member_upload.html
 #, python-format
@@ -6428,10 +6936,12 @@ msgid ""
 "To upload multiple members at once, you can upload a CSV file or you can <a "
 "href=\"%(download_url)s\">download the template</a>."
 msgstr ""
+"Per caricare più membri contemporaneamente, puoi caricare un file CSV oppure "
+"<a href=\"%(download_url)s\">scaricare il modello</a>."
 
 #: rocky/templates/organizations/organization_member_upload.html
 msgid "To create a custom CSV file, make sure it meets the following criteria:"
-msgstr ""
+msgstr "Per creare un file CSV personalizzato, assicurati che soddisfi i seguenti criteri:"
 
 #: rocky/templates/organizations/organization_member_upload.html
 msgid "Upload"
@@ -6443,11 +6953,13 @@ msgid ""
 "An overview of general information and settings for "
 "<strong>%(organization_name)s</strong>."
 msgstr ""
+"Una panoramica delle informazioni generali e delle impostazioni per "
+"<strong>%(organization_name)s</strong>."
 
 #: rocky/templates/organizations/organization_settings.html
 msgid ""
 "<strong>Warning:</strong> Indemnification is not set for this organization."
-msgstr ""
+msgstr "<strong>Avviso:</strong> l'indennizzo non è impostato per questa organizzazione."
 
 #: rocky/templates/organizations/organization_settings.html
 #: rocky/views/indemnification_add.py
@@ -6456,29 +6968,31 @@ msgstr "Aggiungi indennizzo"
 
 #: rocky/templates/partials/current_config.html
 msgid "Current configuration"
-msgstr ""
+msgstr "Configurazione attuale"
 
 #: rocky/templates/partials/delete_ooi_modal.html
 msgid "Delete objects"
-msgstr ""
+msgstr "Elimina oggetti"
 
 #: rocky/templates/partials/delete_ooi_modal.html
 msgid ""
 "Are you sure you want to delete all the selected objects? The history of the "
 "deleted objects will still be available."
 msgstr ""
+"Vuoi davvero eliminare tutti gli oggetti selezionati? La cronologia degli "
+"oggetti eliminati resterà disponibile."
 
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 msgid "Edit clearance level settings"
-msgstr ""
+msgstr "Modifica impostazioni del livello di autorizzazione"
 
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 msgid "You are editing clearance level of all the selected objects."
-msgstr ""
+msgstr "Stai modificando il livello di autorizzazione di tutti gli oggetti selezionati."
 
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 msgid "Switching between declare and inherit"
-msgstr ""
+msgstr "Passaggio tra dichiarato ed ereditato"
 
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 msgid ""
@@ -6487,6 +7001,10 @@ msgid ""
 "also recalculate the clearance levels of objects that inherit from these "
 "clearance levels."
 msgstr ""
+"I livelli di autorizzazione possono essere ereditati automaticamente oppure "
+"puoi dichiarare manualmente il livello di autorizzazione di un oggetto. "
+"Passare all'eredità del livello di autorizzazione ricalcolerà anche i "
+"livelli degli oggetti che ereditano da questi livelli."
 
 #: rocky/templates/partials/elements/ooi_detail_settings.html
 msgid "Observed at"
@@ -6508,7 +7026,7 @@ msgstr "Filtra per tipi di OOI"
 
 #: rocky/templates/partials/elements/ooi_tree_condensed_table.html
 msgid "Children"
-msgstr "Bambini"
+msgstr "Figli"
 
 #: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
 #, python-format
@@ -6564,8 +7082,20 @@ msgid "OOI"
 msgstr "OOI"
 
 #: rocky/templates/partials/explanations.html
+msgid "This OOI"
+msgstr "Questo OOI"
+
+#: rocky/templates/partials/explanations.html
 msgid "Origin"
 msgstr "Origine"
+
+#: rocky/templates/partials/explanations.html
+msgid "declared"
+msgstr "dichiarato"
+
+#: rocky/templates/partials/explanations.html
+msgid "inherited from ↓"
+msgstr "ereditato da ↓"
 
 #: rocky/templates/partials/explanations.html
 msgid "Show clearance level inheritance"
@@ -6576,9 +7106,8 @@ msgid "Reproduction"
 msgstr "Riproduzione"
 
 #: rocky/templates/partials/form/checkbox_group_table_form.html
-#, fuzzy
 msgid "Please enable plugin to start scanning."
-msgstr "Abilita il plugin per avviare la scansione"
+msgstr "Abilita il plugin per avviare la scansione."
 
 #: rocky/templates/partials/form/field_input.html
 msgid "Not set"
@@ -6586,7 +7115,7 @@ msgstr "Non impostato"
 
 #: rocky/templates/partials/form/field_input.html
 msgid "Forgot email"
-msgstr "Password dimenticata"
+msgstr "E-mail dimenticata"
 
 #: rocky/templates/partials/form/field_input.html
 msgid "Forgot password"
@@ -6601,7 +7130,7 @@ msgstr "errore"
 #: rocky/templates/partials/form/form_errors.html
 #: rocky/templates/partials/notifications_block.html
 msgid "Error:"
-msgstr ""
+msgstr "Errore:"
 
 #: rocky/templates/partials/form/field_input_help_text.html
 msgid "Open explanation"
@@ -6615,7 +7144,7 @@ msgstr "Chiudi spiegazione"
 #: rocky/templates/partials/notifications_block.html
 #: rocky/templates/two_factor/core/login.html
 msgid "Explanation:"
-msgstr ""
+msgstr "Spiegazione:"
 
 #: rocky/templates/partials/form/indemnification_add_form.html
 msgid ""
@@ -6624,6 +7153,10 @@ msgid ""
 "negative impact on (your) assets. Therefore it is important to know and be "
 "aware of the impact of security scans."
 msgstr ""
+"L'esecuzione di scansioni di sicurezza sugli asset è generalmente consentita "
+"solo se hai il permesso di scansionare tali asset. Alcune scansioni possono "
+"avere un impatto negativo sui tuoi asset. Per questo è importante conoscere "
+"ed essere consapevoli dell'impatto delle scansioni di sicurezza."
 
 #: rocky/templates/partials/form/indemnification_add_form.html
 msgid ""
@@ -6631,10 +7164,13 @@ msgid ""
 "the indemnification you declare that you, as a person, can be held "
 "accountable."
 msgstr ""
+"Prima di poter usare OpenKAT è richiesto un indennizzo "
+"dell'organizzazione. Con l'indennizzo dichiari che tu, come persona, puoi "
+"essere ritenuto responsabile."
 
 #: rocky/templates/partials/form/indemnification_add_form.html
 msgid "Set an indemnification"
-msgstr ""
+msgstr "Imposta un indennizzo"
 
 #: rocky/templates/partials/hyperlink_ooi_type.html
 #, python-format
@@ -6671,6 +7207,10 @@ msgid "Page"
 msgstr "Pagina"
 
 #: rocky/templates/partials/list_paginator.html
+msgid "Current"
+msgstr "Corrente"
+
+#: rocky/templates/partials/list_paginator.html
 msgid "Five Pages Forward"
 msgstr "Cinque pagine avanti"
 
@@ -6684,27 +7224,27 @@ msgstr "Successivo"
 
 #: rocky/templates/partials/mute_findings_modal.html
 msgid "You are muting the selected findings."
-msgstr ""
+msgstr "Stai silenziando i rilevamenti selezionati."
 
 #: rocky/templates/partials/mute_findings_modal.html
 msgid "Reason:"
-msgstr ""
+msgstr "Motivo:"
 
 #: rocky/templates/partials/mute_findings_modal.html
 msgid "Expires by (UTC):"
-msgstr ""
+msgstr "Scade entro (UTC):"
 
 #: rocky/templates/partials/notifications_block.html
 msgid "Confirmation:"
-msgstr ""
+msgstr "Conferma:"
 
 #: rocky/templates/partials/ooi_detail_related_object.html
 msgid "No related object known for"
-msgstr ""
+msgstr "Nessun oggetto correlato noto per"
 
 #: rocky/templates/partials/ooi_detail_toolbar.html
 msgid "Generate Report"
-msgstr ""
+msgstr "Genera report"
 
 #: rocky/templates/partials/ooi_detail_toolbar.html
 #, python-format
@@ -6712,12 +7252,12 @@ msgid "Edit %(display_type)s"
 msgstr "Modifica %(display_type)s"
 
 #: rocky/templates/partials/ooi_head.html
-#, python-format
-msgid ""
-"An overview of \"%(ooi)s\", object type \"%(type)s\". This shows general "
-"information and its related objects. It also gives the possibility to add "
-"additional related objects, or to scan for them."
-msgstr ""
+msgid "Data from:"
+msgstr "Dati da:"
+
+#: rocky/templates/partials/ooi_head.html
+msgid "(Now)"
+msgstr "(Ora)"
 
 #: rocky/templates/partials/ooi_list_toolbar.html
 msgid "Scan for objects"
@@ -6792,13 +7332,12 @@ msgid "Select organization"
 msgstr "Seleziona organizzazione"
 
 #: rocky/templates/partials/organizations_menu_dropdown.html
-#, fuzzy
 msgid "All organizations"
-msgstr "Le mie organizzazioni"
+msgstr "Tutte le organizzazioni"
 
 #: rocky/templates/partials/page-meta.html
 msgid "Logged in as:"
-msgstr ""
+msgstr "Accesso effettuato come:"
 
 #: rocky/templates/partials/pagination.html
 msgid "of"
@@ -6809,9 +7348,8 @@ msgid "first"
 msgstr "primo"
 
 #: rocky/templates/partials/pagination.html
-#, fuzzy
 msgid "previous"
-msgstr "Precedente"
+msgstr "precedente"
 
 #: rocky/templates/partials/pagination.html
 msgid "next"
@@ -6848,50 +7386,59 @@ msgid ""
 "This means that the clearance level might stay the same, increase or "
 "decrease, depending on other declared clearance levels."
 msgstr ""
+"Il livello di autorizzazione determina il livello delle scansioni boefje "
+"consentite su questo oggetto. Un oggetto eredita il proprio livello di "
+"autorizzazione dagli oggetti vicini. Questo significa che il livello può "
+"rimanere uguale, aumentare o diminuire, a seconda degli altri livelli di "
+"autorizzazione dichiarati."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Empty clearance level explanation"
-msgstr ""
+msgstr "Spiegazione del livello di autorizzazione vuoto"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Empty:"
-msgstr ""
+msgstr "Vuoto:"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid ""
 "This object has a clearance level of \"empty\". This means that this object "
 "has no clearance level."
 msgstr ""
+"Questo oggetto ha un livello di autorizzazione \"vuoto\". Questo significa "
+"che l'oggetto non ha alcun livello di autorizzazione."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Indemnification warning"
-msgstr ""
+msgstr "Avviso indennizzo"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Indemnification is not set for this organization."
-msgstr ""
+msgstr "L'indennizzo non è impostato per questa organizzazione."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Go to the"
-msgstr ""
+msgstr "Vai alla"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "organization settings page"
-msgstr ""
+msgstr "pagina delle impostazioni dell'organizzazione"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "to add one."
-msgstr ""
+msgstr "per aggiungerne uno."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Set clearance level warning"
-msgstr ""
+msgstr "Avviso impostazione livello di autorizzazione"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid ""
 "You don't have permissions to set the clearance level. Contact your "
 "administrator."
 msgstr ""
+"Non hai le autorizzazioni per impostare il livello di autorizzazione. "
+"Contatta il tuo amministratore."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 #, python-format
@@ -6900,22 +7447,25 @@ msgid ""
 "clearance level is %(member_clearance_level)s and this OOI has level "
 "%(boefje_scan_level)s."
 msgstr ""
+"Non sei autorizzato a impostare il livello di autorizzazione di questo OOI. "
+"Il tuo livello massimo di autorizzazione è %(member_clearance_level)s e "
+"questo OOI ha livello %(boefje_scan_level)s."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Go to your"
-msgstr ""
+msgstr "Vai ai tuoi"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "account details"
-msgstr ""
+msgstr "dettagli dell'account"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "to manage your clearance level."
-msgstr ""
+msgstr "per gestire il tuo livello di autorizzazione."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Current clearance level"
-msgstr ""
+msgstr "Livello di autorizzazione attuale"
 
 #: rocky/templates/tasks/boefje_task_detail.html
 msgid ""
@@ -6939,15 +7489,15 @@ msgstr "Oggetto di input"
 
 #: rocky/templates/tasks/boefjes.html
 msgid "There are no tasks for boefjes."
-msgstr ""
+msgstr "Non ci sono task per i boefjes."
 
 #: rocky/templates/tasks/boefjes.html
 msgid "List of tasks for boefjes."
-msgstr ""
+msgstr "Elenco dei task per i boefjes."
 
 #: rocky/templates/tasks/boefjes.html rocky/templates/tasks/reports.html
 msgid "Organization Code"
-msgstr ""
+msgstr "Codice organizzazione"
 
 #: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
 #: rocky/templates/tasks/ooi_detail_task_list.html
@@ -6958,15 +7508,15 @@ msgstr "Data di creazione"
 #: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
 #: rocky/templates/tasks/reports.html
 msgid "Modified date"
-msgstr ""
+msgstr "Data di modifica"
 
 #: rocky/templates/tasks/normalizers.html
 msgid "There are no tasks for normalizers."
-msgstr ""
+msgstr "Non ci sono task per i normalizer."
 
 #: rocky/templates/tasks/normalizers.html
 msgid "List of tasks for normalizers."
-msgstr ""
+msgstr "Elenco dei task per i normalizer."
 
 #: rocky/templates/tasks/normalizers.html
 msgid "Boefje input OOI"
@@ -6974,35 +7524,43 @@ msgstr "OOI di input Boefje"
 
 #: rocky/templates/tasks/normalizers.html
 msgid "Manually added"
-msgstr ""
+msgstr "Aggiunto manualmente"
 
 #: rocky/templates/tasks/ooi_detail_task_list.html
 msgid "There have been no tasks."
-msgstr ""
+msgstr "Non ci sono stati task."
 
 #: rocky/templates/tasks/partials/stats.html
 msgid "Task statistics - Last 24 hours"
-msgstr ""
+msgstr "Statistiche task - ultime 24 ore"
 
 #: rocky/templates/tasks/partials/stats.html
 msgid "All times in UTC, blocks of 1 hour."
-msgstr ""
+msgstr "Tutti gli orari sono in UTC, blocchi di 1 ora."
 
 #: rocky/templates/tasks/partials/stats.html
 msgid "Timeslot"
-msgstr ""
+msgstr "Fascia oraria"
 
 #: rocky/templates/tasks/partials/stats.html
 msgid "Could not load stats, Scheduler error."
-msgstr ""
+msgstr "Impossibile caricare le statistiche, errore dello Scheduler."
 
 #: rocky/templates/tasks/partials/tab_navigation.html
 msgid "List of tasks"
 msgstr "Elenco dei compiti"
 
 #: rocky/templates/tasks/partials/task_actions.html
+msgid "Loading..."
+msgstr "Caricamento..."
+
+#: rocky/templates/tasks/partials/task_actions.html
 msgid "Yielded objects"
 msgstr "Oggetti prodotti"
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Yielded raw files"
+msgstr "File raw prodotti"
 
 #: rocky/templates/tasks/partials/task_actions.html
 msgid "Reschedule"
@@ -7021,26 +7579,31 @@ msgid ""
 "Report tasks. This task aggregates and presents findings from both Boefjes "
 "and Normalizers."
 msgstr ""
+"Una panoramica dei task per <strong>%(organization)s</strong>. I task sono "
+"suddivisi in Boefjes, Normalizers e Report. I Boefjes scansionano oggetti e "
+"i Normalizers instradano in base al tipo MIME di output. Inoltre esistono "
+"task Report, che aggregano e presentano i rilevamenti provenienti sia dai "
+"Boefjes sia dai Normalizers."
 
 #: rocky/templates/tasks/plugin_detail_task_list.html
 msgid "There are no tasks for"
-msgstr ""
+msgstr "Non ci sono task per"
 
 #: rocky/templates/tasks/plugin_detail_task_list.html
 msgid "List of tasks for"
-msgstr ""
+msgstr "Elenco dei task per"
 
 #: rocky/templates/tasks/reports.html
 msgid "There are no tasks for reports."
-msgstr ""
+msgstr "Non ci sono task per i report."
 
 #: rocky/templates/tasks/reports.html
 msgid "List of tasks for reports."
-msgstr ""
+msgstr "Elenco dei task per i report."
 
 #: rocky/templates/tasks/reports.html
 msgid "Recipe ID"
-msgstr ""
+msgstr "ID ricetta"
 
 #: rocky/templates/two_factor/_wizard_actions.html
 msgid "Log in"
@@ -7129,9 +7692,8 @@ msgid "Use Backup Token"
 msgstr "Utilizza il Token di Backup"
 
 #: rocky/templates/two_factor/core/otp_required.html
-#, fuzzy
 msgid "Permission Denied"
-msgstr "Autorizzazione"
+msgstr "Autorizzazione negata"
 
 #: rocky/templates/two_factor/core/otp_required.html
 msgid ""
@@ -7335,6 +7897,12 @@ msgid ""
 "When a new version of the raw file is generated, the same ExternalScan OOI "
 "should be chosen to ensure that old results are overwritten."
 msgstr ""
+"È possibile selezionare un OOI di input a cui il normalizer collegherà i "
+"nuovi OOI prodotti. Se per il file raw non è stato usato alcun OOI di input, "
+"si può usare un OOI ExternalScan segnaposto. Gli OOI ExternalScan possono "
+"essere creati dalla pagina degli oggetti. Quando viene generata una nuova "
+"versione del file raw, è opportuno scegliere lo stesso OOI ExternalScan per "
+"garantire che i vecchi risultati vengano sovrascritti."
 
 #: rocky/templates/upload_raw.html rocky/views/upload_raw.py
 msgid "Upload raw"
@@ -7342,11 +7910,11 @@ msgstr "Carica raw"
 
 #: rocky/views/bytes_raw.py
 msgid "Getting raw data failed."
-msgstr ""
+msgstr "Recupero dei dati raw non riuscito."
 
 #: rocky/views/bytes_raw.py
 msgid "The task does not have any raw data."
-msgstr ""
+msgstr "Il task non contiene dati raw."
 
 #: rocky/views/finding_list.py rocky/views/ooi_list.py
 msgid "Unknown action."
@@ -7362,19 +7930,33 @@ msgstr "Indennizzo impostato con successo."
 
 #: rocky/views/mixins.py
 msgid "The selected date is in the future."
-msgstr ""
+msgstr "La data selezionata è nel futuro."
 
 #: rocky/views/mixins.py
 msgid "Can not parse date, falling back to show current date."
-msgstr ""
+msgstr "Impossibile interpretare la data; verrà mostrata la data corrente."
+
+#: rocky/views/mixins.py
+#, python-format
+msgid "Could not load origins for OOI: %s from octopoes"
+msgstr "Impossibile caricare le origini per l'OOI: %s da Octopoes"
+
+#: rocky/views/mixins.py
+msgid "Could not load normalizer metas from bytes"
+msgstr "Impossibile caricare i metadati dei normalizer da Bytes"
+
+#: rocky/views/mixins.py
+#, python-format
+msgid "Could not load boefje %s from katalogus"
+msgstr "Impossibile caricare il boefje %s da KAT-alogus"
 
 #: rocky/views/mixins.py
 msgid "You do not have the permission to add items to a dashboard."
-msgstr ""
+msgstr "Non hai l'autorizzazione per aggiungere elementi a una dashboard."
 
 #: rocky/views/mixins.py
 msgid "Dashboard item has been added."
-msgstr ""
+msgstr "L'elemento della dashboard è stato aggiunto."
 
 #: rocky/views/ooi_add.py
 #, python-format
@@ -7385,6 +7967,8 @@ msgstr "Aggiungi %(ooi_type)s"
 msgid ""
 "Cannot set clearance level. It must be provided and must be a valid number."
 msgstr ""
+"Impossibile impostare il livello di autorizzazione. Deve essere fornito e "
+"deve essere un numero valido."
 
 #: rocky/views/ooi_detail.py
 msgid "Only Question OOIs can be answered."
@@ -7392,7 +7976,7 @@ msgstr "Solo gli OOI di tipo Domanda possono essere risposti."
 
 #: rocky/views/ooi_detail.py
 msgid "Question has been answered."
-msgstr ""
+msgstr "La domanda ha ricevuto risposta."
 
 #: rocky/views/ooi_detail_related_object.py
 msgid " (as "
@@ -7448,7 +8032,7 @@ msgstr "Uno degli OOI non esiste"
 #: rocky/views/ooi_list.py
 #, python-format
 msgid "Successfully set scan profile to %s for %d OOIs."
-msgstr ""
+msgstr "Profilo di scansione impostato con successo su %s per %d OOI."
 
 #: rocky/views/ooi_list.py
 msgid "An error occurred while setting clearance levels to inherit."
@@ -7467,7 +8051,7 @@ msgstr ""
 #: rocky/views/ooi_list.py
 #, python-format
 msgid "Successfully set %d OOI(s) clearance level to inherit."
-msgstr ""
+msgstr "Livello di autorizzazione impostato su ereditato per %d OOI."
 
 #: rocky/views/ooi_list.py
 msgid "An error occurred while deleting oois."
@@ -7475,7 +8059,7 @@ msgstr "Si è verificato un errore durante l'eliminazione degli OOI."
 
 #: rocky/views/ooi_list.py
 msgid "An error occurred while deleting OOIs: one of the OOIs doesn't exist."
-msgstr ""
+msgstr "Si è verificato un errore durante l'eliminazione degli OOI: uno degli OOI non esiste."
 
 #: rocky/views/ooi_list.py
 #, python-format
@@ -7492,11 +8076,11 @@ msgstr "Seleziona almeno un risultato."
 
 #: rocky/views/ooi_mute.py
 msgid "Finding(s) successfully unmuted."
-msgstr ""
+msgstr "Rilevamenti riattivati con successo."
 
 #: rocky/views/ooi_mute.py
 msgid "Finding(s) successfully muted."
-msgstr "Risultato/i mutato/i con successo."
+msgstr "Rilevamenti silenziati con successo."
 
 #: rocky/views/ooi_tree.py
 msgid "Tree Visualisation"
@@ -7508,7 +8092,7 @@ msgstr "Visualizzazione grafica"
 
 #: rocky/views/ooi_view.py
 msgid "Observed_at: "
-msgstr ""
+msgstr "Observed_at: "
 
 #: rocky/views/ooi_view.py
 msgid "OOI types: "
@@ -7524,7 +8108,7 @@ msgstr "Tipo di liquidazione: "
 
 #: rocky/views/ooi_view.py
 msgid "Searching for: "
-msgstr ""
+msgstr "Ricerca di: "
 
 #: rocky/views/organization_add.py
 msgid "Setup"
@@ -7545,7 +8129,7 @@ msgstr "Organizzazione %s aggiornata con successo."
 
 #: rocky/views/organization_member_add.py
 msgid "Add column titles, followed by each object on a new line."
-msgstr ""
+msgstr "Aggiungi i titoli delle colonne, seguiti da ciascun oggetto su una nuova riga."
 
 #: rocky/views/organization_member_add.py
 msgid "The columns are: "
@@ -7635,12 +8219,14 @@ msgstr "Ricalcolati {number_of_bits} bit. Durata: {duration}"
 
 #: rocky/views/page_actions.py
 msgid "Could not process your request, action required."
-msgstr ""
+msgstr "Impossibile elaborare la richiesta, azione richiesta."
 
 #: rocky/views/scan_profile.py
 msgid ""
 "Cannot set clearance level. The clearance type must be inherited or declared."
 msgstr ""
+"Impossibile impostare il livello di autorizzazione. Il tipo di autorizzazione "
+"deve essere ereditato o dichiarato."
 
 #: rocky/views/scans.py
 msgid "Scans"
@@ -7648,7 +8234,7 @@ msgstr "Scansioni"
 
 #: rocky/views/scheduler.py
 msgid "Your report has been scheduled."
-msgstr ""
+msgstr "Il tuo report è stato pianificato."
 
 #: rocky/views/scheduler.py
 msgid ""
@@ -7656,15 +8242,19 @@ msgid ""
 "will be added to the object list when they are in. It may take some time, a "
 "refresh of the page may be needed to show the results."
 msgstr ""
+"Il tuo task è pianificato e verrà presto avviato in background. I risultati "
+"verranno aggiunti all'elenco degli oggetti quando saranno disponibili. "
+"Potrebbe richiedere del tempo; potrebbe essere necessario aggiornare la "
+"pagina per vedere i risultati."
 
 #: rocky/views/tasks.py
 #, python-brace-format
 msgid "Fetching tasks failed: no connection with scheduler: {error}"
-msgstr ""
+msgstr "Recupero dei task non riuscito: nessuna connessione con lo scheduler: {error}"
 
 #: rocky/views/tasks.py
 msgid "All Tasks"
-msgstr ""
+msgstr "Tutti i task"
 
 #: rocky/views/upload_csv.py
 msgid "Add column titles. Followed by each object on a new line."
@@ -7702,6 +8292,9 @@ msgid ""
 "values 0, 1, 2, 3, and 4 for the corresponding clearance level (other values "
 "are ignored) "
 msgstr ""
+"I livelli di autorizzazione possono essere controllati tramite una colonna "
+"'clearance' con valori numerici 0, 1, 2, 3 e 4 per il livello di "
+"autorizzazione corrispondente; gli altri valori vengono ignorati "
 
 #: rocky/views/upload_csv.py
 msgid "Object(s) could not be created for row number(s): "
@@ -7714,16 +8307,19 @@ msgstr "Oggetto/i aggiunto/i con successo."
 #: rocky/views/upload_raw.py
 #, python-format
 msgid "Raw file could not be uploaded to Bytes: status code %d"
-msgstr ""
+msgstr "Impossibile caricare il file raw su Bytes: codice di stato %d"
 
 #: rocky/views/upload_raw.py
 #, python-format
 msgid "Raw file could not be uploaded to Bytes: %s"
-msgstr ""
+msgstr "Impossibile caricare il file raw su Bytes: %s"
 
 #: rocky/views/upload_raw.py
 msgid "Raw file successfully added."
 msgstr "File raw aggiunto con successo."
+
+#~ msgid "Findings @ "
+#~ msgstr "Risultati @ "
 
 #~ msgid "Clearance level has been set"
 #~ msgstr "Il livello di autorizzazione è stato impostato"
@@ -7995,10 +8591,10 @@ msgstr "File raw aggiunto con successo."
 #~ "Tool). An Open-Source-project developed by the Ministry of Health, "
 #~ "Welfare and Sport to make your and our world a safer place."
 #~ msgstr ""
-#~ "OpenKAT è lo \"Strumento di Analisi delle "
-#~ "Vulnerabilità\" (Vulnerabilities Analysis Tool). Un progetto open source "
-#~ "sviluppato dal Ministero della Salute, del Benessere e dello Sport per "
-#~ "rendere il nostro mondo e il vostro un luogo più sicuro."
+#~ "OpenKAT è lo \"Strumento di Analisi delle Vulnerabilità\" "
+#~ "(Vulnerabilities Analysis Tool). Un progetto open source sviluppato dal "
+#~ "Ministero della Salute, del Benessere e dello Sport per rendere il nostro "
+#~ "mondo e il vostro un luogo più sicuro."
 
 #~ msgid ""
 #~ "OpenKAT is able to give insight into security risks on your online "


### PR DESCRIPTION
## Summary
- Update the Italian gettext catalog to the current POT state
- Translate all active Italian messages and remove fuzzy/untranslated entries
- Clean up inconsistent Italian terminology in visible UI strings

## Validation
- msgfmt --statistics --check rocky/rocky/locale/it/LC_MESSAGES/django.po
- msgattrib --untranslated --no-obsolete rocky/rocky/locale/it/LC_MESSAGES/django.po
- msgattrib --only-fuzzy --no-obsolete rocky/rocky/locale/it/LC_MESSAGES/django.po
- git diff --check