### PR TITLE
Update German translations

### DIFF
--- a/rocky/rocky/locale/de/LC_MESSAGES/django.po
+++ b/rocky/rocky/locale/de/LC_MESSAGES/django.po
@@ -4,16 +4,14 @@
 # alster <alsternerd@users.noreply.hosted.weblate.org>, 2024, 2025.
 # LibreTranslate <noreply-mt-libretranslate@weblate.org>, 2024, 2025.
 # Ettore Atalan <atalanttore@googlemail.com>, 2025.
-#: reports/forms.py
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: OpenKAT\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-20 07:38+0000\n"
-"PO-Revision-Date: 2025-08-22 09:39+0000\n"
-"Last-Translator: Ettore Atalan <atalanttore@googlemail.com>\n"
-"Language-Team: German <https://hosted.weblate.org/projects/openkat/nl-kat-"
-"coordination/de/>\n"
+"POT-Creation-Date: 2026-03-28 14:22+0000\n"
+"PO-Revision-Date: 2026-07-14 00:00+0000\n"
+"Last-Translator: Brenno de Winter <brenno@dewinter.com>\n"
+"Language-Team: German <https://hosted.weblate.org/projects/openkat/nl-kat-coordination/de/>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -108,16 +106,17 @@ msgstr "Der Name der Ogranisation."
 
 #: account/forms/account_setup.py
 msgid "explanation-organization-name"
-msgstr ""
+msgstr "Erklärung-Organisationsname"
 
 #: account/forms/account_setup.py
 #, python-brace-format
 msgid "A unique code of maximum {code_length} characters in length."
 msgstr ""
+"Ein eindeutiger Code mit einer maximalen Länge von {code_length} Zeichen."
 
 #: account/forms/account_setup.py
 msgid "explanation-organization-code"
-msgstr ""
+msgstr "Erklärung-Organisationscode"
 
 #: account/forms/account_setup.py
 msgid "Organization name is required to proceed."
@@ -141,6 +140,10 @@ msgid ""
 "have permission to scan these assets. I am aware of the implications a scan "
 "(with a higher scan level) brings on my systems."
 msgstr ""
+"Ich erkläre, dass OpenKAT die Vermögenswerte meiner Organisation scannen "
+"darf und dass ich die Erlaubnis zum Scannen dieser Vermögenswerte habe. Ich "
+"bin mir der Auswirkungen eines Scans (mit einem höheren Scan-Level) auf "
+"meine Systeme bewusst."
 
 #: account/forms/account_setup.py
 msgid ""
@@ -148,6 +151,9 @@ msgid ""
 "organization. I have the experience and knowledge to know what the "
 "consequences might be and can be held responsible for them."
 msgstr ""
+"Ich erkläre, dass ich berechtigt bin, diese Entschädigung im Namen meiner "
+"Organisation zu leisten. Ich verfüge über die Erfahrung und das Wissen, um "
+"die möglichen Folgen zu kennen und kann dafür verantwortlich gemacht werden."
 
 #: account/forms/account_setup.py
 msgid "Trusted to change Clearance Levels."
@@ -265,13 +271,13 @@ msgstr "Backup Token"
 
 #: account/mixins.py
 msgid "Clearance level has been set."
-msgstr ""
+msgstr "Die Freigabestufe wurde festgelegt."
 
 #: account/mixins.py
 #, python-format
 msgid ""
-"Could not raise clearance level of %s to L%s. Indemnification not present at "
-"organization %s."
+"Could not raise clearance level of %s to L%s. Indemnification not present at"
+" organization %s."
 msgstr ""
 "Konnte die Freigabestufe von %s nicht auf L%s erhöhen. Entschädigung nicht "
 "vorhanden bei Organisation %s."
@@ -283,8 +289,8 @@ msgid ""
 "level of L%s. Contact your administrator to receive a higher clearance."
 msgstr ""
 "Konnte die Freigabestufe von %s nicht auf F%s erhöhen. Es wurde Ihnen eine "
-"Freigabestufe von F%s anvertraut. Wenden Sie sich an Ihren Administrator, um "
-"eine höhere Freigabestufe zu erhalten."
+"Freigabestufe von F%s anvertraut. Wenden Sie sich an Ihren Administrator, um"
+" eine höhere Freigabestufe zu erhalten."
 
 #: account/mixins.py
 #, python-format
@@ -299,7 +305,7 @@ msgstr ""
 
 #: account/models.py
 msgid "The email must be set"
-msgstr ""
+msgstr "Die E-Mail muss festgelegt werden"
 
 #: account/models.py
 msgid "Superuser must have is_staff=True."
@@ -344,7 +350,7 @@ msgstr "Beitrittsdatum"
 
 #: account/models.py
 msgid "The clearance level of the user for all organizations."
-msgstr ""
+msgstr "Die Freigabestufe des Benutzers für alle Organisationen."
 
 #: account/models.py
 msgid "name"
@@ -383,12 +389,14 @@ msgstr "OOI Freigabe"
 
 #: account/templates/account_detail.html
 msgid "You don't have any clearance to scan objects."
-msgstr ""
+msgstr "Sie haben keine Berechtigung zum Scannen von Objekten."
 
 #: account/templates/account_detail.html
 msgid ""
 "Get in contact with the admin to give you the necessary clearance level."
 msgstr ""
+"Nehmen Sie Kontakt mit dem Administrator auf, um die erforderliche "
+"Freigabestufe zu erhalten."
 
 #: account/templates/account_detail.html
 msgid "You have currently accepted clearance up to level"
@@ -409,7 +417,7 @@ msgstr ""
 #: account/templates/account_detail.html
 #, python-format
 msgid "Withdraw L%(acl)s clearance and responsibility"
-msgstr ""
+msgstr "L%(acl)s Freigabe und Verantwortung entziehen"
 
 #: account/templates/account_detail.html
 msgid "Explanation OOI clearance"
@@ -420,19 +428,19 @@ msgstr "Erläuterung OOI-Freigabe"
 msgid ""
 "You are granted clearance for level L%(tcl)s by your admin. Before you can "
 "change OOI clearance levels up to this level, you need to accept this "
-"permission. Remember: <strong>with great power comes great responsibility.</"
-"strong>"
+"permission. Remember: <strong>with great power comes great "
+"responsibility.</strong>"
 msgstr ""
 "You are granted clearance for level F%(tcl)s by your admin. Before you can "
 "change OOI clearance levels up to this level, you need to accept this "
-"permission. Remember: <strong>with great power comes great responsibility.</"
-"strong>"
+"permission. Remember: <strong>with great power comes great "
+"responsibility.</strong>"
 
 #: account/templates/account_detail.html
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 #, python-format
 msgid "Accept level L%(tcl)s clearance and responsibility"
-msgstr ""
+msgstr "Akzeptieren Sie die Freigabe und Verantwortung der Stufe L%(tcl)s"
 
 #: account/templates/password_reset.html
 msgid "Use the form below to reset your password."
@@ -456,8 +464,8 @@ msgstr "Bestätigen Sie das zurückgesetzte Passwort"
 #: account/templates/password_reset_confirm.html
 msgid "Use the form below to confirm resetting your password"
 msgstr ""
-"Verwenden Sie das nachstehende Formular, um das Zurücksetzen Ihres Passworts "
-"zu bestätigen"
+"Verwenden Sie das nachstehende Formular, um das Zurücksetzen Ihres Passworts"
+" zu bestätigen"
 
 #: account/templates/password_reset_confirm.html
 msgid "Confirm password"
@@ -472,6 +480,8 @@ msgid ""
 "The password reset link was invalid, possibly because it has already been "
 "used.  Please request a new password reset."
 msgstr ""
+"Der Link zum Zurücksetzen des Passworts war ungültig, möglicherweise weil er"
+" bereits verwendet wurde.  Bitte fordern Sie einen neuen Passwort-Reset an."
 
 #: account/templates/password_reset_email.html
 #, python-format
@@ -479,55 +489,60 @@ msgid ""
 "You're receiving this email because you requested a password reset for your "
 "user account at %(site_name)s."
 msgstr ""
+"Sie erhalten diese E-Mail, weil Sie eine Passwortzurücksetzung für Ihr "
+"Benutzerkonto unter %(site_name)s beantragt haben."
 
 #: account/templates/password_reset_email.html
 #: account/templates/registration_email.html
 msgid "Please go to the following page and choose a new password:"
 msgstr ""
+"Bitte gehen Sie auf die folgende Seite und wählen Sie ein neues Passwort:"
 
 #: account/templates/password_reset_email.html
 #: account/templates/registration_email.html
 msgid "Sincerely,"
-msgstr ""
+msgstr "Aufrichtig,"
 
 #: account/templates/password_reset_email.html
 #: account/templates/registration_email.html
 msgid "The OpenKAT team"
-msgstr ""
+msgstr "Das OpenKAT-Team"
 
 #: account/templates/password_reset_subject.txt
 #, python-format
 msgid "Password reset on %(site_name)s"
-msgstr ""
+msgstr "Passwort-Reset auf %(site_name)s"
 
 #: account/templates/recover_email.html account/views/recover_email.py
 msgid "Recover email address"
-msgstr ""
+msgstr "E-Mail-Adresse wiederherstellen"
 
 #: account/templates/recover_email.html
 msgid "Information on how to recover your connected email address"
-msgstr ""
+msgstr "Informationen zum Wiederherstellen Ihrer verbundenen E-Mail-Adresse"
 
 #: account/templates/recover_email.html
 msgid "Forgotten email address?"
-msgstr ""
+msgstr "E-Mail-Adresse vergessen?"
 
 #: account/templates/recover_email.html
 msgid ""
 "If you don’t remember the email address connected to your account, contact:"
 msgstr ""
+"Wenn Sie sich nicht an die mit Ihrem Konto verknüpfte E-Mail-Adresse "
+"erinnern, wenden Sie sich an:"
 
 #: account/templates/recover_email.html
 msgid "Please contact the system administrator."
-msgstr ""
+msgstr "Bitte wenden Sie sich an den Systemadministrator."
 
 #: account/templates/recover_email.html
 msgid "Back to login"
-msgstr ""
+msgstr "Zurück zum Login"
 
 #: account/templates/recover_email.html
 msgid "Back to Home"
-msgstr ""
+msgstr "Zurück nach Hause"
 
 #: account/templates/registration_email.html
 #, python-format
@@ -535,73 +550,80 @@ msgid ""
 "Welcome to OpenKAT. You're receiving this email because you have been added "
 "to organization \"%(organization)s\" at %(site_name)s."
 msgstr ""
+"Willkommen bei OpenKAT. Sie erhalten diese E-Mail, weil Sie zur Organisation"
+" „%(organization)s“ unter %(site_name)s hinzugefügt wurden."
 
 #: account/templates/registration_subject.txt
 #, python-format
 msgid "Verify OpenKAT account on %(site_name)s"
-msgstr ""
+msgstr "Überprüfen Sie das OpenKAT-Konto auf %(site_name)s"
 
 #: account/validators.py
 msgid ""
 "Your password must contain at least the following but longer passwords are "
 "recommended:"
 msgstr ""
+"Ihr Passwort muss mindestens Folgendes enthalten, längere Passwörter werden "
+"jedoch empfohlen:"
 
 #: account/validators.py
 msgid " characters"
-msgstr ""
+msgstr "Charaktere"
 
 #: account/validators.py
 msgid " digits"
-msgstr ""
+msgstr "Ziffern"
 
 #: account/validators.py
 msgid " letters"
-msgstr ""
+msgstr "Buchstaben"
 
 #: account/validators.py
 msgid ""
 " special characters such as: {str(validators.get('special_characters',''))}"
-msgstr ""
+msgstr "Sonderzeichen wie: {str(validators.get('special_characters',''))}"
 
 #: account/validators.py
 msgid " lower case letters"
-msgstr ""
+msgstr "Kleinbuchstaben"
 
 #: account/validators.py
 msgid " upper case letters"
-msgstr ""
+msgstr "Großbuchstaben"
 
 #: account/views/login.py
 msgid "Your session has timed out. Please login again."
-msgstr ""
+msgstr "Ihre Sitzung ist abgelaufen. Bitte melden Sie sich erneut an."
 
 #: account/views/login.py rocky/templates/header.html
 msgid "OpenKAT"
-msgstr ""
+msgstr "OpenKAT"
 
 #: account/views/login.py account/views/password_reset.py
 #: account/views/recover_email.py rocky/templates/partials/secondary-menu.html
 #: rocky/templates/two_factor/core/login.html
 msgid "Login"
-msgstr ""
+msgstr "Login"
 
 #: account/views/login.py
 msgid "Two factor authentication"
-msgstr ""
+msgstr "Zwei-Faktor-Authentifizierung"
 
 #: account/views/password_reset.py
 msgid "We couldn't send a password reset link. Contact "
 msgstr ""
+"Wir konnten keinen Link zum Zurücksetzen des Passworts senden. Kontakt"
 
 #: account/views/password_reset.py
 msgid ""
 "We couldn't send a password reset link. Contact your system administrator."
 msgstr ""
+"Wir konnten keinen Link zum Zurücksetzen des Passworts senden. Kontaktieren "
+"Sie Ihren Systemadministrator."
 
 #: components/modal/template.html
 msgid "Close modal"
-msgstr ""
+msgstr "Modal schließen"
 
 #: components/modal/template.html
 #: crisis_room/templates/partials/delete_dashboard_item_modal.html
@@ -624,146 +646,159 @@ msgstr ""
 #: rocky/templates/partials/mute_findings_modal.html
 #: rocky/templates/two_factor/_wizard_actions.html
 msgid "Cancel"
-msgstr ""
+msgstr "Stornieren"
 
 #: crisis_room/forms.py
 msgid "Title on dashboard"
-msgstr ""
+msgstr "Titel auf dem Dashboard"
 
 #: crisis_room/forms.py
 msgid "Dashboard item size"
-msgstr ""
+msgstr "Größe des Dashboard-Elements"
 
 #: crisis_room/forms.py
 msgid "Full width"
-msgstr ""
+msgstr "Volle Breite"
 
 #: crisis_room/forms.py
 msgid "Half width"
-msgstr ""
+msgstr "Halbe Breite"
 
 #: crisis_room/forms.py
 msgid "An item with that name already exists. Try a different title."
 msgstr ""
+"Ein Element mit diesem Namen existiert bereits. Versuchen Sie es mit einem "
+"anderen Titel."
 
 #: crisis_room/forms.py
 msgid "An error occurred while adding dashboard item."
-msgstr ""
+msgstr "Beim Hinzufügen eines Dashboard-Elements ist ein Fehler aufgetreten."
 
 #: crisis_room/forms.py
 msgid "Number of rows in list"
-msgstr ""
+msgstr "Anzahl der Zeilen in der Liste"
 
 #: crisis_room/forms.py
 msgid "List sorting by"
-msgstr ""
+msgstr "Listensortierung nach"
 
 #: crisis_room/forms.py
 msgid "Type (A-Z)"
-msgstr ""
+msgstr "Typ (A-Z)"
 
 #: crisis_room/forms.py
 msgid "Type (Z-A)"
-msgstr ""
+msgstr "Typ (Z-A)"
 
 #: crisis_room/forms.py
 msgid "Clearance level (Low-High)"
-msgstr ""
+msgstr "Freigabeniveau (Niedrig-Hoch)"
 
 #: crisis_room/forms.py
 msgid "Clearance level (High-Low)"
-msgstr ""
+msgstr "Freigabeniveau (Hoch-Niedrig)"
 
 #: crisis_room/forms.py
 msgid "Show table columns"
-msgstr ""
+msgstr "Tabellenspalten anzeigen"
 
 #: crisis_room/forms.py
 msgid "Severity (Low-High)"
-msgstr ""
+msgstr "Schweregrad (Niedrig-Hoch)"
 
 #: crisis_room/forms.py
 msgid "Severity (High-Low)"
-msgstr ""
+msgstr "Schweregrad (Hoch-Niedrig)"
 
 #: crisis_room/forms.py
 msgid "Finding (A-Z)"
-msgstr ""
+msgstr "Finden (A-Z)"
 
 #: crisis_room/forms.py
 msgid "Finding (Z-A)"
-msgstr ""
+msgstr "Finden (Z-A)"
 
 #: crisis_room/models.py
 msgid "Findings Dashboard"
-msgstr ""
+msgstr "Ergebnis-Dashboard"
 
 #: crisis_room/models.py
 msgid ""
-"Where on the dashboard do you want to show the data? Position {} is the most "
-"top level and the max position is {}."
+"Where on the dashboard do you want to show the data? Position {} is the most"
+" top level and the max position is {}."
 msgstr ""
+"Wo auf dem Dashboard möchten Sie die Daten anzeigen? Position {} ist die "
+"oberste Ebene und die maximale Position ist {}."
 
 #: crisis_room/models.py
 msgid "Will be displayed on the general crisis room, for all organizations."
-msgstr ""
+msgstr "Wird im allgemeinen Krisenraum aller Organisationen angezeigt."
 
 #: crisis_room/models.py
 msgid "Will be displayed on a single organization dashboard"
-msgstr ""
+msgstr "Wird auf einem einzigen Organisations-Dashboard angezeigt"
 
 #: crisis_room/models.py
 msgid "Will be displayed on the findings dashboard for all organizations"
-msgstr ""
+msgstr "Wird im Ergebnis-Dashboard für alle Organisationen angezeigt"
 
 #: crisis_room/models.py
 msgid "Can change position up or down of a dashboard item."
 msgstr ""
+"Kann die Position eines Dashboard-Elements nach oben oder unten ändern."
 
 #: crisis_room/models.py
 msgid "You have to choose between a recipe or a query, but not both."
 msgstr ""
+"Sie müssen zwischen einem Rezept oder einer Abfrage wählen, aber nicht "
+"beides."
 
 #: crisis_room/models.py
 msgid "You have set a query and not where it is from. Also set the source."
 msgstr ""
+"Sie haben eine Abfrage eingestellt und nicht, woher sie stammt. Legen Sie "
+"auch die Quelle fest."
 
 #: crisis_room/models.py
 msgid ""
 "DashboardItem must contain at least a 'recipe' or a 'source' with a 'query'."
 msgstr ""
+"DashboardItem muss mindestens ein „Rezept“ oder eine „Quelle“ mit einer "
+"„Abfrage“ enthalten."
 
 #: crisis_room/models.py
 msgid "Max dashboard items reached."
-msgstr ""
+msgstr "Maximale Anzahl an Dashboard-Elementen erreicht."
 
 #: crisis_room/templates/crisis_room.html
 #: crisis_room/templates/organization_crisis_room.html
 #: rocky/templates/header.html
 msgid "Crisis room"
-msgstr ""
+msgstr "Krisenraum"
 
 #: crisis_room/templates/crisis_room.html
 msgid "Crisis room overview for all organizations."
-msgstr ""
+msgstr "Krisenraumübersicht für alle Organisationen."
 
 #: crisis_room/templates/crisis_room_dashboards.html
 msgid "Dashboards"
-msgstr ""
+msgstr "Dashboards"
 
 #: crisis_room/templates/crisis_room_dashboards.html
 msgid ""
 "On this page you can see an overview of the dashboards for all "
 "organizations. **More context can be written here**"
 msgstr ""
+"Auf dieser Seite sehen Sie eine Übersicht der Dashboards für alle "
+"Organisationen. **Mehr Kontext kann hier geschrieben werden**"
 
 #: crisis_room/templates/crisis_room_dashboards.html
 msgid "dashboards"
-msgstr ""
+msgstr "Dashboards"
 
 #: crisis_room/templates/crisis_room_dashboards.html
 msgid "There are no dashboards to display."
-msgstr ""
+msgstr "Es sind keine Dashboards zum Anzeigen vorhanden."
 
 #: crisis_room/templates/crisis_room_findings.html
 #: crisis_room/templates/partials/crisis_room_findings_table.html
@@ -771,31 +806,38 @@ msgstr ""
 #: reports/templates/partials/report_findings_table.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Findings overview"
-msgstr ""
+msgstr "Befundübersicht"
 
 #: crisis_room/templates/crisis_room_findings.html
 msgid ""
 "\n"
-"                            This overview shows the total number of findings "
-"per\n"
-"                            severity that have been identified for all "
-"organizations.\n"
-"                            This data is based on the latest Crisis Room "
-"Findings Report\n"
+"                            This overview shows the total number of findings per\n"
+"                            severity that have been identified for all organizations.\n"
+"                            This data is based on the latest Crisis Room Findings Report\n"
 "                            of each organization.\n"
 "                        "
 msgstr ""
+"\n"
+"Diese Übersicht zeigt die Gesamtzahl der Befunde pro\n"
+"                            Schweregrade, die für alle Organisationen identifiziert wurden.\n"
+"                            Diese Daten basieren auf dem neuesten Crisis Room Findings Report\n"
+"                            jeder Organisation."
 
 #: crisis_room/templates/crisis_room_findings.html
 msgid "Findings per organization"
-msgstr ""
+msgstr "Ergebnisse pro Organisation"
 
 #: crisis_room/templates/crisis_room_findings.html
 msgid ""
 "This table shows the findings that have been identified for each "
-"organization, sorted by the finding types and grouped by organizations. This "
-"data is based on the latest Crisis Room Findings Report of each organization."
+"organization, sorted by the finding types and grouped by organizations. This"
+" data is based on the latest Crisis Room Findings Report of each "
+"organization."
 msgstr ""
+"Diese Tabelle zeigt die Ergebnisse, die für jede Organisation identifiziert "
+"wurden, sortiert nach Ergebnistypen und gruppiert nach Organisationen. Diese"
+" Daten basieren auf dem neuesten Crisis Room Findings Report jeder "
+"Organisation."
 
 #: crisis_room/templates/crisis_room_findings.html
 #: reports/report_types/findings_report/report.html
@@ -803,17 +845,21 @@ msgid ""
 "No findings have been identified yet. As soon as they have been identified, "
 "they will be shown on this page."
 msgstr ""
+"Es liegen noch keine Befunde vor. Sobald sie identifiziert wurden, werden "
+"sie auf dieser Seite angezeigt."
 
 #: crisis_room/templates/crisis_room_findings.html
 msgid ""
 "There are no organizations yet. After creating an organization, the "
 "identified findings will be shown here."
 msgstr ""
+"Es gibt noch keine Organisationen. Nach dem Anlegen einer Organisation "
+"werden hier die ermittelten Erkenntnisse angezeigt."
 
 #: crisis_room/templates/crisis_room_header.html
 #: crisis_room/templates/organization_crisis_room_header.html
 msgid "Crisis room navigation"
-msgstr ""
+msgstr "Navigation im Krisenraum"
 
 #: crisis_room/templates/crisis_room_header.html
 #: crisis_room/templates/partials/new_dashboard_item_action_button.html
@@ -829,8 +875,8 @@ msgstr ""
 #: reports/report_types/web_system_report/report.html
 #: reports/templates/partials/report_findings_table.html
 #: reports/templates/partials/report_sidemenu.html
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
-#: rocky/templates/header.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
 #: rocky/templates/oois/ooi_detail_findings_list.html
 #: rocky/templates/oois/ooi_detail_findings_overview.html
 #: rocky/templates/oois/ooi_page_tabs.html
@@ -839,30 +885,32 @@ msgstr ""
 #: rocky/views/finding_list.py rocky/views/finding_type_add.py
 #: rocky/views/ooi_view.py
 msgid "Findings"
-msgstr ""
+msgstr "Erkenntnisse"
 
 #: crisis_room/templates/organization_crisis_room.html
 msgid "Options for dashboard"
-msgstr ""
+msgstr "Optionen für das Dashboard"
 
 #: crisis_room/templates/organization_crisis_room.html
 msgid "Show all descriptions"
-msgstr ""
+msgstr "Alle Beschreibungen anzeigen"
 
 #: crisis_room/templates/organization_crisis_room.html
 msgid "Hide all descriptions"
-msgstr ""
+msgstr "Alle Beschreibungen ausblenden"
 
 #: crisis_room/templates/organization_crisis_room.html
 #: crisis_room/templates/partials/delete_dashboard_modal.html
 msgid "Delete dashboard"
-msgstr ""
+msgstr "Dashboard löschen"
 
 #: crisis_room/templates/organization_crisis_room.html
 msgid ""
 "There are no dashboards yet. Click on \"Add dashboard\" to create a new "
 "dashboard."
 msgstr ""
+"Es gibt noch keine Dashboards. Klicken Sie auf „Dashboard hinzufügen“, um "
+"ein neues Dashboard zu erstellen."
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 #: katalogus/templates/partials/objects_to_scan.html
@@ -873,50 +921,52 @@ msgstr "Objektliste"
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid "Finding list"
-msgstr ""
+msgstr "Fundliste"
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 #: crisis_room/templates/partials/new_dashboard_item_action_button.html
 msgid "Report section"
-msgstr ""
+msgstr "Abschnitt „Bericht“."
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid "There are no dashboard items added yet."
-msgstr ""
+msgstr "Es wurden noch keine Dashboard-Elemente hinzugefügt."
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid ""
-"You can add dashboard items via the filters on the objects and findings page "
-"or you can add a report section."
+"You can add dashboard items via the filters on the objects and findings page"
+" or you can add a report section."
 msgstr ""
+"Sie können Dashboard-Elemente über die Filter auf der Seite „Objekte und "
+"Ergebnisse“ hinzufügen oder einen Berichtsabschnitt hinzufügen."
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid "Add objects"
-msgstr ""
+msgstr "Objekte hinzufügen"
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid "Add findings"
-msgstr ""
+msgstr "Erkenntnisse hinzufügen"
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid "Add report section"
-msgstr ""
+msgstr "Berichtsabschnitt hinzufügen"
 
 #: crisis_room/templates/organization_crisis_room_header.html
 #: crisis_room/templates/partials/new_dashboard_modal.html
 msgid "Add dashboard"
-msgstr ""
+msgstr "Dashboard hinzufügen"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid "Findings per organization overview"
-msgstr ""
+msgstr "Übersicht über die Ergebnisse pro Organisation"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: reports/templates/partials/report_findings_table.html
 #: reports/templates/partials/report_severity_totals_table.html
 #: tools/forms/finding_type.py
 msgid "Finding types"
-msgstr ""
+msgstr "Typen finden"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: reports/report_types/dns_report/report.html
@@ -927,15 +977,15 @@ msgstr ""
 #: rocky/templates/partials/ooi_report_findings_block_table.html
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "Occurrences"
-msgstr ""
+msgstr "Vorkommen"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid "Highest risk level"
-msgstr ""
+msgstr "Höchste Risikostufe"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid "Critical finding types"
-msgstr ""
+msgstr "Kritische Befundtypen"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
@@ -949,7 +999,7 @@ msgstr ""
 #: rocky/templates/tasks/ooi_detail_task_list.html
 #: rocky/templates/tasks/plugin_detail_task_list.html
 msgid "Details"
-msgstr ""
+msgstr "Details"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
@@ -964,7 +1014,7 @@ msgstr ""
 #: rocky/templates/tasks/ooi_detail_task_list.html
 #: rocky/templates/tasks/plugin_detail_task_list.html
 msgid "Close details"
-msgstr ""
+msgstr "Details schließen"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
@@ -979,67 +1029,75 @@ msgstr ""
 #: rocky/templates/tasks/ooi_detail_task_list.html
 #: rocky/templates/tasks/plugin_detail_task_list.html
 msgid "Open details"
-msgstr ""
+msgstr "Details öffnen"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid ""
-"This overview shows the total number of findings per severity that have been "
-"identified for this organization."
+"This overview shows the total number of findings per severity that have been"
+" identified for this organization."
 msgstr ""
+"Diese Übersicht zeigt die Gesamtzahl der Befunde pro Schweregrad, die für "
+"diese Organisation identifiziert wurden."
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: reports/report_types/findings_report/report.html
 msgid "Critical and high findings"
-msgstr ""
+msgstr "Kritische und hohe Ergebnisse"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: reports/report_types/findings_report/report.html
 msgid ""
 "This table shows the top 25 critical and high findings that have been "
-"identified for this organization, grouped by finding types. A table with all "
-"the identified findings can be found in the Findings Report."
+"identified for this organization, grouped by finding types. A table with all"
+" the identified findings can be found in the Findings Report."
 msgstr ""
+"Diese Tabelle zeigt die 25 wichtigsten kritischen und schwerwiegendsten "
+"Ergebnisse, die für diese Organisation identifiziert wurden, gruppiert nach "
+"Ergebnistypen. Eine Tabelle mit allen ermittelten Befunden finden Sie im "
+"Befundbericht."
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid "No findings have been identified. Check report for more details."
 msgstr ""
+"Es wurden keine Befunde festgestellt. Weitere Einzelheiten finden Sie im "
+"Bericht."
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid "View findings report"
-msgstr ""
+msgstr "Ergebnisbericht anzeigen"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Edit report recipe"
-msgstr ""
+msgstr "Berichtsrezept bearbeiten"
 
 #: crisis_room/templates/partials/dashboard_finding_list.html
 #, python-format
 msgid "Showing %(length)s findings"
-msgstr ""
+msgstr "Zeigt %(length)s-Ergebnisse"
 
 #: crisis_room/templates/partials/dashboard_finding_list.html
 msgid "Go to findings"
-msgstr ""
+msgstr "Gehen Sie zu den Ergebnissen"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
 msgid "Findings table "
-msgstr ""
+msgstr "Befundtabelle"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: crisis_room/templates/partials/dashboard_ooi_list_table.html
 #: rocky/templates/findings/finding_list.html
 #: rocky/templates/oois/ooi_list.html
 msgid "column headers with buttons are sortable"
-msgstr ""
+msgstr "Spaltenüberschriften mit Schaltflächen sind sortierbar"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
 #, python-format
 msgid "Show details for %(finding)s"
-msgstr ""
+msgstr "Details für %(finding)s anzeigen"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
@@ -1048,7 +1106,7 @@ msgstr ""
 #: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
 #: rocky/views/mixins.py
 msgid "Tree"
-msgstr ""
+msgstr "Baum"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
@@ -1057,14 +1115,15 @@ msgstr ""
 #: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
 #: rocky/views/mixins.py
 msgid "Graph"
-msgstr ""
+msgstr "Graph"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: reports/report_types/dns_report/report.html
 #: rocky/templates/oois/ooi_detail_findings_list.html
-#: rocky/templates/oois/ooi_detail_findings_overview.html rocky/views/mixins.py
+#: rocky/templates/oois/ooi_detail_findings_overview.html
+#: rocky/views/mixins.py
 msgid "Severity"
-msgstr ""
+msgstr "Schwere"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: reports/report_types/dns_report/report.html
@@ -1072,45 +1131,45 @@ msgstr ""
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 #: rocky/views/mixins.py
 msgid "Finding"
-msgstr ""
+msgstr "Finden"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
 #: rocky/templates/partials/ooi_report_findings_block_table.html
 msgid "Finding type"
-msgstr ""
+msgstr "Typ finden"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
 #, python-format
 msgid "Show details for %(finding_type)s"
-msgstr ""
+msgstr "Details für %(finding_type)s anzeigen"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
 msgid "OOI type"
-msgstr ""
+msgstr "OOI-Typ"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
 #, python-format
 msgid "Show %(ooi_type)s objects"
-msgstr ""
+msgstr "%(ooi_type)s-Objekte anzeigen"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/views/mixins.py
 msgid "Location"
-msgstr ""
+msgstr "Standort"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #, python-format
 msgid "Show details for %(ooi)s"
-msgstr ""
+msgstr "Details für %(ooi)s anzeigen"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
 msgid "Risk score"
-msgstr ""
+msgstr "Risikobewertung"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: katalogus/templates/normalizer_detail.html
@@ -1121,9 +1180,10 @@ msgstr ""
 #: reports/templates/summary/report_asset_overview.html tools/forms/boefje.py
 #: tools/forms/finding_type.py rocky/templates/findings/finding_list.html
 #: rocky/templates/oois/ooi_detail.html
-#: rocky/templates/oois/ooi_detail_findings_list.html rocky/templates/scan.html
+#: rocky/templates/oois/ooi_detail_findings_list.html
+#: rocky/templates/scan.html
 msgid "Description"
-msgstr ""
+msgstr "Beschreibung"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: reports/report_types/multi_organization_report/recommendations.html
@@ -1131,7 +1191,7 @@ msgstr ""
 #: reports/templates/partials/report_severity_totals_table.html
 #: rocky/templates/findings/finding_list.html
 msgid "Recommendation"
-msgstr ""
+msgstr "Empfehlung"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: reports/report_types/vulnerability_report/report.py
@@ -1141,61 +1201,62 @@ msgstr ""
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "Source"
-msgstr ""
+msgstr "Quelle"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: reports/templates/partials/report_findings_table.html
 #: rocky/templates/findings/finding_list.html
 msgid "Impact"
-msgstr ""
+msgstr "Auswirkungen"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Options for dashboard items"
-msgstr ""
+msgstr "Optionen für Dashboard-Elemente"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Show description"
-msgstr ""
+msgstr "Beschreibung anzeigen"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Hide description"
-msgstr ""
+msgstr "Beschreibung ausblenden"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Position up"
-msgstr ""
+msgstr "Aufstellen"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Position down"
-msgstr ""
+msgstr "Nach unten positionieren"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Rerun report"
-msgstr ""
+msgstr "Bericht erneut ausführen"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 #: crisis_room/templates/partials/delete_dashboard_item_modal.html
 msgid "Delete item"
-msgstr ""
+msgstr "Artikel löschen"
 
 #: crisis_room/templates/partials/dashboard_ooi_list.html
 #, python-format
 msgid "Showing %(length)s objects"
-msgstr ""
+msgstr "Zeigt %(length)s-Objekte"
 
 #: crisis_room/templates/partials/dashboard_ooi_list.html
 msgid "Go to objects"
-msgstr ""
+msgstr "Gehen Sie zu Objekten"
 
 #: crisis_room/templates/partials/dashboard_ooi_list_table.html
 #: rocky/templates/oois/ooi_list.html
 msgid "Objects "
-msgstr ""
+msgstr "Objekte"
 
 #: crisis_room/templates/partials/delete_dashboard_item_modal.html
 #, python-format
 msgid "Are you sure you want to delete '%(name)s' from this dashboard?"
 msgstr ""
+"Sind Sie sicher, dass Sie „%(name)s“ aus diesem Dashboard löschen möchten?"
 
 #: crisis_room/templates/partials/delete_dashboard_item_modal.html
 #: crisis_room/templates/partials/delete_dashboard_modal.html
@@ -1216,14 +1277,16 @@ msgid ""
 "Are you sure you want to delete dashboard '%(dashboard)s'? All the items on "
 "the dashboard will be deleted as well."
 msgstr ""
+"Sind Sie sicher, dass Sie das Dashboard „%(dashboard)s“ löschen möchten? "
+"Alle Elemente im Dashboard werden ebenfalls gelöscht."
 
 #: crisis_room/templates/partials/new_dashboard_item_action_button.html
 msgid "Actions for adding dashboard items"
-msgstr ""
+msgstr "Aktionen zum Hinzufügen von Dashboard-Elementen"
 
 #: crisis_room/templates/partials/new_dashboard_item_action_button.html
 msgid "Add item"
-msgstr ""
+msgstr "Artikel hinzufügen"
 
 #: crisis_room/templates/partials/new_dashboard_item_action_button.html
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
@@ -1232,26 +1295,33 @@ msgstr ""
 #: reports/templates/summary/ooi_selection.html tools/forms/ooi.py
 #: tools/view_helpers.py rocky/templates/admin/delete_confirmation.html
 #: rocky/templates/admin/delete_selected_confirmation.html
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
-#: rocky/templates/header.html rocky/views/ooi_add.py rocky/views/ooi_list.py
-#: rocky/views/ooi_view.py rocky/views/upload_csv.py rocky/views/upload_raw.py
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
+#: rocky/views/ooi_add.py rocky/views/ooi_list.py rocky/views/ooi_view.py
+#: rocky/views/upload_csv.py rocky/views/upload_raw.py
 msgid "Objects"
-msgstr ""
+msgstr "Objekte"
 
 #: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
 msgid "Add dashboard item"
-msgstr ""
+msgstr "Dashboard-Element hinzufügen"
 
 #: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
 msgid ""
-"To  add a <strong>report section</strong>, go to the history page and open a "
-"report. Then go to the section that you want to add to your dashboard and "
-"press the options button next to the section name to create a dashboard item."
+"To  add a <strong>report section</strong>, go to the history page and open a"
+" report. Then go to the section that you want to add to your dashboard and "
+"press the options button next to the section name to create a dashboard "
+"item."
 msgstr ""
+"Um einen <strong>Berichtsabschnitt</strong> hinzuzufügen, gehen Sie zur "
+"Verlaufsseite und öffnen Sie einen Bericht. Gehen Sie dann zu dem Abschnitt,"
+" den Sie zu Ihrem Dashboard hinzufügen möchten, und klicken Sie auf die "
+"Optionsschaltfläche neben dem Abschnittsnamen, um ein Dashboard-Element zu "
+"erstellen."
 
 #: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
 msgid "Go to report history"
-msgstr ""
+msgstr "Gehen Sie zum Berichtsverlauf"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #, python-format
@@ -1259,6 +1329,8 @@ msgid ""
 "\n"
 "    Add %(item_type)s to dashboard\n"
 msgstr ""
+"\n"
+"Fügen Sie %(item_type)s zum Dashboard hinzu\n"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #, python-format
@@ -1266,6 +1338,8 @@ msgid ""
 "Add these %(item_type)s with the selected filters to the dashboard of your "
 "choice."
 msgstr ""
+"Fügen Sie diese %(item_type)s mit den ausgewählten Filtern dem Dashboard "
+"Ihrer Wahl hinzu."
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
@@ -1276,61 +1350,73 @@ msgstr ""
 #: rocky/templates/partials/notifications_block.html
 #: rocky/templates/two_factor/core/login.html
 msgid "explanation"
-msgstr ""
+msgstr "Erläuterung"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid "You do not have a custom dashboard yet"
-msgstr ""
+msgstr "Sie haben noch kein benutzerdefiniertes Dashboard"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #, python-format
 msgid ""
-"In order to add these %(item_type)s to a dashboard, you first need to create "
-"a dashboard. Please add a dashboard in the crisis room of your organization."
+"In order to add these %(item_type)s to a dashboard, you first need to create"
+" a dashboard. Please add a dashboard in the crisis room of your "
+"organization."
 msgstr ""
+"Um diese %(item_type)s zu einem Dashboard hinzuzufügen, müssen Sie zunächst "
+"ein Dashboard erstellen. Bitte fügen Sie im Krisenraum Ihrer Organisation "
+"ein Dashboard hinzu."
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 #: rocky/templates/findings/finding_list.html
 #: rocky/templates/oois/ooi_list.html
 msgid "Add to dashboard"
-msgstr ""
+msgstr "Zum Dashboard hinzufügen"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid "Go to crisis room"
-msgstr ""
+msgstr "Gehen Sie in den Krisenraum"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid "Add report section to dashboard"
-msgstr ""
+msgstr "Berichtsabschnitt zum Dashboard hinzufügen"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid ""
-"In order to add this report section to a dashboard, you first need to create "
-"a dashboard. Please create a dashboard in the crisis room of your "
+"In order to add this report section to a dashboard, you first need to create"
+" a dashboard. Please create a dashboard in the crisis room of your "
 "organization."
 msgstr ""
+"Um diesen Berichtsabschnitt zu einem Dashboard hinzuzufügen, müssen Sie "
+"zunächst ein Dashboard erstellen. Bitte erstellen Sie ein Dashboard im "
+"Krisenraum Ihrer Organisation."
 
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid "Report must be scheduled for dashboard items"
-msgstr ""
+msgstr "Der Bericht muss für Dashboard-Elemente geplant werden"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid ""
 "In order for dashboard information to be updated on a regular basis instead "
-"of showing static data, the report should be scheduled. The frequency of the "
-"schedules recurrence determines how fresh the data on the dashboard will be."
+"of showing static data, the report should be scheduled. The frequency of the"
+" schedules recurrence determines how fresh the data on the dashboard will "
+"be."
 msgstr ""
+"Damit die Dashboard-Informationen regelmäßig aktualisiert werden, anstatt "
+"statische Daten anzuzeigen, sollte der Bericht geplant werden. Die "
+"Häufigkeit der Wiederholung der Zeitpläne bestimmt, wie aktuell die Daten im"
+" Dashboard sind."
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 msgid "Applied filters"
-msgstr ""
+msgstr "Angewandte Filter"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 msgid "Object types"
-msgstr ""
+msgstr "Objekttypen"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 #: katalogus/templates/change_clearance_level.html onboarding/forms.py
@@ -1338,16 +1424,17 @@ msgstr ""
 #: reports/templates/summary/ooi_selection.html tools/forms/boefje.py
 #: tools/forms/ooi.py rocky/templates/oois/ooi_page_tabs.html
 #: rocky/templates/partials/explanations.html
-#: rocky/templates/scan_profiles/scan_profile_detail.html rocky/views/mixins.py
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+#: rocky/views/mixins.py
 msgid "Clearance level"
-msgstr ""
+msgstr "Freigabeniveau"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 #: reports/templates/partials/report_ooi_list.html
 #: reports/templates/summary/ooi_selection.html tools/forms/ooi.py
 #: rocky/views/mixins.py
 msgid "Clearance type"
-msgstr ""
+msgstr "Freigabetyp"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 #: reports/templates/report_overview/modal_partials/delete_modal.html
@@ -1355,86 +1442,93 @@ msgstr ""
 #: reports/templates/report_overview/report_history_table.html
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Input objects"
-msgstr ""
+msgstr "Eingabeobjekte"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 msgid "Show all objects"
-msgstr ""
+msgstr "Alle Objekte anzeigen"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 #: reports/templates/partials/report_types_selection.html
 msgid "No filters applied"
-msgstr ""
+msgstr "Keine Filter angewendet"
 
 #: crisis_room/templates/partials/report_section_action_button.html
 msgid "Add section to dashboard"
-msgstr ""
+msgstr "Abschnitt zum Dashboard hinzufügen"
 
 #: katalogus/client.py
 msgid ""
 "The KATalogus has an unexpected error. Check the logs for further details."
 msgstr ""
+"Der KATalogus hat einen unerwarteten Fehler. Weitere Details finden Sie in "
+"den Protokollen."
 
 #: katalogus/client.py
 #, python-format
 msgid "An HTTP %d error occurred. Check logs for more info."
 msgstr ""
+"Es ist ein HTTP %d-Fehler aufgetreten. Weitere Informationen finden Sie in "
+"den Protokollen."
 
 #: katalogus/client.py
 msgid "An HTTP error occurred. Check logs for more info."
 msgstr ""
+"Es ist ein HTTP-Fehler aufgetreten. Weitere Informationen finden Sie in den "
+"Protokollen."
 
 #: katalogus/client.py
 msgid "Boefje with this name already exists."
-msgstr ""
+msgstr "Boefje mit diesem Namen existiert bereits."
 
 #: katalogus/client.py
 msgid "Boefje with this ID already exists."
-msgstr ""
+msgstr "Boefje mit dieser ID existiert bereits."
 
 #: katalogus/client.py
 msgid "Access to resource not allowed"
-msgstr ""
+msgstr "Zugriff auf Ressource nicht erlaubt"
 
 #: katalogus/client.py
 msgid "User is not allowed to see plugin settings"
-msgstr ""
+msgstr "Der Benutzer darf die Plugin-Einstellungen nicht sehen"
 
 #: katalogus/client.py
 msgid "User is not allowed to set plugin settings"
-msgstr ""
+msgstr "Der Benutzer darf keine Plugin-Einstellungen festlegen"
 
 #: katalogus/client.py
 msgid "User is not allowed to delete plugin settings"
-msgstr ""
+msgstr "Der Benutzer darf Plugin-Einstellungen nicht löschen"
 
 #: katalogus/client.py
 msgid "User is not allowed to view plugin settings"
-msgstr ""
+msgstr "Der Benutzer darf die Plugin-Einstellungen nicht anzeigen"
 
 #: katalogus/client.py
 msgid "User is not allowed to access the other organization"
 msgstr ""
+"Dem Benutzer ist der Zugriff auf die andere Organisation nicht gestattet"
 
 #: katalogus/client.py
 msgid "User is not allowed to enable plugins"
-msgstr ""
+msgstr "Der Benutzer darf keine Plugins aktivieren"
 
 #: katalogus/client.py
 msgid "User is not allowed to disable plugins"
-msgstr ""
+msgstr "Dem Benutzer ist es nicht gestattet, Plugins zu deaktivieren"
 
 #: katalogus/client.py
 msgid "User is not allowed to create plugins"
-msgstr ""
+msgstr "Der Benutzer darf keine Plugins erstellen"
 
 #: katalogus/client.py
 msgid "User is not allowed to edit plugins"
-msgstr ""
+msgstr "Der Benutzer darf keine Plugins bearbeiten"
 
 #: katalogus/forms/katalogus_filter.py
 msgid "Show all"
-msgstr ""
+msgstr "Alle anzeigen"
 
 #: katalogus/forms/katalogus_filter.py
 #: katalogus/templates/partials/enable_disable_plugin.html
@@ -1443,7 +1537,7 @@ msgstr ""
 #: reports/report_types/dns_report/report.html
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Enabled"
-msgstr ""
+msgstr "Ermöglicht"
 
 #: katalogus/forms/katalogus_filter.py
 #: katalogus/templates/partials/enable_disable_plugin.html
@@ -1452,39 +1546,42 @@ msgstr ""
 #: reports/templates/report_overview/scheduled_reports_table.html
 #: reports/templates/summary/selected_plugins.html
 msgid "Disabled"
-msgstr ""
+msgstr "Deaktiviert"
 
 #: katalogus/forms/katalogus_filter.py
 msgid "Enabled-Disabled"
-msgstr ""
+msgstr "Aktiviert-Deaktiviert"
 
 #: katalogus/forms/katalogus_filter.py
 msgid "Disabled-Enabled"
-msgstr ""
+msgstr "Deaktiviert-Aktiviert"
 
 #: katalogus/forms/katalogus_filter.py
 msgid "Filter options"
-msgstr ""
+msgstr "Filteroptionen"
 
 #: katalogus/forms/katalogus_filter.py
 msgid "Sorting options"
-msgstr ""
+msgstr "Sortiermöglichkeiten"
 
 #: katalogus/forms/plugin_settings.py
 msgid "This field is required."
-msgstr ""
+msgstr "Dieses Feld ist erforderlich."
 
 #: katalogus/templates/about_plugins.html
 #: katalogus/templates/partials/plugins_navigation.html
 msgid "About plugins"
-msgstr ""
+msgstr "Über Plugins"
 
 #: katalogus/templates/about_plugins.html katalogus/templates/katalogus.html
 msgid ""
-"Plugins gather data, objects and insight. Each plugin has its own focus area "
-"and strengths and may be able to work with other plugins to gain even more "
+"Plugins gather data, objects and insight. Each plugin has its own focus area"
+" and strengths and may be able to work with other plugins to gain even more "
 "insights."
 msgstr ""
+"Plugins sammeln Daten, Objekte und Erkenntnisse. Jedes Plugin hat seinen "
+"eigenen Schwerpunkt und seine eigenen Stärken und kann möglicherweise mit "
+"anderen Plugins zusammenarbeiten, um noch mehr Erkenntnisse zu gewinnen."
 
 #: katalogus/templates/about_plugins.html katalogus/templates/boefjes.html
 msgid ""
@@ -1492,62 +1589,71 @@ msgid ""
 "issues, and give insight. Each boefje is a separate scan that can run on a "
 "selection of objects."
 msgstr ""
+"Boefjes werden zum Scannen nach Objekten verwendet. Sie erkennen "
+"Schwachstellen und Sicherheitsprobleme und geben Einblicke. Bei jedem Boefje"
+" handelt es sich um einen separaten Scan, der für eine Auswahl von Objekten "
+"ausgeführt werden kann."
 
 #: katalogus/templates/about_plugins.html katalogus/templates/normalizers.html
 msgid ""
 "Normalizers analyze the information and turn it into objects for the data "
 "model in Octopoes."
 msgstr ""
+"Normalizers analysiert die Informationen und wandelt sie in Objekte für das "
+"Datenmodell in Octopoes um."
 
 #: katalogus/templates/about_plugins.html
 msgid ""
-"Bits are business rules that look for insight within the current dataset and "
-"search for specific insight and draw conclusions."
+"Bits are business rules that look for insight within the current dataset and"
+" search for specific insight and draw conclusions."
 msgstr ""
+"Bits sind Geschäftsregeln, die nach Erkenntnissen innerhalb des aktuellen "
+"Datensatzes suchen und nach bestimmten Erkenntnissen suchen und "
+"Schlussfolgerungen ziehen."
 
 #: katalogus/templates/boefje_detail.html
 #: katalogus/templates/partials/plugin_tile_modal.html
 #: katalogus/templates/plugin_container_image.html
 msgid "Scan level"
-msgstr ""
+msgstr "Scanebene"
 
 #: katalogus/templates/boefje_detail.html
 #: katalogus/templates/normalizer_detail.html
 msgid "Consumes"
-msgstr ""
+msgstr "Verbraucht"
 
 #: katalogus/templates/boefje_detail.html
 #, python-format
 msgid "%(plugin_name)s is able to scan the following object types:"
-msgstr ""
+msgstr "%(plugin_name)s kann die folgenden Objekttypen scannen:"
 
 #: katalogus/templates/boefje_detail.html
 #: katalogus/templates/normalizer_detail.html
 #, python-format
 msgid "%(plugin_name)s does not need any input objects."
-msgstr ""
+msgstr "%(plugin_name)s benötigt keine Eingabeobjekte."
 
 #: katalogus/templates/boefje_detail.html
 #: katalogus/templates/normalizer_detail.html
 #: katalogus/templates/partials/plugin_tile_modal.html
 msgid "Produces"
-msgstr ""
+msgstr "Produziert"
 
 #: katalogus/templates/boefje_detail.html
 #: katalogus/templates/normalizer_detail.html
 #: katalogus/templates/partials/plugin_tile_modal.html
 #, python-format
 msgid "%(plugin_name)s can produce the following output:"
-msgstr ""
+msgstr "%(plugin_name)s kann die folgende Ausgabe erzeugen:"
 
 #: katalogus/templates/boefje_detail.html
 #, python-format
 msgid "%(plugin_name)s doesn't produce any output mime types."
-msgstr ""
+msgstr "%(plugin_name)s erzeugt keine Ausgabe-MIME-Typen."
 
 #: katalogus/templates/boefje_setup.html
 msgid "Boefje variant setup"
-msgstr ""
+msgstr "Boefje-Varianten-Setup"
 
 #: katalogus/templates/boefje_setup.html
 #: rocky/templates/organizations/organization_member_list.html
@@ -1558,54 +1664,58 @@ msgstr "Bearbeiten"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Boefje setup"
-msgstr ""
+msgstr "Boefje-Setup"
 
 #: katalogus/templates/boefje_setup.html
 msgid ""
 "You can create a new Boefje. If you want more information on this, you can "
-"check out the <a href=\"https://docs.openkat.nl/developer_documentation/"
-"development_tutorial/creating_a_boefje.html\">documentation</a>."
+"check out the <a "
+"href=\"https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html\">documentation</a>."
 msgstr ""
+"Sie können ein neues Boefje erstellen. Wenn Sie weitere Informationen hierzu"
+" wünschen, können Sie sich die Dokumentation <a "
+"href=\"https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html\"></a>"
+" ansehen."
 
 #: katalogus/templates/boefje_setup.html
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 msgid "Save changes"
-msgstr ""
+msgstr "Änderungen speichern"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Discard changes"
-msgstr ""
+msgstr "Änderungen verwerfen"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Create variant"
-msgstr ""
+msgstr "Variante erstellen"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Discard variant"
-msgstr ""
+msgstr "Variante verwerfen"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Create new Boefje"
-msgstr ""
+msgstr "Erstellen Sie ein neues Boefje"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Discard new Boefje"
-msgstr ""
+msgstr "Entsorgen Sie das neue Boefje"
 
 #: katalogus/templates/boefjes.html
 msgid "Add Boefje"
-msgstr ""
+msgstr "Fügen Sie Boefje hinzu"
 
 #: katalogus/templates/boefjes.html katalogus/templates/katalogus.html
 #: katalogus/templates/normalizers.html
 msgid "available"
-msgstr ""
+msgstr "verfügbar"
 
 #: katalogus/templates/change_clearance_level.html
 #: katalogus/templates/partials/objects_to_scan.html
 #: reports/templates/partials/report_setup_scan.html
 msgid "scan level warning"
-msgstr ""
+msgstr "Scan-Level-Warnung"
 
 #: katalogus/templates/change_clearance_level.html
 #, python-format
@@ -1613,10 +1723,12 @@ msgid ""
 "%(plugin_name)s will only scan objects with a corresponding clearance level "
 "of <strong>L%(scan_level)s</strong> or higher."
 msgstr ""
+"%(plugin_name)s scannt nur Objekte mit einer entsprechenden Freigabestufe "
+"von <strong>L%(scan_level)s</strong> oder höher."
 
 #: katalogus/templates/change_clearance_level.html
 msgid "Scan object"
-msgstr ""
+msgstr "Objekt scannen"
 
 #: katalogus/templates/change_clearance_level.html
 #, python-format
@@ -1625,115 +1737,126 @@ msgid ""
 "be advised that by continuing you will declare a level %(scan_level)s on "
 "these objects."
 msgstr ""
+"Die folgenden Objekte sind für die Stufe %(scan_level)s noch nicht "
+"freigegeben. Bitte beachten Sie, dass Sie durch Fortfahren eine Stufe "
+"%(scan_level)s für diese Objekte deklarieren."
 
 #: katalogus/templates/change_clearance_level.html
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/summary/report_asset_overview.html
 msgid "Selected objects"
-msgstr ""
+msgstr "Ausgewählte Objekte"
 
 #: katalogus/templates/change_clearance_level.html
 #: reports/templates/report_overview/report_history_table.html
 #: reports/templates/summary/ooi_selection.html rocky/views/mixins.py
 msgid "Object"
-msgstr ""
+msgstr "Objekt"
 
 #: katalogus/templates/change_clearance_level.html
 msgid "Are you sure you want to scan anyways?"
-msgstr ""
+msgstr "Sind Sie sicher, dass Sie trotzdem scannen möchten?"
 
 #: katalogus/templates/change_clearance_level.html
 #: rocky/templates/oois/ooi_detail.html
 msgid "Scan"
-msgstr ""
+msgstr "Scan"
 
 #: katalogus/templates/clone_settings.html
 #: katalogus/templates/confirmation_clone_settings.html
 msgid "Clone settings"
-msgstr ""
+msgstr "Kloneinstellungen"
 
 #: katalogus/templates/clone_settings.html
 #, python-format
 msgid ""
 "Use the form below to clone the settings from "
-"<strong>%(current_organization)s</strong> to the selected organization. This "
-"includes both the KAT-alogus settings as well as enabled and disabled "
+"<strong>%(current_organization)s</strong> to the selected organization. This"
+" includes both the KAT-alogus settings as well as enabled and disabled "
 "plugins."
 msgstr ""
+"Verwenden Sie das folgende Formular, um die Einstellungen von "
+"<strong>%(current_organization)s</strong> in die ausgewählte Organisation zu"
+" klonen. Dies umfasst sowohl die KAT-alogus-Einstellungen als auch "
+"aktivierte und deaktivierte Plugins."
 
 #: katalogus/templates/confirmation_clone_settings.html
 msgid "Clone"
-msgstr ""
+msgstr "Klon"
 
 #: katalogus/templates/katalogus.html
 msgid "All plugins"
-msgstr ""
+msgstr "Alle Plugins"
 
 #: katalogus/templates/katalogus_settings.html
 msgid "KAT-alogus settings"
-msgstr ""
+msgstr "KAT-Alogus-Einstellungen"
 
 #: katalogus/templates/katalogus_settings.html
 msgid ""
 "There are currently no settings defined. Add settings at the plugin detail "
 "page."
 msgstr ""
+"Derzeit sind keine Einstellungen definiert. Fügen Sie Einstellungen auf der "
+"Plugin-Detailseite hinzu."
 
 #: katalogus/templates/katalogus_settings.html
 #: rocky/templates/two_factor/core/otp_required.html
 msgid "Go back"
-msgstr ""
+msgstr "Geh zurück"
 
 #: katalogus/templates/katalogus_settings.html
 msgid "This is an overview of the latest settings of all plugins."
 msgstr ""
+"Dies ist eine Übersicht über die neuesten Einstellungen aller Plugins."
 
 #: katalogus/templates/katalogus_settings.html
 msgid "Latest plugin settings"
-msgstr ""
+msgstr "Neueste Plugin-Einstellungen"
 
 #: katalogus/templates/katalogus_settings.html
 #: rocky/templates/tasks/ooi_detail_task_list.html
 msgid "Plugin"
-msgstr ""
+msgstr "Plugin"
 
 #: katalogus/templates/katalogus_settings.html
 #: katalogus/templates/plugin_settings_list.html
 #: rocky/templates/oois/ooi_delete.html
 msgid "Value"
-msgstr ""
+msgstr "Wert"
 
 #: katalogus/templates/normalizer_detail.html
 #, python-format
 msgid "%(plugin_name)s is able to process the following mime types:"
 msgstr ""
+"%(plugin_name)s ist in der Lage, die folgenden Mime-Typen zu verarbeiten:"
 
 #: katalogus/templates/partials/boefje_tile.html
 msgid "This object type is required"
-msgstr ""
+msgstr "Dieser Objekttyp ist erforderlich"
 
 #: katalogus/templates/partials/boefje_tile.html
 msgid "Scan level:"
-msgstr ""
+msgstr "Scanebene:"
 
 #: katalogus/templates/partials/boefje_tile.html
 msgid "Publisher:"
-msgstr ""
+msgstr "Herausgeber:"
 
 #: katalogus/templates/partials/boefje_tile.html
 #: katalogus/templates/partials/plugin_tile.html
 #: katalogus/templates/partials/plugin_tile_modal.html
 msgid "See details"
-msgstr ""
+msgstr "Siehe Details"
 
 #: katalogus/templates/partials/enable_disable_plugin.html
 msgid "Enable"
-msgstr ""
+msgstr "Aktivieren"
 
 #: katalogus/templates/partials/enable_disable_plugin.html
 #: rocky/templates/two_factor/profile/disable.html
 msgid "Disable"
-msgstr ""
+msgstr "Deaktivieren"
 
 #: katalogus/templates/partials/katalogus_filter.html
 #: rocky/templates/findings/findings_filter.html
@@ -1741,7 +1864,7 @@ msgstr ""
 #: rocky/templates/partials/organization_member_list_filters.html
 #: rocky/templates/tasks/partials/task_filter.html
 msgid "Hide filters"
-msgstr ""
+msgstr "Filter ausblenden"
 
 #: katalogus/templates/partials/katalogus_filter.html
 #: rocky/templates/findings/findings_filter.html
@@ -1749,7 +1872,7 @@ msgstr ""
 #: rocky/templates/partials/organization_member_list_filters.html
 #: rocky/templates/tasks/partials/task_filter.html
 msgid "Show filters"
-msgstr ""
+msgstr "Filter anzeigen"
 
 #: katalogus/templates/partials/katalogus_filter.html
 #: rocky/templates/findings/findings_filter.html
@@ -1757,29 +1880,29 @@ msgstr ""
 #: rocky/templates/partials/organization_member_list_filters.html
 #: rocky/templates/tasks/partials/task_filter.html
 msgid "applied"
-msgstr ""
+msgstr "angewandt"
 
 #: katalogus/templates/partials/katalogus_filter.html
 msgid "Filter plugins"
-msgstr ""
+msgstr "Filter-Plugins"
 
 #: katalogus/templates/partials/katalogus_filter.html
 msgid "Clear filter"
-msgstr ""
+msgstr "Filter löschen"
 
 #: katalogus/templates/partials/katalogus_header.html
 #: katalogus/views/change_clearance_level.py katalogus/views/katalogus.py
 #: katalogus/views/katalogus_settings.py katalogus/views/plugin_detail.py
 #: katalogus/views/plugin_settings_add.py
 #: katalogus/views/plugin_settings_delete.py
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
-#: rocky/templates/header.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
 msgid "KAT-alogus"
-msgstr ""
+msgstr "KAT-alogus"
 
 #: katalogus/templates/partials/katalogus_header.html
 msgid "An overview of all available plugins."
-msgstr ""
+msgstr "Eine Übersicht aller verfügbaren Plugins."
 
 #: katalogus/templates/partials/katalogus_header.html
 #: katalogus/templates/plugin_settings_list.html
@@ -1800,23 +1923,23 @@ msgstr "Tabellenansicht"
 
 #: katalogus/templates/partials/modal_report_types.html
 msgid "Required for"
-msgstr ""
+msgstr "Erforderlich für"
 
 #: katalogus/templates/partials/modal_report_types.html
 msgid "report types"
-msgstr ""
+msgstr "Berichtstypen"
 
 #: katalogus/templates/partials/modal_report_types.html
 msgid "Report types for "
-msgstr ""
+msgstr "Berichtstypen für"
 
 #: katalogus/templates/partials/no_enabling_permission_message.html
 msgid "No permission to enable/disable plugins"
-msgstr ""
+msgstr "Keine Berechtigung zum Aktivieren/Deaktivieren von Plugins"
 
 #: katalogus/templates/partials/no_enabling_permission_message.html
 msgid "Contact your administrator to request permission."
-msgstr ""
+msgstr "Wenden Sie sich an Ihren Administrator, um die Erlaubnis anzufordern."
 
 #: katalogus/templates/partials/objects_to_scan.html
 #, python-format
@@ -1827,10 +1950,15 @@ msgid ""
 "<strong>L%(scan_level)s</strong>. Use the filter to show OOI's with a lower "
 "clearance level."
 msgstr ""
+"Dieser Boefje scannt nur Objekte mit einer entsprechenden Freigabestufe von "
+"<strong>L%(scan_level)s</strong> oder höher. Es gibt keine Entschädigung für"
+" diesen Boefje zum Scannen eines OOI mit einer niedrigeren Freigabestufe als"
+" <strong>L%(scan_level)s</strong>. Verwenden Sie den Filter, um OOIs mit "
+"einem niedrigeren Freigabeniveau anzuzeigen."
 
 #: katalogus/templates/partials/objects_to_scan.html
 msgid "Warning scan level:"
-msgstr ""
+msgstr "Warnungs-Scan-Stufe:"
 
 #: katalogus/templates/partials/objects_to_scan.html
 msgid ""
@@ -1839,6 +1967,11 @@ msgid ""
 "now on out, until it manually gets set to something else again. This means "
 "that all other enabled Boefjes will use this higher clearance level aswel."
 msgstr ""
+"Das Scannen von OOIs mit einer niedrigeren Freigabestufe führt dazu, dass "
+"OpenKAT die Freigabestufe für diesen OOI erhöht, nicht nur für diesen Scan, "
+"sondern von nun an, bis er manuell wieder auf etwas anderes eingestellt "
+"wird. Dies bedeutet, dass alle anderen aktivierten Boefjes ebenfalls diese "
+"höhere Freigabestufe verwenden."
 
 #: katalogus/templates/partials/objects_to_scan.html
 #, python-format
@@ -1847,6 +1980,9 @@ msgid ""
 "Add objects with a complying clearance level, or alter the clearance level "
 "of existing objects."
 msgstr ""
+"Sie verfügen derzeit über keine Objekte, die der Scanstufe %(name)s "
+"entsprechen. Fügen Sie Objekte mit einer entsprechenden Freigabestufe hinzu "
+"oder ändern Sie die Freigabestufe vorhandener Objekte."
 
 #: katalogus/templates/partials/objects_to_scan.html
 #, python-format
@@ -1877,20 +2013,20 @@ msgstr "Erforderlich für:"
 
 #: katalogus/templates/partials/plugin_tile_modal.html
 msgid "Boefje details"
-msgstr ""
+msgstr "Boefje-Details"
 
 #: katalogus/templates/partials/plugin_tile_modal.html reports/forms.py
 #: reports/templates/report_overview/report_history_table.html
 msgid "Report types"
-msgstr ""
+msgstr "Berichtstypen"
 
 #: katalogus/templates/partials/plugin_tile_modal.html
 msgid "This boefje is required by the following report types."
-msgstr ""
+msgstr "Dieses Protokoll ist für die folgenden Berichtstypen erforderlich."
 
 #: katalogus/templates/partials/plugin_tile_modal.html
 msgid "Go to boefje detail page"
-msgstr ""
+msgstr "Gehen Sie zur Boefje-Detailseite"
 
 #: katalogus/templates/partials/plugins.html
 msgid "Plugins overview:"
@@ -1921,7 +2057,7 @@ msgstr "Aktionen"
 
 #: katalogus/templates/partials/plugins.html
 msgid "Detail page"
-msgstr ""
+msgstr "Detailseite"
 
 #: katalogus/templates/partials/plugins_navigation.html
 #: reports/templates/report_overview/report_overview_navigation.html
@@ -1947,43 +2083,47 @@ msgstr "Alle"
 
 #: katalogus/templates/plugin_container_image.html tools/forms/boefje.py
 msgid "Container image"
-msgstr ""
+msgstr "Containerbild"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "The container image for this Boefje is:"
-msgstr ""
+msgstr "Das Container-Image für diesen Boefje ist:"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Variants"
-msgstr ""
+msgstr "Varianten"
 
 #: katalogus/templates/plugin_container_image.html
 msgid ""
 "Boefje variants that use the same container image. For more information "
 "about Boefje variants you can read the documentation."
 msgstr ""
+"Boefje-Varianten, die dasselbe Container-Image verwenden. Weitere "
+"Informationen zu Boefje-Varianten finden Sie in der Dokumentation."
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Add variant"
-msgstr ""
+msgstr "Variante hinzufügen"
 
 #: katalogus/templates/plugin_container_image.html
 #: rocky/templates/partials/notifications_block.html
 msgid "confirmation"
-msgstr ""
+msgstr "Bestätigung"
 
 #: katalogus/templates/plugin_container_image.html
 #, python-format
 msgid "Variant %(plugin.name)s created."
-msgstr ""
+msgstr "Variante %(plugin.name)s erstellt."
 
 #: katalogus/templates/plugin_container_image.html
 msgid "The Boefje variant is successfully created and can now be used."
 msgstr ""
+"Die Variante Boefje wurde erfolgreich erstellt und kann nun verwendet "
+"werden."
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Overview of variants"
-msgstr ""
+msgstr "Übersicht der Varianten"
 
 #: katalogus/templates/plugin_container_image.html
 #: reports/report_types/tls_report/report.html
@@ -1994,36 +2134,36 @@ msgstr ""
 #: rocky/templates/tasks/plugin_detail_task_list.html
 #: rocky/templates/tasks/reports.html
 msgid "Status"
-msgstr ""
+msgstr "Status"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Age"
-msgstr ""
+msgstr "Alter"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Scan interval"
-msgstr ""
+msgstr "Scanintervall"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Run on"
-msgstr ""
+msgstr "Lauf weiter"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "current"
-msgstr ""
+msgstr "aktuell"
 
 #: katalogus/templates/plugin_container_image.html
 #: reports/report_types/dns_report/report.html
 msgid "minutes"
-msgstr ""
+msgstr "Minuten"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Default system scan frequency"
-msgstr ""
+msgstr "Standardmäßige System-Scan-Häufigkeit"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Boefje ID"
-msgstr ""
+msgstr "Boefje-ID"
 
 #: katalogus/templates/plugin_container_image.html
 #: reports/templates/report_overview/modal_partials/delete_modal.html
@@ -2032,51 +2172,53 @@ msgstr ""
 #: reports/templates/report_overview/subreports_table.html
 #: rocky/templates/tasks/reports.html
 msgid "Creation date"
-msgstr ""
+msgstr "Erstellungsdatum"
 
 #: katalogus/templates/plugin_container_image.html tools/forms/boefje.py
 msgid "Arguments"
-msgstr ""
+msgstr "Argumente"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "The following arguments are used for this Boefje variant:"
-msgstr ""
+msgstr "Für diese Boefje-Variante werden folgende Argumente verwendet:"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "There are no arguments used for this Boefje variant."
-msgstr ""
+msgstr "Für diese Boefje-Variante werden keine Argumente verwendet."
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Edit variant"
-msgstr ""
+msgstr "Variante bearbeiten"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "This Boefje has no variants yet."
-msgstr ""
+msgstr "Für diesen Boefje gibt es noch keine Varianten."
 
 #: katalogus/templates/plugin_container_image.html
 msgid ""
-"You can make a variant and change the arguments and JSON Schema to customize "
-"it to fit your needs."
+"You can make a variant and change the arguments and JSON Schema to customize"
+" it to fit your needs."
 msgstr ""
+"Sie können eine Variante erstellen und die Argumente sowie das JSON-Schema "
+"ändern, um es an Ihre Bedürfnisse anzupassen."
 
 #: katalogus/templates/plugin_settings_add.html
 msgid "Add setting"
 msgid_plural "Add settings"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Einstellungen hinzufügen"
+msgstr[1] "Einstellungen hinzufügen"
 
 #: katalogus/templates/plugin_settings_add.html
 msgid "Setting"
 msgid_plural "Settings"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Einstellungen"
+msgstr[1] "Einstellungen"
 
 #: katalogus/templates/plugin_settings_add.html
 msgid "Add setting and enable boefje"
 msgid_plural "Add settings and enable boefje"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Fügen Sie Einstellungen hinzu und aktivieren Sie Boefje"
+msgstr[1] "Fügen Sie Einstellungen hinzu und aktivieren Sie Boefje"
 
 #: katalogus/templates/plugin_settings_delete.html
 msgid "Delete settings"
@@ -2092,13 +2234,16 @@ msgstr ""
 
 #: katalogus/templates/plugin_settings_list.html
 msgid ""
-"In the table below the settings for this specific Boefje can be seen. Set or "
-"change the value of the variables by editing the settings."
+"In the table below the settings for this specific Boefje can be seen. Set or"
+" change the value of the variables by editing the settings."
 msgstr ""
+"In der Tabelle unten sind die Einstellungen für diesen speziellen Boefje zu "
+"sehen. Legen Sie den Wert der Variablen fest oder ändern Sie ihn, indem Sie "
+"die Einstellungen bearbeiten."
 
 #: katalogus/templates/plugin_settings_list.html
 msgid "Configure Settings"
-msgstr ""
+msgstr "Konfigurieren Sie die Einstellungen"
 
 #: katalogus/templates/plugin_settings_list.html
 msgid "Overview of settings"
@@ -2106,7 +2251,7 @@ msgstr "Übersicht der Einstellungen"
 
 #: katalogus/templates/plugin_settings_list.html
 msgid "Variable"
-msgstr ""
+msgstr "Variable"
 
 #: katalogus/views/change_clearance_level.py
 msgid "Session has terminated, please select objects again."
@@ -2143,118 +2288,139 @@ msgstr ""
 
 #: katalogus/views/plugin_enable_disable.py
 msgid "{} '{}' disabled."
-msgstr ""
+msgstr "{} '{}' deaktiviert."
 
 #: katalogus/views/plugin_enable_disable.py
 msgid "{} '{}' enabled."
-msgstr ""
+msgstr "{} '{}' ermöglicht."
 
 #: katalogus/views/plugin_enable_disable.py
 msgid ""
 "You have not acknowledged your clearance level. Go to your profile page to "
 "acknowledge your clearance level."
 msgstr ""
+"Sie haben Ihre Freigabestufe nicht bestätigt. Gehen Sie zu Ihrer "
+"Profilseite, um Ihre Freigabestufe zu bestätigen."
 
 #: katalogus/views/plugin_enable_disable.py
 msgid ""
 "Your clearance level is not set. Go to your profile page to see your "
 "clearance or contact the administrator to set a clearance level."
 msgstr ""
+"Ihre Freigabestufe ist nicht festgelegt. Gehen Sie zu Ihrer Profilseite, um "
+"Ihre Freigabe anzuzeigen, oder wenden Sie sich an den Administrator, um eine"
+" Freigabestufe festzulegen."
 
 #: katalogus/views/plugin_enable_disable.py
 msgid ""
 "Your clearance level is L{}. Contact your administrator to get a higher "
 "clearance level."
 msgstr ""
+"Ihr Freigabelevel ist L{}. Wenden Sie sich an Ihren Administrator, um eine "
+"höhere Freigabestufe zu erhalten."
 
 #: katalogus/views/plugin_enable_disable.py
 msgid "To enable {} you need at least a clearance level of L{}. "
-msgstr ""
+msgstr "Um {} zu aktivieren, benötigen Sie mindestens die Freigabestufe L{}."
 
 #: katalogus/views/plugin_settings_add.py
 msgid "Trying to add settings to boefje without schema"
-msgstr ""
+msgstr "Ich versuche, Einstellungen ohne Schema zu boefje hinzuzufügen"
 
 #: katalogus/views/plugin_settings_add.py
 msgid "No changes to the settings added: no form data present"
 msgstr ""
+"Keine Änderungen an den Einstellungen hinzugefügt: keine Formulardaten "
+"vorhanden"
 
 #: katalogus/views/plugin_settings_add.py
 msgid "Added settings for '{}'"
-msgstr ""
+msgstr "Einstellungen für „{}“ hinzugefügt"
 
 #: katalogus/views/plugin_settings_add.py
 msgid "Failed adding settings"
-msgstr ""
+msgstr "Das Hinzufügen der Einstellungen ist fehlgeschlagen"
 
 #: katalogus/views/plugin_settings_add.py
 msgid "Enabling {} failed"
-msgstr ""
+msgstr "Die Aktivierung von {} ist fehlgeschlagen"
 
 #: katalogus/views/plugin_settings_add.py
 msgid "Boefje '{}' enabled."
-msgstr ""
+msgstr "Boefje '{}' aktiviert."
 
 #: katalogus/views/plugin_settings_add.py
 msgid "Add settings"
-msgstr ""
+msgstr "Einstellungen hinzufügen"
 
 #: katalogus/views/plugin_settings_delete.py
 msgid "Settings for plugin {} successfully deleted."
-msgstr ""
+msgstr "Einstellungen für Plugin {} erfolgreich gelöscht."
 
 #: katalogus/views/plugin_settings_delete.py
 msgid "Plugin {} has no settings."
-msgstr ""
+msgstr "Plugin {} hat keine Einstellungen."
 
 #: katalogus/views/plugin_settings_delete.py
 msgid ""
 "Failed deleting Settings for plugin {}. Check the Katalogus logs for more "
 "info."
 msgstr ""
+"Die Einstellungen für das Plugin {} konnten nicht gelöscht werden. Weitere "
+"Informationen finden Sie in den Katalogus-Protokollen."
 
 #: onboarding/forms.py
 msgid ""
 "The clearance level determines how aggressive the object can be scanned by "
 "plugins. A higher clearance level means more aggressive scans are allowed."
 msgstr ""
+"Die Freigabestufe bestimmt, wie aggressiv das Objekt von Plugins gescannt "
+"werden kann. Eine höhere Freigabestufe bedeutet, dass aggressivere Scans "
+"zulässig sind."
 
 #: onboarding/forms.py tools/forms/ooi.py
 msgid "explanation-clearance-level"
-msgstr ""
+msgstr "Erklärung-Freigabe-Ebene"
 
 #: onboarding/forms.py
 msgid "Please enter a valid URL starting with 'http://' or 'https://'."
 msgstr ""
+"Bitte geben Sie ein gültiges URL ein, beginnend mit „http://“ oder "
+"„https://“."
 
 #: onboarding/templates/partials/onboarding_header.html
 msgid "Onboarding"
-msgstr ""
+msgstr "Onboarding"
 
 #: onboarding/templates/partials/step_1_introduction_text.html
 msgid "Welcome to OpenKAT!"
-msgstr ""
+msgstr "Willkommen bei OpenKAT!"
 
 #: onboarding/templates/partials/step_1_introduction_text.html
 msgid ""
-"Welcome to the onboarding of OpenKAT. We will walk you through some steps to "
-"set everything up."
+"Welcome to the onboarding of OpenKAT. We will walk you through some steps to"
+" set everything up."
 msgstr ""
+"Willkommen beim Onboarding von OpenKAT. Wir führen Sie durch einige "
+"Schritte, um alles einzurichten."
 
 #: onboarding/templates/partials/step_1_introduction_text.html
 msgid ""
-"At the end of this onboarding you have added your first object, created your "
-"first DNS report and learned about some basic concepts used within OpenKAT."
+"At the end of this onboarding you have added your first object, created your"
+" first DNS report and learned about some basic concepts used within OpenKAT."
 msgstr ""
+"Am Ende dieses Onboardings haben Sie Ihr erstes Objekt hinzugefügt, Ihren "
+"ersten DNS-Bericht erstellt und einige grundlegende Konzepte kennengelernt, "
+"die in OpenKAT verwendet werden."
 
 #: onboarding/templates/partials/step_1_introduction_text.html
 msgid "The full documentation for OpenKAT can be found at:"
-msgstr ""
+msgstr "Die vollständige Dokumentation für OpenKAT finden Sie unter:"
 
 #: onboarding/templates/partials/step_2_organization_text.html
 #: rocky/templates/organizations/organization_add.html
 msgid "Organization setup"
-msgstr ""
+msgstr "Organisationsaufbau"
 
 #: onboarding/templates/partials/step_2_organization_text.html
 msgid ""
@@ -2262,36 +2428,43 @@ msgid ""
 "be changed later in the interface. The organization code cannot be changed "
 "as this is used by the database."
 msgstr ""
+"Bitte geben Sie die folgenden Organisationsdaten ein. Der Organisationsname "
+"kann später in der Benutzeroberfläche geändert werden. Der Organisationscode"
+" kann nicht geändert werden, da dieser von der Datenbank verwendet wird."
 
 #: onboarding/templates/step_10_report.html
 #: reports/report_types/concatenated_report/report.py
 msgid "Report"
-msgstr ""
+msgstr "Bericht"
 
 #: onboarding/templates/step_10_report.html
 msgid "Boefjes are scanning"
-msgstr ""
+msgstr "Boefjes scannt"
 
 #: onboarding/templates/step_10_report.html
 msgid ""
 "The enabled Boefjes are running in the background to gather the data for "
 "your DNS Report. This may take a few minutes."
 msgstr ""
+"Die aktivierten Boefjes werden im Hintergrund ausgeführt, um die Daten für "
+"Ihren DNS-Bericht zu sammeln. Dies kann einige Minuten dauern."
 
 #: onboarding/templates/step_10_report.html
 msgid ""
 "In the meantime you can explore OpenKAT and view your DNS Report on the "
 "Reports page once it has been generated."
 msgstr ""
+"In der Zwischenzeit können Sie OpenKAT erkunden und Ihren DNS-Bericht auf "
+"der Seite „Berichte“ anzeigen, sobald er erstellt wurde."
 
 #: onboarding/templates/step_10_report.html
 msgid "Continue to OpenKAT"
-msgstr ""
+msgstr "Weiter zu OpenKAT"
 
 #: onboarding/templates/step_1_introduction_registration.html
 #: onboarding/templates/step_1a_introduction.html
 msgid "Let's get started"
-msgstr ""
+msgstr "Fangen wir an"
 
 #: onboarding/templates/step_2a_organization_setup.html
 #: onboarding/templates/step_2b_organization_update.html
@@ -2299,7 +2472,7 @@ msgstr ""
 #: rocky/templates/organizations/organization_settings.html
 #: rocky/templates/partials/organization_properties_table.html
 msgid "Organization details"
-msgstr ""
+msgstr "Details zur Organisation"
 
 #: onboarding/templates/step_2a_organization_setup.html
 #: rocky/templates/forms/json_schema_form.html
@@ -2311,54 +2484,65 @@ msgstr ""
 #: rocky/templates/partials/form/indemnification_add_form.html
 #: rocky/templates/two_factor/_wizard_actions.html
 msgid "Submit"
-msgstr ""
+msgstr "Einreichen"
 
 #: onboarding/templates/step_2b_organization_update.html
 msgid "Submit changes"
-msgstr ""
+msgstr "Änderungen einreichen"
 
 #: onboarding/templates/step_2b_organization_update.html
 #: onboarding/templates/step_3_indemnification_setup.html
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 #: onboarding/templates/step_7_clearance_level_introduction.html
 msgid "Continue"
-msgstr ""
+msgstr "Weitermachen"
 
 #: onboarding/templates/step_3_indemnification_setup.html
 msgid "Indemnification setup"
-msgstr ""
+msgstr "Entschädigungseinrichtung"
 
 #: onboarding/templates/step_3_indemnification_setup.html
 msgid "Indemnification on the organization is already present."
-msgstr ""
+msgstr "Eine Entschädigung der Organisation liegt bereits vor."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 msgid "User clearance level"
-msgstr ""
+msgstr "Benutzerfreigabestufe"
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 msgid ""
-"The user clearance level specifies the maximum scan level for security scans "
-"and the maximum clearance level you can assign to objects (e.g. a URL)."
+"The user clearance level specifies the maximum scan level for security scans"
+" and the maximum clearance level you can assign to objects (e.g. a URL)."
 msgstr ""
+"Die Benutzerfreigabestufe gibt die maximale Scanstufe für Sicherheitsscans "
+"und die maximale Freigabestufe an, die Sie Objekten zuweisen können (z. B. "
+"ein URL)."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 msgid ""
 "The administrator assigns a maximum user clearance level to each user. This "
 "will make sure that only trusted users can start more aggressive scans."
 msgstr ""
+"Der Administrator weist jedem Benutzer eine maximale Benutzerfreigabestufe "
+"zu. Dadurch wird sichergestellt, dass nur vertrauenswürdige Benutzer "
+"aggressivere Scans starten können."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 msgid ""
 "A user must accept a clearance level, before they perform actions in "
 "OpenKAT. Here you may accept the maximum trusted clearance level, as "
-"assigned by your administrator. On your user settings page you can choose to "
-"lower your accepted clearance level after completing the onboarding."
+"assigned by your administrator. On your user settings page you can choose to"
+" lower your accepted clearance level after completing the onboarding."
 msgstr ""
+"Ein Benutzer muss eine Freigabestufe akzeptieren, bevor er Aktionen in "
+"OpenKAT ausführen kann. Hier können Sie die von Ihrem Administrator "
+"zugewiesene maximale vertrauenswürdige Freigabestufe akzeptieren. Auf Ihrer "
+"Benutzereinstellungsseite können Sie nach Abschluss des Onboardings Ihre "
+"akzeptierte Freigabestufe senken."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 msgid "What is my clearance level?"
-msgstr ""
+msgstr "Wie hoch ist mein Freigabelevel?"
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 #, python-format
@@ -2370,6 +2554,12 @@ msgid ""
 "<strong>%(ooi)s</strong> </br> Contact your administrator to receive a "
 "higher clearance."
 msgstr ""
+"Leider können Sie das Onboarding nicht fortsetzen. </br> Ihr Administrator "
+"hat Ihnen die Freigabestufe <strong>L%(tcl)s</strong> anvertraut. </br> Zum "
+"Scannen benötigen Sie mindestens die Freigabestufe "
+"<strong>L%(dns_report_least_clearance_level)s</strong>. "
+"<strong>%(ooi)s</strong> </br> Wenden Sie sich an Ihren Administrator, um "
+"eine höhere Freigabe zu erhalten."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 #: onboarding/templates/step_5_add_scan_ooi.html
@@ -2388,6 +2578,9 @@ msgid ""
 "<strong>L%(tcl)s</strong>. </br> You must first accept this clearance level "
 "to continue."
 msgstr ""
+"Ihr Administrator hat Ihnen die Freigabestufe <strong>L%(tcl)s</strong> "
+"anvertraut. </br> Sie müssen diese Freigabestufe zunächst akzeptieren, um "
+"fortfahren zu können."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 #, python-format
@@ -2395,10 +2588,12 @@ msgid ""
 "Your administrator has <strong>trusted</strong> you with a clearance level "
 "of <strong>L%(tcl)s</strong>."
 msgstr ""
+"Ihr Administrator hat Ihnen <strong> vertraut</strong> mit der Freigabestufe"
+" <strong>L%(tcl)s</strong>."
 
 #: onboarding/templates/step_5_add_scan_ooi.html
 msgid "Add an object"
-msgstr ""
+msgstr "Fügen Sie ein Objekt hinzu"
 
 #: onboarding/templates/step_5_add_scan_ooi.html
 msgid ""
@@ -2406,11 +2601,14 @@ msgid ""
 "URLs. In the onboarding we will add an URL object, such as our vulnerable "
 "OpenKAT website: https://mispo.es."
 msgstr ""
+"OpenKAT verwendet verschiedene Arten von Objekten, wie IP-Adressen, "
+"Hostnamen und URLs. Beim Onboarding werden wir ein URL-Objekt hinzufügen, "
+"beispielsweise unsere anfällige OpenKAT-Website: https://mispo.es."
 
 #: onboarding/templates/step_5_add_scan_ooi.html
 #: rocky/templates/partials/ooi_detail_related_object.html
 msgid "Related objects"
-msgstr ""
+msgstr "Verwandte Objekte"
 
 #: onboarding/templates/step_5_add_scan_ooi.html
 msgid ""
@@ -2420,6 +2618,12 @@ msgid ""
 "collects and adds these related objects by running scans. Objects can also "
 "be manually added."
 msgstr ""
+"Die meisten Objekte sind von der Existenz verwandter Objekte abhängig. "
+"Beispielsweise muss ein URL mit einem Netzwerk, einem Hostnamen, einem FQDN "
+"(vollqualifizierter Domänenname) und einer IP-Adresse verbunden sein. Wenn "
+"möglich, sammelt OpenKAT diese zugehörigen Objekte automatisch und fügt sie "
+"hinzu, indem es Scans durchführt. Objekte können auch manuell hinzugefügt "
+"werden."
 
 #: onboarding/templates/step_5_add_scan_ooi.html
 msgid "Create object"
@@ -2427,15 +2631,20 @@ msgstr "Objekt erstellen"
 
 #: onboarding/templates/step_6_set_clearance_level.html
 msgid "Set object clearance level"
-msgstr ""
+msgstr "Stellen Sie den Objektabstand ein"
 
 #: onboarding/templates/step_6_set_clearance_level.html
 msgid ""
-"After creating a new object you can set a clearance level for this object. A "
-"clearance level determines how aggressive the object can be scanned. A "
+"After creating a new object you can set a clearance level for this object. A"
+" clearance level determines how aggressive the object can be scanned. A "
 "higher clearance level, means that more aggressive scans are allowed. "
 "Clearance levels can always be adjusted later on."
 msgstr ""
+"Nachdem Sie ein neues Objekt erstellt haben, können Sie für dieses Objekt "
+"eine Freigabestufe festlegen. Eine Sicherheitsstufe bestimmt, wie aggressiv "
+"das Objekt gescannt werden kann. Eine höhere Freigabestufe bedeutet, dass "
+"aggressivere Scans zulässig sind. Die Freigabewerte können später jederzeit "
+"angepasst werden."
 
 #: onboarding/templates/step_6_set_clearance_level.html
 #, python-format
@@ -2444,22 +2653,30 @@ msgid ""
 "L%(dns_report_least_clearance_level)s, meaning only informational scans are "
 "allowed."
 msgstr ""
+"Für das Onboarding verwenden wir die Freigabestufe "
+"L%(dns_report_least_clearance_level)s, was bedeutet, dass nur "
+"Informationsscans zulässig sind."
 
 #: onboarding/templates/step_6_set_clearance_level.html
 msgid "Set clearance level"
-msgstr ""
+msgstr "Abstandsstufe einstellen"
 
 #: onboarding/templates/step_7_clearance_level_introduction.html
 msgid "Plugin introduction"
-msgstr ""
+msgstr "Plugin-Einführung"
 
 #: onboarding/templates/step_7_clearance_level_introduction.html
 msgid ""
 "OpenKAT uses plugins to scan your objects. Each plugin has a scan level to "
-"specify how aggressive the scan is. Plugins can only scan those objects with "
-"a clearance level that is equal to, or higher than the scan level of the "
+"specify how aggressive the scan is. Plugins can only scan those objects with"
+" a clearance level that is equal to, or higher than the scan level of the "
 "plugin. Plugin scan level are indicated by the number of cat paws."
 msgstr ""
+"OpenKAT verwendet Plugins zum Scannen Ihrer Objekte. Jedes Plugin verfügt "
+"über eine Scan-Stufe, um anzugeben, wie aggressiv der Scan ist. Plugins "
+"können nur Objekte scannen, deren Freigabestufe gleich oder höher als die "
+"Scanstufe des Plugins ist. Der Plugin-Scan-Level wird durch die Anzahl der "
+"Katzenpfoten angezeigt."
 
 #: onboarding/templates/step_7_clearance_level_introduction.html
 msgid ""
@@ -2467,6 +2684,10 @@ msgid ""
 "performs non-intrusive scans which look for publicly available information. "
 "It scans objects with a clearance level of 1 or higher."
 msgstr ""
+"Das Plugin <strong>DNS Zone</strong> hat einen Scan-Level von 1, was "
+"bedeutet, dass es nicht-intrusive Scans durchführt, die nach öffentlich "
+"verfügbaren Informationen suchen. Es scannt Objekte mit einer Freigabestufe "
+"von 1 oder höher."
 
 #: onboarding/templates/step_7_clearance_level_introduction.html
 msgid ""
@@ -2474,46 +2695,62 @@ msgid ""
 "more aggressive and could potentially break things. It scans objects with a "
 "clearance level of 3 or higher."
 msgstr ""
+"Das Plugin <strong>Fierce</strong> hat eine Scan-Stufe von 3, was bedeutet, "
+"dass es aggressiver ist und möglicherweise Dinge kaputt machen kann. Es "
+"scannt Objekte mit einer Freigabestufe von 3 oder höher."
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid "Enabling plugins and start scanning"
-msgstr ""
+msgstr "Plugins aktivieren und mit dem Scannen beginnen"
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid ""
 "OpenKAT uses plugins to scan, check and analyze. There are three types of "
 "plugins."
 msgstr ""
+"OpenKAT nutzt Plugins zum Scannen, Prüfen und Analysieren. Es gibt drei "
+"Arten von Plugins."
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid ""
 "The first plugin are <b>Boefjes</b>, which scan objects for data. These are "
 "security tools like nmap, LeakIX and WPscan. </p>"
 msgstr ""
+"Das erste Plugin ist <b>Boefjes</b>, das Objekte nach Daten durchsucht. "
+"Dabei handelt es sich um Sicherheitstools wie nmap, LeakIX und WPscan. </p>"
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid ""
-"The other two plugins are <b>Normalizers</b> and <b>Bits</b>, which are used "
-"to process the output of Boefjes. They can create findings and related "
+"The other two plugins are <b>Normalizers</b> and <b>Bits</b>, which are used"
+" to process the output of Boefjes. They can create findings and related "
 "objects. Bits are also used to create organization specific findings, based "
 "on policy requirements. </p>"
 msgstr ""
+"Die anderen beiden Plugins sind <b>Normalizers</b> und <b>Bits</b>, die zur "
+"Verarbeitung der Ausgabe von Boefjes verwendet werden. Sie können Befunde "
+"und zugehörige Objekte erstellen. Bits werden auch verwendet, um "
+"organisationsspezifische Ergebnisse basierend auf Richtlinienanforderungen "
+"zu erstellen. </p>"
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid ""
 "For the onboarding we will enable the Boefjes shown below. Once enabled "
-"these Boefjes gather publicly available information on suitable objects with "
-"a clearance level of 1 or higher. Normalizers and Bits are enabled by "
+"these Boefjes gather publicly available information on suitable objects with"
+" a clearance level of 1 or higher. Normalizers and Bits are enabled by "
 "default."
 msgstr ""
+"Für das Onboarding aktivieren wir den unten gezeigten Boefjes. Nach der "
+"Aktivierung sammeln diese Boefjes öffentlich verfügbare Informationen zu "
+"geeigneten Objekten mit einer Freigabestufe von 1 oder höher. Normalizers "
+"und Bits sind standardmäßig aktiviert."
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid "Enable and continue"
-msgstr ""
+msgstr "Aktivieren und fortfahren"
 
 #: onboarding/templates/step_9_choose_report_type.html
 msgid "Generate a report"
-msgstr ""
+msgstr "Erstellen Sie einen Bericht"
 
 #: onboarding/templates/step_9_choose_report_type.html
 msgid ""
@@ -2521,46 +2758,54 @@ msgid ""
 "can generate different types of reports in OpenKAT. Each report may require "
 "one or more plugins that provide the input for the report."
 msgstr ""
+"Berichte können verwendet werden, um mehr Einblicke in die Vermögenswerte "
+"Ihrer Organisation zu gewinnen. Sie können in OpenKAT verschiedene Arten von"
+" Berichten generieren. Für jeden Bericht sind möglicherweise ein oder "
+"mehrere Plugins erforderlich, die die Eingaben für den Bericht "
+"bereitstellen."
 
 #: onboarding/templates/step_9_choose_report_type.html
 msgid ""
 "For the onboarding we will generate a DNS report for your added URL. In the "
 "previous step you enabled the required plugins for this report."
 msgstr ""
+"Für das Onboarding erstellen wir einen DNS-Bericht für Ihren hinzugefügten "
+"URL. Im vorherigen Schritt haben Sie die erforderlichen Plugins für diesen "
+"Bericht aktiviert."
 
 #: onboarding/templates/step_9_choose_report_type.html
 msgid "Generate DNS Report"
-msgstr ""
+msgstr "Generieren Sie den DNS-Bericht"
 
 #: onboarding/view_helpers.py
 msgid "1: Welcome"
-msgstr ""
+msgstr "1: Willkommen"
 
 #: onboarding/view_helpers.py
 msgid "2: Organization setup"
-msgstr ""
+msgstr "2: Organisationsaufbau"
 
 #: onboarding/view_helpers.py
 msgid "3: Add object"
-msgstr ""
+msgstr "3: Objekt hinzufügen"
 
 #: onboarding/view_helpers.py
 msgid "4: Plugins"
-msgstr ""
+msgstr "4: Plugins"
 
 #: onboarding/view_helpers.py
 msgid "5: Generating report"
-msgstr ""
+msgstr "5: Bericht erstellen"
 
 #: onboarding/views.py
 #, python-brace-format
 msgid "{org_name} successfully created."
-msgstr ""
+msgstr "{org_name} erfolgreich erstellt."
 
 #: onboarding/views.py
 #, python-brace-format
 msgid "{org_name} successfully updated."
-msgstr ""
+msgstr "{org_name} erfolgreich aktualisiert."
 
 #: onboarding/views.py
 msgid "Creating an object"
@@ -2568,32 +2813,34 @@ msgstr "Objekt erstellen"
 
 #: onboarding/views.py
 msgid "Fetch the parent DNS zone of a hostname"
-msgstr ""
+msgstr "Rufen Sie die übergeordnete DNS-Zone eines Hostnamens ab"
 
 #: onboarding/views.py
 msgid "Finds subdomains by brute force"
-msgstr ""
+msgstr "Findet Subdomains mit roher Gewalt"
 
 #: onboarding/views.py
 msgid "Please select a plugin to proceed."
-msgstr ""
+msgstr "Bitte wählen Sie ein Plugin aus, um fortzufahren."
 
 #: onboarding/views.py
 msgid "Please select all required plugins to proceed."
-msgstr ""
+msgstr "Bitte wählen Sie alle erforderlichen Plugins aus, um fortzufahren."
 
 #: onboarding/views.py reports/views/aggregate_report.py
 #: reports/views/generate_report.py
 msgid "An error occurred while enabling {}. The plugin is not available."
 msgstr ""
+"Beim Aktivieren von {} ist ein Fehler aufgetreten. Das Plugin ist nicht "
+"verfügbar."
 
 #: onboarding/views.py
 msgid "Plugins successfully enabled."
-msgstr ""
+msgstr "Plugins erfolgreich aktiviert."
 
 #: onboarding/views.py
 msgid "Web URL not found."
-msgstr ""
+msgstr "Web URL nicht gefunden."
 
 #: onboarding/views.py
 msgid ""
@@ -2601,111 +2848,115 @@ msgid ""
 "waiting for Boefjes to complete. In the meantime get familiar with OpenKAT "
 "and visit the Reports History tab later."
 msgstr ""
+"Die Erstellung Ihres Berichts ist für etwa drei Minuten geplant, da wir auf "
+"den Abschluss von Boefjes warten. Machen Sie sich in der Zwischenzeit mit "
+"OpenKAT vertraut und besuchen Sie später die Registerkarte "
+"„Berichtsverlauf“."
 
 #: reports/forms.py tools/forms/ooi_form.py
 msgid "Filter by OOI types"
-msgstr ""
+msgstr "Filtern Sie nach OOI-Typen"
 
 #: reports/forms.py
 msgid "Today"
-msgstr ""
+msgstr "Heute"
 
 #: reports/forms.py
 msgid "Different date"
-msgstr ""
+msgstr "Anderes Datum"
 
 #: reports/forms.py
 msgid "No, just once"
-msgstr ""
+msgstr "Nein, nur einmal"
 
 #: reports/forms.py
 msgid "Yes, repeat"
-msgstr ""
+msgstr "Ja, wiederholen"
 
 #: reports/forms.py
 msgid "Start date"
-msgstr ""
+msgstr "Startdatum"
 
 #: reports/forms.py
 msgid "Start time (UTC)"
-msgstr ""
+msgstr "Startzeit (UTC)"
 
 #: reports/forms.py
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Recurrence"
-msgstr ""
+msgstr "Wiederauftreten"
 
 #: reports/forms.py
 msgid "No recurrence, just once"
-msgstr ""
+msgstr "Keine Wiederholung, nur einmal"
 
 #: reports/forms.py
 msgid "Daily"
-msgstr ""
+msgstr "Täglich"
 
 #: reports/forms.py
 msgid "Weekly"
-msgstr ""
+msgstr "Wöchentlich"
 
 #: reports/forms.py
 msgid "Monthly"
-msgstr ""
+msgstr "Monatlich"
 
 #: reports/forms.py
 msgid "Yearly"
-msgstr ""
+msgstr "Jährlich"
 
 #: reports/forms.py
 msgid "day"
-msgstr ""
+msgstr "Tag"
 
 #: reports/forms.py
 msgid "week"
-msgstr ""
+msgstr "Woche"
 
 #: reports/forms.py
 msgid "month"
-msgstr ""
+msgstr "Monat"
 
 #: reports/forms.py
 msgid "year"
-msgstr ""
+msgstr "Jahr"
 
 #: reports/forms.py
 msgid "Never"
-msgstr ""
+msgstr "Niemals"
 
 #: reports/forms.py
 msgid "On"
-msgstr ""
+msgstr "An"
 
 #: reports/forms.py
 msgid "After"
-msgstr ""
+msgstr "Nach"
 
 #: reports/forms.py
 msgid "Report name format"
-msgstr ""
+msgstr "Format des Berichtsnamens"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/report_types/multi_organization_report/appendix.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Appendix"
-msgstr ""
+msgstr "Anhang"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Currently filtered on"
-msgstr ""
+msgstr "Derzeit gefiltert nach"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/partials/report_sidemenu.html
 #: reports/templates/summary/report_asset_overview.html
 msgid "Selected Report Types"
-msgstr ""
+msgstr "Ausgewählte Berichtstypen"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Selected report types"
-msgstr ""
+msgstr "Ausgewählte Berichtstypen"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/partials/plugin_overview_table.html
@@ -2715,41 +2966,41 @@ msgstr ""
 #: reports/templates/report_overview/subreports_table.html
 #: reports/templates/summary/report_asset_overview.html
 msgid "Report type"
-msgstr ""
+msgstr "Berichtstyp"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Service Versions and Health"
-msgstr ""
+msgstr "Dienstversionen und Zustand"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Service, version and health"
-msgstr ""
+msgstr "Service, Version und Zustand"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/summary/service_health.html rocky/templates/footer.html
 #: rocky/templates/health.html
 msgid "Service"
-msgstr ""
+msgstr "Service"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/summary/service_health.html rocky/templates/health.html
 msgid "Version"
-msgstr ""
+msgstr "Version"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: rocky/templates/footer.html rocky/views/health.py
 msgid "Health"
-msgstr ""
+msgstr "Gesundheit"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: rocky/templates/health.html
 msgid "Healthy"
-msgstr ""
+msgstr "Gesund"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Unhealthy"
-msgstr ""
+msgstr "Ungesund"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Used Config objects"
@@ -2786,15 +3037,18 @@ msgstr "Assetübersicht"
 #: reports/report_types/aggregate_organisation_report/asset_overview.html
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid ""
-"An overview of the manually released scanned assets. Assets in <strong>bold</"
-"strong> are taken as a starting point, assets that are not in bold were "
-"found by OpenKAT itself."
+"An overview of the manually released scanned assets. Assets in "
+"<strong>bold</strong> are taken as a starting point, assets that are not in "
+"bold were found by OpenKAT itself."
 msgstr ""
+"Eine Übersicht der manuell freigegebenen gescannten Assets. Vermögenswerte "
+"in <strong>bold</strong> werden als Ausgangspunkt genommen, Vermögenswerte, "
+"die nicht fett gedruckt sind, wurden von OpenKAT selbst gefunden."
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 #: reports/report_types/aggregate_organisation_report/report.html
 msgid "Overview of the basic security status"
-msgstr ""
+msgstr "Übersicht über den grundlegenden Sicherheitsstatus"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 msgid ""
@@ -2802,39 +3056,42 @@ msgid ""
 "assets. Basic security in order. In principle, all values in this table "
 "should be checked off."
 msgstr ""
+"Diese Tabelle gibt einen Überblick über den grundsätzlichen "
+"Sicherheitsstatus der bekannten Vermögenswerte. Grundsicherung in Ordnung. "
+"Grundsätzlich sollten alle Werte in dieser Tabelle abgehakt werden."
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 msgid "Basic security status"
-msgstr ""
+msgstr "Grundlegender Sicherheitsstatus"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 #: reports/report_types/ipv6_report/report.html
 #: reports/report_types/multi_organization_report/ipv6.html
 #: reports/report_types/systems_report/report.html
 msgid "System type"
-msgstr ""
+msgstr "Systemtyp"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Safe connections"
-msgstr ""
+msgstr "Sichere Verbindungen"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 msgid "System Specific"
-msgstr ""
+msgstr "Systemspezifisch"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 msgid "RPKI"
-msgstr ""
+msgstr "RPKI"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/rpki_report/report.html
 #: reports/report_types/safe_connections_report/report.html
 msgid "server"
-msgstr ""
+msgstr "Server"
 
 #: reports/report_types/aggregate_organisation_report/findings.html
 #: reports/report_types/aggregate_organisation_report/report.html
@@ -2842,53 +3099,58 @@ msgid ""
 "This chapter contains information about the findings that have been "
 "identified for this organization."
 msgstr ""
+"Dieses Kapitel enthält Informationen zu den Ergebnissen, die für diese "
+"Organisation ermittelt wurden."
 
 #: reports/report_types/aggregate_organisation_report/recommendations.html
 #: reports/report_types/multi_organization_report/recommendations.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Recommendations"
-msgstr ""
+msgstr "Empfehlungen"
 
 #: reports/report_types/aggregate_organisation_report/recommendations.html
 #, python-format
 msgid "There is <i>%(total_findings)s</i> vulnerability"
 msgid_plural "There are <i>%(total_findings)s</i> vulnerabilities"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Es gibt <i>%(total_findings)s</i>-Schwachstellen"
+msgstr[1] "Es gibt <i>%(total_findings)s</i>-Schwachstellen"
 
 #: reports/report_types/aggregate_organisation_report/recommendations.html
 #, python-format
 msgid "found on <i>%(total_systems)s</i> system."
 msgid_plural "found on <i>%(total_systems)s</i> systems."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "gefunden auf <i>%(total_systems)s</i>-Systemen."
+msgstr[1] "gefunden auf <i>%(total_systems)s</i>-Systemen."
 
 #: reports/report_types/aggregate_organisation_report/recommendations.html
 #: reports/report_types/multi_organization_report/recommendations.html
 msgid "There are no recommendations."
-msgstr ""
+msgstr "Es gibt keine Empfehlungen."
 
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Basic security"
-msgstr ""
+msgstr "Grundsicherheit"
 
 #: reports/report_types/aggregate_organisation_report/report.html
 msgid ""
 "In this chapter, first a table of compliance checks is displayed, followed "
 "by a detailed examination of compliance issues for each component."
 msgstr ""
+"In diesem Kapitel wird zunächst eine Tabelle mit Konformitätsprüfungen "
+"angezeigt, gefolgt von einer detaillierten Untersuchung der "
+"Konformitätsprobleme für jede Komponente."
 
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "System specific"
-msgstr ""
+msgstr "Systemspezifisch"
 
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Resource Public Key Infrastructure"
-msgstr ""
+msgstr "Ressourcen-Public-Key-Infrastruktur"
 
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/report_types/aggregate_organisation_report/vulnerabilities.html
@@ -2896,16 +3158,16 @@ msgstr ""
 #: reports/report_types/vulnerability_report/report.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Vulnerabilities"
-msgstr ""
+msgstr "Schwachstellen"
 
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/report_types/aggregate_organisation_report/vulnerabilities.html
 msgid "Vulnerabilities found are grouped per system."
-msgstr ""
+msgstr "Gefundene Schwachstellen werden nach System gruppiert."
 
 #: reports/report_types/aggregate_organisation_report/report.py
 msgid "Aggregate Organisation Report"
-msgstr ""
+msgstr "Aggregierter Organisationsbericht"
 
 #: reports/report_types/aggregate_organisation_report/rpki.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
@@ -2916,6 +3178,12 @@ msgid ""
 "misconfigurations and malicious route intercepts through verified route "
 "announcements, ensuring reliable server access and secure internet traffic."
 msgstr ""
+"Dieser Abschnitt enthält grundlegende Sicherheitsinformationen zur "
+"Ressourcen-Public-Key-Infrastruktur. Wenn Ihr Webserver RPKI für seine IP-"
+"Adressen und zugehörigen Nameserver verwendet, erhöht er den Schutz der "
+"Besucher vor Fehlkonfigurationen und böswilligen Routenabhörungen durch "
+"verifizierte Routenankündigungen und gewährleistet so einen zuverlässigen "
+"Serverzugriff und sicheren Internetverkehr."
 
 #: reports/report_types/aggregate_organisation_report/safe_connections.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
@@ -2926,41 +3194,48 @@ msgid ""
 "strong encryption which protects the data from interception during "
 "communiction."
 msgstr ""
+"In diesem Kapitel prüfen wir, ob die Verbindungen aller IP-Ports des Systems"
+" sicher sind. Sichere Verbindungen sind wichtig, um unbefugten Zugriff und "
+"Datenschutzverletzungen zu verhindern. Starke Verschlüsselungen sind von "
+"entscheidender Bedeutung, da sie eine starke Verschlüsselung gewährleisten, "
+"die die Daten vor dem Abfangen während der Kommunikation schützt."
 
 #: reports/report_types/aggregate_organisation_report/summary.html
 #: reports/report_types/multi_organization_report/summary.html
 #: rocky/views/ooi_tree.py
 msgid "Summary"
-msgstr ""
+msgstr "Zusammenfassung"
 
 #: reports/report_types/aggregate_organisation_report/summary.html
 msgid "Critical Vulnerabilities"
-msgstr ""
+msgstr "Kritische Schwachstellen"
 
 #: reports/report_types/aggregate_organisation_report/summary.html
 msgid "IPs scanned"
-msgstr ""
+msgstr "IPs gescannt"
 
 #: reports/report_types/aggregate_organisation_report/summary.html
 msgid "Hostnames scanned"
-msgstr ""
+msgstr "Gescannte Hostnamen"
 
 #: reports/report_types/aggregate_organisation_report/summary.html
 msgid "Terms in report"
-msgstr ""
+msgstr "Begriffe im Bericht"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/rpki_report/report.html
 #: reports/report_types/safe_connections_report/report.html
 #, python-format
 msgid ""
-"This table shows which checks were performed. Following that, the compliance "
-"issues, if any, are shown for each %(type)s Server."
+"This table shows which checks were performed. Following that, the compliance"
+" issues, if any, are shown for each %(type)s Server."
 msgstr ""
+"Diese Tabelle zeigt, welche Prüfungen durchgeführt wurden. Anschließend "
+"werden etwaige Compliance-Probleme für jeden %(type)s-Server angezeigt."
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 msgid "Check overview"
-msgstr ""
+msgstr "Übersicht prüfen"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/mail_report/report.html
@@ -2970,7 +3245,7 @@ msgstr ""
 #: reports/report_types/safe_connections_report/report.html
 #: reports/report_types/web_system_report/report.html
 msgid "Check"
-msgstr ""
+msgstr "Überprüfen"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/mail_report/report.html
@@ -2979,18 +3254,18 @@ msgstr ""
 #: reports/report_types/safe_connections_report/report.html
 #: reports/report_types/web_system_report/report.html
 msgid "Compliance"
-msgstr ""
+msgstr "Einhaltung"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/rpki_report/report.html
 msgid "IPs are compliant"
-msgstr ""
+msgstr "IPs sind konform"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/safe_connections_report/report.html
 #: reports/report_types/vulnerability_report/report.html
 msgid "Host:"
-msgstr ""
+msgstr "Gastgeber:"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/mail_report/report.html
@@ -2999,7 +3274,7 @@ msgstr ""
 #: reports/report_types/safe_connections_report/report.html
 #: reports/report_types/web_system_report/report.html
 msgid "Compliance issue"
-msgstr ""
+msgstr "Compliance-Problem"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/mail_report/report.html
@@ -3013,7 +3288,7 @@ msgstr ""
 #: rocky/templates/partials/ooi_report_findings_block_table.html
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "Risk level"
-msgstr ""
+msgstr "Risikostufe"
 
 #: reports/report_types/aggregate_organisation_report/system_specific_overview.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
@@ -3022,28 +3297,43 @@ msgid ""
 "security and compliance issues come into play for different systems. They "
 "are listed here under each other."
 msgstr ""
+"Hier werden systemtypspezifische Prüfungen durchgeführt. Für verschiedene "
+"Systeme spielen unterschiedliche Sicherheits- und Compliance-Probleme eine "
+"Rolle. Sie sind hier untereinander aufgeführt."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Term Overview"
-msgstr ""
+msgstr "Begriffsübersicht"
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid "For definitions of terms used in this chapter, see the glossary below."
 msgstr ""
+"Definitionen der in diesem Kapitel verwendeten Begriffe finden Sie im "
+"folgenden Glossar."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
 "Web servers and domains are examples of digital assets within this "
-"framework. Web servers are essential for hosting and serving websites or web "
-"applications, while domains represent the online addresses used to access "
-"these resources. Other examples of assets in the IT realm include databases, "
-"user accounts, software applications, and networking infrastructure. Asset "
+"framework. Web servers are essential for hosting and serving websites or web"
+" applications, while domains represent the online addresses used to access "
+"these resources. Other examples of assets in the IT realm include databases,"
+" user accounts, software applications, and networking infrastructure. Asset "
 "management is a critical aspect of cybersecurity, involving the "
 "identification, classification, and protection of these assets to safeguard "
 "against threats and ensure the overall security and functionality of an "
 "organization's IT environment."
 msgstr ""
+"Webserver und Domänen sind Beispiele für digitale Assets in diesem Rahmen. "
+"Webserver sind für das Hosten und Bereitstellen von Websites oder "
+"Webanwendungen unerlässlich, während Domänen die Online-Adressen darstellen,"
+" die für den Zugriff auf diese Ressourcen verwendet werden. Weitere "
+"Beispiele für Vermögenswerte im IT-Bereich sind Datenbanken, Benutzerkonten,"
+" Softwareanwendungen und Netzwerkinfrastruktur. Das Asset-Management ist ein"
+" entscheidender Aspekt der Cybersicherheit und umfasst die Identifizierung, "
+"Klassifizierung und den Schutz dieser Assets, um sie vor Bedrohungen zu "
+"schützen und die allgemeine Sicherheit und Funktionalität der IT-Umgebung "
+"eines Unternehmens sicherzustellen."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
@@ -3051,13 +3341,20 @@ msgid ""
 "hostnames or the IP address has a declared scan level that is at least L1. "
 "Type systems are web servers, mail servers and name servers (DNS)."
 msgstr ""
+"Mehrere Hostnamen, die zu einer IP-Adresse aufgelöst werden, wobei "
+"mindestens einer der Hostnamen oder die IP-Adresse eine deklarierte "
+"Scanebene hat, die mindestens L1 ist. Typsysteme sind Webserver, Mailserver "
+"und Nameserver (DNS)."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
 "A fundamental component of the client-server model. A web server uses "
-"protocols like HTTP or HTTPS to facilitate communication between clients and "
-"the server."
+"protocols like HTTP or HTTPS to facilitate communication between clients and"
+" the server."
 msgstr ""
+"Ein grundlegender Bestandteil des Client-Server-Modells. Ein Webserver "
+"verwendet Protokolle wie HTTP oder HTTPS, um die Kommunikation zwischen "
+"Clients und dem Server zu erleichtern."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
@@ -3071,16 +3368,33 @@ msgid ""
 "emails, handling tasks such as authentication, spam filtering, and message "
 "storage."
 msgstr ""
+"Ein Mailserver ist eine spezielle Softwareanwendung oder ein Hardwaregerät, "
+"das das Senden, Empfangen und Speichern von E-Mails innerhalb eines "
+"Computernetzwerks ermöglicht. Ein Mailserver arbeitet mit dem Simple Mail "
+"Transfer Protocol (SMTP) für ausgehende Nachrichten und entweder dem "
+"Internet Message Access Protocol (IMAP) oder dem Post Office Protocol (POP) "
+"für eingehende Nachrichten und verwaltet die E-Mail-Kommunikation, indem er "
+"Nachrichten zwischen Benutzern weiterleitet und sie speichert, bis sie "
+"abgerufen werden. Der Server gewährleistet die effiziente und sichere "
+"Übertragung von E-Mails und übernimmt Aufgaben wie Authentifizierung, Spam-"
+"Filterung und Nachrichtenspeicherung."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
-"A nameserver, or Domain Name System (DNS) server, is a critical component of "
-"the internet infrastructure responsible for translating human-readable "
-"domain names into IP addresses, enabling the seamless navigation of the web. "
-"When a user enters a domain name in a web browser, the nameserver is queried "
-"to obtain the corresponding IP address of the server hosting the associated "
-"website or service."
+"A nameserver, or Domain Name System (DNS) server, is a critical component of"
+" the internet infrastructure responsible for translating human-readable "
+"domain names into IP addresses, enabling the seamless navigation of the web."
+" When a user enters a domain name in a web browser, the nameserver is "
+"queried to obtain the corresponding IP address of the server hosting the "
+"associated website or service."
 msgstr ""
+"Ein Nameserver oder Domain Name System (DNS)-Server ist eine wichtige "
+"Komponente der Internet-Infrastruktur, die für die Übersetzung "
+"menschenlesbarer Domänennamen in IP-Adressen verantwortlich ist und so die "
+"nahtlose Navigation im Web ermöglicht. Wenn ein Benutzer einen Domänennamen "
+"in einen Webbrowser eingibt, wird der Nameserver abgefragt, um die "
+"entsprechende IP-Adresse des Servers zu erhalten, der die zugehörige Website"
+" oder den zugehörigen Dienst hostet."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
@@ -3095,15 +3409,26 @@ msgid ""
 "medical images, like X-rays, CT scans, and MRIs, utilizing a standardized "
 "format."
 msgstr ""
+"Ein DICOM-Server, der für Digital Imaging and Communications in Medicine "
+"steht, ist ein spezialisierter Server, der für die Speicherung, den Abruf "
+"und den Austausch von medizinischen Bildern und zugehörigen Informationen im"
+" Gesundheitswesen konzipiert ist. DICOM ist ein weit verbreiteter Standard, "
+"der Interoperabilität und Konsistenz bei der Kommunikation medizinischer "
+"Bilder und zugehöriger Daten zwischen verschiedenen Geräten und Systemen "
+"gewährleistet, wie z. B. medizinischen Bildgebungsgeräten, "
+"Bildarchivierungs- und Kommunikationssystemen (PACS) und radiologischen "
+"Informationssystemen (RIS). DICOM-Server speichern und verwalten "
+"patientenspezifische medizinische Bilder wie Röntgenaufnahmen, CT-Scans und "
+"MRTs in einem standardisierten Format."
 
 #: reports/report_types/aggregate_organisation_report/vulnerabilities.html
 #: reports/report_types/multi_organization_report/vulnerabilities.html
 msgid "No CVEs have been found."
-msgstr ""
+msgstr "Es wurden keine CVEs gefunden."
 
 #: reports/report_types/dns_report/report.html
 msgid "Records found"
-msgstr ""
+msgstr "Datensätze gefunden"
 
 #: reports/report_types/dns_report/report.html
 msgid ""
@@ -3111,24 +3436,31 @@ msgid ""
 "DNSZone. Additionally the security measures table shows whether or not DNS "
 "relating security measures are enabled."
 msgstr ""
+"Der DNS-Bericht gibt einen Überblick über die DNS-Einträge, die für die "
+"DNSZone gefunden wurden. Darüber hinaus zeigt die "
+"Sicherheitsmaßnahmentabelle, ob DNS-bezogene Sicherheitsmaßnahmen aktiviert "
+"sind oder nicht."
 
 #: reports/report_types/dns_report/report.html
 msgid ""
 "<strong>Disclaimer:</strong> Not all DNSRecords are parsed in OpenKAT. DNS "
 "record types that are parsed and could be displayed in the table are:"
 msgstr ""
+"<strong>Haftungsausschluss:</strong> Nicht alle DNS-Einträge werden in "
+"OpenKAT analysiert. DNS-Datensatztypen, die analysiert werden und in der "
+"Tabelle angezeigt werden könnten, sind:"
 
 #: reports/report_types/dns_report/report.html
 msgid "All existing DNS record types can be found here:"
-msgstr ""
+msgstr "Alle vorhandenen DNS-Datensatztypen finden Sie hier:"
 
 #: reports/report_types/dns_report/report.html
 msgid "Record"
-msgstr ""
+msgstr "Aufzeichnen"
 
 #: reports/report_types/dns_report/report.html
 msgid "TTL"
-msgstr ""
+msgstr "TTL"
 
 #: reports/report_types/dns_report/report.html
 msgid "Data"
@@ -3136,17 +3468,20 @@ msgstr "Daten"
 
 #: reports/report_types/dns_report/report.html
 msgid "No records have been found."
-msgstr ""
+msgstr "Es wurden keine Aufzeichnungen gefunden."
 
 #: reports/report_types/dns_report/report.html
 msgid "Security measures"
-msgstr ""
+msgstr "Sicherheitsmaßnahmen"
 
 #: reports/report_types/dns_report/report.html
 msgid ""
-"The security measures table below shows which DNS relating security measures "
-"are enabled based on the contents of the DNS records."
+"The security measures table below shows which DNS relating security measures"
+" are enabled based on the contents of the DNS records."
 msgstr ""
+"Die folgende Sicherheitsmaßnahmentabelle zeigt, welche DNS-bezogenen "
+"Sicherheitsmaßnahmen basierend auf den Inhalten der DNS-Datensätze aktiviert"
+" sind."
 
 #: reports/report_types/dns_report/report.html
 #: reports/templates/partials/report_ooi_list.html
@@ -3172,11 +3507,11 @@ msgstr "Nein"
 #: reports/report_types/dns_report/report.html
 #: reports/templates/partials/report_findings_table.html
 msgid "Other findings found"
-msgstr ""
+msgstr "Weitere Funde gefunden"
 
 #: reports/report_types/dns_report/report.html
 msgid "Findings information"
-msgstr ""
+msgstr "Informationen zu Befunden"
 
 #: reports/report_types/dns_report/report.py
 msgid "DNS Report"
@@ -3187,20 +3522,24 @@ msgid ""
 "DNS reports focus on domain name system configuration and potential "
 "weaknesses."
 msgstr ""
+"DNS-Berichte konzentrieren sich auf die Konfiguration des Domain-Name-"
+"Systems und mögliche Schwachstellen."
 
 #: reports/report_types/findings_report/report.html
 msgid ""
 "The Findings Report contains information about the findings that have been "
 "identified for the selected asset and organization."
 msgstr ""
+"Der Ergebnisbericht enthält Informationen zu den Ergebnissen, die für das "
+"ausgewählte Asset und die ausgewählte Organisation ermittelt wurden."
 
 #: reports/report_types/findings_report/report.py
 msgid "Findings Report"
-msgstr ""
+msgstr "Befundbericht"
 
 #: reports/report_types/findings_report/report.py
 msgid "Shows all the finding types and their occurrences."
-msgstr ""
+msgstr "Zeigt alle Befundtypen und deren Vorkommen an."
 
 #: reports/report_types/ipv6_report/report.html
 msgid ""
@@ -3209,204 +3548,225 @@ msgid ""
 "over IPv6 or not. A green compliance check is shown if this is the case. A "
 "grey compliance cross is shown if no IPv6 address was detected."
 msgstr ""
+"Der IPv6-Bericht bietet einen Überblick über den aktuellen IPv6-Status des "
+"identifizierten Systems. Die folgende Tabelle zeigt, ob die Domäne über IPv6"
+" erreichbar ist oder nicht. In diesem Fall wird eine grüne "
+"Konformitätsprüfung angezeigt. Wenn keine IPv6-Adresse erkannt wurde, wird "
+"ein graues Konformitätskreuz angezeigt."
 
 #: reports/report_types/ipv6_report/report.html
 msgid "IPv6 overview"
-msgstr ""
+msgstr "IPv6-Übersicht"
 
 #: reports/report_types/ipv6_report/report.html
 #: reports/report_types/systems_report/report.html
 msgid "Domain"
-msgstr ""
+msgstr "Domain"
 
 #: reports/report_types/ipv6_report/report.py
 msgid "IPv6 Report"
-msgstr ""
+msgstr "IPv6-Bericht"
 
 #: reports/report_types/ipv6_report/report.py
 msgid "Check whether hostnames point to IPv6 addresses."
-msgstr ""
+msgstr "Überprüfen Sie, ob Hostnamen auf IPv6-Adressen verweisen."
 
 #: reports/report_types/mail_report/report.html
 msgid ""
 "The Mail Report provides an overview of the compliance checks associated "
 "with email servers. The current compliance checks the presence of SPF, DKIM "
 "and DMARC records. The table below shows for each of these checks how many "
-"of the identified mail servers are compliant, and if applicable a compliance "
-"issue description and risk level. The risk level may be different for your "
+"of the identified mail servers are compliant, and if applicable a compliance"
+" issue description and risk level. The risk level may be different for your "
 "specific environment."
 msgstr ""
+"Der Mail-Bericht bietet einen Überblick über die Compliance-Prüfungen, die "
+"mit E-Mail-Servern verbunden sind. Die aktuelle Compliance prüft das "
+"Vorhandensein der Datensätze SPF, DKIM und DMARC. Die folgende Tabelle zeigt"
+" für jede dieser Prüfungen, wie viele der identifizierten Mailserver konform"
+" sind, und gegebenenfalls eine Beschreibung des Compliance-Problems und der "
+"Risikostufe. Das Risikoniveau kann je nach Umgebung unterschiedlich sein."
 
 #: reports/report_types/mail_report/report.html
 msgid "Mailserver compliance"
-msgstr ""
+msgstr "Mailserver-Konformität"
 
 #: reports/report_types/mail_report/report.html
 msgid "mailservers compliant"
-msgstr ""
+msgstr "Mailserver kompatibel"
 
 #: reports/report_types/mail_report/report.html
 msgid "No mailservers have been found on this system."
-msgstr ""
+msgstr "Auf diesem System wurden keine Mailserver gefunden."
 
 #: reports/report_types/mail_report/report.py
 msgid "Mail Report"
-msgstr ""
+msgstr "Mail-Bericht"
 
 #: reports/report_types/mail_report/report.py
 msgid ""
 "System specific Mail Report that focusses on IP addresses and hostnames."
 msgstr ""
+"Systemspezifischer Mail-Bericht, der sich auf IP-Adressen und Hostnamen "
+"konzentriert."
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Overview of included assets"
-msgstr ""
+msgstr "Übersicht der enthaltenen Assets"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Asset"
-msgstr ""
+msgstr "Vermögenswert"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
 msgid "Amount"
-msgstr ""
+msgstr "Menge"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "IP addresses"
-msgstr ""
+msgstr "IP-Adressen"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Domain names"
-msgstr ""
+msgstr "Domainnamen"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Assets with most critical vulnerabilities"
-msgstr ""
+msgstr "Assets mit den kritischsten Schwachstellen"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Vulnerability"
-msgstr ""
+msgstr "Verletzlichkeit"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Organisation"
-msgstr ""
+msgstr "Organisation"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "No vulnerabilities found."
-msgstr ""
+msgstr "Keine Schwachstellen gefunden."
 
 #: reports/report_types/multi_organization_report/basic_security_details.html
 msgid "Overview of safe connections"
-msgstr ""
+msgstr "Übersicht über sichere Verbindungen"
 
 #: reports/report_types/multi_organization_report/basic_security_details.html
 #: reports/report_types/safe_connections_report/report.html
 msgid "Only Safe Ciphers"
-msgstr ""
+msgstr "Nur sichere Chiffren"
 
 #: reports/report_types/multi_organization_report/basic_security_details.html
 #: reports/report_types/safe_connections_report/report.html
 msgid "services are compliant"
-msgstr ""
+msgstr "Dienstleistungen sind konform"
 
 #: reports/report_types/multi_organization_report/basic_security_details.html
 msgid "System specific checks"
-msgstr ""
+msgstr "Systemspezifische Prüfungen"
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid "IPv6"
-msgstr ""
+msgstr "IPv6"
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid ""
-"IPv6 includes improvements in security features compared to IPv4. While IPv4 "
-"can implement security measures, IPv6 was designed with security in mind, "
+"IPv6 includes improvements in security features compared to IPv4. While IPv4"
+" can implement security measures, IPv6 was designed with security in mind, "
 "and its adoption can contribute to a more secure internet."
 msgstr ""
+"IPv6 enthält im Vergleich zu IPv4 Verbesserungen bei den "
+"Sicherheitsfunktionen. Während IPv4 Sicherheitsmaßnahmen implementieren "
+"kann, wurde IPv6 unter Berücksichtigung der Sicherheit entwickelt und seine "
+"Einführung kann zu einem sichereren Internet beitragen."
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid "In total "
-msgstr ""
+msgstr "In Summe"
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid " out of "
-msgstr ""
+msgstr "von"
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid " systems have an IPv6 connection."
-msgstr ""
+msgstr "Systeme verfügen über einen IPv6-Anschluss."
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid "Overview of IP version compliance"
-msgstr ""
+msgstr "Übersicht über die Versionskonformität von IP"
 
 #: reports/report_types/multi_organization_report/open_ports.html
 msgid ""
 "See an overview of open ports found over all systems and the services these "
 "systems provide."
 msgstr ""
+"Sehen Sie sich eine Übersicht über die offenen Ports aller Systeme und die "
+"von diesen Systemen bereitgestellten Dienste an."
 
 #: reports/report_types/multi_organization_report/open_ports.html
 msgid "Overview of detected open ports"
-msgstr ""
+msgstr "Übersicht über erkannte offene Ports"
 
 #: reports/report_types/multi_organization_report/open_ports.html
 #: reports/report_types/open_ports_report/report.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Open ports"
-msgstr ""
+msgstr "Offene Ports"
 
 #: reports/report_types/multi_organization_report/open_ports.html
 msgid "Occurrences (IP addresses)"
-msgstr ""
+msgstr "Vorkommen (IP-Adressen)"
 
 #: reports/report_types/multi_organization_report/open_ports.html
 #: reports/templates/summary/service_health.html
 msgid "Services"
-msgstr ""
+msgstr "Dienstleistungen"
 
 #: reports/report_types/multi_organization_report/open_ports.html
 msgid "No open ports found."
-msgstr ""
+msgstr "Keine offenen Ports gefunden."
 
 #: reports/report_types/multi_organization_report/recommendations.html
 msgid "Overview of recommendations"
-msgstr ""
+msgstr "Übersicht der Empfehlungen"
 
 #: reports/report_types/multi_organization_report/recommendations.html
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "Occurrence"
-msgstr ""
+msgstr "Auftreten"
 
 #: reports/report_types/multi_organization_report/report.html
 msgid "No findings have been identified yet."
-msgstr ""
+msgstr "Es liegen noch keine Befunde vor."
 
 #: reports/report_types/multi_organization_report/report.py
 msgid "Multi Organization Report"
-msgstr ""
+msgstr "Bericht über mehrere Organisationen"
 
 #: reports/report_types/multi_organization_report/summary.html
 msgid "Best scoring security check"
-msgstr ""
+msgstr "Bester Sicherheitscheck"
 
 #: reports/report_types/multi_organization_report/summary.html
 msgid "Worst scoring security check"
-msgstr ""
+msgstr "Sicherheitskontrolle mit der schlechtesten Bewertung"
 
 #: reports/report_types/multi_organization_report/vulnerabilities.html
 msgid ""
 "Vulnerabilities found are grouped per system. Here, we only consider CVE "
 "vulnerabilities."
 msgstr ""
+"Gefundene Schwachstellen werden nach System gruppiert. Hier betrachten wir "
+"nur die Schwachstellen CVE."
 
 #: reports/report_types/multi_organization_report/vulnerabilities.html
 msgid "Vulnerabilities grouped per system"
-msgstr ""
+msgstr "Nach System gruppierte Schwachstellen"
 
 #: reports/report_types/multi_organization_report/vulnerabilities.html
 msgid "total"
-msgstr ""
+msgstr "gesamt"
 
 #: reports/report_types/name_server_report/report.html
 msgid ""
@@ -3419,73 +3779,92 @@ msgid ""
 "identified are shown too. The risk level may be different for your specific "
 "environment."
 msgstr ""
+"Der Nameserverbericht bietet einen Überblick über die Compliance-Prüfungen, "
+"die für die identifizierten Domain Name Server (DNS) durchgeführt wurden. "
+"Die Konformitätsprüfungen überprüfen das Vorhandensein und die Gültigkeit "
+"von DNSSEC und ob keine unnötigen Ports als offen identifiziert wurden. Die "
+"folgende Tabelle gibt einen Überblick über die verfügbaren Prüfungen, "
+"einschließlich der Frage, ob das System die durchgeführten Prüfungen "
+"bestanden hat. Außerdem werden die Risikostufe und die Gründe für die "
+"Feststellung eines Problems angezeigt. Das Risikoniveau kann je nach "
+"Umgebung unterschiedlich sein."
 
 #: reports/report_types/name_server_report/report.html
 msgid "Name server compliance"
-msgstr ""
+msgstr "Konformität mit Nameservern"
 
 #: reports/report_types/name_server_report/report.html
 msgid "DNSSEC Present"
-msgstr ""
+msgstr "DNSSEC Vorhanden"
 
 #: reports/report_types/name_server_report/report.html
 msgid "name servers compliant"
-msgstr ""
+msgstr "Nameserver kompatibel"
 
 #: reports/report_types/name_server_report/report.html
 msgid "Valid DNSSEC"
-msgstr ""
+msgstr "Gültig DNSSEC"
 
 #: reports/report_types/name_server_report/report.html
 #: reports/report_types/web_system_report/report.html
 msgid "No unnecessary ports open"
-msgstr ""
+msgstr "Es werden keine unnötigen Ports geöffnet"
 
 #: reports/report_types/name_server_report/report.html
 msgid "No nameservers have been found on this system."
-msgstr ""
+msgstr "Auf diesem System wurden keine Nameserver gefunden."
 
 #: reports/report_types/name_server_report/report.py
 msgid "Name Server Report"
-msgstr ""
+msgstr "Nameserverbericht"
 
 #: reports/report_types/name_server_report/report.py
 msgid "Name Server Report checks name servers on basic security standards."
 msgstr ""
+"Der Nameserver-Bericht überprüft Nameserver auf grundlegende "
+"Sicherheitsstandards."
 
 #: reports/report_types/open_ports_report/report.html
 msgid ""
-"The Open Ports Report provides an overview of the open ports identified on a "
-"system. The ports that are marked as <b>bold</b> were identified by direct "
-"scans performed by OpenKAT (such as nmap). Ports that are not marked in bold "
-"were identified through external services and/or scans (such as Shodan). "
+"The Open Ports Report provides an overview of the open ports identified on a"
+" system. The ports that are marked as <b>bold</b> were identified by direct "
+"scans performed by OpenKAT (such as nmap). Ports that are not marked in bold"
+" were identified through external services and/or scans (such as Shodan). "
 "Scans with the same hostnames, ports and IPs are merged."
 msgstr ""
+"Der Open Ports Report bietet einen Überblick über die offenen Ports, die auf"
+" einem System identifiziert wurden. Die als <b>bold</b> gekennzeichneten "
+"Ports wurden durch direkte Scans identifiziert, die von OpenKAT (z. B. nmap)"
+" durchgeführt wurden. Nicht fett markierte Ports wurden durch externe "
+"Dienste und/oder Scans (z. B. Shodan) identifiziert. Scans mit denselben "
+"Hostnamen, Ports und IPs werden zusammengeführt."
 
 #: reports/report_types/open_ports_report/report.html
 msgid "Overview of open ports found for the scanned assets"
 msgstr ""
+"Übersicht über die offenen Ports, die für die gescannten Assets gefunden "
+"wurden"
 
 #: reports/report_types/open_ports_report/report.html
 #: reports/report_types/systems_report/report.html
 msgid "IP address"
-msgstr ""
+msgstr "IP-Adresse"
 
 #: reports/report_types/open_ports_report/report.html
 msgid "Hostnames"
-msgstr ""
+msgstr "Hostnamen"
 
 #: reports/report_types/open_ports_report/report.html
 msgid "Direct scan"
-msgstr ""
+msgstr "Direkter Scan"
 
 #: reports/report_types/open_ports_report/report.py
 msgid "Open Ports Report"
-msgstr ""
+msgstr "Offener Ports-Bericht"
 
 #: reports/report_types/open_ports_report/report.py
 msgid "Find open ports of IP addresses"
-msgstr ""
+msgstr "Finden Sie offene Ports von IP-Adressen"
 
 #: reports/report_types/rpki_report/report.html
 msgid ""
@@ -3495,167 +3874,203 @@ msgid ""
 "misconfigurations and malicious route intercepts through verified route "
 "announcements, ensuring reliable server access and secure internet traffic."
 msgstr ""
+"Dieser Abschnitt enthält grundlegende Sicherheitsinformationen zur Resource "
+"Public Key Infrastructure (RPKI). Wenn Ihr Webserver RPKI für seine IP-"
+"Adressen und zugehörigen Nameserver verwendet, erhöht er den Schutz der "
+"Besucher vor Fehlkonfigurationen und böswilligen Routenabhörungen durch "
+"verifizierte Routenankündigungen und gewährleistet so einen zuverlässigen "
+"Serverzugriff und sicheren Internetverkehr."
 
 #: reports/report_types/rpki_report/report.html
 msgid ""
 "The RPKI Report shows if an RPKI route announcement was available for the "
 "system and if this announcement is not expired."
 msgstr ""
+"Der Bericht RPKI zeigt, ob eine Routenankündigung RPKI für das System "
+"verfügbar war und ob diese Ankündigung nicht abgelaufen ist."
 
 #: reports/report_types/rpki_report/report.html
 msgid "RPKI compliance"
-msgstr ""
+msgstr "RPKI-Konformität"
 
 #: reports/report_types/rpki_report/report.html
 msgid "RPKI Available"
-msgstr ""
+msgstr "RPKI Verfügbar"
 
 #: reports/report_types/rpki_report/report.html
 msgid "RPKI valid"
-msgstr ""
+msgstr "RPKI gültig"
 
 #: reports/report_types/rpki_report/report.html
 msgid "RPKI record is not valid."
-msgstr ""
+msgstr "Der RPKI-Eintrag ist ungültig."
 
 #: reports/report_types/rpki_report/report.html
 msgid "RPKI record does not exist."
-msgstr ""
+msgstr "Der Eintrag RPKI existiert nicht."
 
 #: reports/report_types/rpki_report/report.html
 #: reports/report_types/safe_connections_report/report.html
 msgid "No IPs have been found on this system."
-msgstr ""
+msgstr "Auf diesem System wurde kein IPs gefunden."
 
 #: reports/report_types/rpki_report/report.py
 msgid "RPKI Report"
-msgstr ""
+msgstr "RPKI-Bericht"
 
 #: reports/report_types/rpki_report/report.py
 msgid ""
-"Shows whether the IP is covered by a valid RPKI ROA. For a hostname it shows "
-"the IP addresses and whether they are covered by a valid RPKI ROA."
+"Shows whether the IP is covered by a valid RPKI ROA. For a hostname it shows"
+" the IP addresses and whether they are covered by a valid RPKI ROA."
 msgstr ""
+"Zeigt an, ob der IP durch einen gültigen RPKI ROA abgedeckt ist. Für einen "
+"Hostnamen werden die IP-Adressen angezeigt und ob diese durch einen gültigen"
+" RPKI ROA abgedeckt sind."
 
 #: reports/report_types/safe_connections_report/report.html
 msgid ""
 "The Safe Connections report provides an overview of the performed checks "
 "with regard to encrypted communication channels such as HTTPS. The table "
-"below gives an overview of the available checks including whether the system "
-"passed the performed checks. The risk level and reasoning as to why an issue "
-"was identified are shown too. The risk level may be different for your "
-"specific environment."
+"below gives an overview of the available checks including whether the system"
+" passed the performed checks. The risk level and reasoning as to why an "
+"issue was identified are shown too. The risk level may be different for your"
+" specific environment."
 msgstr ""
+"Der Bericht „Sichere Verbindungen“ bietet einen Überblick über die "
+"durchgeführten Prüfungen in Bezug auf verschlüsselte Kommunikationskanäle "
+"wie HTTPS. Die folgende Tabelle gibt einen Überblick über die verfügbaren "
+"Prüfungen, einschließlich der Frage, ob das System die durchgeführten "
+"Prüfungen bestanden hat. Außerdem werden die Risikostufe und die Gründe für "
+"die Feststellung eines Problems angezeigt. Das Risikoniveau kann je nach "
+"Umgebung unterschiedlich sein."
 
 #: reports/report_types/safe_connections_report/report.html
 msgid "Safe connections compliance"
-msgstr ""
+msgstr "Einhaltung sicherer Verbindungen"
 
 #: reports/report_types/safe_connections_report/report.py
 msgid "Safe Connections Report"
-msgstr ""
+msgstr "Bericht über sichere Verbindungen"
 
 #: reports/report_types/safe_connections_report/report.py
 msgid "Shows whether the IPService contains safe ciphers."
-msgstr ""
+msgstr "Zeigt an, ob der IPService sichere Chiffren enthält."
 
 #: reports/report_types/systems_report/report.html
 msgid ""
-"The System Report provides an overview of the system types (types of similar "
-"services) that were identified for each system. The following system types "
+"The System Report provides an overview of the system types (types of similar"
+" services) that were identified for each system. The following system types "
 "can be identified: DNS servers, Web servers, Mail servers and those "
 "classified as 'Other' servers. Each hostname and/or IP address is given one "
 "or more system types depending on the identified ports and services. The "
 "table below gives an overview of these results."
 msgstr ""
+"Der Systembericht bietet einen Überblick über die Systemtypen (Arten "
+"ähnlicher Dienste), die für jedes System identifiziert wurden. Folgende "
+"Systemtypen können identifiziert werden: DNS-Server, Webserver, Mailserver "
+"und solche, die als „Andere“ Server klassifiziert sind. Jedem Hostnamen "
+"und/oder jeder IP-Adresse werden abhängig von den identifizierten Ports und "
+"Diensten ein oder mehrere Systemtypen zugewiesen. Die folgende Tabelle gibt "
+"einen Überblick über diese Ergebnisse."
 
 #: reports/report_types/systems_report/report.html
 msgid "Selected assets"
-msgstr ""
+msgstr "Ausgewählte Vermögenswerte"
 
 #: reports/report_types/systems_report/report.html
 msgid "No system types have been identified on this system."
-msgstr ""
+msgstr "Auf diesem System wurden keine Systemtypen identifiziert."
 
 #: reports/report_types/systems_report/report.py
 msgid "System Report"
-msgstr ""
+msgstr "Systembericht"
 
 #: reports/report_types/systems_report/report.py
 msgid "Combine IP addresses, hostnames and services into systems."
-msgstr ""
+msgstr "Kombinieren Sie IP-Adressen, Hostnamen und Dienste zu Systemen."
 
 #: reports/report_types/tls_report/report.html
 msgid ""
 "The TLS Report shows which TLS protocols and ciphers were identified on the "
 "host for the provided port."
 msgstr ""
+"Der TLS-Bericht zeigt, welche TLS-Protokolle und -Verschlüsselungen auf dem "
+"Host für den bereitgestellten Port identifiziert wurden."
 
 #: reports/report_types/tls_report/report.html
 msgid ""
 "The table below provides an overview of the identified TLS protocols and "
 "ciphers, including a status suggestion."
 msgstr ""
+"Die folgende Tabelle bietet einen Überblick über die identifizierten TLS-"
+"Protokolle und -Verschlüsselungen, einschließlich eines Statusvorschlags."
 
 #: reports/report_types/tls_report/report.html
 msgid "Ciphers"
-msgstr ""
+msgstr "Chiffren"
 
 #: reports/report_types/tls_report/report.html
 msgid "Protocol"
-msgstr ""
+msgstr "Protokoll"
 
 #: reports/report_types/tls_report/report.html
 msgid "Encryption Algorithm"
-msgstr ""
+msgstr "Verschlüsselungsalgorithmus"
 
 #: reports/report_types/tls_report/report.html
 msgid "Bits"
-msgstr ""
+msgstr "Bits"
 
 #: reports/report_types/tls_report/report.html
 msgid "Key Size"
-msgstr ""
+msgstr "Schlüsselgröße"
 
 #: reports/report_types/tls_report/report.html
 #: rocky/templates/organizations/organization_list.html
 #: rocky/templates/organizations/organization_settings.html
 msgid "Code"
-msgstr ""
+msgstr "Code"
 
 #: reports/report_types/tls_report/report.html
 msgid "Phase out"
-msgstr ""
+msgstr "Ausstieg"
 
 #: reports/report_types/tls_report/report.html
 msgid "Good"
-msgstr ""
+msgstr "Gut"
 
 #: reports/report_types/tls_report/report.html
 msgid ""
 "No ciphers were found for this combination of IP address, port and service."
 msgstr ""
+"Für diese Kombination aus IP-Adresse, Port und Dienst wurden keine Chiffren "
+"gefunden."
 
 #: reports/report_types/tls_report/report.html
 msgid ""
-"The list below gives an overview of the findings based on the identified TLS "
-"protocols and ciphers. This includes the reasoning why the cipher or "
+"The list below gives an overview of the findings based on the identified TLS"
+" protocols and ciphers. This includes the reasoning why the cipher or "
 "protocol is marked as a finding."
 msgstr ""
+"Die folgende Liste gibt einen Überblick über die Ergebnisse basierend auf "
+"den identifizierten TLS-Protokollen und -Chiffren. Dazu gehört auch die "
+"Begründung, warum die Chiffre oder das Protokoll als Befund markiert wird."
 
 #: reports/report_types/tls_report/report.py
 msgid "TLS Report"
-msgstr ""
+msgstr "TLS-Bericht"
 
 #: reports/report_types/tls_report/report.py
 msgid ""
 "TLS Report assesses the security of data encryption and transmission "
 "protocols."
 msgstr ""
+"Der TLS-Bericht bewertet die Sicherheit von Datenverschlüsselungs- und "
+"Übertragungsprotokollen."
 
 #: reports/report_types/vulnerability_report/report.html
 msgid "No vulnerabilities have been found on this system."
-msgstr ""
+msgstr "Auf diesem System wurden keine Schwachstellen gefunden."
 
 #: reports/report_types/vulnerability_report/report.html
 msgid ""
@@ -3664,302 +4079,351 @@ msgid ""
 "the table shows the CVE scoring, the number of occurrences, and the CVE "
 "details."
 msgstr ""
+"Der Schwachstellenbericht bietet einen Überblick über alle identifizierten "
+"CVE-Schwachstellen, die auf den ausgewählten Systemen identifiziert wurden. "
+"Für jedes CVE zeigt die Tabelle die CVE-Bewertung, die Anzahl der Vorkommen "
+"und die CVE-Details an."
 
 #: reports/report_types/vulnerability_report/report.html
 msgid "vulnerabilities on this system"
-msgstr ""
+msgstr "Schwachstellen in diesem System"
 
 #: reports/report_types/vulnerability_report/report.html
 msgid "Advice"
-msgstr ""
+msgstr "Beratung"
 
 #: reports/report_types/vulnerability_report/report.py
 msgid "Vulnerability Report"
-msgstr ""
+msgstr "Schwachstellenbericht"
 
 #: reports/report_types/vulnerability_report/report.py
 msgid "Vulnerabilities found are grouped for each system."
-msgstr ""
+msgstr "Gefundene Schwachstellen werden für jedes System gruppiert."
 
 #: reports/report_types/vulnerability_report/report.py
 msgid "First seen"
-msgstr ""
+msgstr "Zum ersten Mal gesehen"
 
 #: reports/report_types/vulnerability_report/report.py
 msgid "Last seen"
-msgstr ""
+msgstr "Zuletzt gesehen"
 
 #: reports/report_types/vulnerability_report/report.py
 msgid "Evidence"
-msgstr ""
+msgstr "Beweis"
 
 #: reports/report_types/web_system_report/report.html
 msgid ""
-"The Web System Report provides an overview of various web server checks that "
-"were performed against the scanned system(s). For each performed check the "
+"The Web System Report provides an overview of various web server checks that"
+" were performed against the scanned system(s). For each performed check the "
 "table below shows whether or not the server is compliant with the checks. A "
 "description of why this compliant check failed is also shown, including an "
 "general risk level. The risk level may be different for your specific "
 "environment."
 msgstr ""
+"Der Websystembericht bietet einen Überblick über verschiedene "
+"Webserverprüfungen, die für das/die gescannte(n) System(e) durchgeführt "
+"wurden. Für jede durchgeführte Prüfung zeigt die folgende Tabelle, ob der "
+"Server die Prüfungen erfüllt oder nicht. Außerdem wird beschrieben, warum "
+"diese Konformitätsprüfung fehlgeschlagen ist, einschließlich einer "
+"allgemeinen Risikostufe. Das Risikoniveau kann je nach Umgebung "
+"unterschiedlich sein."
 
 #: reports/report_types/web_system_report/report.html
 msgid "Web system compliance"
-msgstr ""
+msgstr "Web-System-Compliance"
 
 #: reports/report_types/web_system_report/report.html
 msgid "CSP Present"
-msgstr ""
+msgstr "CSP Vorhanden"
 
 #: reports/report_types/web_system_report/report.html
 msgid "webservers compliant"
-msgstr ""
+msgstr "Webserver kompatibel"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Secure CSP Header"
-msgstr ""
+msgstr "Sicherer CSP-Header"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Redirects HTTP to HTTPS"
-msgstr ""
+msgstr "Leitet HTTP zu HTTPS um"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Offers HTTPS"
-msgstr ""
+msgstr "Angebote HTTPS"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Has a Security.txt"
-msgstr ""
+msgstr "Hat eine Security.txt"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Has a certificate"
-msgstr ""
+msgstr "Hat ein Zertifikat"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Certificate is valid"
-msgstr ""
+msgstr "Das Zertifikat ist gültig"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Certificate is not expiring soon"
-msgstr ""
+msgstr "Das Zertifikat läuft nicht bald ab"
 
 #: reports/report_types/web_system_report/report.html
 msgid "No webservers have been found on this system."
-msgstr ""
+msgstr "Auf diesem System wurden keine Webserver gefunden."
 
 #: reports/report_types/web_system_report/report.py
 msgid "Web System Report"
-msgstr ""
+msgstr "Websystembericht"
 
 #: reports/report_types/web_system_report/report.py
 msgid "Web System Reports check web systems on basic security standards."
 msgstr ""
+"Web-Systemberichte überprüfen Web-Systeme auf grundlegende "
+"Sicherheitsstandards."
 
 #: reports/templates/partials/export_report_settings.html
 msgid "Report schedule"
-msgstr ""
+msgstr "Berichtsplan"
 
 #: reports/templates/partials/export_report_settings.html
 msgid ""
 "When scheduling your report, you have two options. You can either choose to "
 "generate it just once now, or set it to run automatically at regular "
-"intervals, like daily, weekly, or monthly. If you need the report just for a "
-"single occasion, select the one-time option."
+"intervals, like daily, weekly, or monthly. If you need the report just for a"
+" single occasion, select the one-time option."
 msgstr ""
+"Beim Planen Ihres Berichts haben Sie zwei Möglichkeiten. Sie können es jetzt"
+" entweder nur einmal generieren oder so einstellen, dass es automatisch in "
+"regelmäßigen Abständen ausgeführt wird, z. B. täglich, wöchentlich oder "
+"monatlich. Wenn Sie den Bericht nur für einen einzigen Anlass benötigen, "
+"wählen Sie die Option „Einmalig“."
 
 #: reports/templates/partials/export_report_settings.html
 #: reports/templates/report_overview/report_history_table.html
 msgid "Report name"
-msgstr ""
+msgstr "Berichtsname"
 
 #: reports/templates/partials/export_report_settings.html
 #, python-format, python-brace-format
 msgid ""
 "When generating reports, it is possible to give the report a name. The name "
-"can be static or dynamic. The default format for a report is '${report_type} "
-"for ${oois_count} objects'. These placeholders automatically adapt based on "
-"the report details. This format could for example return 'Aggregate Report "
+"can be static or dynamic. The default format for a report is '${report_type}"
+" for ${oois_count} objects'. These placeholders automatically adapt based on"
+" the report details. This format could for example return 'Aggregate Report "
 "for 15 objects'. Another placeholder that can be used is '${ooi}', which "
-"will show the name of the object when there is only one object. You can also "
-"customize the name by adding prefixes, suffixes, or other formats like '%%W' "
-"for the week number, using options from <a href=\"https://strftime.org/\" "
-"target=\"_blank\" rel=\"noopener\">Python strftime code</a>."
+"will show the name of the object when there is only one object. You can also"
+" customize the name by adding prefixes, suffixes, or other formats like "
+"'%%W' for the week number, using options from <a "
+"href=\"https://strftime.org/\" target=\"_blank\" rel=\"noopener\">Python "
+"strftime code</a>."
 msgstr ""
+"Beim Generieren von Berichten besteht die Möglichkeit, dem Bericht einen "
+"Namen zu geben. Der Name kann statisch oder dynamisch sein. Das "
+"Standardformat für einen Bericht ist „${report_type} für "
+"${oois_count}-Objekte“. Diese Platzhalter passen sich automatisch an die "
+"Berichtsdetails an. Dieses Format könnte beispielsweise „Aggregierter "
+"Bericht für 15 Objekte“ zurückgeben. Ein weiterer Platzhalter, der verwendet"
+" werden kann, ist „${ooi}“, der den Namen des Objekts anzeigt, wenn nur ein "
+"Objekt vorhanden ist. Sie können den Namen auch anpassen, indem Sie Präfixe,"
+" Suffixe oder andere Formate wie „%%W“ für die Wochennummer hinzufügen und "
+"dabei Optionen aus <a href=\"https://strftime.org/\" target=\"_blank\" "
+"rel=\"noopener\">Python strftime code</a> verwenden."
 
 #: reports/templates/partials/export_report_settings.html
 #: reports/templates/partials/generate_report_header.html
 #: reports/templates/partials/new_report_action_button.html
 #: reports/views/generate_report.py
 msgid "Generate report"
-msgstr ""
+msgstr "Bericht erstellen"
 
 #: reports/templates/partials/generate_report_header.html
 msgid "To generate an aggregate report, complete the following steps."
 msgstr ""
+"Führen Sie die folgenden Schritte aus, um einen Gesamtbericht zu erstellen."
 
 #: reports/templates/partials/generate_report_header.html
 msgid "To generate a multi report, complete the following steps."
 msgstr ""
+"Um einen Mehrfachbericht zu erstellen, führen Sie die folgenden Schritte "
+"aus."
 
 #: reports/templates/partials/generate_report_header.html
 msgid "To generate separate report(s), complete the following steps."
 msgstr ""
+"Führen Sie die folgenden Schritte aus, um separate Berichte zu erstellen."
 
 #: reports/templates/partials/generate_report_sidemenu.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Table of contents"
-msgstr ""
+msgstr "Inhaltsverzeichnis"
 
 #: reports/templates/partials/new_report_action_button.html
 msgid "Actions for creating a new report"
-msgstr ""
+msgstr "Aktionen zum Erstellen eines neuen Berichts"
 
 #: reports/templates/partials/new_report_action_button.html
 msgid "Separate report(s)"
-msgstr ""
+msgstr "Separate(r) Bericht(e)"
 
 #: reports/templates/partials/new_report_action_button.html
 #: reports/views/aggregate_report.py
 msgid "Aggregate report"
-msgstr ""
+msgstr "Gesamtbericht"
 
 #: reports/templates/partials/new_report_action_button.html
 #: reports/views/multi_report.py
 msgid "Multi report"
-msgstr ""
+msgstr "Mehrfachbericht"
 
 #: reports/templates/partials/plugin_overview_table.html
 #: reports/templates/partials/report_sidemenu.html
 #: rocky/templates/oois/ooi_page_tabs.html
 msgid "Overview"
-msgstr ""
+msgstr "Überblick"
 
 #: reports/templates/partials/plugin_overview_table.html
 msgid "Plugin overview table"
-msgstr ""
+msgstr "Plugin-Übersichtstabelle"
 
 #: reports/templates/partials/plugin_overview_table.html
 #: reports/templates/partials/report_setup_scan.html
 msgid "Required plugins"
-msgstr ""
+msgstr "Erforderliche Plugins"
 
 #: reports/templates/partials/plugin_overview_table.html
 #: reports/templates/partials/report_setup_scan.html
 msgid "Suggested plugins"
-msgstr ""
+msgstr "Empfohlene Plugins"
 
 #: reports/templates/partials/plugin_overview_table.html
 msgid "Action required"
-msgstr ""
+msgstr "Aktion erforderlich"
 
 #: reports/templates/partials/plugin_overview_table.html
 msgid "Ready"
-msgstr ""
+msgstr "Bereit"
 
 #: reports/templates/partials/report_findings_table.html
 msgid ""
 "This table provides an overview of the identified findings on the scanned "
 "systems. For each finding type it shows the risk level, the number of "
 "occurrences and the first known occurrence of the finding. The risk level "
-"may be different for your specific environment. The details can be seen when "
-"expanding a row. A description, the source, impact and recommendation of the "
-"finding can be found here. It also shows in which findings the finding type "
-"occurred."
+"may be different for your specific environment. The details can be seen when"
+" expanding a row. A description, the source, impact and recommendation of "
+"the finding can be found here. It also shows in which findings the finding "
+"type occurred."
 msgstr ""
+"Diese Tabelle gibt einen Überblick über die identifizierten Befunde auf den "
+"gescannten Systemen. Für jeden Befundtyp werden die Risikostufe, die Anzahl "
+"der Vorkommnisse und das erste bekannte Vorkommen des Befundes angezeigt. "
+"Das Risikoniveau kann je nach Umgebung unterschiedlich sein. Die Details "
+"können beim Erweitern einer Zeile angezeigt werden. Eine Beschreibung, "
+"Quelle, Auswirkung und Empfehlung des Befundes finden Sie hier. Außerdem "
+"wird angezeigt, in welchen Befunden der Befundtyp vorkommt."
 
 #: reports/templates/partials/report_findings_table.html
 msgid "First known occurrence"
-msgstr ""
+msgstr "Erstes bekanntes Vorkommen"
 
 #: reports/templates/partials/report_findings_table.html
 msgid "Open in report"
-msgstr ""
+msgstr "Im Bericht öffnen"
 
 #: reports/templates/partials/report_findings_table.html
 msgid ""
 "No critical and high findings have been identified for this organization."
 msgstr ""
+"Für diese Organisation wurden keine kritischen und hohen Befunde "
+"festgestellt."
 
 #: reports/templates/partials/report_findings_table.html
 msgid "No findings have been identified for this organization."
-msgstr ""
+msgstr "Für diese Organisation liegen keine Befunde vor."
 
 #: reports/templates/partials/report_header.html
 msgid "Download as PDF"
-msgstr ""
+msgstr "Als PDF herunterladen"
 
 #: reports/templates/partials/report_header.html
 #: rocky/templates/partials/ooi_list_toolbar.html
 msgid "Download as JSON"
-msgstr ""
+msgstr "Als JSON herunterladen"
 
 #: reports/templates/partials/report_header.html
 msgid "Open asset reports"
-msgstr ""
+msgstr "Anlagenberichte öffnen"
 
 #: reports/templates/partials/report_header.html
 msgid "This is the OpenKAT report for organization"
-msgstr ""
+msgstr "Dies ist der OpenKAT-Bericht für die Organisation"
 
 #: reports/templates/partials/report_header.html
 msgid ""
 "All selected report types for the selected objects are displayed one below "
 "the other."
 msgstr ""
+"Alle ausgewählten Berichtstypen für die ausgewählten Objekte werden "
+"untereinander angezeigt."
 
 #: reports/templates/partials/report_header.html
 msgid "Created with data from:"
-msgstr ""
+msgstr "Erstellt mit Daten von:"
 
 #: reports/templates/partials/report_header.html
 msgid "Created on:"
-msgstr ""
+msgstr "Erstellt am:"
 
 #: reports/templates/partials/report_header.html
 msgid "Created from recipe:"
-msgstr ""
+msgstr "Erstellt nach Rezept:"
 
 #: reports/templates/partials/report_header.html
 msgid "Recipe created by:"
-msgstr ""
+msgstr "Rezept erstellt von:"
 
 #: reports/templates/partials/report_header.html
 #, python-format
 msgid "This sector contains %(length)s scanned organizations."
-msgstr ""
+msgstr "Dieser Sektor enthält %(length)s gescannte Organisationen."
 
 #: reports/templates/partials/report_header.html
 msgid "Of these organizations"
-msgstr ""
+msgstr "Von diesen Organisationen"
 
 #: reports/templates/partials/report_header.html
 msgid "organizations have tag"
-msgstr ""
+msgstr "Organisationen haben ein Tag"
 
 #: reports/templates/partials/report_header.html
 msgid "The basic security scores are around "
-msgstr ""
+msgstr "Die grundlegenden Sicherheitswerte liegen bei rund"
 
 #: reports/templates/partials/report_header.html
 #, python-format
 msgid "A total of %(total)s critical vulnerabilities have been identified."
-msgstr ""
+msgstr "Insgesamt wurden kritische Schwachstellen %(total)s identifiziert."
 
 #: reports/templates/partials/report_introduction.html
 msgid "Introduction"
-msgstr ""
+msgstr "Einführung"
 
 #: reports/templates/partials/report_introduction.html
 msgid ""
 "This report gives an overview of the current state of security for your "
-"organisation for the selected date. The summary section provides an overview "
-"of the selected systems (objects), plugins and reports. This is followed "
+"organisation for the selected date. The summary section provides an overview"
+" of the selected systems (objects), plugins and reports. This is followed "
 "with the findings for each report."
 msgstr ""
+"Dieser Bericht gibt einen Überblick über den aktuellen Sicherheitsstand "
+"Ihrer Organisation für das ausgewählte Datum. Der Zusammenfassungsbereich "
+"bietet einen Überblick über die ausgewählten Systeme (Objekte), Plugins und "
+"Berichte. Anschließend werden die Ergebnisse für jeden Bericht aufgeführt."
 
 #: reports/templates/partials/report_names_form.html
 msgid "Report names:"
-msgstr ""
+msgstr "Berichtsnamen:"
 
 #: reports/templates/partials/report_names_form.html
 #: rocky/templates/forms/widgets/checkbox_group_table.html
@@ -3974,36 +4438,36 @@ msgstr "Erforderlich"
 
 #: reports/templates/partials/report_names_form.html
 msgid "Add reference date"
-msgstr ""
+msgstr "Referenzdatum hinzufügen"
 
 #: reports/templates/partials/report_names_form.html
 #: reports/templates/report_overview/modal_partials/rename_modal.html
 msgid "Reset"
-msgstr ""
+msgstr "Zurücksetzen"
 
 #: reports/templates/partials/report_names_form.html
 msgid "No reference date"
-msgstr ""
+msgstr "Kein Referenzdatum"
 
 #: reports/templates/partials/report_names_form.html
 msgid "Day"
-msgstr ""
+msgstr "Tag"
 
 #: reports/templates/partials/report_names_form.html
 msgid "Week"
-msgstr ""
+msgstr "Woche"
 
 #: reports/templates/partials/report_names_form.html
 msgid "Month"
-msgstr ""
+msgstr "Monat"
 
 #: reports/templates/partials/report_names_form.html
 msgid "Year"
-msgstr ""
+msgstr "Jahr"
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "Object selection"
-msgstr ""
+msgstr "Objektauswahl"
 
 #: reports/templates/partials/report_ooi_list.html
 msgid ""
@@ -4011,52 +4475,68 @@ msgid ""
 "continue with a live set or you can select the objects manually from the "
 "table below."
 msgstr ""
+"Wählen Sie aus, welche Objekte Sie in Ihren Bericht aufnehmen möchten. Sie "
+"können entweder mit einem Live-Set fortfahren oder die Objekte manuell aus "
+"der Tabelle unten auswählen."
 
 #: reports/templates/partials/report_ooi_list.html
 msgid ""
-"A live set is a set of objects based on the applied filters. Any object that "
-"matches this applied filter (now or in the future) will be used as input for "
-"the scheduled report. If your live set filter (e.g. 'hostnames' with 'L2 "
-"clearance' that are 'declared') shows 2 hostnames that match the filter "
+"A live set is a set of objects based on the applied filters. Any object that"
+" matches this applied filter (now or in the future) will be used as input "
+"for the scheduled report. If your live set filter (e.g. 'hostnames' with 'L2"
+" clearance' that are 'declared') shows 2 hostnames that match the filter "
 "today, the scheduled report will run for those 2 hostnames. If you add 3 "
-"more hostnames tomorrow (with the same filter criteria), your next scheduled "
-"report will contain 5 hostnames. Your live set will update as you go."
+"more hostnames tomorrow (with the same filter criteria), your next scheduled"
+" report will contain 5 hostnames. Your live set will update as you go."
 msgstr ""
+"Ein Live-Set ist eine Menge von Objekten, die auf den angewendeten Filtern "
+"basieren. Jedes Objekt, das diesem angewendeten Filter entspricht (jetzt "
+"oder in Zukunft), wird als Eingabe für den geplanten Bericht verwendet. Wenn"
+" Ihr Live-Set-Filter (z. B. „Hostnamen“ mit „L2-Freigabe“, die „deklariert“ "
+"sind) zwei Hostnamen anzeigt, die heute mit dem Filter übereinstimmen, wird "
+"der geplante Bericht für diese beiden Hostnamen ausgeführt. Wenn Sie morgen "
+"drei weitere Hostnamen hinzufügen (mit denselben Filterkriterien), enthält "
+"Ihr nächster geplanter Bericht fünf Hostnamen. Ihr Live-Set wird im Laufe "
+"der Zeit aktualisiert."
 
 #: reports/templates/partials/report_ooi_list.html
 msgid ""
 "Based on the current dataset, your selected filters result in the following "
 "objects."
 msgstr ""
+"Basierend auf dem aktuellen Datensatz führen Ihre ausgewählten Filter zu den"
+" folgenden Objekten."
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "objects selected"
-msgstr ""
+msgstr "Objekte ausgewählt"
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "Deselect all objects"
-msgstr ""
+msgstr "Alle Objekte abwählen"
 
 #: reports/templates/partials/report_ooi_list.html
 #: rocky/templates/oois/ooi_list.html
 #, python-format
 msgid "Showing %(length)s of %(total)s objects"
-msgstr ""
+msgstr "Zeigt %(length)s von %(total)s-Objekten"
 
 #: reports/templates/partials/report_ooi_list.html
 #, python-format
 msgid "Select all %(total_oois)s object"
 msgid_plural "Select all %(total_oois)s objects"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Wählen Sie alle %(total_oois)s-Objekte aus"
+msgstr[1] "Wählen Sie alle %(total_oois)s-Objekte aus"
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "Object name"
-msgstr ""
+msgstr "Objektname"
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "Report(s) may be empty due to no objects in the selected filters."
 msgstr ""
+"Berichte sind möglicherweise leer, da sich in den ausgewählten Filtern keine"
+" Objekte befinden."
 
 #: reports/templates/partials/report_ooi_list.html
 msgid ""
@@ -4064,53 +4544,65 @@ msgid ""
 "Future reports may contain data. It is still possible to generate the "
 "(potentially empty) report."
 msgstr ""
+"Berichte, die den ausgewählten Filtern entsprechen, sind zu diesem Zeitpunkt"
+" leer. Zukünftige Berichte können Daten enthalten. Es ist weiterhin möglich,"
+" den (möglicherweise leeren) Bericht zu erstellen."
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "Continue with live set"
-msgstr ""
+msgstr "Weiter mit Live-Set"
 
 #: reports/templates/partials/report_ooi_list.html
 #: reports/templates/partials/report_types_selection.html
 msgid "Continue with selection"
-msgstr ""
+msgstr "Fahren Sie mit der Auswahl fort"
 
 #: reports/templates/partials/report_setup_scan.html
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 #: reports/views/multi_report.py
 msgid "Configuration"
-msgstr ""
+msgstr "Konfiguration"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Set up the required plugins for this report."
-msgstr ""
+msgstr "Richten Sie die erforderlichen Plugins für diesen Bericht ein."
 
 #: reports/templates/partials/report_setup_scan.html
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugins"
-msgstr ""
+msgstr "Plugins"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid ""
 "KAT will be able to generate a full report when all the required and "
 "suggested boefjes are enabled."
 msgstr ""
+"KAT kann einen vollständigen Bericht erstellen, wenn alle erforderlichen und"
+" vorgeschlagenen Boefjes aktiviert sind."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid ""
 "If you choose not to enable a plugin, the data that plugin would collect or "
-"produce will be left out of the report which will then be generated based on "
-"the available data collected by the enabled plugins."
+"produce will be left out of the report which will then be generated based on"
+" the available data collected by the enabled plugins."
 msgstr ""
+"Wenn Sie sich dafür entscheiden, ein Plugin nicht zu aktivieren, werden die "
+"Daten, die das Plugin sammeln oder erzeugen würde, im Bericht nicht "
+"berücksichtigt, der dann auf der Grundlage der verfügbaren Daten erstellt "
+"wird, die von den aktivierten Plugins erfasst werden."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid ""
 "Some plugins are mandatory as they are crucial for a report type. Reports "
 "that don't have their requirements met will be skipped."
 msgstr ""
+"Einige Plugins sind obligatorisch, da sie für einen Berichtstyp von "
+"entscheidender Bedeutung sind. Berichte, deren Anforderungen nicht erfüllt "
+"sind, werden übersprungen."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Warning! Before you proceed read the following points:"
-msgstr ""
+msgstr "Warnung! Bevor Sie fortfahren, lesen Sie die folgenden Punkte:"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid ""
@@ -4118,57 +4610,64 @@ msgid ""
 "enabled plugins and set clearance levels. This means that scans will run "
 "automatically. Be patient; plugins may take some time before they have "
 "collected all their data. Enabling them just before report generation will "
-"likely result in inaccurate reports, as plugins have not finished collecting "
-"data."
+"likely result in inaccurate reports, as plugins have not finished collecting"
+" data."
 msgstr ""
+"OpenKAT ist darauf ausgelegt, mithilfe der aktivierten Plugins regelmäßig "
+"alle bekannten Objekte zu scannen und Freigabestufen festzulegen. Das "
+"bedeutet, dass die Scans automatisch ausgeführt werden. Sei geduldig; Es "
+"kann einige Zeit dauern, bis Plugins alle Daten erfasst haben. Wenn Sie sie "
+"kurz vor der Berichtserstellung aktivieren, werden die Berichte "
+"wahrscheinlich ungenau, da die Plugins die Datenerfassung noch nicht "
+"abgeschlossen haben."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Good job! All required plugins are enabled."
-msgstr ""
+msgstr "Gute Arbeit! Alle erforderlichen Plugins sind aktiviert."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "This report type requires the following plugins to be enabled:"
-msgstr ""
+msgstr "Für diesen Berichtstyp müssen die folgenden Plugins aktiviert sein:"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Toggle all required plugins"
-msgstr ""
+msgstr "Schalten Sie alle erforderlichen Plugins um"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Show enabled plugins"
-msgstr ""
+msgstr "Aktivierte Plugins anzeigen"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "There are no required plugins."
-msgstr ""
+msgstr "Es sind keine Plugins erforderlich."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Good job! All suggested plugins are enabled."
-msgstr ""
+msgstr "Gute Arbeit! Alle vorgeschlagenen Plugins sind aktiviert."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "The following plugins are optional to generate the report:"
-msgstr ""
+msgstr "Die folgenden Plugins sind optional, um den Bericht zu erstellen:"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Toggle all optional plugins"
-msgstr ""
+msgstr "Schalten Sie alle optionalen Plugins um"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Hide suggested plugins"
-msgstr ""
+msgstr "Vorgeschlagene Plugins ausblenden"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Show more suggested plugins"
-msgstr ""
+msgstr "Weitere vorgeschlagene Plugins anzeigen"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "There are no optional plugins."
-msgstr ""
+msgstr "Es gibt keine optionalen Plugins."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Enable selected plugins and continue"
-msgstr ""
+msgstr "Ausgewählte Plugins aktivieren und fortfahren"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid ""
@@ -4177,72 +4676,82 @@ msgid ""
 "            severity that have been identified for this organization.\n"
 "        "
 msgstr ""
+"\n"
+"Diese Übersicht zeigt die Gesamtzahl der Befunde pro\n"
+"            Schweregrad, die für diese Organisation identifiziert wurden."
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Total per severity overview"
-msgstr ""
+msgstr "Gesamtübersicht pro Schweregrad"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Critical"
-msgstr ""
+msgstr "Kritisch"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "High"
-msgstr ""
+msgstr "Hoch"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Medium"
-msgstr ""
+msgstr "Medium"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Low"
-msgstr ""
+msgstr "Niedrig"
 
 #: reports/templates/partials/report_severity_totals_table.html
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Pending"
-msgstr ""
+msgstr "Ausstehend"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Unknown"
-msgstr ""
+msgstr "Unbekannt"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Total"
-msgstr ""
+msgstr "Gesamt"
 
 #: reports/templates/partials/report_sidemenu.html
 msgid "Selected Objects"
-msgstr ""
+msgstr "Ausgewählte Objekte"
 
 #: reports/templates/partials/report_sidemenu.html
 msgid "Selected Plugins"
-msgstr ""
+msgstr "Ausgewählte Plugins"
 
 #: reports/templates/partials/report_sidemenu.html
 msgid "Used Config Objects"
-msgstr ""
+msgstr "Verwendete Konfigurationsobjekte"
 
 #: reports/templates/partials/report_types_selection.html
 msgid "Choose report types"
-msgstr ""
+msgstr "Wählen Sie Berichtstypen"
 
 #: reports/templates/partials/report_types_selection.html
 msgid ""
-"Various types of reports, such as DNS reports and TLS reports, are essential "
-"for identifying vulnerabilities in different aspects of a system's security. "
-"DNS reports focus on domain name system configuration and potential "
-"weaknesses, while TLS reports assess the security of data encryption and "
-"transmission protocols, helping organizations pinpoint areas where security "
-"improvements are needed."
+"Various types of reports, such as DNS reports and TLS reports, are essential"
+" for identifying vulnerabilities in different aspects of a system's "
+"security. DNS reports focus on domain name system configuration and "
+"potential weaknesses, while TLS reports assess the security of data "
+"encryption and transmission protocols, helping organizations pinpoint areas "
+"where security improvements are needed."
 msgstr ""
+"Verschiedene Arten von Berichten, wie z. B. DNS-Berichte und TLS-Berichte, "
+"sind für die Identifizierung von Schwachstellen in verschiedenen Aspekten "
+"der Systemsicherheit unerlässlich. DNS-Berichte konzentrieren sich auf die "
+"Konfiguration von Domain-Name-Systemen und potenzielle Schwachstellen, "
+"während TLS-Berichte die Sicherheit von Datenverschlüsselungs- und "
+"Übertragungsprotokollen bewerten und Unternehmen dabei helfen, Bereiche zu "
+"identifizieren, in denen Sicherheitsverbesserungen erforderlich sind."
 
 #: reports/templates/partials/report_types_selection.html
 #, python-format
 msgid "Selected object (%(total_oois)s)"
 msgid_plural "Selected objects (%(total_oois)s)"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Ausgewählte Objekte (%(total_oois)s)"
+msgstr[1] "Ausgewählte Objekte (%(total_oois)s)"
 
 #: reports/templates/partials/report_types_selection.html
 #, python-format
@@ -4250,43 +4759,45 @@ msgid ""
 "You have selected a live set in the previous step. Based on the current "
 "dataset, this live set results in %(total_oois)s objects."
 msgstr ""
+"Sie haben im vorherigen Schritt ein Live-Set ausgewählt. Basierend auf dem "
+"aktuellen Datensatz führt dieser Live-Satz zu %(total_oois)s-Objekten."
 
 #: reports/templates/partials/report_types_selection.html
 msgid "Applied filters:"
-msgstr ""
+msgstr "Angewandte Filter:"
 
 #: reports/templates/partials/report_types_selection.html
 #, python-format
 msgid "You have selected %(total_oois)s object in the previous step."
 msgid_plural "You have selected %(total_oois)s objects in the previous step."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Sie haben im vorherigen Schritt %(total_oois)s-Objekte ausgewählt."
+msgstr[1] "Sie haben im vorherigen Schritt %(total_oois)s-Objekte ausgewählt."
 
 #: reports/templates/partials/report_types_selection.html
 msgid "Change selection"
-msgstr ""
+msgstr "Auswahl ändern"
 
 #: reports/templates/partials/report_types_selection.html
 msgid "Available report types"
-msgstr ""
+msgstr "Verfügbare Berichtstypen"
 
 #: reports/templates/partials/report_types_selection.html
 msgid "All report types that are available for your selection."
-msgstr ""
+msgstr "Alle Berichtstypen, die für Ihre Auswahl verfügbar sind."
 
 #: reports/templates/partials/report_types_selection.html
 msgid "Toggle all report types"
-msgstr ""
+msgstr "Alle Berichtstypen umschalten"
 
 #: reports/templates/partials/return_button.html
 #, python-format
 msgid "%(btn_text)s"
-msgstr ""
+msgstr "%(btn_text)s"
 
 #: reports/templates/report_overview/modal_partials/delete_modal.html
 #: reports/templates/report_overview/modal_partials/share_modal.html
 msgid "Delete the following report(s):"
-msgstr ""
+msgstr "Löschen Sie den/die folgenden Bericht(e):"
 
 #: reports/templates/report_overview/modal_partials/delete_modal.html
 #: reports/templates/report_overview/modal_partials/share_modal.html
@@ -4295,6 +4806,10 @@ msgid ""
 "report can still be accessed on timestamps before the deletion. Only the "
 "report is removed from the view, not the data it is based on."
 msgstr ""
+"Gelöschte Berichte werden ab dem Zeitpunkt des Löschens aus der Ansicht "
+"entfernt. Der Bericht ist mit den Zeitstempeln vor der Löschung weiterhin "
+"abrufbar. Nur der Bericht wird aus der Ansicht entfernt, nicht die Daten, "
+"auf denen er basiert."
 
 #: reports/templates/report_overview/modal_partials/delete_modal.html
 #: reports/templates/report_overview/modal_partials/share_modal.html
@@ -4303,6 +4818,9 @@ msgid ""
 "is part of a combined report, it will remain available in the combined "
 "report."
 msgstr ""
+"Es ist weiterhin möglich, einen neuen Bericht für dasselbe Datum zu "
+"erstellen. Wenn der Bericht Teil eines kombinierten Berichts ist, bleibt er "
+"im kombinierten Bericht verfügbar."
 
 #: reports/templates/report_overview/modal_partials/delete_modal.html
 #: reports/templates/report_overview/modal_partials/rerun_modal.html
@@ -4310,81 +4828,89 @@ msgstr ""
 #: reports/templates/report_overview/scheduled_reports_table.html
 #: reports/templates/report_overview/subreports_table.html
 msgid "Reference date"
-msgstr ""
+msgstr "Referenzdatum"
 
 #: reports/templates/report_overview/modal_partials/enable_disable_schedule_modal.html
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Disable schedule"
-msgstr ""
+msgstr "Zeitplan deaktivieren"
 
 #: reports/templates/report_overview/modal_partials/enable_disable_schedule_modal.html
 #, python-format
 msgid ""
-"Are you sure you want to disable the schedule for <strong>%(report_name)s</"
-"strong>? The recipe will still exist and the schedule can be enabled later "
-"on."
+"Are you sure you want to disable the schedule for "
+"<strong>%(report_name)s</strong>? The recipe will still exist and the "
+"schedule can be enabled later on."
 msgstr ""
+"Sind Sie sicher, dass Sie den Zeitplan für <strong>%(report_name)s</strong> "
+"deaktivieren möchten? Das Rezept bleibt bestehen und der Zeitplan kann "
+"später aktiviert werden."
 
 #: reports/templates/report_overview/modal_partials/rename_modal.html
 msgid "Rename the following report(s):"
-msgstr ""
+msgstr "Benennen Sie den/die folgenden Bericht(e) um:"
 
 #: reports/templates/report_overview/modal_partials/rename_modal.html
 #: reports/templates/report_overview/report_history_table.html
 msgid "Rename"
-msgstr ""
+msgstr "Umbenennen"
 
 #: reports/templates/report_overview/modal_partials/rerun_modal.html
 msgid "Rerun the following report(s):"
-msgstr ""
+msgstr "Führen Sie den/die folgenden Bericht(e) erneut aus:"
 
 #: reports/templates/report_overview/modal_partials/rerun_modal.html
 msgid ""
 "By submitting you're generating the selected reports again, using the "
 "current data."
 msgstr ""
+"Durch das Absenden generieren Sie die ausgewählten Berichte erneut und "
+"verwenden dabei die aktuellen Daten."
 
 #: reports/templates/report_overview/modal_partials/rerun_modal.html
 #: reports/templates/report_overview/report_history_table.html
 msgid "Rerun"
-msgstr ""
+msgstr "Wiederholung"
 
 #: reports/templates/report_overview/report_history.html
 msgid "Reports history"
-msgstr ""
+msgstr "Berichtet den Verlauf"
 
 #: reports/templates/report_overview/report_history.html
 msgid ""
 "On this page you can see all the reports that have been generated in the "
 "past. To create a new report, click the 'Generate Report' button."
 msgstr ""
+"Auf dieser Seite sehen Sie alle Berichte, die in der Vergangenheit erstellt "
+"wurden. Um einen neuen Bericht zu erstellen, klicken Sie auf die "
+"Schaltfläche „Bericht erstellen“."
 
 #: reports/templates/report_overview/report_history_table.html
 #: reports/templates/report_overview/subreports.html
 #, python-format
 msgid "Showing %(length)s of %(total)s reports"
-msgstr ""
+msgstr "Zeigt %(length)s von %(total)s-Berichten"
 
 #: reports/templates/report_overview/report_history_table.html
 #: rocky/templates/tasks/reports.html
 msgid "Reports:"
-msgstr ""
+msgstr "Berichte:"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "Shows parent report details"
-msgstr ""
+msgstr "Zeigt Details des übergeordneten Berichts an"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "Close asset report object details"
-msgstr ""
+msgstr "Schließen Sie die Objektdetails des Asset-Berichts"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "Open asset report object details"
-msgstr ""
+msgstr "Öffnen Sie die Objektdetails des Asset-Berichts"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "Asset reports details"
-msgstr ""
+msgstr "Details zu Vermögensberichten"
 
 #: reports/templates/report_overview/report_history_table.html
 #, python-format
@@ -4395,26 +4921,30 @@ msgid_plural ""
 "This report consists of %(counter)s asset reports with the following report "
 "types and objects:"
 msgstr[0] ""
+"Dieser Bericht besteht aus %(counter)s-Asset-Berichten mit den folgenden "
+"Berichtstypen und Objekten:"
 msgstr[1] ""
+"Dieser Bericht besteht aus %(counter)s-Asset-Berichten mit den folgenden "
+"Berichtstypen und Objekten:"
 
 #: reports/templates/report_overview/report_history_table.html
 #: reports/templates/report_overview/subreports_header.html
 #: reports/templates/report_overview/subreports_table.html
 #: reports/views/report_overview.py
 msgid "Asset reports"
-msgstr ""
+msgstr "Vermögensberichte"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "Shows asset report details"
-msgstr ""
+msgstr "Zeigt Details zum Asset-Bericht an"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "View all asset reports"
-msgstr ""
+msgstr "Alle Asset-Berichte anzeigen"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "No reports have been generated yet."
-msgstr ""
+msgstr "Es wurden noch keine Berichte generiert."
 
 #: reports/templates/report_overview/report_overview_header.html
 #: reports/views/base.py rocky/templates/header.html
@@ -4425,99 +4955,103 @@ msgstr "Berichte"
 
 #: reports/templates/report_overview/report_overview_header.html
 msgid "An overview of reports that are scheduled or have been generated."
-msgstr ""
+msgstr "Eine Übersicht über geplante oder generierte Berichte."
 
 #: reports/templates/report_overview/report_overview_navigation.html
 msgid "Scheduled"
-msgstr ""
+msgstr "Geplant"
 
 #: reports/templates/report_overview/report_overview_navigation.html
 msgid "History"
-msgstr ""
+msgstr "Geschichte"
 
 #: reports/templates/report_overview/scheduled_reports.html
 msgid "Scheduled reports"
-msgstr ""
+msgstr "Geplante Berichte"
 
 #: reports/templates/report_overview/scheduled_reports.html
 msgid ""
-"On this page you can see all the reports that are or have been scheduled. To "
-"schedule a report, select a start date and recurrence while generating a "
+"On this page you can see all the reports that are or have been scheduled. To"
+" schedule a report, select a start date and recurrence while generating a "
 "report."
 msgstr ""
+"Auf dieser Seite können Sie alle Berichte sehen, die geplant sind oder "
+"wurden. Um einen Bericht zu planen, wählen Sie beim Erstellen eines Berichts"
+" ein Startdatum und eine Wiederholung aus."
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 #, python-format
 msgid "Showing %(length)s of %(total)s schedules"
-msgstr ""
+msgstr "Zeigt %(length)s von %(total)s-Zeitplänen"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Scheduled reports:"
-msgstr ""
+msgstr "Geplante Berichte:"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Scheduled for"
-msgstr ""
+msgstr "Geplant für"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Schedule status"
-msgstr ""
+msgstr "Zeitplanstatus"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Once"
-msgstr ""
+msgstr "Einmal"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Recent reports"
-msgstr ""
+msgstr "Aktuelle Berichte"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Scheduled Reports:"
-msgstr ""
+msgstr "Geplante Berichte:"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Show report details"
-msgstr ""
+msgstr "Berichtsdetails anzeigen"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "objects"
-msgstr ""
+msgstr "Objekte"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Enable schedule"
-msgstr ""
+msgstr "Zeitplan aktivieren"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "No scheduled reports have been generated yet."
-msgstr ""
+msgstr "Es wurden noch keine geplanten Berichte generiert."
 
 #: reports/templates/report_overview/subreports_header.html
 msgid "Back to Reports History"
-msgstr ""
+msgstr "Zurück zum Berichtsverlauf"
 
 #: reports/templates/report_overview/subreports_header.html
 msgid "An overview of all underlying reports of"
-msgstr ""
+msgstr "Eine Übersicht aller zugrunde liegenden Berichte von"
 
 #: reports/templates/report_overview/subreports_header.html
 #: reports/templates/report_overview/subreports_table.html
 msgid "Shows report details"
-msgstr ""
+msgstr "Zeigt Berichtsdetails an"
 
 #: reports/templates/report_overview/subreports_table.html
 #: rocky/templates/tasks/boefjes.html
 #: rocky/templates/tasks/plugin_detail_task_list.html
 msgid "Input Object"
-msgstr ""
+msgstr "Eingabeobjekt"
 
 #: reports/templates/report_schedules/delete_recipe_modal.html
 msgid "Delete report recipe"
-msgstr ""
+msgstr "Berichtsrezept löschen"
 
 #: reports/templates/report_schedules/delete_recipe_modal.html
 #, python-format
 msgid "Are you sure you want to delete report recipe \"%(name)s\"?"
 msgstr ""
+"Sind Sie sicher, dass Sie das Berichtsrezept „%(name)s“ löschen möchten?"
 
 #: reports/templates/report_schedules/delete_recipe_modal.html
 msgid ""
@@ -4525,164 +5059,191 @@ msgid ""
 "not be possible anymore to see or enable the schedule. You will find "
 "previously generated reports in the report history tab."
 msgstr ""
+"Wenn Sie dieses Berichtsrezept löschen, wird es dauerhaft gelöscht. Der "
+"Zeitplan kann nicht mehr angezeigt oder aktiviert werden. Zuvor erstellte "
+"Berichte finden Sie auf der Registerkarte „Berichtsverlauf“."
 
 #: reports/templates/summary/report_asset_overview.html
 msgid ""
-"The objects listed in the table below were used to generate this report. For "
-"each object in the table it additionally shows the clearance level and "
+"The objects listed in the table below were used to generate this report. For"
+" each object in the table it additionally shows the clearance level and "
 "whether or not the object was added by a user ('Declared') or indirectly "
 "identified through another service or system ('Inherited')."
 msgstr ""
+"Zur Erstellung dieses Berichts wurden die in der folgenden Tabelle "
+"aufgeführten Objekte verwendet. Für jedes Objekt in der Tabelle wird "
+"zusätzlich die Freigabestufe angezeigt und ob das Objekt von einem Benutzer "
+"hinzugefügt („Deklariert“) oder indirekt über einen anderen Dienst oder ein "
+"anderes System identifiziert („Geerbt“) wurde."
 
 #: reports/templates/summary/report_asset_overview.html
 msgid "No objects found."
-msgstr ""
+msgstr "Keine Objekte gefunden."
 
 #: reports/templates/summary/report_asset_overview.html
 msgid ""
 "The table below shows which reports were chosen to generate this report, "
 "including a report description."
 msgstr ""
+"Die folgende Tabelle zeigt, welche Berichte zur Erstellung dieses Berichts "
+"ausgewählt wurden, einschließlich einer Berichtsbeschreibung."
 
 #: reports/templates/summary/report_asset_overview.html
 msgid "No report types found."
-msgstr ""
+msgstr "Keine Berichtstypen gefunden."
 
 #: reports/templates/summary/selected_plugins.html
 msgid ""
 "The table below shows all required or optional plugins for the selected "
 "reports."
 msgstr ""
+"Die folgende Tabelle zeigt alle erforderlichen oder optionalen Plugins für "
+"die ausgewählten Berichte."
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Required and optional plugins"
-msgstr ""
+msgstr "Erforderliche und optionale Plugins"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugin enabled"
-msgstr ""
+msgstr "Plugin aktiviert"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugin options"
-msgstr ""
+msgstr "Plugin-Optionen"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugin scan level"
-msgstr ""
+msgstr "Plugin-Scanebene"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Enabled."
-msgstr ""
+msgstr "Ermöglicht."
 
 #: reports/templates/summary/selected_plugins.html
 msgid "required"
-msgstr ""
+msgstr "erforderlich"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "optional"
-msgstr ""
+msgstr "optional"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugin extra info"
-msgstr ""
+msgstr "Zusätzliche Plugin-Infos"
 
 #: reports/templates/summary/selected_plugins.html
 msgid ""
 "There are no required or optional plugins needed for the selected report "
 "types."
 msgstr ""
+"Für die ausgewählten Berichtstypen sind keine erforderlichen oder optionalen"
+" Plugins erforderlich."
 
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 #: reports/views/multi_report.py
 msgid "Select objects"
-msgstr ""
+msgstr "Wählen Sie Objekte aus"
 
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 #: reports/views/multi_report.py
 msgid "Select report types"
-msgstr ""
+msgstr "Wählen Sie Berichtstypen aus"
 
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 #: reports/views/multi_report.py
 msgid "Export setup"
-msgstr ""
+msgstr "Setup exportieren"
 
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 msgid "Save report"
-msgstr ""
+msgstr "Bericht speichern"
 
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 msgid "You do not have the required permissions to enable plugins."
 msgstr ""
+"Sie verfügen nicht über die erforderlichen Berechtigungen zum Aktivieren von"
+" Plugins."
 
 #: reports/views/base.py
 msgid "Select at least one OOI to proceed."
-msgstr ""
+msgstr "Wählen Sie mindestens einen OOI aus, um fortzufahren."
 
 #: reports/views/base.py
 msgid "Select at least one report type to proceed."
-msgstr ""
+msgstr "Wählen Sie mindestens einen Berichtstyp aus, um fortzufahren."
 
 #: reports/views/mixins.py
 msgid ""
 "No data could be found for %(report_types). Object(s) did not exist on "
 "%(date)s."
 msgstr ""
+"Für %(report_types) konnten keine Daten gefunden werden. Objekt(e) "
+"existierten nicht auf %(date)s."
 
 #: reports/views/multi_report.py
 msgid "View report"
-msgstr ""
+msgstr "Bericht ansehen"
 
 #: reports/views/report_overview.py
 msgid "Not enough permissions"
-msgstr ""
+msgstr "Nicht genügend Berechtigungen"
 
 #: reports/views/report_overview.py
 msgid "Recipe '{}' deleted successfully"
-msgstr ""
+msgstr "Rezept „{}“ erfolgreich gelöscht"
 
 #: reports/views/report_overview.py
 msgid "Recipe not found."
-msgstr ""
+msgstr "Rezept nicht gefunden."
 
 #: reports/views/report_overview.py
 msgid "No schedule or recipe selected"
-msgstr ""
+msgstr "Kein Zeitplan oder Rezept ausgewählt"
 
 #: reports/views/report_overview.py
 msgid ""
 "Schedule disabled successfully. '{}' will not be generated automatically "
 "until the schedule is enabled again."
 msgstr ""
+"Zeitplan erfolgreich deaktiviert. „{}“ wird erst dann automatisch generiert,"
+" wenn der Zeitplan wieder aktiviert wird."
 
 #: reports/views/report_overview.py
 msgid ""
 "Schedule enabled successfully. '{}' will be generated according to schedule."
-msgstr ""
+msgstr "Zeitplan erfolgreich aktiviert. „{}“ wird gemäß Zeitplan generiert."
 
 #: reports/views/report_overview.py
 msgid "An unexpected error occurred, please check logs for more info."
 msgstr ""
+"Es ist ein unerwarteter Fehler aufgetreten. Weitere Informationen finden Sie"
+" in den Protokollen."
 
 #: reports/views/report_overview.py
 msgid "Other OOI type selected than Report"
-msgstr ""
+msgstr "Anderer OOI-Typ als Bericht ausgewählt"
 
 #: reports/views/report_overview.py
 msgid "Deletion successful."
-msgstr ""
+msgstr "Löschung erfolgreich."
 
 #: reports/views/report_overview.py
 msgid ""
 "Multi organization reports cannot be rescheduled. It consists of imported "
 "data from different organizations and is not based on newly generated data."
 msgstr ""
+"Berichte über mehrere Organisationen können nicht neu geplant werden. Es "
+"besteht aus importierten Daten verschiedener Organisationen und basiert "
+"nicht auf neu generierten Daten."
 
 #: reports/views/report_overview.py
 msgid ""
 "Rerun successful. It may take a moment before the new report has been "
 "generated."
 msgstr ""
+"Wiederholung erfolgreich. Es kann einen Moment dauern, bis der neue Bericht "
+"erstellt wurde."
 
 #: reports/views/report_overview.py
 #, python-format
@@ -4690,379 +5251,391 @@ msgid ""
 "Couldn't rerun %s, since the recipe for this report has been disabled or "
 "deleted."
 msgstr ""
+"%s konnte nicht erneut ausgeführt werden, da das Rezept für diesen Bericht "
+"deaktiviert oder gelöscht wurde."
 
 #: reports/views/report_overview.py
 msgid "Renaming failed. Empty report name found."
-msgstr ""
+msgstr "Umbenennung fehlgeschlagen. Leerer Berichtsname gefunden."
 
 #: reports/views/report_overview.py
 msgid "Report names and reports does not match."
-msgstr ""
+msgstr "Berichtsnamen und Berichte stimmen nicht überein."
 
 #: reports/views/report_overview.py
 msgid "Reports successfully renamed."
-msgstr ""
+msgstr "Berichte erfolgreich umbenannt."
 
 #: reports/views/report_overview.py
 msgid "Report {} could not be renamed."
-msgstr ""
+msgstr "Bericht {} konnte nicht umbenannt werden."
 
 #: reports/views/view_helpers.py
 msgid "1: Select objects"
-msgstr ""
+msgstr "1: Objekte auswählen"
 
 #: reports/views/view_helpers.py
 msgid "2: Choose report types"
-msgstr ""
+msgstr "2: Berichtstypen auswählen"
 
 #: reports/views/view_helpers.py
 msgid "3: Configuration"
-msgstr ""
+msgstr "3: Konfiguration"
 
 #: reports/views/view_helpers.py
 msgid "4: Export setup"
-msgstr ""
+msgstr "4: Setup exportieren"
 
 #: reports/views/view_helpers.py
 msgid "3: Export setup"
-msgstr ""
+msgstr "3: Setup exportieren"
 
 #: tools/forms/base.py
 msgid "Date"
-msgstr ""
-
-#: tools/forms/base.py tools/forms/scheduler.py
-msgid "The selected date is in the future. Please select a different date."
-msgstr ""
+msgstr "Datum"
 
 #: tools/forms/boefje.py
 msgid "For example: -sTU --top-ports 1000"
-msgstr ""
+msgstr "Beispiel: -sTU --top-ports 1000"
 
 #: tools/forms/boefje.py
 msgid "JSON Schema"
-msgstr ""
+msgstr "JSON-Schema"
 
 #: tools/forms/boefje.py
 msgid "Input object type"
-msgstr ""
+msgstr "Eingabeobjekttyp"
 
 #: tools/forms/boefje.py
 msgid "Output mime types"
-msgstr ""
+msgstr "Ausgabe-MIME-Typen"
 
 #: tools/forms/boefje.py
 msgid "Scan type"
-msgstr ""
+msgstr "Scantyp"
 
 #: tools/forms/boefje.py
 msgid "Interval amount"
-msgstr ""
+msgstr "Intervallbetrag"
 
 #: tools/forms/boefje.py
 msgid ""
 "Specify the scanning interval for this Boefje. The default is 24 hours. For "
 "example: 5 minutes will let the Boefje scan every 5 minutes."
 msgstr ""
+"Geben Sie das Scanintervall für diesen Boefje an. Der Standardwert ist 24 "
+"Stunden. Beispiel: 5 Minuten lässt den Boefje alle 5 Minuten scannen."
 
 #: tools/forms/boefje.py
 msgid "Interval frequency"
-msgstr ""
+msgstr "Intervallfrequenz"
 
 #: tools/forms/boefje.py
 msgid "Object creation/change"
-msgstr ""
+msgstr "Objekterstellung/-änderung"
 
 #: tools/forms/boefje.py
 msgid ""
 "Choose weather the Boefje should run after creating and/or changing an "
 "object. "
 msgstr ""
+"Wählen Sie aus, ob der Boefje nach dem Erstellen und/oder Ändern eines "
+"Objekts ausgeführt werden soll."
 
 #: tools/forms/finding_type.py
 msgid "KAT-ID"
-msgstr ""
+msgstr "KAT-ID"
 
 #: tools/forms/finding_type.py
 msgid "Unique ID within OpenKAT, for this type"
-msgstr ""
+msgstr "Eindeutige ID innerhalb von OpenKAT für diesen Typ"
 
 #: tools/forms/finding_type.py
 msgid "Title"
-msgstr ""
+msgstr "Titel"
 
 #: tools/forms/finding_type.py
 msgid "Give the finding type a fitting title"
-msgstr ""
+msgstr "Geben Sie dem Befundtyp einen passenden Titel"
 
 #: tools/forms/finding_type.py
 msgid "Describe the finding type"
-msgstr ""
+msgstr "Beschreiben Sie den Befundtyp"
 
 #: tools/forms/finding_type.py
 msgid "Risk"
-msgstr ""
+msgstr "Risiko"
 
 #: tools/forms/finding_type.py
 msgid "Solution"
-msgstr ""
+msgstr "Lösung"
 
 #: tools/forms/finding_type.py
 msgid "How can this be solved?"
-msgstr ""
+msgstr "Wie kann das gelöst werden?"
 
 #: tools/forms/finding_type.py
 msgid "Describe how this type of finding can be solved"
-msgstr ""
+msgstr "Beschreiben Sie, wie diese Art von Befund gelöst werden kann"
 
 #: tools/forms/finding_type.py
 msgid "References"
-msgstr ""
+msgstr "Referenzen"
 
 #: tools/forms/finding_type.py
 msgid "Please give some references on the solution"
-msgstr ""
+msgstr "Bitte geben Sie einige Referenzen zur Lösung an"
 
 #: tools/forms/finding_type.py
 msgid "Please give sources and references on the suggested solution"
-msgstr ""
+msgstr "Bitte geben Sie Quellen und Referenzen zur vorgeschlagenen Lösung an"
 
 #: tools/forms/finding_type.py
 msgid "Impact description"
-msgstr ""
+msgstr "Beschreibung der Auswirkungen"
 
 #: tools/forms/finding_type.py
 msgid "Describe the solutions impact"
-msgstr ""
+msgstr "Beschreiben Sie die Auswirkungen der Lösungen"
 
 #: tools/forms/finding_type.py
 msgid "Solution chance"
-msgstr ""
+msgstr "Lösungschance"
 
 #: tools/forms/finding_type.py
 msgid "Solution impact"
-msgstr ""
+msgstr "Auswirkungen der Lösung"
 
 #: tools/forms/finding_type.py
 msgid "Solution effort"
-msgstr ""
+msgstr "Lösungsaufwand"
 
 #: tools/forms/finding_type.py
 msgid "ID should start with "
-msgstr ""
+msgstr "ID sollte mit beginnen"
 
 #: tools/forms/finding_type.py
 msgid "Finding type already exists"
-msgstr ""
+msgstr "Der Befundtyp ist bereits vorhanden"
 
 #: tools/forms/finding_type.py
 msgid "Click to select one of the available options"
-msgstr ""
+msgstr "Klicken Sie, um eine der verfügbaren Optionen auszuwählen"
 
 #: tools/forms/finding_type.py
 #: rocky/templates/partials/finding_occurrence_definition_list.html
 msgid "Proof"
-msgstr ""
+msgstr "Nachweisen"
 
 #: tools/forms/finding_type.py
 msgid "Provide evidence of your finding"
-msgstr ""
+msgstr "Legen Sie Beweise für Ihre Feststellung vor"
 
 #: tools/forms/finding_type.py
 msgid "Describe your finding"
-msgstr ""
+msgstr "Beschreiben Sie Ihren Befund"
 
 #: tools/forms/finding_type.py
 msgid "Reproduce finding"
-msgstr ""
+msgstr "Befund reproduzieren"
 
 #: tools/forms/finding_type.py
 msgid "Please explain how to reproduce your finding"
-msgstr ""
+msgstr "Bitte erläutern Sie, wie Sie Ihren Befund reproduzieren können"
 
 #: tools/forms/finding_type.py tools/forms/upload_raw.py
 msgid "Date/Time (UTC)"
-msgstr ""
+msgstr "Datum/Uhrzeit (UTC)"
 
 #: tools/forms/finding_type.py tools/forms/upload_raw.py
 msgid "Doc! I'm from the future, I'm here to take you back!"
 msgstr ""
+"Doktor! Ich komme aus der Zukunft, ich bin hier, um dich zurückzubringen!"
 
 #: tools/forms/finding_type.py
 msgid "OOI doesn't exist"
-msgstr ""
+msgstr "OOI existiert nicht"
 
 #: tools/forms/findings.py
 msgid "Show non-muted findings"
-msgstr ""
+msgstr "Nicht stummgeschaltete Ergebnisse anzeigen"
 
 #: tools/forms/findings.py
 msgid "Show muted findings"
-msgstr ""
+msgstr "Stummgeschaltete Ergebnisse anzeigen"
 
 #: tools/forms/findings.py
 msgid "Show muted and non-muted findings"
-msgstr ""
+msgstr "Stummgeschaltete und nicht stummgeschaltete Ergebnisse anzeigen"
 
 #: tools/forms/findings.py
 msgid "Filter by severity"
-msgstr ""
+msgstr "Nach Schweregrad filtern"
 
 #: tools/forms/findings.py
 msgid "Filter by muted findings"
-msgstr ""
+msgstr "Filtern Sie nach stummgeschalteten Ergebnissen"
 
 #: tools/forms/findings.py tools/forms/ooi_form.py tools/forms/scheduler.py
 msgid "Search"
-msgstr ""
+msgstr "Suchen"
 
 #: tools/forms/findings.py
 msgid "Object ID contains (case sensitive)"
-msgstr ""
+msgstr "Objekt-ID enthält (Groß-/Kleinschreibung beachten)"
 
 #: tools/forms/ooi.py
 msgid "Filter types"
-msgstr ""
+msgstr "Filtertypen"
 
 #: tools/forms/ooi.py
 msgid "Clearance Level"
-msgstr ""
+msgstr "Freigabeebene"
 
 #: tools/forms/ooi.py
 msgid "Next scan"
-msgstr ""
+msgstr "Nächster Scan"
 
 #: tools/forms/ooi.py
 msgid "Show objects that don't meet the Boefjes scan level."
-msgstr ""
+msgstr "Zeigt Objekte an, die die Scanstufe Boefjes nicht erfüllen."
 
 #: tools/forms/ooi.py
 msgid "Show Boefjes that exceed the objects clearance level."
 msgstr ""
+"Zeigen Sie Boefjes an, die die Freigabegrenze für Objekte überschreiten."
 
 #: tools/forms/ooi.py
 msgid ""
-"All the boefjes with a scan level below or equal to the clearance level will "
-"be allowed to scan this object."
+"All the boefjes with a scan level below or equal to the clearance level will"
+" be allowed to scan this object."
 msgstr ""
+"Alle Boefjes mit einer Scanebene unterhalb oder gleich der Freigabeebene "
+"dürfen dieses Objekt scannen."
 
 #: tools/forms/ooi.py
 msgid "Expires by (UTC)"
-msgstr ""
+msgstr "Läuft ab um (UTC)"
 
 #: tools/forms/ooi_form.py
 msgid "option"
-msgstr ""
+msgstr "Option"
 
 #: tools/forms/ooi_form.py
 #, python-brace-format
 msgid "Optionally choose a {option_label}"
-msgstr ""
+msgstr "Wählen Sie optional einen {option_label}"
 
 #: tools/forms/ooi_form.py
 #, python-brace-format
 msgid "Please choose a {option_label}"
-msgstr ""
+msgstr "Bitte wählen Sie einen {option_label}"
 
 #: tools/forms/ooi_form.py
 msgid "Filter by clearance level"
-msgstr ""
+msgstr "Filtern Sie nach Freigabestufe"
 
 #: tools/forms/ooi_form.py
 msgid "Filter by clearance type"
-msgstr ""
+msgstr "Filtern Sie nach Freigabetyp"
 
 #: tools/forms/scheduler.py
 msgid "From"
-msgstr ""
+msgstr "Aus"
 
 #: tools/forms/scheduler.py
 msgid "To"
-msgstr ""
+msgstr "Zu"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Cancelled"
-msgstr ""
+msgstr "Abgesagt"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Completed"
-msgstr ""
+msgstr "Vollendet"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Dispatched"
-msgstr ""
+msgstr "Versendet"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Failed"
-msgstr ""
+msgstr "Fehlgeschlagen"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Queued"
-msgstr ""
+msgstr "In der Warteschlange"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Running"
-msgstr ""
+msgstr "Läuft"
 
 #: tools/forms/scheduler.py
 msgid "Search by object name"
+msgstr "Suche nach Objektnamen"
+
+#: tools/forms/scheduler.py
+msgid "The selected date is in the future. Please select a different date."
 msgstr ""
+"Das ausgewählte Datum liegt in der Zukunft. Bitte wählen Sie ein anderes "
+"Datum aus."
 
 #: tools/forms/settings.py
 msgid "--- Show all ----"
-msgstr ""
+msgstr "--- Alles anzeigen ----"
 
 #: tools/forms/settings.py
 msgid "recommendation"
-msgstr ""
+msgstr "Empfehlung"
 
 #: tools/forms/settings.py
 msgid "low"
-msgstr ""
+msgstr "niedrig"
 
 #: tools/forms/settings.py
 msgid "medium"
-msgstr ""
+msgstr "Medium"
 
 #: tools/forms/settings.py
 msgid "high"
-msgstr ""
+msgstr "hoch"
 
 #: tools/forms/settings.py
 msgid "very high"
-msgstr ""
+msgstr "sehr hoch"
 
 #: tools/forms/settings.py
 msgid "critical"
-msgstr ""
+msgstr "kritisch"
 
 #: tools/forms/settings.py
 msgid "quickfix"
-msgstr ""
+msgstr "Quickfix"
 
 #: tools/forms/settings.py
 msgid "Declared"
-msgstr ""
+msgstr "Erklärt"
 
 #: tools/forms/settings.py
 msgid "Inherited"
-msgstr ""
+msgstr "Geerbt"
 
 #: tools/forms/settings.py
 msgid "Empty"
-msgstr ""
+msgstr "Leer"
 
 #: tools/forms/settings.py
 msgid "Add one finding type ID per line."
-msgstr ""
+msgstr "Fügen Sie pro Zeile eine Ergebnistyp-ID hinzu."
 
 #: tools/forms/settings.py
 msgid "Add the date and time of your finding (UTC)"
-msgstr ""
+msgstr "Fügen Sie Datum und Uhrzeit Ihres Befundes hinzu (UTC)"
 
 #: tools/forms/settings.py
 msgid "Add the date and time of when the raw file was generated (UTC)"
-msgstr ""
+msgstr "Fügen Sie Datum und Uhrzeit der Erstellung der Rohdatei hinzu (UTC)."
 
 #: tools/forms/settings.py
 msgid ""
@@ -5070,20 +5643,30 @@ msgid ""
 "to see the status of your network through time. Select a datetime to change "
 "the view to represent that moment in time."
 msgstr ""
+"OpenKAT speichert bei jeder Beobachtung eine Zeitangabe, sodass Sie den "
+"Status Ihres Netzwerks im Laufe der Zeit sehen können. Wählen Sie ein Datum "
+"und eine Uhrzeit aus, um die Ansicht so zu ändern, dass sie diesen Zeitpunkt"
+" darstellt."
 
 #: tools/forms/settings.py
 msgid ""
-"<p>The name of the Docker image. For example: <i>'ghcr.io/minvws/openkat/"
-"nmap'</i>. In OpenKAT, all Boefjes with the same container image will be "
-"seen as 'variants' and will be shown together on the Boefje detail page. </"
-"p> "
+"<p>The name of the Docker image. For example: "
+"<i>'ghcr.io/minvws/openkat/nmap'</i>. In OpenKAT, all Boefjes with the same "
+"container image will be seen as 'variants' and will be shown together on the"
+" Boefje detail page. </p> "
 msgstr ""
+"<p>Der Name des Docker-Images. Zum Beispiel: "
+"<i>'ghcr.io/minvws/openkat/nmap'</i>. In OpenKAT werden alle Boefjes mit "
+"demselben Containerbild als „Varianten“ betrachtet und gemeinsam auf der "
+"Detailseite von Boefje angezeigt. </p>"
 
 #: tools/forms/settings.py
 msgid ""
 "A description of the Boefje explaining in short what it can do. This will "
 "both be displayed inside the KAT-alogus and on the Boefje details page."
 msgstr ""
+"Eine Beschreibung des Boefje, in der kurz erklärt wird, was er kann. Dies "
+"wird sowohl im KAT-alogus als auch auf der Boefje-Detailseite angezeigt."
 
 #: tools/forms/settings.py
 msgid ""
@@ -5091,164 +5674,201 @@ msgid ""
 "objects, press and hold the 'ctrl'/'command' key and then click the items "
 "you want to select. "
 msgstr ""
+"Wählen Sie die Objekttypen aus, die Ihr Boefje nutzt. Um mehrere Objekte "
+"auszuwählen, halten Sie die „Strg“-/Befehlstaste gedrückt und klicken Sie "
+"dann auf die Elemente, die Sie auswählen möchten."
 
 #: tools/forms/settings.py
 msgid ""
 "<p>If any other settings are needed for your Boefje, add these as a JSON "
 "Schema, otherwise, leave the field empty or 'null'.</p> <p> This JSON is "
-"used as the basis for a form for the user. When the user enables this Boefje "
-"they can get the option to give extra information. For example, it can "
+"used as the basis for a form for the user. When the user enables this Boefje"
+" they can get the option to give extra information. For example, it can "
 "contain an API key that the script requires.</p> <p>More information about "
-"what the schema.json file looks like can be found <a href='https://docs."
-"openkat.nl/developer_documentation/development_tutorial/creating_a_boefje."
-"html'> here</a>.</p> "
+"what the schema.json file looks like can be found <a "
+"href='https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html'>"
+" here</a>.</p> "
 msgstr ""
+"<p>Wenn für Ihr Boefje weitere Einstellungen erforderlich sind, fügen Sie "
+"diese als JSON-Schema hinzu. Andernfalls lassen Sie das Feld leer oder auf "
+"'null'.</p> <p>Dieses JSON wird als Grundlage für ein Formular für den "
+"Benutzer verwendet. Wenn der Benutzer dieses Boefje aktiviert, kann er "
+"zusätzliche Informationen angeben. Es kann zum Beispiel einen API-Schlüssel "
+"enthalten, den das Skript benötigt.</p> <p>Weitere Informationen dazu, wie "
+"die Datei schema.json aussieht, finden Sie <a "
+"href='https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html'>hier</a>.</p>"
+" "
 
 #: tools/forms/settings.py
 msgid ""
 "<p>Add a set of mime types that are produced by this Boefje, separated by "
-"commas. For example: <i>'text/html'</i>, <i>'image/jpeg'</i> or <i>'boefje/"
-"{boefje-id}'</i></p> <p>These output mime types will be shown on the Boefje "
-"detail page as information for other users. </p> "
+"commas. For example: <i>'text/html'</i>, <i>'image/jpeg'</i> or "
+"<i>'boefje/{boefje-id}'</i></p> <p>These output mime types will be shown on "
+"the Boefje detail page as information for other users. </p> "
 msgstr ""
+"<p>Fügen Sie eine Reihe von Mime-Typen hinzu, die von diesem Boefje erzeugt "
+"werden, getrennt durch Kommas. Zum Beispiel: <i>'text/html'</i>, "
+"<i>'image/jpeg'</i> oder <i>'boefje/{boefje-id}'</i></p> <p>Diese Ausgabe-"
+"MIME-Typen werden auf dem angezeigt Boefje-Detailseite als Information für "
+"andere Benutzer. </p>"
 
 #: tools/forms/settings.py
 msgid ""
 "<p>Select a clearance level for your Boefje. For more information about the "
-"different clearance levels please check the <a href='https://docs.openkat.nl/"
-"manual/usermanual.html#scan-levels-clearance-indemnities'> documentation</a>."
-"</p> "
+"different clearance levels please check the <a "
+"href='https://docs.openkat.nl/manual/usermanual.html#scan-levels-clearance-"
+"indemnities'> documentation</a>.</p> "
 msgstr ""
+"<p>Wählen Sie eine Freigabestufe für Ihren Boefje. Weitere Informationen zu "
+"den verschiedenen Freigabestufen finden Sie in der Dokumentation <a "
+"href='https://docs.openkat.nl/manual/usermanual.html#scan-levels-clearance-"
+"indemnities'></a>.</p>"
 
 #: tools/forms/settings.py
 msgid ""
-"Choose when this Boefje will scan objects. It can run on a given interval or "
-"it can run every time an object has been created or changed. "
+"Choose when this Boefje will scan objects. It can run on a given interval or"
+" it can run every time an object has been created or changed. "
 msgstr ""
+"Wählen Sie aus, wann dieser Boefje Objekte scannen soll. Es kann in einem "
+"bestimmten Intervall oder jedes Mal ausgeführt werden, wenn ein Objekt "
+"erstellt oder geändert wurde."
 
 #: tools/forms/settings.py
 msgid "Depth of the tree."
-msgstr ""
+msgstr "Tiefe des Baumes."
 
 #: tools/forms/upload_csv.py
 msgid "Only CSV file supported"
-msgstr ""
+msgstr "Nur die Datei CSV wird unterstützt"
 
 #: tools/forms/upload_csv.py
 msgid "File could not be decoded"
-msgstr ""
+msgstr "Datei konnte nicht dekodiert werden"
 
 #: tools/forms/upload_csv.py
 msgid "No file selected"
-msgstr ""
+msgstr "Keine Datei ausgewählt"
 
 #: tools/forms/upload_csv.py
 msgid "The uploaded file is empty."
-msgstr ""
+msgstr "Die hochgeladene Datei ist leer."
 
 #: tools/forms/upload_csv.py
 msgid "The number of columns do not meet the requirements."
-msgstr ""
+msgstr "Die Anzahl der Spalten entspricht nicht den Anforderungen."
 
 #: tools/forms/upload_csv.py
 msgid "OOI Type in CSV does not meet the criteria."
-msgstr ""
+msgstr "OOI Der Typ CSV erfüllt die Kriterien nicht."
 
 #: tools/forms/upload_csv.py
 msgid "An error has occurred during the parsing of the csv file:"
-msgstr ""
+msgstr "Beim Parsen der CSV-Datei ist ein Fehler aufgetreten:"
 
 #: tools/forms/upload_csv.py
 msgid "Upload CSV file"
-msgstr ""
+msgstr "Laden Sie die CSV-Datei hoch"
 
 #: tools/forms/upload_csv.py
 msgid "Only accepts CSV file."
-msgstr ""
+msgstr "Akzeptiert nur die Datei CSV."
 
 #: tools/forms/upload_oois.py rocky/templates/partials/explanations.html
 msgid "Object Type"
-msgstr ""
+msgstr "Objekttyp"
 
 #: tools/forms/upload_oois.py
 msgid "Choose a type of which objects are added."
-msgstr ""
+msgstr "Wählen Sie einen Typ aus, von dem Objekte hinzugefügt werden sollen."
 
 #: tools/forms/upload_raw.py
 msgid "Mime types"
-msgstr ""
+msgstr "Pantomimentypen"
 
 #: tools/forms/upload_raw.py
 msgid ""
-"<p>Add a set of mime types, separated by commas, for example:</"
-"p><p><i>\"text/html, image/jpeg\"</i> or <i>\"boefje/dns-records\"</i>.</"
-"p><p>Mime types are used to match the correct normalizer to a raw file. When "
-"the mime type \"boefje/dns-records\" is added, the normalizer expects the "
-"raw file to contain dns scan information.</p>"
+"<p>Add a set of mime types, separated by commas, for "
+"example:</p><p><i>\"text/html, image/jpeg\"</i> or <i>\"boefje/dns-"
+"records\"</i>.</p><p>Mime types are used to match the correct normalizer to "
+"a raw file. When the mime type \"boefje/dns-records\" is added, the "
+"normalizer expects the raw file to contain dns scan information.</p>"
 msgstr ""
+"<p>Fügen Sie eine Reihe von durch Kommas getrennten MIME-Typen hinzu, zum "
+"Beispiel:</p><p><i>\"text/html, image/jpeg\"</i> oder <i>\"boefje/dns-"
+"records\"</i>.</p><p>Mime-Typen werden verwendet, um den richtigen "
+"Normalisierer einer Rohdatei zuzuordnen. Wenn der MIME-Typ „boefje/dns-"
+"records“ hinzugefügt wird, erwartet der Normalisierer, dass die Rohdatei "
+"DNS-Scaninformationen enthält.</p>"
 
 #: tools/forms/upload_raw.py rocky/templates/partials/ooi_list_toolbar.html
 #: rocky/templates/upload_raw.html
 msgid "Upload raw file"
-msgstr ""
+msgstr "Rohdatei hochladen"
 
 #: tools/forms/upload_raw.py
 msgid "Input or Scan OOI"
-msgstr ""
+msgstr "Geben Sie OOI ein oder scannen Sie es"
 
 #: tools/forms/upload_raw.py
 msgid "Click to select one of the available options, or type one yourself"
 msgstr ""
+"Klicken Sie, um eine der verfügbaren Optionen auszuwählen, oder geben Sie "
+"selbst eine ein"
 
 #: tools/forms/upload_raw.py
 msgid "OOI doesn't exist, try another valid time"
 msgstr ""
+"OOI existiert nicht. Versuchen Sie es mit einem anderen gültigen Zeitpunkt"
 
 #: tools/models.py
 msgid ""
-"A short code containing only lower-case unicode letters, numbers, hyphens or "
-"underscores that will be used in URLs and paths."
+"A short code containing only lower-case unicode letters, numbers, hyphens or"
+" underscores that will be used in URLs and paths."
 msgstr ""
+"Ein Funktionscode, der nur Unicode-Kleinbuchstaben, Zahlen, Bindestriche "
+"oder Unterstriche enthält und in URLs und Pfaden verwendet wird."
 
 #: tools/models.py
 msgid ""
 "This organization code is reserved by OpenKAT and cannot be used. Choose "
 "another organization code."
 msgstr ""
+"Dieser Organisationscode ist für OpenKAT reserviert und kann nicht verwendet"
+" werden. Wählen Sie einen anderen Organisationscode."
 
 #: tools/models.py
 msgid "new"
-msgstr ""
+msgstr "neu"
 
 #: tools/templatetags/ooi_extra.py
 msgid "Unknown user"
-msgstr ""
+msgstr "Unbekannter Benutzer"
 
 #: tools/view_helpers.py rocky/templates/header.html
 #: rocky/templates/organizations/organization_member_list.html
 #: rocky/views/organization_member_edit.py
 msgid "Members"
-msgstr ""
+msgstr "Mitglieder"
 
 #: rocky/forms.py
 msgid "Current status"
-msgstr ""
+msgstr "Aktueller Stand"
 
 #: rocky/forms.py rocky/templates/organizations/organization_member_list.html
 msgid "Active"
-msgstr ""
+msgstr "Aktiv"
 
 #: rocky/forms.py rocky/templates/organizations/organization_member_list.html
 msgid "New"
-msgstr ""
+msgstr "Neu"
 
 #: rocky/forms.py
 msgid "Account status"
-msgstr ""
+msgstr "Kontostatus"
 
 #: rocky/forms.py
 msgid "Not blocked"
-msgstr ""
+msgstr "Nicht blockiert"
 
 #: rocky/messaging.py
 msgid ""
@@ -5256,242 +5876,262 @@ msgid ""
 "needs at least a clearance level of L{} in order to do a proper onboarding. "
 "Edit this member and change the clearance level if necessary."
 msgstr ""
+"Sie haben diesem Mitglied mit der Freigabestufe L{} vertraut. Dieses "
+"Mitglied benötigt mindestens die Freigabestufe L{}, um ein ordnungsgemäßes "
+"Onboarding durchführen zu können. Bearbeiten Sie dieses Mitglied und ändern "
+"Sie bei Bedarf die Freigabestufe."
 
 #: rocky/paginator.py
 msgid "That page number is not an integer"
-msgstr ""
+msgstr "Diese Seitenzahl ist keine ganze Zahl"
 
 #: rocky/paginator.py
 msgid "That page number is less than 1"
-msgstr ""
+msgstr "Diese Seitenzahl ist kleiner als 1"
 
 #: rocky/paginator.py
 msgid "That page contains no results"
-msgstr ""
+msgstr "Diese Seite enthält keine Ergebnisse"
 
 #: rocky/scheduler.py
 msgid ""
 "The Scheduler has an unexpected error. Check the Scheduler logs for further "
 "details."
 msgstr ""
+"Der Planer hat einen unerwarteten Fehler. Weitere Details finden Sie in den "
+"Scheduler-Protokollen."
 
 #: rocky/scheduler.py
 msgid "Could not connect to Scheduler. Service is possibly down."
 msgstr ""
+"Es konnte keine Verbindung zum Planer hergestellt werden. Der Dienst ist "
+"möglicherweise ausgefallen."
 
 #: rocky/scheduler.py
 msgid "Your request could not be validated."
-msgstr ""
+msgstr "Ihre Anfrage konnte nicht bestätigt werden."
 
 #: rocky/scheduler.py
 msgid "Task could not be found."
-msgstr ""
+msgstr "Aufgabe konnte nicht gefunden werden."
 
 #: rocky/scheduler.py
 msgid ""
 "Scheduler is receiving too many requests. Increase SCHEDULER_PQ_MAXSIZE or "
 "wait for task to finish."
 msgstr ""
+"Der Planer erhält zu viele Anfragen. Erhöhen Sie SCHEDULER_PQ_MAXSIZE oder "
+"warten Sie, bis die Aufgabe abgeschlossen ist."
 
 #: rocky/scheduler.py
 msgid "Bad request. Your request could not be interpreted by the Scheduler."
 msgstr ""
+"Ungültige Anforderung. Ihre Anfrage konnte vom Planer nicht interpretiert "
+"werden."
 
 #: rocky/scheduler.py
 msgid "The Scheduler has received a conflict. Your task is already in queue."
 msgstr ""
+"Der Scheduler hat einen Konflikt erhalten. Ihre Aufgabe befindet sich "
+"bereits in der Warteschlange."
 
 #: rocky/scheduler.py
 msgid "A HTTPError occurred. See Scheduler logs for more info."
 msgstr ""
+"Es ist ein HTTP-Fehler aufgetreten. Weitere Informationen finden Sie unter "
+"Scheduler-Protokolle."
 
 #: rocky/scheduler.py
 msgid "Schedule list: "
-msgstr ""
+msgstr "Zeitplanliste:"
 
 #: rocky/scheduler.py
 msgid "Task list: "
-msgstr ""
+msgstr "Aufgabenliste:"
 
 #: rocky/settings.py
 msgid "Blue light"
-msgstr ""
+msgstr "Blaues Licht"
 
 #: rocky/settings.py
 msgid "Blue medium"
-msgstr ""
+msgstr "Blau mittel"
 
 #: rocky/settings.py
 msgid "Blue dark"
-msgstr ""
+msgstr "Dunkelblau"
 
 #: rocky/settings.py
 msgid "Green light"
-msgstr ""
+msgstr "Grünes Licht"
 
 #: rocky/settings.py
 msgid "Green medium"
-msgstr ""
+msgstr "Grünes Medium"
 
 #: rocky/settings.py
 msgid "Green dark"
-msgstr ""
+msgstr "Grün dunkel"
 
 #: rocky/settings.py
 msgid "Yellow light"
-msgstr ""
+msgstr "Gelbes Licht"
 
 #: rocky/settings.py
 msgid "Yellow medium"
-msgstr ""
+msgstr "Gelb mittel"
 
 #: rocky/settings.py
 msgid "Yellow dark"
-msgstr ""
+msgstr "Gelb dunkel"
 
 #: rocky/settings.py
 msgid "Orange light"
-msgstr ""
+msgstr "Orangefarbenes Licht"
 
 #: rocky/settings.py
 msgid "Orange medium"
-msgstr ""
+msgstr "Orange mittel"
 
 #: rocky/settings.py
 msgid "Orange dark"
-msgstr ""
+msgstr "Orange dunkel"
 
 #: rocky/settings.py
 msgid "Red light"
-msgstr ""
+msgstr "Rotlicht"
 
 #: rocky/settings.py
 msgid "Red medium"
-msgstr ""
+msgstr "Rotes Medium"
 
 #: rocky/settings.py
 msgid "Red dark"
-msgstr ""
+msgstr "Rot dunkel"
 
 #: rocky/settings.py
 msgid "Violet light"
-msgstr ""
+msgstr "Violettes Licht"
 
 #: rocky/settings.py
 msgid "Violet medium"
-msgstr ""
+msgstr "Violettes Medium"
 
 #: rocky/settings.py
 msgid "Violet dark"
-msgstr ""
+msgstr "Violett dunkel"
 
 #: rocky/settings.py
 msgid "Plain"
-msgstr ""
+msgstr "Schmucklos"
 
 #: rocky/settings.py
 msgid "Solid"
-msgstr ""
+msgstr "Solide"
 
 #: rocky/settings.py
 msgid "Dashed"
-msgstr ""
+msgstr "Gestrichelt"
 
 #: rocky/settings.py
 msgid "Dotted"
-msgstr ""
+msgstr "Gepunktet"
 
 #: rocky/templates/403.html
 msgid "Error code 403: Unauthorized"
-msgstr ""
+msgstr "Fehlercode 403: Nicht autorisiert"
 
 #: rocky/templates/403.html
 msgid "Your account is not authorized to access this page or organization."
 msgstr ""
+"Ihr Konto ist nicht berechtigt, auf diese Seite oder Organisation "
+"zuzugreifen."
 
 #: rocky/templates/403.html
 msgid "Please contact your system administrator."
-msgstr ""
+msgstr "Bitte wenden Sie sich an Ihren Systemadministrator."
 
 #: rocky/templates/403.html rocky/templates/404.html
 msgid "You may want to go back to the"
-msgstr ""
+msgstr "Vielleicht möchten Sie dorthin zurückkehren"
 
 #: rocky/templates/403.html rocky/templates/404.html
 msgid "Crisis Room"
-msgstr ""
+msgstr "Krisenraum"
 
 #: rocky/templates/404.html
 msgid "Error code 404: Page not found"
-msgstr ""
+msgstr "Fehlercode 404: Seite nicht gefunden"
 
 #: rocky/templates/404.html
 msgid ""
 "The page you wanted to see or the file you wanted to view was not found."
 msgstr ""
+"Die Seite, die Sie sehen wollten, oder die Datei, die Sie ansehen wollten, "
+"wurde nicht gefunden."
 
 #: rocky/templates/admin/base.html
 msgid "Skip to main content"
-msgstr ""
+msgstr "Zum Hauptinhalt springen"
 
 #: rocky/templates/admin/base.html
 msgid "Welcome,"
-msgstr ""
+msgstr "Willkommen,"
 
 #: rocky/templates/admin/base.html
 msgid "View site"
-msgstr ""
+msgstr "Website ansehen"
 
 #: rocky/templates/admin/base.html
 msgid "Documentation"
-msgstr ""
+msgstr "Dokumentation"
 
 #: rocky/templates/admin/base.html
 msgid "Change password"
-msgstr ""
+msgstr "Kennwort ändern"
 
 #: rocky/templates/admin/base.html
 msgid "Log out"
-msgstr ""
+msgstr "Abmelden"
 
 #: rocky/templates/admin/base.html rocky/templates/header.html
 msgid "Breadcrumbs"
-msgstr ""
+msgstr "Paniermehl"
 
 #: rocky/templates/admin/base.html rocky/templates/admin/change_form.html
 #: rocky/templates/admin/change_list.html
 #: rocky/templates/admin/delete_confirmation.html
 #: rocky/templates/admin/delete_selected_confirmation.html
 msgid "Home"
-msgstr ""
+msgstr "Heim"
 
 #: rocky/templates/admin/change_form.html
 #, python-format
 msgid "Add %(name)s"
-msgstr ""
+msgstr "Fügen Sie %(name)s hinzu"
 
 #: rocky/templates/admin/change_form.html
 #: rocky/templates/admin/change_list.html
 msgid "Please correct the error below."
 msgid_plural "Please correct the errors below."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Bitte korrigieren Sie die Fehler unten."
+msgstr[1] "Bitte korrigieren Sie die Fehler unten."
 
 #: rocky/templates/admin/change_list.html
 msgid "Filter"
-msgstr ""
+msgstr "Filter"
 
 #: rocky/templates/admin/change_list.html
 msgid "Hide counts"
-msgstr ""
+msgstr "Zählungen ausblenden"
 
 #: rocky/templates/admin/change_list.html
 msgid "Show counts"
-msgstr ""
+msgstr "Show zählt"
 
 #: rocky/templates/admin/change_list.html
 msgid "Clear all filters"
-msgstr ""
+msgstr "Alle Filter löschen"
 
 #: rocky/templates/admin/delete_confirmation.html
 #, python-format
@@ -5500,13 +6140,18 @@ msgid ""
 "related objects, but your account doesn't have permission to delete the "
 "following types of objects"
 msgstr ""
+"Das Löschen von %(object_name)s „%(escaped_object)s“ würde zum Löschen "
+"verwandter Objekte führen, Ihr Konto verfügt jedoch nicht über die "
+"Berechtigung zum Löschen der folgenden Objekttypen"
 
 #: rocky/templates/admin/delete_confirmation.html
 #, python-format
 msgid ""
-"Deleting the %(object_name)s '%(escaped_object)s' would require deleting the "
-"following protected related objects"
+"Deleting the %(object_name)s '%(escaped_object)s' would require deleting the"
+" following protected related objects"
 msgstr ""
+"Das Löschen des %(object_name)s „%(escaped_object)s“ würde das Löschen der "
+"folgenden geschützten zugehörigen Objekte erfordern"
 
 #: rocky/templates/admin/delete_confirmation.html
 #, python-format
@@ -5514,20 +6159,22 @@ msgid ""
 "Are you sure you want to delete the %(object_name)s \"%(escaped_object)s\"? "
 "All of the following related items will be deleted"
 msgstr ""
+"Sind Sie sicher, dass Sie %(object_name)s „%(escaped_object)s“ löschen "
+"möchten? Alle folgenden zugehörigen Elemente werden gelöscht"
 
 #: rocky/templates/admin/delete_confirmation.html
 #: rocky/templates/admin/delete_selected_confirmation.html
 msgid "Yes, I’m sure"
-msgstr ""
+msgstr "Ja, ich bin sicher"
 
 #: rocky/templates/admin/delete_confirmation.html
 #: rocky/templates/admin/delete_selected_confirmation.html
 msgid "No, take me back"
-msgstr ""
+msgstr "Nein, nimm mich zurück"
 
 #: rocky/templates/admin/delete_selected_confirmation.html
 msgid "Delete multiple objects"
-msgstr ""
+msgstr "Mehrere Objekte löschen"
 
 #: rocky/templates/admin/delete_selected_confirmation.html
 #, python-format
@@ -5536,6 +6183,9 @@ msgid ""
 "objects, but your account doesn't have permission to delete the following "
 "types of objects"
 msgstr ""
+"Das Löschen des ausgewählten %(objects_name)s würde zum Löschen verwandter "
+"Objekte führen, Ihr Konto verfügt jedoch nicht über die Berechtigung zum "
+"Löschen der folgenden Objekttypen"
 
 #: rocky/templates/admin/delete_selected_confirmation.html
 #, python-format
@@ -5543,6 +6193,8 @@ msgid ""
 "Deleting the selected %(objects_name)s would require deleting the following "
 "protected related objects"
 msgstr ""
+"Das Löschen des ausgewählten %(objects_name)s würde das Löschen der "
+"folgenden geschützten zugehörigen Objekte erfordern"
 
 #: rocky/templates/admin/delete_selected_confirmation.html
 #, python-format
@@ -5550,64 +6202,69 @@ msgid ""
 "Are you sure you want to delete the selected %(objects_name)s? All of the "
 "following objects and their related items will be deleted"
 msgstr ""
+"Sind Sie sicher, dass Sie das ausgewählte %(objects_name)s löschen möchten? "
+"Alle folgenden Objekte und die zugehörigen Elemente werden gelöscht"
 
 #: rocky/templates/admin/popup_response.html
 msgid "Popup closing…"
-msgstr ""
+msgstr "Popup wird geschlossen…"
 
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
-#: rocky/templates/header.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
 msgid "Close menu"
-msgstr ""
+msgstr "Menü schließen"
 
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
-#: rocky/templates/header.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
 msgid "Main navigation"
-msgstr ""
+msgstr "Hauptnavigation"
 
 #: rocky/templates/dashboard_client.html
 msgid "Indemnifications"
-msgstr ""
+msgstr "Entschädigungen"
 
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html
 #: rocky/templates/partials/secondary-menu.html
 msgid "Logout"
-msgstr ""
+msgstr "Abmelden"
 
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html
 msgid "Welcome"
-msgstr ""
+msgstr "Willkommen"
 
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html
 msgid "User overview"
-msgstr ""
+msgstr "Benutzerübersicht"
 
 #: rocky/templates/dashboard_redteam.html
 #: rocky/templates/partials/notifications_block.html
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "warning"
-msgstr ""
+msgstr "Warnung"
 
 #: rocky/templates/dashboard_redteam.html
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 #: rocky/templates/partials/notifications_block.html
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "Warning:"
-msgstr ""
+msgstr "Warnung:"
 
 #: rocky/templates/dashboard_redteam.html
 msgid "Organization code missing"
-msgstr ""
+msgstr "Organisationscode fehlt"
 
 #: rocky/templates/finding_type_add.html
 #: rocky/templates/partials/findings_list_toolbar.html
 #: rocky/views/finding_type_add.py
 msgid "Add finding type"
-msgstr ""
+msgstr "Befundtyp hinzufügen"
 
 #: rocky/templates/finding_type_add.html
 msgid "Finding Type"
-msgstr ""
+msgstr "Typ finden"
 
 #: rocky/templates/findings/finding_add.html
 #: rocky/templates/oois/ooi_detail_findings_list.html
@@ -5615,11 +6272,11 @@ msgstr ""
 #: rocky/templates/partials/findings_list_toolbar.html
 #: rocky/views/finding_add.py
 msgid "Add finding"
-msgstr ""
+msgstr "Befund hinzufügen"
 
 #: rocky/templates/findings/finding_list.html
-msgid "Findings @ "
-msgstr ""
+msgid "Findings "
+msgstr "Erkenntnisse"
 
 #: rocky/templates/findings/finding_list.html
 #, python-format
@@ -5628,95 +6285,103 @@ msgid ""
 "<strong>%(organization_name)s</strong>. Each finding relates to an object. "
 "Click a finding for additional information."
 msgstr ""
+"Eine Übersicht aller gefundenen Ergebnisse OpenKAT für die Organisation "
+"<strong>%(organization_name)s</strong>. Jeder Befund bezieht sich auf ein "
+"Objekt. Klicken Sie auf einen Befund, um weitere Informationen zu erhalten."
 
 #: rocky/templates/findings/finding_list.html
 #, python-format
 msgid "Showing %(length)s of %(total)s findings"
-msgstr ""
+msgstr "Zeigt %(length)s der %(total)s-Ergebnisse"
 
 #: rocky/templates/findings/finding_list.html
 #: rocky/templates/partials/mute_findings_modal.html
 msgid "Mute findings"
-msgstr ""
+msgstr "Stumme Ergebnisse"
 
 #: rocky/templates/findings/finding_list.html
 msgid "Unmute findings"
-msgstr ""
+msgstr "Stummschaltung der Ergebnisse aufheben"
 
 #: rocky/templates/findings/findings_filter.html
 #: rocky/templates/partials/elements/ooi_list_settings_form.html
 #: rocky/templates/tasks/partials/task_filter.html
 msgid "Set filters"
-msgstr ""
+msgstr "Filter setzen"
 
 #: rocky/templates/findings/findings_filter.html
 #: rocky/templates/partials/elements/ooi_list_settings_form.html
 #: rocky/templates/tasks/partials/task_filter.html
 msgid "Clear filters"
-msgstr ""
+msgstr "Filter löschen"
 
 #: rocky/templates/footer.html rocky/views/privacy_statement.py
 msgid "Privacy Statement"
-msgstr ""
+msgstr "Datenschutzerklärung"
 
 #: rocky/templates/forms/json_schema_form.html
 msgid "Fill out this form to answer the Question (again):"
-msgstr ""
+msgstr "Füllen Sie dieses Formular aus, um die Frage (erneut) zu beantworten:"
 
 #: rocky/templates/graph-d3.html
 msgid ""
 "Click a circle to collapse / expand the tree, click the text to view the "
 "tree from that OOI and hover over the text to see details."
 msgstr ""
+"Klicken Sie auf einen Kreis, um den Baum zu reduzieren/zu erweitern, klicken"
+" Sie auf den Text, um den Baum von diesem OOI aus anzuzeigen, und bewegen "
+"Sie den Mauszeiger über den Text, um Details anzuzeigen."
 
 #: rocky/templates/graph-d3.html
 msgid "Tree graph"
-msgstr ""
+msgstr "Baumdiagramm"
 
 #: rocky/templates/header.html
 msgid "Menu"
-msgstr ""
+msgstr "Speisekarte"
 
 #: rocky/templates/header.html
 msgid "OpenKAT logo, go to the homepage of OpenKAT"
-msgstr ""
+msgstr "OpenKAT-Logo, gehen Sie zur Homepage von OpenKAT"
 
 #: rocky/templates/header.html rocky/templates/tasks/ooi_detail_task_list.html
 #: rocky/templates/tasks/partials/tasks_overview_header.html
 #: rocky/templates/tasks/plugin_detail_task_list.html
 #: rocky/views/task_detail.py rocky/views/tasks.py
 msgid "Tasks"
-msgstr ""
+msgstr "Aufgaben"
 
 #: rocky/templates/health.html
 msgid "Health Checks"
-msgstr ""
+msgstr "Gesundheitschecks"
 
 #: rocky/templates/health.html
 msgid "Health checks"
-msgstr ""
+msgstr "Gesundheitschecks"
 
 #: rocky/templates/health.html
 msgid "Additional"
-msgstr ""
+msgstr "Zusätzlich"
 
 #: rocky/templates/indemnification_present.html
 msgid "Indemnification"
-msgstr ""
+msgstr "Entschädigung"
 
 #: rocky/templates/indemnification_present.html
 msgid ""
 "Indemnification on the organization present. You may now add objects and "
 "start scans."
 msgstr ""
+"Entschädigung der anwesenden Organisation. Sie können nun Objekte hinzufügen"
+" und Scans starten."
 
 #: rocky/templates/indemnification_present.html
 msgid "Go to Objects"
-msgstr ""
+msgstr "Gehen Sie zu Objekte"
 
 #: rocky/templates/indemnification_present.html
 msgid "Go to"
-msgstr ""
+msgstr "Gehe zu"
 
 #: rocky/templates/landing_page.html
 msgid "Welcome to OpenKAT"
@@ -5724,11 +6389,11 @@ msgstr "Willkommen bei OpenKAT"
 
 #: rocky/templates/landing_page.html
 msgid "Kwetsbaarheden Analyse Tool"
-msgstr ""
+msgstr "Kwetsbaarheden-Analysetool"
 
 #: rocky/templates/landing_page.html
 msgid "What is OpenKAT?"
-msgstr ""
+msgstr "Was ist OpenKAT?"
 
 #: rocky/templates/landing_page.html
 msgid ""
@@ -5736,261 +6401,306 @@ msgid ""
 "by the Ministry of Health, Welfare and Sport to make your and our world "
 "safer."
 msgstr ""
+"OpenKAT ist ein Tool zur Schwachstellenanalyse. Ein Open-Source-Projekt, das"
+" vom Ministerium für Gesundheit, Wohlfahrt und Sport entwickelt wurde, um "
+"Ihre und unsere Welt sicherer zu machen."
 
 #: rocky/templates/landing_page.html
 msgid "OpenKAT sees"
-msgstr ""
+msgstr "OpenKAT sieht"
 
 #: rocky/templates/landing_page.html
 msgid ""
 "Dozens of tools are integrated in OpenKAT to view the world (digital and "
 "analog)."
 msgstr ""
+"In OpenKAT sind Dutzende Tools integriert, um die Welt (digital und analog) "
+"zu betrachten."
 
 #: rocky/templates/landing_page.html
 msgid "Our motto is therefore: I see, I see, what you do not see."
-msgstr ""
+msgstr "Unser Motto lautet daher: Ich sehe, ich sehe, was Sie nicht sehen."
 
 #: rocky/templates/landing_page.html
 msgid "OpenKAT knows"
-msgstr ""
+msgstr "OpenKAT weiß es"
 
 #: rocky/templates/landing_page.html
 msgid ""
 "OpenKAT does not forget (just like that), and can be queried without "
 "scanning again. Also about a historical situation."
 msgstr ""
+"OpenKAT vergisst es nicht (einfach so) und kann ohne erneutes Scannen "
+"abgefragt werden. Auch über eine historische Situation."
 
 #: rocky/templates/landing_page.html
 msgid "OpenKAT is secure"
-msgstr ""
+msgstr "OpenKAT ist sicher"
 
 #: rocky/templates/landing_page.html
 msgid ""
 "Forensically secured storage of evidence is one of the basic ingredients of "
 "OpenKAT."
 msgstr ""
+"Die forensisch gesicherte Aufbewahrung von Beweismitteln ist einer der "
+"Grundbestandteile von OpenKAT."
 
 #: rocky/templates/landing_page.html
 msgid "OpenKAT is sweet"
-msgstr ""
+msgstr "OpenKAT ist süß"
 
 #: rocky/templates/landing_page.html
 msgid ""
-"OpenKAT thinks about privacy, and stores what is necessary, within the rules "
-"of your organization and the law."
+"OpenKAT thinks about privacy, and stores what is necessary, within the rules"
+" of your organization and the law."
 msgstr ""
+"OpenKAT denkt an den Datenschutz und speichert das Notwendige im Rahmen der "
+"Regeln Ihrer Organisation und des Gesetzes."
 
 #: rocky/templates/landing_page.html
 msgid "A wide playing field"
-msgstr ""
+msgstr "Ein weites Spielfeld"
 
 #: rocky/templates/landing_page.html
 msgid ""
-"OpenKAT makes a copy of the actual reality by means of the integrated tools. "
-"Within this copy you can search for answers to countless security and policy "
-"questions. Expected and unexpected changes in the world are made visible, "
-"and where necessary reported or made known directly to the right people."
+"OpenKAT makes a copy of the actual reality by means of the integrated tools."
+" Within this copy you can search for answers to countless security and "
+"policy questions. Expected and unexpected changes in the world are made "
+"visible, and where necessary reported or made known directly to the right "
+"people."
 msgstr ""
+"OpenKAT erstellt mithilfe der integrierten Tools eine Kopie der "
+"tatsächlichen Realität. In diesem Exemplar können Sie nach Antworten auf "
+"unzählige Sicherheits- und Richtlinienfragen suchen. Erwartete und "
+"unerwartete Veränderungen in der Welt werden sichtbar gemacht und bei Bedarf"
+" direkt den richtigen Personen gemeldet oder mitgeteilt."
 
 #: rocky/templates/legal/privacy_statement.html
 msgid "OpenKAT Privacy Statement"
-msgstr ""
+msgstr "OpenKAT Datenschutzerklärung"
 
 #: rocky/templates/legal/privacy_statement.html
 msgid ""
 "OpenKAT is dedicated to protecting the confidentiality and privacy of "
-"information entrusted to it. As part of this fundamental obligation, OpenKAT "
-"is committed to the appropriate protection and use of personal information "
+"information entrusted to it. As part of this fundamental obligation, OpenKAT"
+" is committed to the appropriate protection and use of personal information "
 "(sometimes referred to as \"personal data\", \"personally identifiable "
 "information\" or \"PII\") that has been collected online."
 msgstr ""
+"OpenKAT ist bestrebt, die Vertraulichkeit und Privatsphäre der ihm "
+"anvertrauten Informationen zu schützen. Im Rahmen dieser grundlegenden "
+"Verpflichtung verpflichtet sich OpenKAT zum angemessenen Schutz und zur "
+"angemessenen Nutzung personenbezogener Daten (manchmal auch als "
+"„personenbezogene Daten“, „persönlich identifizierbare Informationen“ oder "
+"„PII“ bezeichnet), die online erfasst wurden."
 
 #: rocky/templates/oois/error.html
 msgid "Object List"
-msgstr ""
+msgstr "Objektliste"
 
 #: rocky/templates/oois/error.html
 msgid "An error occurred. Please contact a system administrator."
 msgstr ""
+"Es ist ein Fehler aufgetreten. Bitte wenden Sie sich an einen "
+"Systemadministrator."
 
 #: rocky/templates/oois/ooi_add.html
 #, python-format
 msgid "Add a %(display_type)s"
-msgstr ""
+msgstr "Fügen Sie einen %(display_type)s hinzu"
 
 #: rocky/templates/oois/ooi_add.html
 msgid ""
 "Here you can add the asset of the client. Findings can be added to these in "
 "the findings page."
 msgstr ""
+"Hier können Sie das Asset des Kunden hinzufügen. Befunde können diesen auf "
+"der Befundseite hinzugefügt werden."
 
 #: rocky/templates/oois/ooi_add.html
 #, python-format
 msgid "Add %(display_type)s"
-msgstr ""
+msgstr "Fügen Sie %(display_type)s hinzu"
 
 #: rocky/templates/oois/ooi_add_type_select.html
 #: rocky/templates/oois/ooi_detail_add_related_object.html
 #: rocky/templates/partials/elements/ooi_add_type_select_form.html
 #: rocky/templates/partials/ooi_list_toolbar.html rocky/views/ooi_add.py
 msgid "Add object"
-msgstr ""
+msgstr "Objekt hinzufügen"
 
 #: rocky/templates/oois/ooi_add_type_select.html
 msgid "Select the type of object you want to create."
-msgstr ""
+msgstr "Wählen Sie den Objekttyp aus, den Sie erstellen möchten."
 
 #: rocky/templates/oois/ooi_delete.html
 #, python-format
 msgid "Delete %(primary_key)s"
-msgstr ""
+msgstr "Löschen Sie %(primary_key)s"
 
 #: rocky/templates/oois/ooi_delete.html
 msgid "Are you sure?"
-msgstr ""
+msgstr "Bist du sicher?"
 
 #: rocky/templates/oois/ooi_delete.html
 #, python-format
 msgid "Here you can delete the %(display_type)s."
-msgstr ""
+msgstr "Hier können Sie den %(display_type)s löschen."
 
 #: rocky/templates/oois/ooi_delete.html
 msgid "To be deleted object(s)"
-msgstr ""
+msgstr "Zu löschende(s) Objekt(e)"
 
 #: rocky/templates/oois/ooi_delete.html
 #: rocky/templates/partials/elements/ooi_tree_condensed_table.html
 msgid "Key"
-msgstr ""
+msgstr "Schlüssel"
 
 #: rocky/templates/oois/ooi_delete.html
 #: rocky/templates/partials/ooi_detail_toolbar.html
 #, python-format
 msgid "Delete %(display_type)s"
-msgstr ""
+msgstr "Löschen Sie %(display_type)s"
 
 #: rocky/templates/oois/ooi_delete.html
 msgid "Deletion not possible for types: KATFindingType and CVEFindingType"
 msgstr ""
+"Für die Typen KATFindingType und CVEFindingType ist das Löschen nicht "
+"möglich"
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "using boefjes"
-msgstr ""
+msgstr "Boefjes verwenden"
 
 #: rocky/templates/oois/ooi_detail.html
 #: rocky/templates/organizations/organization_settings.html
 msgid "indemnification warning"
-msgstr ""
+msgstr "Schadensersatzwarnung"
 
 #: rocky/templates/oois/ooi_detail.html
 #, python-format
 msgid ""
-"<strong>Warning:</strong> There is no indemnification for this organization. "
-"Go to the <a href=\"%(organization_settings)s\">organization settings page</"
-"a> to add one."
+"<strong>Warning:</strong> There is no indemnification for this organization."
+" Go to the <a href=\"%(organization_settings)s\">organization settings "
+"page</a> to add one."
 msgstr ""
+"<strong>Warnung:</strong> Es gibt keine Entschädigung für diese "
+"Organisation. Gehen Sie zur Seite <a "
+"href=\"%(organization_settings)s\">Organisationseinstellungen</a>, um eine "
+"hinzuzufügen."
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "Permission warning"
-msgstr ""
+msgstr "Erlaubniswarnung"
 
 #: rocky/templates/oois/ooi_detail.html
 msgid ""
 "<strong>Warning:</strong> You don't have the proper permission at the "
 "organizational level to scan objects. Contact your administrator."
 msgstr ""
+"<strong>Warnung:</strong> Sie verfügen nicht über die entsprechende "
+"Berechtigung auf Organisationsebene, um Objekte zu scannen. Kontaktieren Sie"
+" Ihren Administrator."
 
 #: rocky/templates/oois/ooi_detail.html
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Scan warning"
-msgstr ""
+msgstr "Scanwarnung"
 
 #: rocky/templates/oois/ooi_detail.html
 #, python-format
 msgid ""
-"<strong>Warning:</strong> You are not allowed to scan this OOI. Your maximum "
-"clearance level is %(member_clearance_level)s and this OOI has level "
+"<strong>Warning:</strong> You are not allowed to scan this OOI. Your maximum"
+" clearance level is %(member_clearance_level)s and this OOI has level "
 "%(boefje_scan_level)s. Go to your <a href=\"%(account_details)s\">account "
 "details</a> to manage your clearance level."
 msgstr ""
+"<strong>Warnung:</strong> Sie dürfen diesen OOI nicht scannen. Ihre maximale"
+" Freigabestufe ist %(member_clearance_level)s und diese OOI hat die Stufe "
+"%(boefje_scan_level)s. Gehen Sie zu Ihren <a "
+"href=\"%(account_details)s\">-Kontodetails</a>, um Ihre Freigabestufe zu "
+"verwalten."
 
 #: rocky/templates/oois/ooi_detail.html rocky/templates/scan.html
 msgid "Boefjes overview"
-msgstr ""
+msgstr "Boefjes-Übersicht"
 
 #: rocky/templates/oois/ooi_detail.html
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 #: rocky/templates/scan.html rocky/templates/tasks/boefjes.html
 #: rocky/templates/tasks/normalizers.html
 msgid "Boefje"
-msgstr ""
+msgstr "Boefje"
 
 #: rocky/templates/oois/ooi_detail.html rocky/templates/scan.html
 msgid "Scan profile"
-msgstr ""
+msgstr "Scanprofil"
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "Unable to start scan. See the warning for more details."
 msgstr ""
+"Der Scan kann nicht gestartet werden. Weitere Einzelheiten finden Sie in der"
+" Warnung."
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "Start scan"
-msgstr ""
+msgstr "Scan starten"
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "There are no boefjes enabled to scan an OOI of type"
-msgstr ""
+msgstr "Es sind keine Boefjes zum Scannen eines OOI des Typs aktiviert"
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "See"
-msgstr ""
+msgstr "Sehen"
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "to find and enable boefjes that can scan within the current level."
 msgstr ""
+"um Boefjes zu finden und zu aktivieren, die innerhalb der aktuellen Ebene "
+"scannen können."
 
 #: rocky/templates/oois/ooi_detail_add_related_object.html
 #: rocky/templates/partials/ooi_detail_related_object.html
 msgid "Add related object"
-msgstr ""
+msgstr "Zugehöriges Objekt hinzufügen"
 
 #: rocky/templates/oois/ooi_detail_add_related_object.html
 #: rocky/templates/oois/ooi_detail_object.html
 msgid "Object details"
-msgstr ""
+msgstr "Objektdetails"
 
 #: rocky/templates/oois/ooi_detail_add_related_object.html
 #: rocky/templates/partials/elements/ooi_add_type_select_form.html
 msgid "Object type"
-msgstr ""
+msgstr "Objekttyp"
 
 #: rocky/templates/oois/ooi_detail_add_related_object.html
 #: rocky/templates/partials/elements/ooi_add_type_select_form.html
 msgid "Choose an object type to add"
-msgstr ""
+msgstr "Wählen Sie einen Objekttyp zum Hinzufügen aus"
 
 #: rocky/templates/oois/ooi_detail_add_related_object.html
 #: rocky/templates/partials/elements/ooi_add_type_select_form.html
 msgid "Select an object type to add."
-msgstr ""
+msgstr "Wählen Sie einen Objekttyp zum Hinzufügen aus."
 
 #: rocky/templates/oois/ooi_detail_findings_list.html
 msgid "Overview of findings for"
-msgstr ""
+msgstr "Überblick über die Ergebnisse für"
 
 #: rocky/templates/oois/ooi_detail_findings_list.html
 msgid "Score"
-msgstr ""
+msgstr "Punktzahl"
 
 #: rocky/templates/oois/ooi_detail_findings_list.html
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "Finding details"
-msgstr ""
+msgstr "Details finden"
 
 #: rocky/templates/oois/ooi_detail_findings_overview.html
 msgid "Overview of the number of findings and their severity found on"
-msgstr ""
+msgstr "Übersicht über die Anzahl der Befunde und deren Schweregrad auf"
 
 #: rocky/templates/oois/ooi_detail_findings_overview.html
 msgid ""
@@ -5998,206 +6708,225 @@ msgid ""
 "table shows the number of unique findings found as well as the number of "
 "occurrences."
 msgstr ""
+"Befunde können mehrfach vorkommen. Um einen besseren Einblick zu geben, "
+"zeigt die folgende Tabelle die Anzahl der gefundenen Einzelfunde sowie die "
+"Anzahl der Vorkommen."
 
 #: rocky/templates/oois/ooi_detail_findings_overview.html
 msgid "See finding details"
-msgstr ""
+msgstr "Siehe Funddetails"
 
 #: rocky/templates/oois/ooi_detail_findings_overview.html
 msgid "Total findings"
-msgstr ""
+msgstr "Gesamtbefunde"
 
 #: rocky/templates/oois/ooi_detail_object.html
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Inactive"
-msgstr ""
+msgstr "Inaktiv"
 
 #: rocky/templates/oois/ooi_detail_origins_declarations.html
 msgid "Declarations"
-msgstr ""
+msgstr "Erklärungen"
 
 #: rocky/templates/oois/ooi_detail_origins_inference.html
 msgid "Inferred by"
-msgstr ""
+msgstr "Abgeleitet von"
 
 #: rocky/templates/oois/ooi_detail_origins_inference.html
 msgid "Bit"
-msgstr ""
+msgstr "Bisschen"
 
 #: rocky/templates/oois/ooi_detail_origins_inference.html
 msgid "Parameters"
-msgstr ""
+msgstr "Parameter"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "Last observed by"
-msgstr ""
+msgstr "Zuletzt beobachtet von"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "Task ID"
-msgstr ""
+msgstr "Aufgaben-ID"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "When"
-msgstr ""
+msgstr "Wann"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 #: rocky/templates/tasks/normalizers.html
 msgid "Normalizer"
-msgstr ""
+msgstr "Normalizer"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "This scan was manually created."
-msgstr ""
+msgstr "Dieser Scan wurde manuell erstellt."
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "The boefje has since been deleted or disabled."
-msgstr ""
+msgstr "Das Boefje wurde inzwischen gelöscht oder deaktiviert."
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "No Raw file could be found, this might point to an error in OpenKAT"
 msgstr ""
+"Es konnte keine Raw-Datei gefunden werden. Dies deutet möglicherweise auf "
+"einen Fehler in OpenKAT hin"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Warning"
-msgstr ""
+msgstr "Warnung"
 
 #: rocky/templates/oois/ooi_edit.html
 #, python-format
 msgid "Edit %(type)s: %(ooi_human_readable)s"
-msgstr ""
+msgstr "Bearbeiten Sie %(type)s: %(ooi_human_readable)s"
 
 #: rocky/templates/oois/ooi_edit.html
 msgid "Primary key fields cannot be edited."
-msgstr ""
+msgstr "Primärschlüsselfelder können nicht bearbeitet werden."
 
 #: rocky/templates/oois/ooi_edit.html
 #, python-format
 msgid "Save %(display_type)s"
-msgstr ""
+msgstr "Speichern Sie %(display_type)s"
 
 #: rocky/templates/oois/ooi_findings.html
 msgid "Currently no findings have been identified for OOI"
-msgstr ""
+msgstr "Für OOI liegen derzeit keine Befunde vor"
 
 #: rocky/templates/oois/ooi_list.html
 #, python-format
 msgid ""
-"An overview of objects found for organization <strong>%(organization_name)s</"
-"strong>. Objects can be added manually or by running Boefjes. Click an "
-"object for additional information."
+"An overview of objects found for organization "
+"<strong>%(organization_name)s</strong>. Objects can be added manually or by "
+"running Boefjes. Click an object for additional information."
 msgstr ""
+"Eine Übersicht der für die Organisation "
+"<strong>%(organization_name)s</strong> gefundenen Objekte. Objekte können "
+"manuell oder durch Ausführen von Boefjes hinzugefügt werden. Klicken Sie auf"
+" ein Objekt, um weitere Informationen zu erhalten."
 
 #: rocky/templates/oois/ooi_list.html
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Edit clearance level"
-msgstr ""
+msgstr "Freigabestufe bearbeiten"
 
 #: rocky/templates/oois/ooi_mute_finding.html
 msgid "Mute finding:"
-msgstr ""
+msgstr "Stummschaltung:"
 
 #: rocky/templates/oois/ooi_mute_finding.html
 msgid "Give a reason below why you want to mute this finding."
 msgstr ""
+"Geben Sie unten einen Grund an, warum Sie dieses Ergebnis stummschalten "
+"möchten."
 
 #: rocky/templates/oois/ooi_mute_finding.html
 #: rocky/templates/partials/mute_findings_modal.html
 #: rocky/templates/partials/ooi_detail_toolbar.html
 msgid "Mute finding"
-msgstr ""
+msgstr "Stummschaltung"
 
 #: rocky/templates/oois/ooi_mute_finding.html
 msgid "Mute"
-msgstr ""
+msgstr "Stumm"
 
 #: rocky/templates/oois/ooi_page_tabs.html
 msgid "List of views for OOI"
-msgstr ""
+msgstr "Liste der Ansichten für OOI"
 
 #: rocky/templates/oois/ooi_past_due_warning.html
 msgid "This object is past due"
-msgstr ""
+msgstr "Dieses Objekt ist überfällig"
 
 #: rocky/templates/oois/ooi_past_due_warning.html
 msgid "This object is past due and has been deleted"
-msgstr ""
+msgstr "Dieses Objekt ist überfällig und wurde gelöscht"
 
 #: rocky/templates/oois/ooi_past_due_warning.html
 msgid ""
 "This object is past due. You are viewing the object state in a past state."
 msgstr ""
+"Dieses Objekt ist überfällig. Sie sehen den Objektstatus in einem früheren "
+"Zustand."
 
 #: rocky/templates/oois/ooi_past_due_warning.html
 msgid ""
 "You will not be able to add Findings or other OOI's to past due objects."
 msgstr ""
+"Sie können keine Befunde oder andere OOIs zu überfälligen Objekten "
+"hinzufügen."
 
 #: rocky/templates/oois/ooi_past_due_warning.html
 #: rocky/templates/partials/hyperlink_ooi_id.html
 #, python-format
 msgid "Show details for %(name)s"
-msgstr ""
+msgstr "Details für %(name)s anzeigen"
 
 #: rocky/templates/oois/ooi_past_due_warning.html
 msgid "View the current state"
-msgstr ""
+msgstr "Sehen Sie sich den aktuellen Status an"
 
 #: rocky/templates/oois/ooi_past_due_warning.html
 msgid ""
 "You will not be able to add Findings or other OOI's, this object has been "
 "deleted and is no longer available."
 msgstr ""
+"Sie können keine Befunde oder andere OOIs hinzufügen. Dieses Objekt wurde "
+"gelöscht und ist nicht mehr verfügbar."
 
 #: rocky/templates/oois/ooi_summary.html
 msgid "Summary for"
-msgstr ""
+msgstr "Zusammenfassung für"
 
 #: rocky/templates/oois/ooi_summary.html
 msgid "Below you can see findings that were found for"
-msgstr ""
+msgstr "Nachfolgend sehen Sie die Ergebnisse, die für gefunden wurden"
 
 #: rocky/templates/oois/ooi_summary.html
 msgid "and direct  children of this"
-msgstr ""
+msgstr "und direkte Kinder davon"
 
 #: rocky/templates/oois/ooi_summary.html
 msgid "This"
-msgstr ""
+msgstr "Das"
 
 #: rocky/templates/oois/ooi_summary.html
 msgid "tree view"
-msgstr ""
+msgstr "Baumansicht"
 
 #: rocky/templates/oois/ooi_summary.html
 msgid "of the"
-msgstr ""
+msgstr "des"
 
 #: rocky/templates/oois/ooi_summary.html
 msgid "shows the same objects."
-msgstr ""
+msgstr "zeigt die gleichen Objekte."
 
 #: rocky/templates/organizations/organization_add.html
 msgid ""
-"Please enter the following organization details. These details can be edited "
-"within the organization page within OpenKAT when necessary."
+"Please enter the following organization details. These details can be edited"
+" within the organization page within OpenKAT when necessary."
 msgstr ""
+"Bitte geben Sie die folgenden Organisationsdaten ein. Diese Details können "
+"bei Bedarf auf der Organisationsseite in OpenKAT bearbeitet werden."
 
 #: rocky/templates/organizations/organization_edit.html
 msgid "Edit organization"
-msgstr ""
+msgstr "Organisation bearbeiten"
 
 #: rocky/templates/organizations/organization_edit.html
 msgid "Save organization"
-msgstr ""
+msgstr "Organisation retten"
 
 #: rocky/templates/organizations/organization_list.html
 msgid "An overview of all organizations you are a member of."
-msgstr ""
+msgstr "Eine Übersicht aller Organisationen, in denen Sie Mitglied sind."
 
 #: rocky/templates/organizations/organization_list.html
 msgid "Add new organization"
-msgstr ""
+msgstr "Neue Organisation hinzufügen"
 
 #: rocky/templates/organizations/organization_list.html
 #, python-format
@@ -6206,72 +6935,81 @@ msgid ""
 "                            Showing %(total)s organizations\n"
 "                        "
 msgstr ""
+"\n"
+"Zeigt %(total)s-Organisationen"
 
 #: rocky/templates/organizations/organization_list.html
 msgid "Organization overview:"
-msgstr ""
+msgstr "Organisationsübersicht:"
 
 #: rocky/templates/organizations/organization_list.html
 #: rocky/templates/organizations/organization_settings.html
 msgid "Tags"
-msgstr ""
+msgstr "Schlagworte"
 
 #: rocky/templates/organizations/organization_list.html
 msgid "There were no organizations found for your user account"
-msgstr ""
+msgstr "Für Ihr Benutzerkonto wurden keine Organisationen gefunden"
 
 #: rocky/templates/organizations/organization_list.html
 msgid "Actions to perform for all of your organizations."
-msgstr ""
+msgstr "Aktionen, die Sie für alle Ihre Organisationen durchführen können."
 
 #: rocky/templates/organizations/organization_list.html
 #: rocky/templates/organizations/organization_settings.html
 msgid "Rerun all bits"
-msgstr ""
+msgstr "Führen Sie alle Bits erneut aus"
 
 #: rocky/templates/organizations/organization_member_add.html
 msgid "Change account type"
-msgstr ""
+msgstr "Kontotyp ändern"
 
 #: rocky/templates/organizations/organization_member_add_header.html
 #: rocky/views/organization_member_add.py
 msgid "Add member"
-msgstr ""
+msgstr "Mitglied hinzufügen"
 
 #: rocky/templates/organizations/organization_member_add_header.html
 #, python-format
 msgid ""
-"Creating a new member of organization <strong>%(organization)s</strong>. For "
-"detailed information about the different account types, check the <a "
+"Creating a new member of organization <strong>%(organization)s</strong>. For"
+" detailed information about the different account types, check the <a "
 "href=\"https://docs.openkat.nl/basics/users-and-organisations.html#users\" "
 "target=\"_blank\" rel=\"noopener\">documentation</a>."
 msgstr ""
+"Erstellen eines neuen Mitglieds der Organisation "
+"<strong>%(organization)s</strong>. Ausführliche Informationen zu den "
+"verschiedenen Kontotypen finden Sie in der Dokumentation <a "
+"href=\"https://docs.openkat.nl/basics/users-and-organisations.html#users\" "
+"target=\"_blank\" rel=\"noopener\"></a>."
 
 #: rocky/templates/organizations/organization_member_edit.html
 #: rocky/views/organization_member_edit.py
 msgid "Edit member"
-msgstr ""
+msgstr "Mitglied bearbeiten"
 
 #: rocky/templates/organizations/organization_member_edit.html
 msgid "Save member"
-msgstr ""
+msgstr "Mitglied speichern"
 
 #: rocky/templates/organizations/organization_member_list.html
 #, python-format
 msgid "An overview of members of <strong>%(organization_name)s</strong>."
 msgstr ""
+"Eine Übersicht über die Mitglieder von "
+"<strong>%(organization_name)s</strong>."
 
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Add member(s)"
-msgstr ""
+msgstr "Mitglied(er) hinzufügen"
 
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Manually"
-msgstr ""
+msgstr "Manuell"
 
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Upload a CSV"
-msgstr ""
+msgstr "Laden Sie einen CSV hoch"
 
 #: rocky/templates/organizations/organization_member_list.html
 #, python-format
@@ -6280,27 +7018,29 @@ msgid ""
 "                        Showing %(total)s members\n"
 "                    "
 msgstr ""
+"\n"
+"Zeigt %(total)s-Mitglieder"
 
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Member overview:"
-msgstr ""
+msgstr "Mitgliederübersicht:"
 
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Role"
-msgstr ""
+msgstr "Rolle"
 
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Assigned clearance level"
-msgstr ""
+msgstr "Zugewiesene Freigabeebene"
 
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Super user"
-msgstr ""
+msgstr "Superuser"
 
 #: rocky/templates/organizations/organization_member_upload.html
 #: rocky/views/organization_member_add.py
 msgid "Add members"
-msgstr ""
+msgstr "Mitglieder hinzufügen"
 
 #: rocky/templates/organizations/organization_member_upload.html
 #, python-format
@@ -6308,14 +7048,19 @@ msgid ""
 "To upload multiple members at once, you can upload a CSV file or you can <a "
 "href=\"%(download_url)s\">download the template</a>."
 msgstr ""
+"Um mehrere Mitglieder gleichzeitig hochzuladen, können Sie eine CSV-Datei "
+"hochladen oder die Vorlage <a href=\"%(download_url)s\">herunterladen</a>."
 
 #: rocky/templates/organizations/organization_member_upload.html
-msgid "To create a custom CSV file, make sure it meets the following criteria:"
+msgid ""
+"To create a custom CSV file, make sure it meets the following criteria:"
 msgstr ""
+"Stellen Sie zum Erstellen einer benutzerdefinierten CSV-Datei sicher, dass "
+"sie die folgenden Kriterien erfüllt:"
 
 #: rocky/templates/organizations/organization_member_upload.html
 msgid "Upload"
-msgstr ""
+msgstr "Hochladen"
 
 #: rocky/templates/organizations/organization_settings.html
 #, python-format
@@ -6323,177 +7068,201 @@ msgid ""
 "An overview of general information and settings for "
 "<strong>%(organization_name)s</strong>."
 msgstr ""
+"Eine Übersicht über allgemeine Informationen und Einstellungen für "
+"<strong>%(organization_name)s</strong>."
 
 #: rocky/templates/organizations/organization_settings.html
 msgid ""
 "<strong>Warning:</strong> Indemnification is not set for this organization."
 msgstr ""
+"<strong>Warnung:</strong> Für diese Organisation ist keine Entschädigung "
+"festgelegt."
 
 #: rocky/templates/organizations/organization_settings.html
 #: rocky/views/indemnification_add.py
 msgid "Add indemnification"
-msgstr ""
+msgstr "Entschädigung hinzufügen"
 
 #: rocky/templates/partials/current_config.html
 msgid "Current configuration"
-msgstr ""
+msgstr "Aktuelle Konfiguration"
 
 #: rocky/templates/partials/delete_ooi_modal.html
 msgid "Delete objects"
-msgstr ""
+msgstr "Objekte löschen"
 
 #: rocky/templates/partials/delete_ooi_modal.html
 msgid ""
-"Are you sure you want to delete all the selected objects? The history of the "
-"deleted objects will still be available."
+"Are you sure you want to delete all the selected objects? The history of the"
+" deleted objects will still be available."
 msgstr ""
+"Sind Sie sicher, dass Sie alle ausgewählten Objekte löschen möchten? Der "
+"Verlauf der gelöschten Objekte bleibt weiterhin verfügbar."
 
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 msgid "Edit clearance level settings"
-msgstr ""
+msgstr "Bearbeiten Sie die Einstellungen für die Freigabeebene"
 
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 msgid "You are editing clearance level of all the selected objects."
-msgstr ""
+msgstr "Sie bearbeiten den Freigabegrad aller ausgewählten Objekte."
 
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 msgid "Switching between declare and inherit"
-msgstr ""
+msgstr "Wechsel zwischen Deklarieren und Erben"
 
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 msgid ""
 "Clearance levels can be automatically inherited or you can manually declare "
-"the clearance level for an object. Switching to inherit clearance level will "
-"also recalculate the clearance levels of objects that inherit from these "
+"the clearance level for an object. Switching to inherit clearance level will"
+" also recalculate the clearance levels of objects that inherit from these "
 "clearance levels."
 msgstr ""
+"Freigabestufen können automatisch übernommen werden oder Sie können die "
+"Freigabestufe für ein Objekt manuell angeben. Durch den Wechsel zur "
+"Freigabestufe erben werden auch die Freigabestufen von Objekten neu "
+"berechnet, die von diesen Freigabestufen erben."
 
 #: rocky/templates/partials/elements/ooi_detail_settings.html
 msgid "Observed at"
-msgstr ""
+msgstr "Beobachtet bei"
 
 #: rocky/templates/partials/elements/ooi_detail_settings.html
 #: rocky/templates/partials/elements/ooi_report_settings.html
 msgid "Show settings"
-msgstr ""
+msgstr "Einstellungen anzeigen"
 
 #: rocky/templates/partials/elements/ooi_detail_settings.html
 #: rocky/templates/partials/elements/ooi_report_settings.html
 msgid "Hide settings"
-msgstr ""
+msgstr "Einstellungen ausblenden"
 
 #: rocky/templates/partials/elements/ooi_list_settings_form.html
 msgid "Toggle all OOI types"
-msgstr ""
+msgstr "Alle OOI-Typen umschalten"
 
 #: rocky/templates/partials/elements/ooi_tree_condensed_table.html
 msgid "Children"
-msgstr ""
+msgstr "Kinder"
 
 #: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
 #, python-format
 msgid "Show details for %(object_id)s, with %(child_count)s children."
-msgstr ""
+msgstr "Details für %(object_id)s anzeigen, mit %(child_count)s-Kindern."
 
 #: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
 #, python-format
 msgid ""
 "Show tree for %(object_id)s with only children of type %(object_ooi_type)s"
 msgstr ""
+"Baum für %(object_id)s mit nur untergeordneten Elementen vom Typ "
+"%(object_ooi_type)s anzeigen"
 
 #: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
 #, python-format
 msgid "Unfold %(object_id)s with %(child_count)s children"
-msgstr ""
+msgstr "Entfalten Sie %(object_id)s mit %(child_count)s-Kindern"
 
 #: rocky/templates/partials/elements/ooi_tree_table.html
 msgid "go to:"
-msgstr ""
+msgstr "gehe zu:"
 
 #: rocky/templates/partials/elements/ooi_tree_table.html
 msgid "Go to detailpage"
-msgstr ""
+msgstr "Zur Detailseite gehen"
 
 #: rocky/templates/partials/elements/ooi_tree_table.html
 msgid "detail"
-msgstr ""
+msgstr "Detail"
 
 #: rocky/templates/partials/elements/ooi_tree_table.html
 msgid "Go to tree view"
-msgstr ""
+msgstr "Gehen Sie zur Baumansicht"
 
 #: rocky/templates/partials/elements/ooi_tree_table.html
 msgid "tree"
-msgstr ""
+msgstr "Baum"
 
 #: rocky/templates/partials/elements/ooi_tree_table.html
 msgid "Go to graph view"
-msgstr ""
+msgstr "Gehen Sie zur Diagrammansicht"
 
 #: rocky/templates/partials/elements/ooi_tree_table.html
 msgid "graph"
-msgstr ""
+msgstr "Graph"
 
 #: rocky/templates/partials/explanations.html
 msgid "Clearance level inheritance"
-msgstr ""
+msgstr "Vererbung der Freigabeebene"
 
 #: rocky/templates/partials/explanations.html
 msgid "OOI"
-msgstr ""
+msgstr "OOI"
+
+#: rocky/templates/partials/explanations.html
+msgid "This OOI"
+msgstr "Dieses OOI"
 
 #: rocky/templates/partials/explanations.html
 msgid "Origin"
-msgstr ""
+msgstr "Herkunft"
+
+#: rocky/templates/partials/explanations.html
+msgid "declared"
+msgstr "erklärt"
+
+#: rocky/templates/partials/explanations.html
+msgid "inherited from ↓"
+msgstr "geerbt von ↓"
 
 #: rocky/templates/partials/explanations.html
 msgid "Show clearance level inheritance"
-msgstr ""
+msgstr "Vererbung der Freigabestufe anzeigen"
 
 #: rocky/templates/partials/finding_occurrence_definition_list.html
 msgid "Reproduction"
-msgstr ""
+msgstr "Reproduktion"
 
 #: rocky/templates/partials/form/checkbox_group_table_form.html
 msgid "Please enable plugin to start scanning."
-msgstr ""
+msgstr "Bitte aktivieren Sie das Plugin, um mit dem Scannen zu beginnen."
 
 #: rocky/templates/partials/form/field_input.html
 msgid "Not set"
-msgstr ""
+msgstr "Nicht festgelegt"
 
 #: rocky/templates/partials/form/field_input.html
 msgid "Forgot email"
-msgstr ""
+msgstr "E-Mail vergessen"
 
 #: rocky/templates/partials/form/field_input.html
 msgid "Forgot password"
-msgstr ""
+msgstr "Passwort vergessen"
 
 #: rocky/templates/partials/form/field_input_errors.html
 #: rocky/templates/partials/notifications_block.html
 msgid "error"
-msgstr ""
+msgstr "Fehler"
 
 #: rocky/templates/partials/form/field_input_errors.html
 #: rocky/templates/partials/form/form_errors.html
 #: rocky/templates/partials/notifications_block.html
 msgid "Error:"
-msgstr ""
+msgstr "Fehler:"
 
 #: rocky/templates/partials/form/field_input_help_text.html
 msgid "Open explanation"
-msgstr ""
+msgstr "Erklärung öffnen"
 
 #: rocky/templates/partials/form/field_input_help_text.html
 msgid "Close explanation"
-msgstr ""
+msgstr "Genaue Erklärung"
 
 #: rocky/templates/partials/form/field_input_help_text.html
 #: rocky/templates/partials/notifications_block.html
 #: rocky/templates/two_factor/core/login.html
 msgid "Explanation:"
-msgstr ""
+msgstr "Erläuterung:"
 
 #: rocky/templates/partials/form/indemnification_add_form.html
 msgid ""
@@ -6502,218 +7271,233 @@ msgid ""
 "negative impact on (your) assets. Therefore it is important to know and be "
 "aware of the impact of security scans."
 msgstr ""
+"Das Durchführen von Sicherheitsscans für Assets ist im Allgemeinen nur dann "
+"zulässig, wenn Sie über die Berechtigung zum Scannen dieser Assets verfügen."
+" Bestimmte Scans können sich auch negativ auf (Ihre) Vermögenswerte "
+"auswirken. Daher ist es wichtig, die Auswirkungen von Sicherheitsscans zu "
+"kennen und sich ihrer bewusst zu sein."
 
 #: rocky/templates/partials/form/indemnification_add_form.html
 msgid ""
-"An organization indemnification is required before you can use OpenKAT. With "
-"the indemnification you declare that you, as a person, can be held "
+"An organization indemnification is required before you can use OpenKAT. With"
+" the indemnification you declare that you, as a person, can be held "
 "accountable."
 msgstr ""
+"Bevor Sie OpenKAT nutzen können, ist eine Organisationsentschädigung "
+"erforderlich. Mit der Freistellung erklären Sie, dass Sie als Person zur "
+"Verantwortung gezogen werden können."
 
 #: rocky/templates/partials/form/indemnification_add_form.html
 msgid "Set an indemnification"
-msgstr ""
+msgstr "Legen Sie eine Entschädigung fest"
 
 #: rocky/templates/partials/hyperlink_ooi_type.html
 #, python-format
 msgid "Only show objects of type %(type)s"
-msgstr ""
+msgstr "Nur Objekte vom Typ %(type)s anzeigen"
 
 #: rocky/templates/partials/list_filters.html
 msgid "Hide filter options"
-msgstr ""
+msgstr "Filteroptionen ausblenden"
 
 #: rocky/templates/partials/list_filters.html
 msgid "Show filter options"
-msgstr ""
+msgstr "Filteroptionen anzeigen"
 
 #: rocky/templates/partials/list_paginator.html
 msgid "List pagination"
-msgstr ""
+msgstr "Listenpaginierung"
 
 #: rocky/templates/partials/list_paginator.html
 msgid "Previous Page"
-msgstr ""
+msgstr "Vorherige Seite"
 
 #: rocky/templates/partials/list_paginator.html
 msgid "Previous"
-msgstr ""
+msgstr "Vorherige"
 
 #: rocky/templates/partials/list_paginator.html
 msgid "Five Pages Back"
-msgstr ""
+msgstr "Fünf Seiten zurück"
 
 #: rocky/templates/partials/list_paginator.html
 #: rocky/templates/partials/pagination.html
 msgid "Page"
-msgstr ""
+msgstr "Seite"
+
+#: rocky/templates/partials/list_paginator.html
+msgid "Current"
+msgstr "Aktuell"
 
 #: rocky/templates/partials/list_paginator.html
 msgid "Five Pages Forward"
-msgstr ""
+msgstr "Fünf Seiten vorwärts"
 
 #: rocky/templates/partials/list_paginator.html
 msgid "Next Page"
-msgstr ""
+msgstr "Nächste Seite"
 
 #: rocky/templates/partials/list_paginator.html
 msgid "Next"
-msgstr ""
+msgstr "Nächste"
 
 #: rocky/templates/partials/mute_findings_modal.html
 msgid "You are muting the selected findings."
-msgstr ""
+msgstr "Sie schalten die ausgewählten Ergebnisse stumm."
 
 #: rocky/templates/partials/mute_findings_modal.html
 msgid "Reason:"
-msgstr ""
+msgstr "Grund:"
 
 #: rocky/templates/partials/mute_findings_modal.html
 msgid "Expires by (UTC):"
-msgstr ""
+msgstr "Läuft ab bis (UTC):"
 
 #: rocky/templates/partials/notifications_block.html
 msgid "Confirmation:"
-msgstr ""
+msgstr "Bestätigung:"
 
 #: rocky/templates/partials/ooi_detail_related_object.html
 msgid "No related object known for"
-msgstr ""
+msgstr "Kein verwandtes Objekt bekannt"
 
 #: rocky/templates/partials/ooi_detail_toolbar.html
 msgid "Generate Report"
-msgstr ""
+msgstr "Bericht erstellen"
 
 #: rocky/templates/partials/ooi_detail_toolbar.html
 #, python-format
 msgid "Edit %(display_type)s"
-msgstr ""
+msgstr "Bearbeiten Sie %(display_type)s"
 
 #: rocky/templates/partials/ooi_head.html
-#, python-format
-msgid ""
-"An overview of \"%(ooi)s\", object type \"%(type)s\". This shows general "
-"information and its related objects. It also gives the possibility to add "
-"additional related objects, or to scan for them."
-msgstr ""
+msgid "Data from:"
+msgstr "Daten von:"
+
+#: rocky/templates/partials/ooi_head.html
+msgid "(Now)"
+msgstr "(Jetzt)"
 
 #: rocky/templates/partials/ooi_list_toolbar.html
 msgid "Scan for objects"
-msgstr ""
+msgstr "Nach Objekten suchen"
 
 #: rocky/templates/partials/ooi_list_toolbar.html
 #: rocky/templates/upload_csv.html rocky/views/upload_csv.py
 msgid "Upload CSV"
-msgstr ""
+msgstr "Laden Sie CSV hoch"
 
 #: rocky/templates/partials/ooi_list_toolbar.html
 msgid "Export"
-msgstr ""
+msgstr "Export"
 
 #: rocky/templates/partials/ooi_list_toolbar.html
 msgid "Download as CSV"
-msgstr ""
+msgstr "Als CSV herunterladen"
 
 #: rocky/templates/partials/ooi_report_findings_block.html
 #, python-format
 msgid "%(total)s findings on %(name)s"
-msgstr ""
+msgstr "%(total)s-Ergebnisse zu %(name)s"
 
 #: rocky/templates/partials/ooi_report_findings_block_table.html
 #, python-format
 msgid "Findings for %(type)s %(name)s on %(observed_at)s:"
-msgstr ""
+msgstr "Ergebnisse für %(type)s %(name)s auf %(observed_at)s:"
 
 #: rocky/templates/partials/ooi_report_findings_block_table.html
 msgid "Open finding details"
-msgstr ""
+msgstr "Befunddetails öffnen"
 
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 #, python-format
 msgid "Details of %(object_id)s"
-msgstr ""
+msgstr "Details von %(object_id)s"
 
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid ""
 "The severity of this findingtype has not (yet) been determined by the data "
 "source. This situation requires manual investigation of the severity."
 msgstr ""
+"Der Schweregrad dieses Befundtyps wurde von der Datenquelle (noch) nicht "
+"bestimmt. Diese Situation erfordert eine manuelle Untersuchung des "
+"Schweregrads."
 
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "Total occurrences"
-msgstr ""
+msgstr "Gesamtzahl der Vorkommen"
 
 #: rocky/templates/partials/ooi_tree_toolbar_bottom.html
 msgid "Tree - dense view"
-msgstr ""
+msgstr "Baum - dichte Sicht"
 
 #: rocky/templates/partials/ooi_tree_toolbar_bottom.html
 msgid "Tree - table view"
-msgstr ""
+msgstr "Baum – Tabellenansicht"
 
 #: rocky/templates/partials/organization_member_list_filters.html
 msgid "Update List"
-msgstr ""
+msgstr "Update-Liste"
 
 #: rocky/templates/partials/organization_properties_table.html
 msgid "Organization name"
-msgstr ""
+msgstr "Name der Organisation"
 
 #: rocky/templates/partials/organization_properties_table.html
 msgid "Organization code"
-msgstr ""
+msgstr "Organisationscode"
 
 #: rocky/templates/partials/organizations_menu_dropdown.html
 msgid "Select organization"
-msgstr ""
+msgstr "Organisation auswählen"
 
 #: rocky/templates/partials/organizations_menu_dropdown.html
 msgid "All organizations"
-msgstr ""
+msgstr "Alle Organisationen"
 
 #: rocky/templates/partials/page-meta.html
 msgid "Logged in as:"
-msgstr ""
+msgstr "Angemeldet als:"
 
 #: rocky/templates/partials/pagination.html
 msgid "of"
-msgstr ""
+msgstr "von"
 
 #: rocky/templates/partials/pagination.html
 msgid "first"
-msgstr ""
+msgstr "Erste"
 
 #: rocky/templates/partials/pagination.html
 msgid "previous"
-msgstr ""
+msgstr "vorherige"
 
 #: rocky/templates/partials/pagination.html
 msgid "next"
-msgstr ""
+msgstr "nächste"
 
 #: rocky/templates/partials/pagination.html
 msgid "last"
-msgstr ""
+msgstr "zuletzt"
 
 #: rocky/templates/partials/secondary-menu.html
 msgid "User navigation"
-msgstr ""
+msgstr "Benutzernavigation"
 
 #: rocky/templates/partials/secondary-menu.html
 msgid "Close user navigation"
-msgstr ""
+msgstr "Benutzernavigation schließen"
 
 #: rocky/templates/partials/secondary-menu.html
 msgid "My organizations"
-msgstr ""
+msgstr "Meine Organisationen"
 
 #: rocky/templates/partials/secondary-menu.html
 msgid "Profile"
-msgstr ""
+msgstr "Profil"
 
 #: rocky/templates/partials/skip-to-content.html
 msgid "Go to content"
-msgstr ""
+msgstr "Zum Inhalt gehen"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid ""
@@ -6722,50 +7506,58 @@ msgid ""
 "This means that the clearance level might stay the same, increase or "
 "decrease, depending on other declared clearance levels."
 msgstr ""
+"Die Freigabestufe bestimmt die zulässige Anzahl an Boefje-Scans für dieses "
+"Objekt. Ein Objekt erbt seinen Abstandsgrad von benachbarten Objekten. Das "
+"bedeutet, dass die Freigabestufe je nach anderen angegebenen Freigabestufen "
+"gleich bleiben, sich erhöhen oder verringern kann."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Empty clearance level explanation"
-msgstr ""
+msgstr "Erläuterung der Leerraumhöhe"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Empty:"
-msgstr ""
+msgstr "Leer:"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid ""
 "This object has a clearance level of \"empty\". This means that this object "
 "has no clearance level."
 msgstr ""
+"Dieses Objekt hat die Freigabestufe „leer“. Das bedeutet, dass dieses Objekt"
+" keine Freigabestufe hat."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Indemnification warning"
-msgstr ""
+msgstr "Schadensersatzwarnung"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Indemnification is not set for this organization."
-msgstr ""
+msgstr "Für diese Organisation ist keine Entschädigung vorgesehen."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Go to the"
-msgstr ""
+msgstr "Gehe zum"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "organization settings page"
-msgstr ""
+msgstr "Seite mit den Organisationseinstellungen"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "to add one."
-msgstr ""
+msgstr "um eins hinzuzufügen."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Set clearance level warning"
-msgstr ""
+msgstr "Warnung zur Sicherheitsstufe einstellen"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid ""
 "You don't have permissions to set the clearance level. Contact your "
 "administrator."
 msgstr ""
+"Sie sind nicht berechtigt, die Freigabestufe festzulegen. Kontaktieren Sie "
+"Ihren Administrator."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 #, python-format
@@ -6774,115 +7566,128 @@ msgid ""
 "clearance level is %(member_clearance_level)s and this OOI has level "
 "%(boefje_scan_level)s."
 msgstr ""
+"Sie dürfen die Freigabestufe dieses OOI nicht festlegen. Ihre maximale "
+"Freigabestufe ist %(member_clearance_level)s und diese OOI hat die Stufe "
+"%(boefje_scan_level)s."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Go to your"
-msgstr ""
+msgstr "Gehen Sie zu Ihrem"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "account details"
-msgstr ""
+msgstr "Kontodaten"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "to manage your clearance level."
-msgstr ""
+msgstr "um Ihr Freigabeniveau zu verwalten."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Current clearance level"
-msgstr ""
+msgstr "Aktuelle Freigabestufe"
 
 #: rocky/templates/tasks/boefje_task_detail.html
 msgid ""
 "An overview of the boefje task, the input OOI and the RAW data it generated."
 msgstr ""
+"Eine Übersicht über die Boefje-Aufgabe, die Eingabe OOI und die von ihr "
+"generierten RAW-Daten."
 
 #: rocky/templates/tasks/boefje_task_detail.html
 #: rocky/templates/tasks/partials/task_actions.html
 msgid "Download meta and raw data"
-msgstr ""
+msgstr "Laden Sie Meta- und Rohdaten herunter"
 
 #: rocky/templates/tasks/boefje_task_detail.html
 msgid "Download meta data"
-msgstr ""
+msgstr "Metadaten herunterladen"
 
 #: rocky/templates/tasks/boefje_task_detail.html
 msgid "Input object"
-msgstr ""
+msgstr "Eingabeobjekt"
 
 #: rocky/templates/tasks/boefjes.html
 msgid "There are no tasks for boefjes."
-msgstr ""
+msgstr "Es gibt keine Aufgaben für Boefjes."
 
 #: rocky/templates/tasks/boefjes.html
 msgid "List of tasks for boefjes."
-msgstr ""
+msgstr "Liste der Aufgaben für Boefjes."
 
 #: rocky/templates/tasks/boefjes.html rocky/templates/tasks/reports.html
 msgid "Organization Code"
-msgstr ""
+msgstr "Organisationscode"
 
 #: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
 #: rocky/templates/tasks/ooi_detail_task_list.html
 #: rocky/templates/tasks/plugin_detail_task_list.html
 msgid "Created date"
-msgstr ""
+msgstr "Erstellungsdatum"
 
 #: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
 #: rocky/templates/tasks/reports.html
 msgid "Modified date"
-msgstr ""
+msgstr "Änderungsdatum"
 
 #: rocky/templates/tasks/normalizers.html
 msgid "There are no tasks for normalizers."
-msgstr ""
+msgstr "Es gibt keine Aufgaben für Normalisierer."
 
 #: rocky/templates/tasks/normalizers.html
 msgid "List of tasks for normalizers."
-msgstr ""
+msgstr "Liste der Aufgaben für Normalisierer."
 
 #: rocky/templates/tasks/normalizers.html
 msgid "Boefje input OOI"
-msgstr ""
+msgstr "Boefje Eingang OOI"
 
 #: rocky/templates/tasks/normalizers.html
 msgid "Manually added"
-msgstr ""
+msgstr "Manuell hinzugefügt"
 
 #: rocky/templates/tasks/ooi_detail_task_list.html
 msgid "There have been no tasks."
-msgstr ""
+msgstr "Es gab keine Aufgaben."
 
 #: rocky/templates/tasks/partials/stats.html
 msgid "Task statistics - Last 24 hours"
-msgstr ""
+msgstr "Aufgabenstatistik – Letzte 24 Stunden"
 
 #: rocky/templates/tasks/partials/stats.html
 msgid "All times in UTC, blocks of 1 hour."
-msgstr ""
+msgstr "Alle Zeiten in UTC, Blöcke von 1 Stunde."
 
 #: rocky/templates/tasks/partials/stats.html
 msgid "Timeslot"
-msgstr ""
+msgstr "Zeitfenster"
 
 #: rocky/templates/tasks/partials/stats.html
 msgid "Could not load stats, Scheduler error."
-msgstr ""
+msgstr "Statistiken konnten nicht geladen werden, Fehler im Planer."
 
 #: rocky/templates/tasks/partials/tab_navigation.html
 msgid "List of tasks"
-msgstr ""
+msgstr "Liste der Aufgaben"
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Loading..."
+msgstr "Laden..."
 
 #: rocky/templates/tasks/partials/task_actions.html
 msgid "Yielded objects"
-msgstr ""
+msgstr "Nachgegebene Objekte"
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Yielded raw files"
+msgstr "Ergibt Rohdateien"
 
 #: rocky/templates/tasks/partials/task_actions.html
 msgid "Reschedule"
-msgstr ""
+msgstr "Neu planen"
 
 #: rocky/templates/tasks/partials/task_actions.html
 msgid "Download task data"
-msgstr ""
+msgstr "Aufgabendaten herunterladen"
 
 #: rocky/templates/tasks/partials/tasks_overview_header.html
 #, python-format
@@ -6893,39 +7698,44 @@ msgid ""
 "Report tasks. This task aggregates and presents findings from both Boefjes "
 "and Normalizers."
 msgstr ""
+"Eine Übersicht der Aufgaben für <strong>%(organization)s</strong>. Die "
+"Aufgaben sind in Boefjes, Normalizers und Berichte unterteilt. Boefjes "
+"scannt Objekte und Normalizers verteilt den Ausgabe-MIME-Typ. Zusätzlich "
+"gibt es eine Berichtsaufgabe. Diese Aufgabe fasst die Ergebnisse von Boefjes"
+" und Normalizers zusammen und präsentiert sie."
 
 #: rocky/templates/tasks/plugin_detail_task_list.html
 msgid "There are no tasks for"
-msgstr ""
+msgstr "Es gibt keine Aufgaben für"
 
 #: rocky/templates/tasks/plugin_detail_task_list.html
 msgid "List of tasks for"
-msgstr ""
+msgstr "Liste der Aufgaben für"
 
 #: rocky/templates/tasks/reports.html
 msgid "There are no tasks for reports."
-msgstr ""
+msgstr "Für Berichte gibt es keine Aufgaben."
 
 #: rocky/templates/tasks/reports.html
 msgid "List of tasks for reports."
-msgstr ""
+msgstr "Liste der Aufgaben für Berichte."
 
 #: rocky/templates/tasks/reports.html
 msgid "Recipe ID"
-msgstr ""
+msgstr "Rezept-ID"
 
 #: rocky/templates/two_factor/_wizard_actions.html
 msgid "Log in"
-msgstr ""
+msgstr "Einloggen"
 
 #: rocky/templates/two_factor/_wizard_actions.html
 msgid "Authenticate"
-msgstr ""
+msgstr "Authentifizieren"
 
 #: rocky/templates/two_factor/core/backup_tokens.html
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Backup Tokens"
-msgstr ""
+msgstr "Backup-Token"
 
 #: rocky/templates/two_factor/core/backup_tokens.html
 msgid ""
@@ -6934,45 +7744,53 @@ msgid ""
 "you've used up all your backup tokens, you can generate a new set of backup "
 "tokens. Only the backup tokens shown below will be valid."
 msgstr ""
+"Backup-Tokens können verwendet werden, wenn Ihre primäre Telefonnummer und "
+"Ihre Backup-Telefonnummer nicht verfügbar sind. Die unten aufgeführten "
+"Backup-Tokens können zur Anmeldeüberprüfung verwendet werden. Wenn Sie alle "
+"Ihre Backup-Tokens aufgebraucht haben, können Sie einen neuen Satz Backup-"
+"Tokens erstellen. Nur die unten aufgeführten Backup-Tokens sind gültig."
 
 #: rocky/templates/two_factor/core/backup_tokens.html
 msgid "Print these tokens and keep them somewhere safe."
 msgstr ""
+"Drucken Sie diese Token aus und bewahren Sie sie an einem sicheren Ort auf."
 
 #: rocky/templates/two_factor/core/backup_tokens.html
 msgid "You don't have any backup codes yet."
-msgstr ""
+msgstr "Sie haben noch keine Backup-Codes."
 
 #: rocky/templates/two_factor/core/backup_tokens.html
 msgid "Generate Tokens"
-msgstr ""
+msgstr "Generieren Sie Token"
 
 #: rocky/templates/two_factor/core/backup_tokens.html
 #: rocky/templates/two_factor/core/setup_complete.html
 msgid "Back to Account Security"
-msgstr ""
+msgstr "Zurück zur Kontosicherheit"
 
 #: rocky/templates/two_factor/core/login.html
 msgid "You are logged in."
-msgstr ""
+msgstr "Sie sind angemeldet."
 
 #: rocky/templates/two_factor/core/login.html
 msgid "Two factor authentication is enabled for your account."
-msgstr ""
+msgstr "Für Ihr Konto ist die Zwei-Faktor-Authentifizierung aktiviert."
 
 #: rocky/templates/two_factor/core/login.html
 msgid ""
 "Two factor authentication is not enabled for your account. Enable it to "
 "continue."
 msgstr ""
+"Für Ihr Konto ist die Zwei-Faktor-Authentifizierung nicht aktiviert. "
+"Aktivieren Sie es, um fortzufahren."
 
 #: rocky/templates/two_factor/core/login.html
 msgid "Setup two factor authentication"
-msgstr ""
+msgstr "Richten Sie die Zwei-Faktor-Authentifizierung ein"
 
 #: rocky/templates/two_factor/core/login.html
 msgid "Credentials"
-msgstr ""
+msgstr "Anmeldeinformationen"
 
 #: rocky/templates/two_factor/core/login.html
 msgid ""
@@ -6980,18 +7798,22 @@ msgid ""
 "been generated for you to print and keep safe. Please enter one of these "
 "backup tokens to login to your account."
 msgstr ""
+"Verwenden Sie dieses Formular, um Backup-Token für die Anmeldung einzugeben."
+" Diese Token wurden generiert, damit Sie sie ausdrucken und sicher "
+"aufbewahren können. Bitte geben Sie eines dieser Backup-Tokens ein, um sich "
+"bei Ihrem Konto anzumelden."
 
 #: rocky/templates/two_factor/core/login.html
 msgid "As a last resort, you can use a backup token:"
-msgstr ""
+msgstr "Als letzten Ausweg können Sie ein Backup-Token verwenden:"
 
 #: rocky/templates/two_factor/core/login.html
 msgid "Use Backup Token"
-msgstr ""
+msgstr "Verwenden Sie ein Backup-Token"
 
 #: rocky/templates/two_factor/core/otp_required.html
 msgid "Permission Denied"
-msgstr ""
+msgstr "Zugriff verweigert"
 
 #: rocky/templates/two_factor/core/otp_required.html
 msgid ""
@@ -6999,242 +7821,302 @@ msgid ""
 "authentication for security reasons. You need to enable these security "
 "features in order to access this page."
 msgstr ""
+"Die von Ihnen angeforderte Seite zwingt Benutzer aus Sicherheitsgründen zur "
+"Verifizierung mithilfe einer Zwei-Faktor-Authentifizierung. Sie müssen diese"
+" Sicherheitsfunktionen aktivieren, um auf diese Seite zugreifen zu können."
 
 #: rocky/templates/two_factor/core/otp_required.html
 #: rocky/templates/two_factor/profile/profile.html
 msgid ""
-"Two-factor authentication is not enabled for your account. Enable two-factor "
-"authentication for enhanced account security."
+"Two-factor authentication is not enabled for your account. Enable two-factor"
+" authentication for enhanced account security."
 msgstr ""
+"Die Zwei-Faktor-Authentifizierung ist für Ihr Konto nicht aktiviert. "
+"Aktivieren Sie die Zwei-Faktor-Authentifizierung für mehr Kontosicherheit."
 
 #: rocky/templates/two_factor/core/otp_required.html
 #: rocky/templates/two_factor/core/setup.html
 #: rocky/templates/two_factor/core/setup_complete.html
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Enable Two-Factor Authentication"
-msgstr ""
+msgstr "Aktivieren Sie die Zwei-Faktor-Authentifizierung"
 
 #: rocky/templates/two_factor/core/phone_register.html
 msgid "Add Backup Phone"
-msgstr ""
+msgstr "Ersatztelefon hinzufügen"
 
 #: rocky/templates/two_factor/core/phone_register.html
 msgid ""
 "You'll be adding a backup phone number to your account. This number will be "
 "used if your primary method of registration is not available."
 msgstr ""
+"Sie fügen Ihrem Konto eine Ersatztelefonnummer hinzu. Diese Nummer wird "
+"verwendet, wenn Ihre primäre Registrierungsmethode nicht verfügbar ist."
 
 #: rocky/templates/two_factor/core/phone_register.html
 msgid ""
 "We've sent a token to your phone number. Please enter the token you've "
 "received."
 msgstr ""
+"Wir haben ein Token an Ihre Telefonnummer gesendet. Bitte geben Sie den "
+"Token ein, den Sie erhalten haben."
 
 #: rocky/templates/two_factor/core/setup.html
 msgid ""
 "To start using a token generator, please use your smartphone to scan the QR "
-"code below or use the setup key. For example, use GoogleAuthenticator. Then, "
-"enter the token generated by the app."
+"code below or use the setup key. For example, use GoogleAuthenticator. Then,"
+" enter the token generated by the app."
 msgstr ""
+"Um mit der Nutzung eines Token-Generators zu beginnen, scannen Sie bitte mit"
+" Ihrem Smartphone den untenstehenden QR-Code oder verwenden Sie den Setup-"
+"Schlüssel. Verwenden Sie beispielsweise GoogleAuthenticator. Geben Sie dann "
+"das von der App generierte Token ein."
 
 #: rocky/templates/two_factor/core/setup.html
 msgid "QR code"
-msgstr ""
+msgstr "QR-Code"
 
 #: rocky/templates/two_factor/core/setup.html
 msgid "Setup key"
-msgstr ""
+msgstr "Setup-Schlüssel"
 
 #: rocky/templates/two_factor/core/setup.html
 msgid ""
-"The secret key is a 32 characters representation of the QR code. There are 2 "
-"options to setup the two factor authtentication. You can scan the QR code "
+"The secret key is a 32 characters representation of the QR code. There are 2"
+" options to setup the two factor authtentication. You can scan the QR code "
 "above or you can insert this key using the secret key option of the "
 "authenticator app."
 msgstr ""
+"Der geheime Schlüssel ist eine 32-stellige Darstellung des QR-Codes. Es gibt"
+" zwei Möglichkeiten, die Zwei-Faktor-Authentifizierung einzurichten. Sie "
+"können den obigen QR-Code scannen oder diesen Schlüssel mithilfe der Option "
+"„Geheimer Schlüssel“ der Authentifizierungs-App eingeben."
 
 #: rocky/templates/two_factor/core/setup_complete.html
-msgid "Congratulations, you've successfully enabled two-factor authentication."
+msgid ""
+"Congratulations, you've successfully enabled two-factor authentication."
 msgstr ""
+"Herzlichen Glückwunsch, Sie haben die Zwei-Faktor-Authentifizierung "
+"erfolgreich aktiviert."
 
 #: rocky/templates/two_factor/core/setup_complete.html
 msgid "Start using OpenKAT"
-msgstr ""
+msgstr "Beginnen Sie mit der Verwendung von OpenKAT"
 
 #: rocky/templates/two_factor/core/setup_complete.html
 msgid ""
 "However, it might happen that you don't have access to your primary token "
 "device. To enable account recovery, add a phone number."
 msgstr ""
+"Es kann jedoch vorkommen, dass Sie keinen Zugriff auf Ihr primäres Token-"
+"Gerät haben. Um die Kontowiederherstellung zu aktivieren, fügen Sie eine "
+"Telefonnummer hinzu."
 
 #: rocky/templates/two_factor/core/setup_complete.html
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Add Phone Number"
-msgstr ""
+msgstr "Telefonnummer hinzufügen"
 
 #: rocky/templates/two_factor/profile/disable.html
 msgid "Disable Two-factor Authentication"
-msgstr ""
+msgstr "Deaktivieren Sie die Zwei-Faktor-Authentifizierung"
 
 #: rocky/templates/two_factor/profile/disable.html
 msgid ""
 "You are about to disable two-factor authentication. This weakens your "
 "account security, are you sure?"
 msgstr ""
+"Sie sind dabei, die Zwei-Faktor-Authentifizierung zu deaktivieren. Das "
+"schwächt die Sicherheit Ihres Kontos. Sind Sie sicher?"
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Account Security"
-msgstr ""
+msgstr "Kontosicherheit"
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Tokens will be generated by your token generator."
-msgstr ""
+msgstr "Token werden von Ihrem Token-Generator generiert."
 
 #: rocky/templates/two_factor/profile/profile.html
 #, python-format
 msgid "Primary method: %(primary)s"
-msgstr ""
+msgstr "Primäre Methode: %(primary)s"
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Tokens will be generated by your YubiKey."
-msgstr ""
+msgstr "Token werden von Ihrem YubiKey generiert."
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Backup Phone Numbers"
-msgstr ""
+msgstr "Backup-Telefonnummern"
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid ""
 "If your primary method is not available, we are able to send backup tokens "
 "to the phone numbers listed below."
 msgstr ""
+"Wenn Ihre primäre Methode nicht verfügbar ist, können wir Backup-Tokens an "
+"die unten aufgeführten Telefonnummern senden."
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Unregister"
-msgstr ""
+msgstr "Abmelden"
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid ""
 "If you don't have any device with you, you can access your account using "
 "backup tokens."
 msgstr ""
+"Wenn Sie kein Gerät dabei haben, können Sie mithilfe von Backup-Tokens auf "
+"Ihr Konto zugreifen."
 
 #: rocky/templates/two_factor/profile/profile.html
 #, python-format
 msgid "You have only one backup token remaining."
 msgid_plural "You have %(counter)s backup tokens remaining."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Sie haben noch %(counter)s Backup-Tokens übrig."
+msgstr[1] "Sie haben noch %(counter)s Backup-Tokens übrig."
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Show Codes"
-msgstr ""
+msgstr "Codes anzeigen"
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Disable Two-Factor Authentication"
-msgstr ""
+msgstr "Deaktivieren Sie die Zwei-Faktor-Authentifizierung"
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid ""
-"However we strongly discourage you to do so, you can also disable two-factor "
-"authentication for your account."
+"However we strongly discourage you to do so, you can also disable two-factor"
+" authentication for your account."
 msgstr ""
+"Wir raten Ihnen jedoch dringend davon ab. Sie können die Zwei-Faktor-"
+"Authentifizierung für Ihr Konto auch deaktivieren."
 
 #: rocky/templates/two_factor/twilio/sms_message.html
 #, python-format
 msgid "Your OTP token is %(token)s"
-msgstr ""
+msgstr "Ihr OTP-Token ist %(token)s"
 
 #: rocky/templates/upload_csv.html
 msgid "Automate the creation of multiple objects by uploading a CSV file."
 msgstr ""
+"Automatisieren Sie die Erstellung mehrerer Objekte, indem Sie eine CSV-Datei"
+" hochladen."
 
 #: rocky/templates/upload_csv.html
 msgid "These are the criteria for CSV upload:"
-msgstr ""
+msgstr "Dies sind die Kriterien für den Upload von CSV:"
 
 #: rocky/templates/upload_raw.html
 msgid "Automate the creation of multiple objects by uploading a raw file."
 msgstr ""
+"Automatisieren Sie die Erstellung mehrerer Objekte, indem Sie eine Rohdatei "
+"hochladen."
 
 #: rocky/templates/upload_raw.html
 msgid ""
-"An input OOI can be selected for the normalizer to attach newly yielded OOIs "
-"to. If no input OOI was used for the raw file, a placeholder ExternalScan "
+"An input OOI can be selected for the normalizer to attach newly yielded OOIs"
+" to. If no input OOI was used for the raw file, a placeholder ExternalScan "
 "OOI can be used. ExternalScan OOIs can be created from the objects page. "
 "When a new version of the raw file is generated, the same ExternalScan OOI "
 "should be chosen to ensure that old results are overwritten."
 msgstr ""
+"Für den Normalisierer kann ein Eingang OOI ausgewählt werden, an den neu "
+"ausgegebenes OOIs angehängt werden soll. Wenn für die Rohdatei keine Eingabe"
+" OOI verwendet wurde, kann ein Platzhalter ExternalScan OOI verwendet "
+"werden. ExternalScan OOIs kann über die Seite „Objekte“ erstellt werden. "
+"Wenn eine neue Version der Rohdatei generiert wird, sollte derselbe "
+"ExternalScan OOI gewählt werden, um sicherzustellen, dass alte Ergebnisse "
+"überschrieben werden."
 
 #: rocky/templates/upload_raw.html rocky/views/upload_raw.py
 msgid "Upload raw"
-msgstr ""
+msgstr "Roh hochladen"
 
 #: rocky/views/bytes_raw.py
 msgid "Getting raw data failed."
-msgstr ""
+msgstr "Das Abrufen der Rohdaten ist fehlgeschlagen."
 
 #: rocky/views/bytes_raw.py
 msgid "The task does not have any raw data."
-msgstr ""
+msgstr "Die Aufgabe verfügt über keine Rohdaten."
 
 #: rocky/views/finding_list.py rocky/views/ooi_list.py
 msgid "Unknown action."
-msgstr ""
+msgstr "Unbekannte Aktion."
 
 #: rocky/views/health.py
 msgid "Beautified"
-msgstr ""
+msgstr "Verschönert"
 
 #: rocky/views/indemnification_add.py
 msgid "Indemnification successfully set."
-msgstr ""
+msgstr "Entschädigung erfolgreich festgelegt."
 
 #: rocky/views/mixins.py
 msgid "The selected date is in the future."
-msgstr ""
+msgstr "Das ausgewählte Datum liegt in der Zukunft."
 
 #: rocky/views/mixins.py
 msgid "Can not parse date, falling back to show current date."
 msgstr ""
+"Das Datum kann nicht analysiert werden, es wird auf das aktuelle Datum "
+"zurückgegriffen."
+
+#: rocky/views/mixins.py
+#, python-format
+msgid "Could not load origins for OOI: %s from octopoes"
+msgstr "Die Ursprünge für OOI: %s von Octopoes konnten nicht geladen werden"
+
+#: rocky/views/mixins.py
+msgid "Could not load normalizer metas from bytes"
+msgstr "Normalisierer-Metadaten konnten nicht aus Bytes geladen werden"
+
+#: rocky/views/mixins.py
+#, python-format
+msgid "Could not load boefje %s from katalogus"
+msgstr "Boefje %s konnte nicht aus dem Katalog geladen werden"
 
 #: rocky/views/mixins.py
 msgid "You do not have the permission to add items to a dashboard."
-msgstr ""
+msgstr "Sie sind nicht berechtigt, Elemente zu einem Dashboard hinzuzufügen."
 
 #: rocky/views/mixins.py
 msgid "Dashboard item has been added."
-msgstr ""
+msgstr "Dashboard-Element wurde hinzugefügt."
 
 #: rocky/views/ooi_add.py
 #, python-format
 msgid "Add %(ooi_type)s"
-msgstr ""
+msgstr "Fügen Sie %(ooi_type)s hinzu"
 
 #: rocky/views/ooi_detail.py
 msgid ""
 "Cannot set clearance level. It must be provided and must be a valid number."
 msgstr ""
+"Die Freigabestufe kann nicht festgelegt werden. Es muss angegeben werden und"
+" eine gültige Nummer sein."
 
 #: rocky/views/ooi_detail.py
 msgid "Only Question OOIs can be answered."
-msgstr ""
+msgstr "Es kann nur die Frage OOIs beantwortet werden."
 
 #: rocky/views/ooi_detail.py
 msgid "Question has been answered."
-msgstr ""
+msgstr "Die Frage wurde beantwortet."
 
 #: rocky/views/ooi_detail_related_object.py
 msgid " (as "
-msgstr ""
+msgstr "(als"
 
 #: rocky/views/ooi_findings.py
 msgid "Object findings"
-msgstr ""
+msgstr "Objektbefunde"
 
 #: rocky/views/ooi_list.py
 msgid "No OOIs selected."
-msgstr ""
+msgstr "Kein OOIs ausgewählt."
 
 #: rocky/views/ooi_list.py
 #, python-format
@@ -7242,6 +8124,8 @@ msgid ""
 "Could not raise clearance levels to L%s. Indemnification not present at "
 "organization %s."
 msgstr ""
+"Die Freigabestufen konnten nicht auf L%s erhöht werden. Bei der Organisation"
+" %s liegt keine Entschädigung vor."
 
 #: rocky/views/ooi_list.py
 #, python-format
@@ -7249,6 +8133,9 @@ msgid ""
 "Could not raise clearance level to L%s. You were trusted a clearance level "
 "of L%s. Contact your administrator to receive a higher clearance."
 msgstr ""
+"Die Freigabestufe konnte nicht auf L%s erhöht werden. Ihnen wurde die "
+"Freigabestufe L%s anvertraut. Wenden Sie sich an Ihren Administrator, um "
+"eine höhere Freigabe zu erhalten."
 
 #: rocky/views/ooi_list.py
 #, python-format
@@ -7256,42 +8143,51 @@ msgid ""
 "Could not raise clearance level to L%s. You acknowledged a clearance level "
 "of L%s. Please accept the clearance level below to proceed."
 msgstr ""
+"Die Freigabestufe konnte nicht auf L%s erhöht werden. Sie haben die "
+"Freigabestufe L%s bestätigt. Bitte akzeptieren Sie die unten stehende "
+"Freigabestufe, um fortzufahren."
 
 #: rocky/views/ooi_list.py
 msgid "An error occurred while saving clearance levels."
-msgstr ""
+msgstr "Beim Speichern der Freigabestufen ist ein Fehler aufgetreten."
 
 #: rocky/views/ooi_list.py
 msgid "One of the OOI's doesn't exist"
-msgstr ""
+msgstr "Einer der OOI existiert nicht"
 
 #: rocky/views/ooi_list.py
 #, python-format
 msgid "Successfully set scan profile to %s for %d OOIs."
-msgstr ""
+msgstr "Das Scanprofil wurde erfolgreich auf %s für %d OOIs gesetzt."
 
 #: rocky/views/ooi_list.py
 msgid "An error occurred while setting clearance levels to inherit."
 msgstr ""
+"Beim Festlegen der zu vererbenden Freigabeebenen ist ein Fehler aufgetreten."
 
 #: rocky/views/ooi_list.py
 msgid ""
-"An error occurred while setting clearance levels to inherit: one of the OOIs "
-"doesn't exist."
+"An error occurred while setting clearance levels to inherit: one of the OOIs"
+" doesn't exist."
 msgstr ""
+"Beim Festlegen der zu vererbenden Freigabeebenen ist ein Fehler aufgetreten:"
+" Einer der OOIs ist nicht vorhanden."
 
 #: rocky/views/ooi_list.py
 #, python-format
 msgid "Successfully set %d OOI(s) clearance level to inherit."
 msgstr ""
+"Die Freigabestufe %d OOI(s) wurde erfolgreich auf die Übernahme festgelegt."
 
 #: rocky/views/ooi_list.py
 msgid "An error occurred while deleting oois."
-msgstr ""
+msgstr "Beim Löschen von Oois ist ein Fehler aufgetreten."
 
 #: rocky/views/ooi_list.py
 msgid "An error occurred while deleting OOIs: one of the OOIs doesn't exist."
 msgstr ""
+"Beim Löschen von OOIs ist ein Fehler aufgetreten: Einer der OOIs existiert "
+"nicht."
 
 #: rocky/views/ooi_list.py
 #, python-format
@@ -7299,115 +8195,118 @@ msgid ""
 "Successfully deleted %d ooi(s). Note: Bits can recreate objects "
 "automatically."
 msgstr ""
+"%d ooi(s) erfolgreich gelöscht. Hinweis: Bits können Objekte automatisch neu"
+" erstellen."
 
 #: rocky/views/ooi_mute.py
 msgid "Please select at least one finding."
-msgstr ""
+msgstr "Bitte wählen Sie mindestens einen Befund aus."
 
 #: rocky/views/ooi_mute.py
 msgid "Finding(s) successfully unmuted."
-msgstr ""
+msgstr "Die Stummschaltung der Entdeckung(en) wurde erfolgreich aufgehoben."
 
 #: rocky/views/ooi_mute.py
 msgid "Finding(s) successfully muted."
-msgstr ""
+msgstr "Fund(e) erfolgreich stummgeschaltet."
 
 #: rocky/views/ooi_tree.py
 msgid "Tree Visualisation"
-msgstr ""
+msgstr "Baumvisualisierung"
 
 #: rocky/views/ooi_tree.py
 msgid "Graph Visualisation"
-msgstr ""
+msgstr "Diagrammvisualisierung"
 
 #: rocky/views/ooi_view.py
 msgid "Observed_at: "
-msgstr ""
+msgstr "Beobachtet_at:"
 
 #: rocky/views/ooi_view.py
 msgid "OOI types: "
-msgstr ""
+msgstr "OOI-Typen:"
 
 #: rocky/views/ooi_view.py
 msgid "Clearance level: "
-msgstr ""
+msgstr "Freigabestufe:"
 
 #: rocky/views/ooi_view.py
 msgid "Clearance type: "
-msgstr ""
+msgstr "Freigabetyp:"
 
 #: rocky/views/ooi_view.py
 msgid "Searching for: "
-msgstr ""
+msgstr "Suche nach:"
 
 #: rocky/views/organization_add.py
 msgid "Setup"
-msgstr ""
+msgstr "Aufstellen"
 
 #: rocky/views/organization_add.py
 msgid "Organization added successfully."
-msgstr ""
+msgstr "Organisation erfolgreich hinzugefügt."
 
 #: rocky/views/organization_add.py
 msgid "You are not allowed to add organizations."
-msgstr ""
+msgstr "Es ist Ihnen nicht gestattet, Organisationen hinzuzufügen."
 
 #: rocky/views/organization_edit.py
 #, python-format
 msgid "Organization %s successfully updated."
-msgstr ""
+msgstr "Organisation %s erfolgreich aktualisiert."
 
 #: rocky/views/organization_member_add.py
 msgid "Add column titles, followed by each object on a new line."
 msgstr ""
+"Fügen Sie Spaltentitel hinzu, gefolgt von jedem Objekt in einer neuen Zeile."
 
 #: rocky/views/organization_member_add.py
 msgid "The columns are: "
-msgstr ""
+msgstr "Die Spalten sind:"
 
 #: rocky/views/organization_member_add.py
 msgid "Clearance levels should be between -1 and 4."
-msgstr ""
+msgstr "Die Freigabestufen sollten zwischen -1 und 4 liegen."
 
 #: rocky/views/organization_member_add.py
 msgid "Account type can be one of: "
-msgstr ""
+msgstr "Der Kontotyp kann einer der folgenden sein:"
 
 #: rocky/views/organization_member_add.py
 msgid "Member added successfully."
-msgstr ""
+msgstr "Mitglied erfolgreich hinzugefügt."
 
 #: rocky/views/organization_member_add.py
 msgid "The csv file is missing required columns"
-msgstr ""
+msgstr "In der CSV-Datei fehlen erforderliche Spalten"
 
 #: rocky/views/organization_member_add.py
 #, python-brace-format
 msgid "Invalid account type: '{account_type}'"
-msgstr ""
+msgstr "Ungültiger Kontotyp: „{account_type}“"
 
 #: rocky/views/organization_member_add.py
 #, python-brace-format
 msgid "Invalid data for: '{email}'"
-msgstr ""
+msgstr "Ungültige Daten für: „{email}“"
 
 #: rocky/views/organization_member_add.py
 #, python-brace-format
 msgid "Invalid email address: '{email}'"
-msgstr ""
+msgstr "Ungültige E-Mail-Adresse: „{email}“"
 
 #: rocky/views/organization_member_add.py
 msgid "Successfully processed users from csv."
-msgstr ""
+msgstr "Benutzer aus CSV erfolgreich verarbeitet."
 
 #: rocky/views/organization_member_add.py
 msgid "Error parsing the csv file. Please verify its contents."
-msgstr ""
+msgstr "Fehler beim Parsen der CSV-Datei. Bitte überprüfen Sie den Inhalt."
 
 #: rocky/views/organization_member_edit.py
 #, python-format
 msgid "Member %s successfully updated."
-msgstr ""
+msgstr "Mitglied %s erfolgreich aktualisiert."
 
 #: rocky/views/organization_member_edit.py
 #, python-format
@@ -7417,44 +8316,54 @@ msgid ""
 "level L%s. For this reason the acknowledged clearance level has been set at "
 "the same level as trusted clearance level."
 msgstr ""
+"Die aktualisierte vertrauenswürdige Freigabestufe L%s ist niedriger als die "
+"anerkannte Freigabestufe des Mitglieds L%s. Dieses Mitglied hat nur die "
+"Freigabe für Level L%s. Aus diesem Grund wurde die anerkannte Freigabestufe "
+"auf die gleiche Stufe wie die vertrauenswürdige Freigabestufe gesetzt."
 
 #: rocky/views/organization_member_edit.py
 msgid ""
 "You have trusted this member with a higher trusted level than member "
 "acknowledged. Member must first accept this level to use it."
 msgstr ""
+"Sie haben diesem Mitglied eine höhere Vertrauensstufe als vom Mitglied "
+"bestätigt zugewiesen. Das Mitglied muss dieses Level zunächst akzeptieren, "
+"um es nutzen zu können."
 
 #: rocky/views/organization_member_list.py
 #, python-format
 msgid "Blocked member %s successfully."
-msgstr ""
+msgstr "Mitglied %s erfolgreich blockiert."
 
 #: rocky/views/organization_member_list.py
 #, python-format
 msgid "Unblocked member %s successfully."
-msgstr ""
+msgstr "Mitglied %s erfolgreich entsperrt."
 
 #: rocky/views/organization_settings.py
 #, python-brace-format
 msgid "Recalculated {number_of_bits} bits. Duration: {duration}"
-msgstr ""
+msgstr "Neuberechnete {number_of_bits}-Bits. Dauer: {duration}"
 
 #: rocky/views/page_actions.py
 msgid "Could not process your request, action required."
-msgstr ""
+msgstr "Ihre Anfrage konnte nicht bearbeitet werden. Aktion erforderlich."
 
 #: rocky/views/scan_profile.py
 msgid ""
-"Cannot set clearance level. The clearance type must be inherited or declared."
+"Cannot set clearance level. The clearance type must be inherited or "
+"declared."
 msgstr ""
+"Die Freigabestufe kann nicht festgelegt werden. Der Freigabetyp muss geerbt "
+"oder deklariert werden."
 
 #: rocky/views/scans.py
 msgid "Scans"
-msgstr ""
+msgstr "Scannt"
 
 #: rocky/views/scheduler.py
 msgid "Your report has been scheduled."
-msgstr ""
+msgstr "Ihr Bericht wurde geplant."
 
 #: rocky/views/scheduler.py
 msgid ""
@@ -7462,66 +8371,83 @@ msgid ""
 "will be added to the object list when they are in. It may take some time, a "
 "refresh of the page may be needed to show the results."
 msgstr ""
+"Ihre Aufgabe ist geplant und wird bald im Hintergrund gestartet. Die "
+"Ergebnisse werden der Objektliste hinzugefügt, sobald sie vorhanden sind. Es"
+" kann einige Zeit dauern. Möglicherweise ist eine Aktualisierung der Seite "
+"erforderlich, um die Ergebnisse anzuzeigen."
 
 #: rocky/views/tasks.py
 #, python-brace-format
 msgid "Fetching tasks failed: no connection with scheduler: {error}"
 msgstr ""
+"Das Abrufen von Aufgaben ist fehlgeschlagen: Keine Verbindung mit dem "
+"Planer: {error}"
 
 #: rocky/views/tasks.py
 msgid "All Tasks"
-msgstr ""
+msgstr "Alle Aufgaben"
 
 #: rocky/views/upload_csv.py
 msgid "Add column titles. Followed by each object on a new line."
 msgstr ""
+"Spaltentitel hinzufügen. Gefolgt von jedem Objekt in einer neuen Zeile."
 
 #: rocky/views/upload_csv.py
 msgid ""
 "For URL object type, a column 'raw' with URL values is required, starting "
 "with http:// or https://, optionally a second column 'network' is supported "
 msgstr ""
+"Für den Objekttyp URL ist eine Spalte „raw“ mit URL-Werten erforderlich, "
+"beginnend mit http:// oder https://,. Optional wird eine zweite Spalte "
+"„network“ unterstützt"
 
 #: rocky/views/upload_csv.py
 msgid ""
 "For Hostname object type, a column with 'name' values is required, "
 "optionally a second column 'network' is supported "
 msgstr ""
+"Für den Objekttyp „Hostname“ ist eine Spalte mit „Name“-Werten erforderlich,"
+" optional wird eine zweite Spalte „Netzwerk“ unterstützt"
 
 #: rocky/views/upload_csv.py
 msgid ""
 "For IPAddressV4 and IPAddressV6 object types, a column of 'address' is "
 "required, optionally a second column 'network' is supported "
 msgstr ""
+"Für die Objekttypen IPAddressV4 und IPAddressV6 ist eine Spalte „Adresse“ "
+"erforderlich, optional wird eine zweite Spalte „Netzwerk“ unterstützt"
 
 #: rocky/views/upload_csv.py
 msgid ""
 "Clearance levels can be controlled by a column 'clearance' taking numerical "
-"values 0, 1, 2, 3, and 4 for the corresponding clearance level (other values "
-"are ignored) "
+"values 0, 1, 2, 3, and 4 for the corresponding clearance level (other values"
+" are ignored) "
 msgstr ""
+"Die Freigabestufen können durch eine Spalte „Freigabe“ gesteuert werden, die"
+" numerische Werte 0, 1, 2, 3 und 4 für die entsprechende Freigabestufe "
+"annimmt (andere Werte werden ignoriert)."
 
 #: rocky/views/upload_csv.py
 msgid "Object(s) could not be created for row number(s): "
-msgstr ""
+msgstr "Für die Zeilennummer(n) konnten keine Objekte erstellt werden:"
 
 #: rocky/views/upload_csv.py
 msgid "Object(s) successfully added."
-msgstr ""
+msgstr "Objekt(e) erfolgreich hinzugefügt."
 
 #: rocky/views/upload_raw.py
 #, python-format
 msgid "Raw file could not be uploaded to Bytes: status code %d"
-msgstr ""
+msgstr "Rohdatei konnte nicht nach Bytes hochgeladen werden: Statuscode %d"
 
 #: rocky/views/upload_raw.py
 #, python-format
 msgid "Raw file could not be uploaded to Bytes: %s"
-msgstr ""
+msgstr "Die Rohdatei konnte nicht nach Bytes hochgeladen werden: %s"
 
 #: rocky/views/upload_raw.py
 msgid "Raw file successfully added."
-msgstr ""
+msgstr "Rohdatei erfolgreich hinzugefügt."
 
 #~ msgid "Clearance level has been set"
 #~ msgstr "Die Freigabestufe wurde festgelegt"
@@ -7541,8 +8467,8 @@ msgstr ""
 
 #~ msgid ""
 #~ "I declare that OpenKAT may scan the assets of my organization and that I "
-#~ "have permission to scan these assets. I am aware of the implications a "
-#~ "scan with a higher scan level brings on my systems."
+#~ "have permission to scan these assets. I am aware of the implications a scan "
+#~ "with a higher scan level brings on my systems."
 #~ msgstr ""
 #~ "Ich erkläre, dass OpenKAT die Assets meiner Organisation scannen darf und "
 #~ "dass ich die Erlaubnis habe, diese Assets zu scannen. Ich bin mir der "
@@ -7556,18 +8482,18 @@ msgstr ""
 #~ msgstr ""
 #~ "Ich erkläre, dass ich befugt bin, diese Haftungsfreistellung innerhalb "
 #~ "meiner Organisation abzugeben. Ich verfüge über die Erfahrung und das "
-#~ "Wissen, um die möglichen Folgen zu kennen, und kann für diese "
-#~ "verantwortlich gemacht werden."
+#~ "Wissen, um die möglichen Folgen zu kennen, und kann für diese verantwortlich"
+#~ " gemacht werden."
 
 #~ msgid "Organization setup with separate accounts:"
 #~ msgstr "Einrichtung einer Organisation mit separaten Konten:"
 
 #~ msgid ""
 #~ "Within OpenKAT it is possible to create separate user accounts with the "
-#~ "specific roles. Each with their own functionalities and permissions. This "
-#~ "is useful when multiple people will be working with the same OpenKAT-"
-#~ "setup. You can choose to create the separate accounts during this "
-#~ "introduction or when you’re ready from the OpenKAT users page."
+#~ "specific roles. Each with their own functionalities and permissions. This is"
+#~ " useful when multiple people will be working with the same OpenKAT-setup. "
+#~ "You can choose to create the separate accounts during this introduction or "
+#~ "when you’re ready from the OpenKAT users page."
 #~ msgstr ""
 #~ "Innerhalb von OpenKAT ist es möglich, separate Benutzerkonten mit den "
 #~ "spezifischen Rollen zu erstellen. Jeder mit seinen eigenen Funktionen und "
@@ -7581,16 +8507,16 @@ msgstr ""
 
 #~ msgid ""
 #~ "Alternatively it is also an option to run OpenKAT from a single user "
-#~ "account. Which is useful when you are the only user in the account. You "
-#~ "will be able to access the functionality of the different roles from your "
-#~ "account. You can always add additional user accounts If you’re team "
-#~ "expands in the future."
+#~ "account. Which is useful when you are the only user in the account. You will"
+#~ " be able to access the functionality of the different roles from your "
+#~ "account. You can always add additional user accounts If you’re team expands "
+#~ "in the future."
 #~ msgstr ""
-#~ "Alternativ ist es auch möglich, OpenKAT von einem einzigen Benutzerkonto "
-#~ "aus zu starten. Dies ist nützlich, wenn Sie der einzige Benutzer des "
-#~ "Kontos sind. Sie können dann von Ihrem Konto aus auf die Funktionen der "
-#~ "verschiedenen Rollen zugreifen. Sie können jederzeit weitere "
-#~ "Benutzerkonten hinzufügen, wenn sich Ihr Team in Zukunft erweitert."
+#~ "Alternativ ist es auch möglich, OpenKAT von einem einzigen Benutzerkonto aus"
+#~ " zu starten. Dies ist nützlich, wenn Sie der einzige Benutzer des Kontos "
+#~ "sind. Sie können dann von Ihrem Konto aus auf die Funktionen der "
+#~ "verschiedenen Rollen zugreifen. Sie können jederzeit weitere Benutzerkonten "
+#~ "hinzufügen, wenn sich Ihr Team in Zukunft erweitert."
 
 #~ msgid "Create separate accounts"
 #~ msgstr "Getrennte Konten erstellen"
@@ -7612,8 +8538,8 @@ msgstr ""
 #~ msgstr "Admin"
 
 #~ msgid ""
-#~ "Each organization must have an admin. The admin can create and manage "
-#~ "user accounts as well as organization details."
+#~ "Each organization must have an admin. The admin can create and manage user "
+#~ "accounts as well as organization details."
 #~ msgstr ""
 #~ "Jede Organisation muss einen Administrator haben. Der Administrator kann "
 #~ "Benutzerkonten erstellen und verwalten sowie Details zur Organisation."
@@ -7631,14 +8557,14 @@ msgstr ""
 #~ msgstr "Ein Kundenkonto kann auf Berichte zugreifen."
 
 #~ msgid ""
-#~ "Each organization requires at least one admin and one red teamer account "
-#~ "to function. This introduction will guide you through the setup of both. "
-#~ "After that you can choose to add a client account as well."
+#~ "Each organization requires at least one admin and one red teamer account to "
+#~ "function. This introduction will guide you through the setup of both. After "
+#~ "that you can choose to add a client account as well."
 #~ msgstr ""
-#~ "Jede Organisation benötigt mindestens ein Admin- und ein Red-Teamer-"
-#~ "Konto, um zu funktionieren. Diese Einführung wird Sie durch die "
-#~ "Einrichtung beider Konten führen. Danach können Sie sich entscheiden, "
-#~ "auch ein Kundenkonto hinzuzufügen."
+#~ "Jede Organisation benötigt mindestens ein Admin- und ein Red-Teamer-Konto, "
+#~ "um zu funktionieren. Diese Einführung wird Sie durch die Einrichtung beider "
+#~ "Konten führen. Danach können Sie sich entscheiden, auch ein Kundenkonto "
+#~ "hinzuzufügen."
 
 #~ msgid "Let's add accounts"
 #~ msgstr "Wir wollen Konten hinzufügen"
@@ -7679,8 +8605,8 @@ msgstr ""
 
 #~ msgid ""
 #~ "OpenKAT is the \"Kwetsbaarheden Analyse Tool\" (Vulnerabilities Analysis "
-#~ "Tool). An Open-Source-project developed by the Ministry of Health, "
-#~ "Welfare and Sport to make your and our world a safer place."
+#~ "Tool). An Open-Source-project developed by the Ministry of Health, Welfare "
+#~ "and Sport to make your and our world a safer place."
 #~ msgstr ""
 #~ "OpenKAT ist das \"Kwetsbaarheden Analyse Tool\" (Werkzeug zur Analyse von "
 #~ "Schwachstellen). Ein Open-Source-Projekt, das vom Ministerium für "
@@ -7688,30 +8614,30 @@ msgstr ""
 #~ "sicherer zu machen."
 
 #~ msgid ""
-#~ "OpenKAT is able to give insight into security risks on your online "
-#~ "objects. For example, your websites, mailservers or online data."
+#~ "OpenKAT is able to give insight into security risks on your online objects. "
+#~ "For example, your websites, mailservers or online data."
 #~ msgstr ""
-#~ "OpenKAT ist in der Lage, einen Einblick in die Sicherheitsrisiken auf "
-#~ "Ihren Online-Objekten zu geben. Zum Beispiel Ihre Websites, Mailserver "
-#~ "oder Online-Daten."
+#~ "OpenKAT ist in der Lage, einen Einblick in die Sicherheitsrisiken auf Ihren "
+#~ "Online-Objekten zu geben. Zum Beispiel Ihre Websites, Mailserver oder "
+#~ "Online-Daten."
 
 #~ msgid ""
-#~ "OpenKAT uses plugins to find and assess the area's that might be at risk "
-#~ "and reports these back to you. Each plugin has its own skillset which "
-#~ "could be scanning, normalizing or analyzing data. As a user you decide "
-#~ "which areas you would like to monitor or scan and which insight you would "
-#~ "like to receive."
+#~ "OpenKAT uses plugins to find and assess the area's that might be at risk and"
+#~ " reports these back to you. Each plugin has its own skillset which could be "
+#~ "scanning, normalizing or analyzing data. As a user you decide which areas "
+#~ "you would like to monitor or scan and which insight you would like to "
+#~ "receive."
 #~ msgstr ""
 #~ "OpenKAT verwendet Plugins, um die möglicherweise gefährdeten Bereiche zu "
 #~ "finden und zu bewerten, und meldet diese an Sie zurück. Jedes Plugin hat "
 #~ "seine eigenen Fähigkeiten, die im Scannen, Normalisieren oder Analysieren "
-#~ "von Daten bestehen können. Als Nutzer entscheiden Sie, welche Bereiche "
-#~ "Sie überwachen oder scannen möchten und welche Erkenntnisse Sie erhalten "
+#~ "von Daten bestehen können. Als Nutzer entscheiden Sie, welche Bereiche Sie "
+#~ "überwachen oder scannen möchten und welche Erkenntnisse Sie erhalten "
 #~ "möchten."
 
 #~ msgid ""
-#~ "Within OpenKAT you can view the insights as well as all the data OpenKAT "
-#~ "has found. You can choose to browse through the data or view reports."
+#~ "Within OpenKAT you can view the insights as well as all the data OpenKAT has"
+#~ " found. You can choose to browse through the data or view reports."
 #~ msgstr ""
 #~ "Innerhalb von OpenKAT können Sie die Erkenntnisse sowie alle Daten, die "
 #~ "OpenKAT gefunden hat, einsehen. Sie können wählen, ob Sie die Daten "
@@ -7721,8 +8647,8 @@ msgstr ""
 #~ "During this introduction you will be guided through the steps to create a "
 #~ "report."
 #~ msgstr ""
-#~ "Während dieser Einführung werden Sie durch die Schritte zur Erstellung "
-#~ "eines Berichts geführt."
+#~ "Während dieser Einführung werden Sie durch die Schritte zur Erstellung eines"
+#~ " Berichts geführt."
 
 #~ msgid "OpenKAT introduction"
 #~ msgstr "OpenKAT Einführung"
@@ -7733,25 +8659,24 @@ msgstr ""
 #~ msgid ""
 #~ "Reports within OpenKAT contain an overview of the scanned objects, issues "
 #~ "found within them and known security risks that the object might be "
-#~ "vulnerable to. Each report gives a high overview of the state of the "
-#~ "object as well as detailed information on what OpenKAT found and possible "
+#~ "vulnerable to. Each report gives a high overview of the state of the object "
+#~ "as well as detailed information on what OpenKAT found and possible "
 #~ "solutions."
 #~ msgstr ""
 #~ "Die Berichte in OpenKAT enthalten einen Überblick über die gescannten "
-#~ "Objekte, die darin gefundenen Probleme und die bekannten "
-#~ "Sicherheitsrisiken, für die das Objekt anfällig sein könnte. Jeder "
-#~ "Bericht gibt einen umfassenden Überblick über den Zustand des Objekts "
-#~ "sowie detaillierte Informationen darüber, was OpenKAT gefunden hat, und "
-#~ "mögliche Lösungen."
+#~ "Objekte, die darin gefundenen Probleme und die bekannten Sicherheitsrisiken,"
+#~ " für die das Objekt anfällig sein könnte. Jeder Bericht gibt einen "
+#~ "umfassenden Überblick über den Zustand des Objekts sowie detaillierte "
+#~ "Informationen darüber, was OpenKAT gefunden hat, und mögliche Lösungen."
 
 #~ msgid ""
-#~ "OpenKAT can scan and analyze by using plugins. Each plugin has it's "
-#~ "unique skillset and will collect specific data or give specific insights. "
-#~ "You manage the plugins within your account which let's OpenKAT know which "
+#~ "OpenKAT can scan and analyze by using plugins. Each plugin has it's unique "
+#~ "skillset and will collect specific data or give specific insights. You "
+#~ "manage the plugins within your account which let's OpenKAT know which "
 #~ "plugins to run and on which objects or areas."
 #~ msgstr ""
-#~ "OpenKAT kann mit Hilfe von Plugins scannen und analysieren. Jedes Plugin "
-#~ "hat seine eigenen Fähigkeiten und sammelt spezifische Daten oder gibt "
+#~ "OpenKAT kann mit Hilfe von Plugins scannen und analysieren. Jedes Plugin hat"
+#~ " seine eigenen Fähigkeiten und sammelt spezifische Daten oder gibt "
 #~ "spezifische Einblicke. Sie verwalten die Plugins in Ihrem Konto, damit "
 #~ "OpenKAT weiß, welche Plugins für welche Objekte oder Bereiche ausgeführt "
 #~ "werden sollen."
@@ -7765,20 +8690,20 @@ msgstr ""
 #~ "needs, as well as asks for permission to run plugins that you haven’t "
 #~ "enabled yet but are needed to collect or analyze the data."
 #~ msgstr ""
-#~ "Wenn Sie einen Berichtstyp auswählen, wird OpenKAT Sie durch die "
-#~ "Einrichtung führen. OpenKAT stellt die notwendigen Fragen auf der "
-#~ "Grundlage der Eingaben, die der Bericht benötigt, und bittet um die "
-#~ "Erlaubnis, Plugins auszuführen, die Sie noch nicht aktiviert haben, die "
-#~ "aber für die Erfassung oder Analyse der Daten erforderlich sind."
+#~ "Wenn Sie einen Berichtstyp auswählen, wird OpenKAT Sie durch die Einrichtung"
+#~ " führen. OpenKAT stellt die notwendigen Fragen auf der Grundlage der "
+#~ "Eingaben, die der Bericht benötigt, und bittet um die Erlaubnis, Plugins "
+#~ "auszuführen, die Sie noch nicht aktiviert haben, die aber für die Erfassung "
+#~ "oder Analyse der Daten erforderlich sind."
 
 #~ msgid ""
-#~ "You can also choose to look at the collected data directly or generate "
-#~ "your own report by selecting and running plugins on objects of your "
-#~ "choice. OpenKAT will present the results."
+#~ "You can also choose to look at the collected data directly or generate your "
+#~ "own report by selecting and running plugins on objects of your choice. "
+#~ "OpenKAT will present the results."
 #~ msgstr ""
-#~ "Sie können sich die gesammelten Daten auch direkt ansehen oder Ihren "
-#~ "eigenen Bericht erstellen, indem Sie Plugins für Objekte Ihrer Wahl "
-#~ "auswählen und ausführen. OpenKAT wird die Ergebnisse präsentieren."
+#~ "Sie können sich die gesammelten Daten auch direkt ansehen oder Ihren eigenen"
+#~ " Bericht erstellen, indem Sie Plugins für Objekte Ihrer Wahl auswählen und "
+#~ "ausführen. OpenKAT wird die Ergebnisse präsentieren."
 
 #~ msgid "Permission"
 #~ msgstr "Erlaubnis"
@@ -7789,15 +8714,15 @@ msgstr ""
 #~ "enabling it."
 #~ msgstr ""
 #~ "Plugins können von OpenKAT zur Verfügung gestellt werden, aber sie können "
-#~ "auch von der Gemeinschaft kommen. Bevor ein Plugin ausgeführt werden "
-#~ "kann, müssen Sie ihm die Erlaubnis erteilen, indem Sie es aktivieren."
+#~ "auch von der Gemeinschaft kommen. Bevor ein Plugin ausgeführt werden kann, "
+#~ "müssen Sie ihm die Erlaubnis erteilen, indem Sie es aktivieren."
 
 #~ msgid ""
 #~ "When you generate a report. OpenKAT will let you know which plugins it "
 #~ "requires or suggests so you can choose to enable them."
 #~ msgstr ""
-#~ "Wenn Sie einen Bericht erstellen. OpenKAT teilt Ihnen mit, welche Plugins "
-#~ "es benötigt oder vorschlägt, damit Sie diese aktivieren können."
+#~ "Wenn Sie einen Bericht erstellen. OpenKAT teilt Ihnen mit, welche Plugins es"
+#~ " benötigt oder vorschlägt, damit Sie diese aktivieren können."
 
 #~ msgid "Let's choose a report"
 #~ msgstr "Lassen Sie uns einen Bericht auswählen"
@@ -7808,13 +8733,13 @@ msgstr ""
 #~ msgid ""
 #~ "Within OpenKAT you can view reports for each of your current objects. For "
 #~ "specific reports you can choose one of the available report types and "
-#~ "generate a report. Such as a pentest, a DNS-report or a Mail Report to "
-#~ "give some examples."
+#~ "generate a report. Such as a pentest, a DNS-report or a Mail Report to give "
+#~ "some examples."
 #~ msgstr ""
-#~ "In OpenKAT können Sie Berichte für jedes Ihrer aktuellen Objekte "
-#~ "anzeigen. Für spezifische Berichte können Sie einen der verfügbaren "
-#~ "Berichtstypen auswählen und einen Bericht erstellen. Ein Pentest, ein DNS-"
-#~ "Bericht oder ein Mail-Bericht sind nur einige Beispiele."
+#~ "In OpenKAT können Sie Berichte für jedes Ihrer aktuellen Objekte anzeigen. "
+#~ "Für spezifische Berichte können Sie einen der verfügbaren Berichtstypen "
+#~ "auswählen und einen Bericht erstellen. Ein Pentest, ein DNS-Bericht oder ein"
+#~ " Mail-Bericht sind nur einige Beispiele."
 
 #~ msgid "For this tutorial we will create a DNS-report to get you started."
 #~ msgstr ""
@@ -7822,11 +8747,11 @@ msgstr ""
 #~ "Einstieg zu erleichtern."
 
 #~ msgid ""
-#~ "When you start to generate this report. OpenKAT will guide you through "
-#~ "the necessary steps."
+#~ "When you start to generate this report. OpenKAT will guide you through the "
+#~ "necessary steps."
 #~ msgstr ""
-#~ "Wenn Sie beginnen, diesen Bericht zu erstellen. OpenKAT wird Sie durch "
-#~ "die notwendigen Schritte führen."
+#~ "Wenn Sie beginnen, diesen Bericht zu erstellen. OpenKAT wird Sie durch die "
+#~ "notwendigen Schritte führen."
 
 #~ msgid "Setup scan"
 #~ msgstr "Scan einrichten"
@@ -7835,30 +8760,28 @@ msgstr ""
 #~ msgstr "Lassen Sie OpenKAT wissen, welches Objekt gescannt werden soll"
 
 #~ msgid ""
-#~ "Plugins scan and analyze objects. OpenKAT needs to know which object(s) "
-#~ "you would like to scan and analyze for the DNS-report. So it can tell you "
-#~ "which plugins are available for the chosen object."
+#~ "Plugins scan and analyze objects. OpenKAT needs to know which object(s) you "
+#~ "would like to scan and analyze for the DNS-report. So it can tell you which "
+#~ "plugins are available for the chosen object."
 #~ msgstr ""
 #~ "Plugins scannen und analysieren Objekte. OpenKAT muss wissen, welche(s) "
-#~ "Objekt(e) Sie für den DNS-Bericht scannen und analysieren möchten. So "
-#~ "kann es Ihnen sagen, welche Plugins für das gewählte Objekt verfügbar "
-#~ "sind."
+#~ "Objekt(e) Sie für den DNS-Bericht scannen und analysieren möchten. So kann "
+#~ "es Ihnen sagen, welche Plugins für das gewählte Objekt verfügbar sind."
 
 #~ msgid "Understanding objects"
 #~ msgstr "Objekte verstehen"
 
 #~ msgid ""
-#~ "A lot of things can be an object within the scope of OpenKAT. For example "
-#~ "a mailserver, an IP address, a URL, a DNS record, a hostname or a network "
-#~ "to name a few.  While these objects can be related to each other they are "
-#~ "all objects within OpenKAT that can be scanned to gain valuable insight."
+#~ "A lot of things can be an object within the scope of OpenKAT. For example a "
+#~ "mailserver, an IP address, a URL, a DNS record, a hostname or a network to "
+#~ "name a few.  While these objects can be related to each other they are all "
+#~ "objects within OpenKAT that can be scanned to gain valuable insight."
 #~ msgstr ""
-#~ "Viele Dinge können ein Objekt im Rahmen von OpenKAT sein. Zum Beispiel "
-#~ "ein Mailserver, eine IP-Adresse, eine URL, ein DNS-Eintrag, ein Hostname "
-#~ "oder ein Netzwerk, um nur einige zu nennen.  Obwohl diese Objekte "
-#~ "miteinander in Beziehung stehen können, sind sie alle Objekte innerhalb "
-#~ "von OpenKAT, die gescannt werden können, um wertvolle Erkenntnisse zu "
-#~ "gewinnen."
+#~ "Viele Dinge können ein Objekt im Rahmen von OpenKAT sein. Zum Beispiel ein "
+#~ "Mailserver, eine IP-Adresse, eine URL, ein DNS-Eintrag, ein Hostname oder "
+#~ "ein Netzwerk, um nur einige zu nennen.  Obwohl diese Objekte miteinander in "
+#~ "Beziehung stehen können, sind sie alle Objekte innerhalb von OpenKAT, die "
+#~ "gescannt werden können, um wertvolle Erkenntnisse zu gewinnen."
 
 #~ msgid "Creating, adding and editing objects"
 #~ msgstr "Erstellen, Hinzufügen und Bearbeiten von Objekten"
@@ -7867,8 +8790,8 @@ msgstr ""
 #~ "Within OpenKAT you can view, add and edit objects from the organization’s "
 #~ "object page."
 #~ msgstr ""
-#~ "In OpenKAT können Sie Objekte auf der Objektseite der Organisation "
-#~ "anzeigen, hinzufügen und bearbeiten."
+#~ "In OpenKAT können Sie Objekte auf der Objektseite der Organisation anzeigen,"
+#~ " hinzufügen und bearbeiten."
 
 #~ msgid ""
 #~ "Let’s add an object to scan for the DNS-Report. For this introduction we "
@@ -7883,8 +8806,8 @@ msgstr ""
 #~ "Formular ausfüllen."
 
 #~ msgid ""
-#~ "Additional details and examples can be found by pressing on the help "
-#~ "button next to the input field."
+#~ "Additional details and examples can be found by pressing on the help button "
+#~ "next to the input field."
 #~ msgstr ""
 #~ "Weitere Details und Beispiele finden Sie, wenn Sie auf die Schaltfläche "
 #~ "\"Hilfe\" neben dem Eingabefeld klicken."
@@ -7896,8 +8819,8 @@ msgstr ""
 #~ "Most objects have dependencies on the existence of other objects. For "
 #~ "example a URL needs to be connected to a network, hostname, fqdn (fully "
 #~ "qualified domain name) and IP address. OpenKAT collects these additional "
-#~ "object automatically when possible. By running plugins to collect or "
-#~ "extract this data."
+#~ "object automatically when possible. By running plugins to collect or extract"
+#~ " this data."
 #~ msgstr ""
 #~ "Die meisten Objekte sind von der Existenz anderer Objekte abhängig. Zum "
 #~ "Beispiel muss eine URL mit einem Netzwerk verbunden sein, Hostname, FQDN "
@@ -7911,13 +8834,13 @@ msgstr ""
 #~ "guide you through the process of creating them manually."
 #~ msgstr ""
 #~ "Die zusätzlichen Objekte, die OpenKAT erstellt hat, werden als separate "
-#~ "Objekte zu Ihrer Objektliste hinzugefügt. Wenn OpenKAT sie nicht "
-#~ "automatisch hinzufügen kann, wird es Sie durch den Prozess der manuellen "
-#~ "Erstellung leiten."
+#~ "Objekte zu Ihrer Objektliste hinzugefügt. Wenn OpenKAT sie nicht automatisch"
+#~ " hinzufügen kann, wird es Sie durch den Prozess der manuellen Erstellung "
+#~ "leiten."
 
 #~ msgid ""
-#~ "Based on the url you provided OpenKAT added the necessary additional "
-#~ "objects to create a url object."
+#~ "Based on the url you provided OpenKAT added the necessary additional objects"
+#~ " to create a url object."
 #~ msgstr ""
 #~ "Basierend auf der von Ihnen angegebenen URL hat OpenKAT die notwendigen "
 #~ "zusätzlichen Objekte hinzugefügt, um ein URL-Objekt zu erstellen."
@@ -7934,8 +8857,8 @@ msgstr ""
 #, python-format
 #~ msgid ""
 #~ "These are the findings of a OpenKAT-analysis (%(observed_at)s). Click a "
-#~ "finding for more detailed information about the issue, its origin, "
-#~ "severity and possible solutions."
+#~ "finding for more detailed information about the issue, its origin, severity "
+#~ "and possible solutions."
 #~ msgstr ""
 #~ "Dies sind die Ergebnisse einer OpenKAT-Analyse (%(observed_at)s). Klicken "
 #~ "Sie auf ein Ergebnis, um nähere Informationen über das Problem, seinen "
@@ -7946,41 +8869,33 @@ msgstr ""
 
 #~ msgid ""
 #~ "\n"
-#~ "                            You don't have any clearance to scan objects."
-#~ "<br>\n"
-#~ "                            Get in contact with the admin to give you the "
-#~ "necessary clearance level.\n"
+#~ "                            You don't have any clearance to scan objects.<br>\n"
+#~ "                            Get in contact with the admin to give you the necessary clearance level.\n"
 #~ "                        "
 #~ msgstr ""
 #~ "\n"
-#~ "                            Sie haben keine Berechtigung zum Scannen von "
-#~ "Objekten.<br>\n"
-#~ "                            Setzen Sie sich mit dem Administrator in "
-#~ "Verbindung, damit er Ihnen die erforderliche Freigabestufe erteilt.\n"
+#~ "                            Sie haben keine Berechtigung zum Scannen von Objekten.<br>\n"
+#~ "                            Setzen Sie sich mit dem Administrator in Verbindung, damit er Ihnen die erforderliche Freigabestufe erteilt.\n"
 #~ "                        "
 
 #, python-format
 #~ msgid ""
 #~ "\n"
-#~ "                            Withdraw L%(acl)s clearance and "
-#~ "responsibility\n"
+#~ "                            Withdraw L%(acl)s clearance and responsibility\n"
 #~ "                    "
 #~ msgstr ""
 #~ "\n"
-#~ "                            F%(acl)s Freigabe und Verantwortung "
-#~ "entziehen\n"
+#~ "                            F%(acl)s Freigabe und Verantwortung entziehen\n"
 #~ "                    "
 
 #, python-format
 #~ msgid ""
 #~ "\n"
-#~ "                        Accept level L%(tcl)s clearance and "
-#~ "responsibility\n"
+#~ "                        Accept level L%(tcl)s clearance and responsibility\n"
 #~ "                    "
 #~ msgstr ""
 #~ "\n"
-#~ "                        Freigabe und Verantwortung der Ebene F%(tcl)s "
-#~ "akzeptieren\n"
+#~ "                        Freigabe und Verantwortung der Ebene F%(tcl)s akzeptieren\n"
 #~ "                    "
 
 #~ msgid ""


### PR DESCRIPTION
## Summary
- update the German Django translation catalog from the current Weblate template
- fill previously untranslated strings using machine translation with protected placeholders and OpenKAT domain terms
- update translation metadata

## Validation
- msgfmt --statistics --check rocky/rocky/locale/de/LC_MESSAGES/django.po

Note: these translations were machine-assisted and should be reviewed by a German speaker before release.