### PR TITLE
Update French translations

### DIFF
--- a/rocky/rocky/locale/fr/LC_MESSAGES/django.po
+++ b/rocky/rocky/locale/fr/LC_MESSAGES/django.po
@@ -2,16 +2,14 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # jan klopper <jan@underdark.nl>, 2023.
-#: reports/forms.py
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: OpenKAT\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-20 07:38+0000\n"
-"PO-Revision-Date: 2025-08-22 09:39+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language-Team: French <https://hosted.weblate.org/projects/openkat/nl-kat-"
-"coordination/fr/>\n"
+"POT-Creation-Date: 2026-03-28 14:22+0000\n"
+"PO-Revision-Date: 2026-07-14 00:00+0000\n"
+"Last-Translator: Brenno de Winter <brenno@dewinter.com>\n"
+"Language-Team: French <https://hosted.weblate.org/projects/openkat/nl-kat-coordination/fr/>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -21,11 +19,11 @@ msgstr ""
 
 #: account/admin.py
 msgid "Permissions"
-msgstr ""
+msgstr "Autorisations"
 
 #: account/admin.py
 msgid "Important dates"
-msgstr ""
+msgstr "Dates importantes"
 
 #: account/forms/account_setup.py crisis_room/forms.py
 #: katalogus/templates/katalogus_settings.html
@@ -44,94 +42,96 @@ msgstr ""
 #: rocky/templates/organizations/organization_settings.html
 #: rocky/templates/partials/ooi_detail_related_object.html
 msgid "Name"
-msgstr ""
+msgstr "Nom"
 
 #: account/forms/account_setup.py
 msgid "The name that will be used in order to communicate."
-msgstr ""
+msgstr "Le nom qui sera utilisé pour communiquer."
 
 #: account/forms/account_setup.py
 msgid "Please provide username"
-msgstr ""
+msgstr "Veuillez fournir le nom d'utilisateur"
 
 #: account/forms/account_setup.py
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Email"
-msgstr ""
+msgstr "E-mail"
 
 #: account/forms/account_setup.py
 msgid "Enter an email address."
-msgstr ""
+msgstr "Saisissez une adresse e-mail."
 
 #: account/forms/account_setup.py
 msgid "Password"
-msgstr ""
+msgstr "Mot de passe"
 
 #: account/forms/account_setup.py
 msgid "Choose a super secret password"
-msgstr ""
+msgstr "Choisissez un mot de passe super secret"
 
 #: account/forms/account_setup.py
 msgid "Choose another email."
-msgstr ""
+msgstr "Choisissez un autre e-mail."
 
 #: account/forms/account_setup.py tools/forms/settings.py
 msgid "--- Please select one of the available options ----"
-msgstr ""
+msgstr "--- Veuillez sélectionner l'une des options disponibles ----"
 
 #: account/forms/account_setup.py
 msgid "Account type"
-msgstr ""
+msgstr "Type de compte"
 
 #: account/forms/account_setup.py
 msgid "Please select an account type to proceed."
-msgstr ""
+msgstr "Veuillez sélectionner un type de compte pour continuer."
 
 #: account/forms/account_setup.py
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 msgid "Trusted clearance level"
-msgstr ""
+msgstr "Niveau d'autorisation fiable"
 
 #: account/forms/account_setup.py
 msgid "Select a clearance level you trust this member with."
 msgstr ""
+"Sélectionnez un niveau d'autorisation avec lequel vous faites confiance à ce"
+" membre."
 
 #: account/forms/account_setup.py onboarding/forms.py tools/forms/ooi.py
 msgid "Please select a clearance level to proceed."
-msgstr ""
+msgstr "Veuillez sélectionner un niveau d'autorisation pour continuer."
 
 #: account/forms/account_setup.py tools/models.py
 msgid "The name of the organization."
-msgstr ""
+msgstr "Le nom de l'organisation."
 
 #: account/forms/account_setup.py
 msgid "explanation-organization-name"
-msgstr ""
+msgstr "explication-nom-de l'organisation"
 
 #: account/forms/account_setup.py
 #, python-brace-format
 msgid "A unique code of maximum {code_length} characters in length."
-msgstr ""
+msgstr "Un code unique d’une longueur maximale de caractères {code_length}."
 
 #: account/forms/account_setup.py
 msgid "explanation-organization-code"
-msgstr ""
+msgstr "explication-code-organisation"
 
 #: account/forms/account_setup.py
 msgid "Organization name is required to proceed."
-msgstr ""
+msgstr "Le nom de l’organisation est requis pour continuer."
 
 #: account/forms/account_setup.py
 msgid "Choose another organization."
-msgstr ""
+msgstr "Choisissez une autre organisation."
 
 #: account/forms/account_setup.py
 msgid "Organization code is required to proceed."
-msgstr ""
+msgstr "Le code de l'organisation est requis pour continuer."
 
 #: account/forms/account_setup.py
 msgid "Choose another code for your organization."
-msgstr ""
+msgstr "Choisissez un autre code pour votre organisation."
 
 #: account/forms/account_setup.py
 msgid ""
@@ -139,6 +139,10 @@ msgid ""
 "have permission to scan these assets. I am aware of the implications a scan "
 "(with a higher scan level) brings on my systems."
 msgstr ""
+"Je déclare que OpenKAT peut analyser les actifs de mon organisation et que "
+"j'ai l'autorisation d'analyser ces actifs. Je suis conscient des "
+"implications qu'une analyse (avec un niveau d'analyse plus élevé) apporte "
+"sur mes systèmes."
 
 #: account/forms/account_setup.py
 msgid ""
@@ -146,123 +150,135 @@ msgid ""
 "organization. I have the experience and knowledge to know what the "
 "consequences might be and can be held responsible for them."
 msgstr ""
+"Je déclare que je suis autorisé à donner cette indemnisation au nom de mon "
+"organisation. J'ai l'expérience et les connaissances nécessaires pour "
+"connaître les conséquences possibles et je peux en être tenu responsable."
 
 #: account/forms/account_setup.py
 msgid "Trusted to change Clearance Levels."
-msgstr ""
+msgstr "Approuvé pour modifier les niveaux d'autorisation."
 
 #: account/forms/account_setup.py
 msgid "Acknowledged to change Clearance Levels."
-msgstr ""
+msgstr "Reconnu pour modifier les niveaux d'autorisation."
 
 #: account/forms/account_setup.py rocky/forms.py
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Blocked"
-msgstr ""
+msgstr "Bloqué"
 
 #: account/forms/account_setup.py
 msgid ""
 "Set the members status to blocked, so they don't have access to the "
 "organization anymore."
 msgstr ""
+"Définissez le statut des membres sur bloqué, afin qu'ils n'aient plus accès "
+"à l'organisation."
 
 #: account/forms/account_setup.py
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Accepted clearance level"
-msgstr ""
+msgstr "Niveau d'autorisation accepté"
 
 #: account/forms/account_setup.py
 msgid "Enter tags separated by comma."
-msgstr ""
+msgstr "Entrez les balises séparées par des virgules."
 
 #: account/forms/account_setup.py
 msgid "The two password fields didn’t match."
-msgstr ""
+msgstr "Les deux champs de mot de passe ne correspondent pas."
 
 #: account/forms/account_setup.py
 msgid "New password"
-msgstr ""
+msgstr "Nouveau mot de passe"
 
 #: account/forms/account_setup.py
 msgid "Enter a new password"
-msgstr ""
+msgstr "Entrez un nouveau mot de passe"
 
 #: account/forms/account_setup.py
 msgid "New password confirmation"
-msgstr ""
+msgstr "Confirmation du nouveau mot de passe"
 
 #: account/forms/account_setup.py
 msgid "Repeat the new password"
-msgstr ""
+msgstr "Répétez le nouveau mot de passe"
 
 #: account/forms/account_setup.py
 msgid "Confirm the new password"
-msgstr ""
+msgstr "Confirmez le nouveau mot de passe"
 
 #: account/forms/login.py
 msgid "Please enter a correct email address and password."
-msgstr ""
+msgstr "Veuillez saisir une adresse e-mail et un mot de passe corrects."
 
 #: account/forms/login.py
 msgid "This account is inactive."
-msgstr ""
+msgstr "Ce compte est inactif."
 
 #: account/forms/login.py
 msgid "Insert the email you registered with or got at OpenKAT installation."
 msgstr ""
+"Insérez l'e-mail avec lequel vous vous êtes inscrit ou obtenu lors de "
+"l'installation de OpenKAT."
 
 #: account/forms/organization.py
 msgid "Organization is required."
-msgstr ""
+msgstr "Une organisation est nécessaire."
 
 #: account/forms/organization.py tools/view_helpers.py
 #: rocky/templates/dashboard_redteam.html
 #: rocky/templates/organizations/organization_list.html
 #: rocky/views/organization_add.py
 msgid "Organizations"
-msgstr ""
+msgstr "Organisations"
 
 #: account/forms/organization.py
 msgid "The organization from which to clone settings."
-msgstr ""
+msgstr "Organisation à partir de laquelle cloner les paramètres."
 
 #: account/forms/password_reset.py account/templates/account_detail.html
 msgid "Email address"
-msgstr ""
+msgstr "Adresse email"
 
 #: account/forms/password_reset.py
 msgid "A reset link will be sent to this email"
-msgstr ""
+msgstr "Un lien de réinitialisation sera envoyé à cet e-mail"
 
 #: account/forms/password_reset.py
 msgid "The email address connected to your OpenKAT-account"
-msgstr ""
+msgstr "L'adresse e-mail connectée à votre compte OpenKAT"
 
 #: account/forms/token.py
 msgid ""
 "Insert the token generated by the authenticator app to setup the two factor "
 "authentication."
 msgstr ""
+"Insérez le jeton généré par l'application d'authentification pour configurer"
+" l'authentification à deux facteurs."
 
 #: account/forms/token.py
 msgid "Insert the token generated by your token authenticator app."
 msgstr ""
+"Insérez le jeton généré par votre application d'authentification de jeton."
 
 #: account/forms/token.py
 msgid "Backup token"
-msgstr ""
+msgstr "Jeton de sauvegarde"
 
 #: account/mixins.py
 msgid "Clearance level has been set."
-msgstr ""
+msgstr "Le niveau d'autorisation a été défini."
 
 #: account/mixins.py
 #, python-format
 msgid ""
-"Could not raise clearance level of %s to L%s. Indemnification not present at "
-"organization %s."
+"Could not raise clearance level of %s to L%s. Indemnification not present at"
+" organization %s."
 msgstr ""
+"Impossible d'augmenter le niveau d'autorisation de %s à L%s. Indemnisation "
+"non présente auprès de l'organisation %s."
 
 #: account/mixins.py
 #, python-format
@@ -270,6 +286,9 @@ msgid ""
 "Could not raise clearance level of %s to L%s. You were trusted a clearance "
 "level of L%s. Contact your administrator to receive a higher clearance."
 msgstr ""
+"Impossible d'augmenter le niveau d'autorisation de %s à L%s. On vous a fait "
+"confiance avec un niveau d'autorisation L%s. Contactez votre administrateur "
+"pour recevoir une autorisation plus élevée."
 
 #: account/mixins.py
 #, python-format
@@ -278,170 +297,191 @@ msgid ""
 "level of L%s. Please accept the clearance level first on your profile page "
 "to proceed."
 msgstr ""
+"Impossible d'augmenter le niveau d'autorisation de %s à L%s. Vous avez "
+"reconnu un niveau d'autorisation L%s. Veuillez d'abord accepter le niveau "
+"d'autorisation sur votre page de profil pour continuer."
 
 #: account/models.py
 msgid "The email must be set"
-msgstr ""
+msgstr "L'e-mail doit être défini"
 
 #: account/models.py
 msgid "Superuser must have is_staff=True."
-msgstr ""
+msgstr "Le superutilisateur doit avoir is_staff=True."
 
 #: account/models.py
 msgid "Superuser must have is_superuser=True."
-msgstr ""
+msgstr "Le superutilisateur doit avoir is_superuser=True."
 
 #: account/models.py
 msgid "full name"
-msgstr ""
+msgstr "nom et prénom"
 
 #: account/models.py
 msgid "email"
-msgstr ""
+msgstr "e-mail"
 
 #: account/models.py
 msgid "staff status"
-msgstr ""
+msgstr "statut du personnel"
 
 #: account/models.py
 msgid "Designates whether the user can log into this admin site."
 msgstr ""
+"Indique si l'utilisateur peut se connecter à ce site d'administration."
 
 #: account/models.py tools/models.py
 msgid "active"
-msgstr ""
+msgstr "actif"
 
 #: account/models.py
 msgid ""
 "Designates whether this user should be treated as active. Unselect this "
 "instead of deleting accounts."
 msgstr ""
+"Indique si cet utilisateur doit être traité comme actif. Désélectionnez-la "
+"au lieu de supprimer des comptes."
 
 #: account/models.py
 msgid "date joined"
-msgstr ""
+msgstr "date d'adhésion"
 
 #: account/models.py
 msgid "The clearance level of the user for all organizations."
 msgstr ""
+"Le niveau d'autorisation de l'utilisateur pour toutes les organisations."
 
 #: account/models.py
 msgid "name"
-msgstr ""
+msgstr "nom"
 
 #: account/templates/account_detail.html account/views/account.py
 msgid "Account details"
-msgstr ""
+msgstr "Détails du compte"
 
 #: account/templates/account_detail.html account/templates/password_reset.html
 #: account/views/password_reset.py
 msgid "Reset password"
-msgstr ""
+msgstr "Réinitialiser le mot de passe"
 
 #: account/templates/account_detail.html
 msgid "Full name"
-msgstr ""
+msgstr "Nom et prénom"
 
 #: account/templates/account_detail.html
 msgid "Member type"
-msgstr ""
+msgstr "Type de membre"
 
 #: account/templates/account_detail.html
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: rocky/templates/tasks/normalizers.html
 msgid "Organization"
-msgstr ""
+msgstr "Organisation"
 
 #: account/templates/account_detail.html
 msgid "Permission to set OOI clearance levels"
-msgstr ""
+msgstr "Autorisation de définir les niveaux d'autorisation OOI"
 
 #: account/templates/account_detail.html
 msgid "OOI clearance"
-msgstr ""
+msgstr "Liquidation OOI"
 
 #: account/templates/account_detail.html
 msgid "You don't have any clearance to scan objects."
-msgstr ""
+msgstr "Vous n'avez aucune autorisation pour numériser des objets."
 
 #: account/templates/account_detail.html
 msgid ""
 "Get in contact with the admin to give you the necessary clearance level."
 msgstr ""
+"Contactez l'administrateur pour vous donner le niveau d'autorisation "
+"nécessaire."
 
 #: account/templates/account_detail.html
 msgid "You have currently accepted clearance up to level"
-msgstr ""
+msgstr "Vous avez actuellement accepté une autorisation jusqu'au niveau"
 
 #: account/templates/account_detail.html
 msgid "Explanation OOI Clearance"
-msgstr ""
+msgstr "Explication OOI Liquidation"
 
 #: account/templates/account_detail.html
 msgid ""
 "You can withdraw this at anytime you like, but know that you won't be able "
 "to change clearance levels anymore when you do."
 msgstr ""
+"Vous pouvez le retirer à tout moment, mais sachez que vous ne pourrez plus "
+"modifier les niveaux d'autorisation lorsque vous le ferez."
 
 #: account/templates/account_detail.html
 #, python-format
 msgid "Withdraw L%(acl)s clearance and responsibility"
-msgstr ""
+msgstr "Retirer l'autorisation et la responsabilité L%(acl)s"
 
 #: account/templates/account_detail.html
 msgid "Explanation OOI clearance"
-msgstr ""
+msgstr "Explication OOI dégagement"
 
 #: account/templates/account_detail.html
 #, python-format
 msgid ""
 "You are granted clearance for level L%(tcl)s by your admin. Before you can "
 "change OOI clearance levels up to this level, you need to accept this "
-"permission. Remember: <strong>with great power comes great responsibility.</"
-"strong>"
+"permission. Remember: <strong>with great power comes great "
+"responsibility.</strong>"
 msgstr ""
+"Votre administrateur vous accorde une autorisation pour le niveau L%(tcl)s. "
+"Avant de pouvoir modifier les niveaux d'autorisation OOI jusqu'à ce niveau, "
+"vous devez accepter cette autorisation. N'oubliez pas : <strong>Une grande "
+"puissance implique de grandes responsabilités.</strong>"
 
 #: account/templates/account_detail.html
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 #, python-format
 msgid "Accept level L%(tcl)s clearance and responsibility"
-msgstr ""
+msgstr "Accepter le niveau d'autorisation et de responsabilité L%(tcl)s"
 
 #: account/templates/password_reset.html
 msgid "Use the form below to reset your password."
 msgstr ""
+"Utilisez le formulaire ci-dessous pour réinitialiser votre mot de passe."
 
 #: account/templates/password_reset.html
 #: account/templates/password_reset_confirm.html
 msgid "Send"
-msgstr ""
+msgstr "Envoyer"
 
 #: account/templates/password_reset.html
 #: account/templates/password_reset_confirm.html
 msgid "Back"
-msgstr ""
+msgstr "Dos"
 
 #: account/templates/password_reset_confirm.html
 msgid "Confirm reset password"
-msgstr ""
+msgstr "Confirmer la réinitialisation du mot de passe"
 
 #: account/templates/password_reset_confirm.html
 msgid "Use the form below to confirm resetting your password"
 msgstr ""
+"Utilisez le formulaire ci-dessous pour confirmer la réinitialisation de "
+"votre mot de passe"
 
 #: account/templates/password_reset_confirm.html
 msgid "Confirm password"
-msgstr ""
+msgstr "Confirmez le mot de passe"
 
 #: account/templates/password_reset_confirm.html
 msgid "The link is invalid"
-msgstr ""
+msgstr "Le lien n'est pas valide"
 
 #: account/templates/password_reset_confirm.html
 msgid ""
 "The password reset link was invalid, possibly because it has already been "
 "used.  Please request a new password reset."
 msgstr ""
+"Le lien de réinitialisation du mot de passe n'était pas valide, peut-être "
+"parce qu'il a déjà été utilisé.  Veuillez demander une nouvelle "
+"réinitialisation du mot de passe."
 
 #: account/templates/password_reset_email.html
 #, python-format
@@ -449,55 +489,61 @@ msgid ""
 "You're receiving this email because you requested a password reset for your "
 "user account at %(site_name)s."
 msgstr ""
+"Vous recevez cet e-mail car vous avez demandé une réinitialisation du mot de"
+" passe de votre compte utilisateur sur %(site_name)s."
 
 #: account/templates/password_reset_email.html
 #: account/templates/registration_email.html
 msgid "Please go to the following page and choose a new password:"
 msgstr ""
+"Veuillez vous rendre sur la page suivante et choisir un nouveau mot de "
+"passe :"
 
 #: account/templates/password_reset_email.html
 #: account/templates/registration_email.html
 msgid "Sincerely,"
-msgstr ""
+msgstr "Sincèrement,"
 
 #: account/templates/password_reset_email.html
 #: account/templates/registration_email.html
 msgid "The OpenKAT team"
-msgstr ""
+msgstr "L'équipe OpenKAT"
 
 #: account/templates/password_reset_subject.txt
 #, python-format
 msgid "Password reset on %(site_name)s"
-msgstr ""
+msgstr "Réinitialisation du mot de passe sur %(site_name)s"
 
 #: account/templates/recover_email.html account/views/recover_email.py
 msgid "Recover email address"
-msgstr ""
+msgstr "Récupérer l'adresse e-mail"
 
 #: account/templates/recover_email.html
 msgid "Information on how to recover your connected email address"
-msgstr ""
+msgstr "Informations sur la façon de récupérer votre adresse email connectée"
 
 #: account/templates/recover_email.html
 msgid "Forgotten email address?"
-msgstr ""
+msgstr "Adresse email oubliée ?"
 
 #: account/templates/recover_email.html
 msgid ""
 "If you don’t remember the email address connected to your account, contact:"
 msgstr ""
+"Si vous ne vous souvenez plus de l'adresse email associée à votre compte, "
+"contactez :"
 
 #: account/templates/recover_email.html
 msgid "Please contact the system administrator."
-msgstr ""
+msgstr "Veuillez contacter l'administrateur système."
 
 #: account/templates/recover_email.html
 msgid "Back to login"
-msgstr ""
+msgstr "Retour à la connexion"
 
 #: account/templates/recover_email.html
 msgid "Back to Home"
-msgstr ""
+msgstr "Retour à la maison"
 
 #: account/templates/registration_email.html
 #, python-format
@@ -505,73 +551,83 @@ msgid ""
 "Welcome to OpenKAT. You're receiving this email because you have been added "
 "to organization \"%(organization)s\" at %(site_name)s."
 msgstr ""
+"Bienvenue sur OpenKAT. Vous recevez cet e-mail car vous avez été ajouté à "
+"l'organisation « %(organization)s » à %(site_name)s."
 
 #: account/templates/registration_subject.txt
 #, python-format
 msgid "Verify OpenKAT account on %(site_name)s"
-msgstr ""
+msgstr "Vérifiez le compte OpenKAT sur %(site_name)s"
 
 #: account/validators.py
 msgid ""
 "Your password must contain at least the following but longer passwords are "
 "recommended:"
 msgstr ""
+"Votre mot de passe doit contenir au moins les éléments suivants, mais des "
+"mots de passe plus longs sont recommandés :"
 
 #: account/validators.py
 msgid " characters"
-msgstr ""
+msgstr "personnages"
 
 #: account/validators.py
 msgid " digits"
-msgstr ""
+msgstr "chiffres"
 
 #: account/validators.py
 msgid " letters"
-msgstr ""
+msgstr "courrier"
 
 #: account/validators.py
 msgid ""
 " special characters such as: {str(validators.get('special_characters',''))}"
 msgstr ""
+"caractères spéciaux tels que : "
+"{str(validators.get('special_characters',''))}"
 
 #: account/validators.py
 msgid " lower case letters"
-msgstr ""
+msgstr "lettres minuscules"
 
 #: account/validators.py
 msgid " upper case letters"
-msgstr ""
+msgstr "lettres majuscules"
 
 #: account/views/login.py
 msgid "Your session has timed out. Please login again."
-msgstr ""
+msgstr "Votre session a expiré. Veuillez vous reconnecter."
 
 #: account/views/login.py rocky/templates/header.html
 msgid "OpenKAT"
-msgstr ""
+msgstr "OpenKAT"
 
 #: account/views/login.py account/views/password_reset.py
 #: account/views/recover_email.py rocky/templates/partials/secondary-menu.html
 #: rocky/templates/two_factor/core/login.html
 msgid "Login"
-msgstr ""
+msgstr "Se connecter"
 
 #: account/views/login.py
 msgid "Two factor authentication"
-msgstr ""
+msgstr "Authentification à deux facteurs"
 
 #: account/views/password_reset.py
 msgid "We couldn't send a password reset link. Contact "
 msgstr ""
+"Nous n'avons pas pu envoyer de lien de réinitialisation de mot de passe. "
+"Contact"
 
 #: account/views/password_reset.py
 msgid ""
 "We couldn't send a password reset link. Contact your system administrator."
 msgstr ""
+"Nous n'avons pas pu envoyer de lien de réinitialisation de mot de passe. "
+"Contactez votre administrateur système."
 
 #: components/modal/template.html
 msgid "Close modal"
-msgstr ""
+msgstr "Fermer modale"
 
 #: components/modal/template.html
 #: crisis_room/templates/partials/delete_dashboard_item_modal.html
@@ -594,146 +650,160 @@ msgstr ""
 #: rocky/templates/partials/mute_findings_modal.html
 #: rocky/templates/two_factor/_wizard_actions.html
 msgid "Cancel"
-msgstr ""
+msgstr "Annuler"
 
 #: crisis_room/forms.py
 msgid "Title on dashboard"
-msgstr ""
+msgstr "Titre sur le tableau de bord"
 
 #: crisis_room/forms.py
 msgid "Dashboard item size"
-msgstr ""
+msgstr "Taille des éléments du tableau de bord"
 
 #: crisis_room/forms.py
 msgid "Full width"
-msgstr ""
+msgstr "Pleine largeur"
 
 #: crisis_room/forms.py
 msgid "Half width"
-msgstr ""
+msgstr "Demi-largeur"
 
 #: crisis_room/forms.py
 msgid "An item with that name already exists. Try a different title."
-msgstr ""
+msgstr "Un élément portant ce nom existe déjà. Essayez un autre titre."
 
 #: crisis_room/forms.py
 msgid "An error occurred while adding dashboard item."
 msgstr ""
+"Une erreur s'est produite lors de l'ajout d'un élément du tableau de bord."
 
 #: crisis_room/forms.py
 msgid "Number of rows in list"
-msgstr ""
+msgstr "Nombre de lignes dans la liste"
 
 #: crisis_room/forms.py
 msgid "List sorting by"
-msgstr ""
+msgstr "Trier la liste par"
 
 #: crisis_room/forms.py
 msgid "Type (A-Z)"
-msgstr ""
+msgstr "Tapez (A-Z)"
 
 #: crisis_room/forms.py
 msgid "Type (Z-A)"
-msgstr ""
+msgstr "Type (Z-A)"
 
 #: crisis_room/forms.py
 msgid "Clearance level (Low-High)"
-msgstr ""
+msgstr "Niveau de dégagement (faible-élevé)"
 
 #: crisis_room/forms.py
 msgid "Clearance level (High-Low)"
-msgstr ""
+msgstr "Niveau de dégagement (haut-bas)"
 
 #: crisis_room/forms.py
 msgid "Show table columns"
-msgstr ""
+msgstr "Afficher les colonnes du tableau"
 
 #: crisis_room/forms.py
 msgid "Severity (Low-High)"
-msgstr ""
+msgstr "Gravité (faible-élevée)"
 
 #: crisis_room/forms.py
 msgid "Severity (High-Low)"
-msgstr ""
+msgstr "Gravité (élevée-faible)"
 
 #: crisis_room/forms.py
 msgid "Finding (A-Z)"
-msgstr ""
+msgstr "Recherche (A-Z)"
 
 #: crisis_room/forms.py
 msgid "Finding (Z-A)"
-msgstr ""
+msgstr "Constatation (Z-A)"
 
 #: crisis_room/models.py
 msgid "Findings Dashboard"
-msgstr ""
+msgstr "Tableau de bord des résultats"
 
 #: crisis_room/models.py
 msgid ""
-"Where on the dashboard do you want to show the data? Position {} is the most "
-"top level and the max position is {}."
+"Where on the dashboard do you want to show the data? Position {} is the most"
+" top level and the max position is {}."
 msgstr ""
+"Où sur le tableau de bord souhaitez-vous afficher les données ? La position "
+"{} est le niveau le plus élevé et la position maximale est {}."
 
 #: crisis_room/models.py
 msgid "Will be displayed on the general crisis room, for all organizations."
 msgstr ""
+"Sera affiché sur la salle de crise générale, pour toutes les organisations."
 
 #: crisis_room/models.py
 msgid "Will be displayed on a single organization dashboard"
-msgstr ""
+msgstr "Sera affiché sur un seul tableau de bord d'organisation"
 
 #: crisis_room/models.py
 msgid "Will be displayed on the findings dashboard for all organizations"
 msgstr ""
+"Sera affiché sur le tableau de bord des résultats pour toutes les "
+"organisations"
 
 #: crisis_room/models.py
 msgid "Can change position up or down of a dashboard item."
 msgstr ""
+"Peut changer la position vers le haut ou vers le bas d’un élément du tableau"
+" de bord."
 
 #: crisis_room/models.py
 msgid "You have to choose between a recipe or a query, but not both."
-msgstr ""
+msgstr "Il faut choisir entre une recette ou une requête, mais pas les deux."
 
 #: crisis_room/models.py
 msgid "You have set a query and not where it is from. Also set the source."
 msgstr ""
+"Vous avez défini une requête et vous ne savez pas d'où elle vient. "
+"Définissez également la source."
 
 #: crisis_room/models.py
 msgid ""
 "DashboardItem must contain at least a 'recipe' or a 'source' with a 'query'."
 msgstr ""
+"DashboardItem doit contenir au moins une « recette » ou une « source » avec "
+"une « requête »."
 
 #: crisis_room/models.py
 msgid "Max dashboard items reached."
-msgstr ""
+msgstr "Nombre maximal d'éléments du tableau de bord atteint."
 
 #: crisis_room/templates/crisis_room.html
 #: crisis_room/templates/organization_crisis_room.html
 #: rocky/templates/header.html
 msgid "Crisis room"
-msgstr ""
+msgstr "Salle de crise"
 
 #: crisis_room/templates/crisis_room.html
 msgid "Crisis room overview for all organizations."
-msgstr ""
+msgstr "Aperçu de la salle de crise pour toutes les organisations."
 
 #: crisis_room/templates/crisis_room_dashboards.html
 msgid "Dashboards"
-msgstr ""
+msgstr "Tableaux de bord"
 
 #: crisis_room/templates/crisis_room_dashboards.html
 msgid ""
 "On this page you can see an overview of the dashboards for all "
 "organizations. **More context can be written here**"
 msgstr ""
+"Sur cette page, vous pouvez voir un aperçu des tableaux de bord de toutes "
+"les organisations. **Plus de contexte peut être écrit ici**"
 
 #: crisis_room/templates/crisis_room_dashboards.html
 msgid "dashboards"
-msgstr ""
+msgstr "tableaux de bord"
 
 #: crisis_room/templates/crisis_room_dashboards.html
 msgid "There are no dashboards to display."
-msgstr ""
+msgstr "Il n'y a aucun tableau de bord à afficher."
 
 #: crisis_room/templates/crisis_room_findings.html
 #: crisis_room/templates/partials/crisis_room_findings_table.html
@@ -741,31 +811,38 @@ msgstr ""
 #: reports/templates/partials/report_findings_table.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Findings overview"
-msgstr ""
+msgstr "Aperçu des résultats"
 
 #: crisis_room/templates/crisis_room_findings.html
 msgid ""
 "\n"
-"                            This overview shows the total number of findings "
-"per\n"
-"                            severity that have been identified for all "
-"organizations.\n"
-"                            This data is based on the latest Crisis Room "
-"Findings Report\n"
+"                            This overview shows the total number of findings per\n"
+"                            severity that have been identified for all organizations.\n"
+"                            This data is based on the latest Crisis Room Findings Report\n"
 "                            of each organization.\n"
 "                        "
 msgstr ""
+"\n"
+"Cet aperçu montre le nombre total de résultats par\n"
+"                            gravité qui ont été identifiées pour toutes les organisations.\n"
+"                            Ces données sont basées sur le dernier rapport sur les conclusions de la salle de crise.\n"
+"                            de chaque organisation."
 
 #: crisis_room/templates/crisis_room_findings.html
 msgid "Findings per organization"
-msgstr ""
+msgstr "Résultats par organisation"
 
 #: crisis_room/templates/crisis_room_findings.html
 msgid ""
 "This table shows the findings that have been identified for each "
-"organization, sorted by the finding types and grouped by organizations. This "
-"data is based on the latest Crisis Room Findings Report of each organization."
+"organization, sorted by the finding types and grouped by organizations. This"
+" data is based on the latest Crisis Room Findings Report of each "
+"organization."
 msgstr ""
+"Ce tableau montre les résultats qui ont été identifiés pour chaque "
+"organisation, triés par types de résultats et regroupés par organisations. "
+"Ces données sont basées sur le dernier rapport des conclusions de la salle "
+"de crise de chaque organisation."
 
 #: crisis_room/templates/crisis_room_findings.html
 #: reports/report_types/findings_report/report.html
@@ -773,17 +850,21 @@ msgid ""
 "No findings have been identified yet. As soon as they have been identified, "
 "they will be shown on this page."
 msgstr ""
+"Aucune découverte n’a encore été identifiée. Dès qu'ils auront été "
+"identifiés, ils seront affichés sur cette page."
 
 #: crisis_room/templates/crisis_room_findings.html
 msgid ""
 "There are no organizations yet. After creating an organization, the "
 "identified findings will be shown here."
 msgstr ""
+"Il n'y a pas encore d'organisations. Après avoir créé une organisation, les "
+"résultats identifiés seront affichés ici."
 
 #: crisis_room/templates/crisis_room_header.html
 #: crisis_room/templates/organization_crisis_room_header.html
 msgid "Crisis room navigation"
-msgstr ""
+msgstr "Navigation dans la salle de crise"
 
 #: crisis_room/templates/crisis_room_header.html
 #: crisis_room/templates/partials/new_dashboard_item_action_button.html
@@ -799,8 +880,8 @@ msgstr ""
 #: reports/report_types/web_system_report/report.html
 #: reports/templates/partials/report_findings_table.html
 #: reports/templates/partials/report_sidemenu.html
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
-#: rocky/templates/header.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
 #: rocky/templates/oois/ooi_detail_findings_list.html
 #: rocky/templates/oois/ooi_detail_findings_overview.html
 #: rocky/templates/oois/ooi_page_tabs.html
@@ -809,84 +890,89 @@ msgstr ""
 #: rocky/views/finding_list.py rocky/views/finding_type_add.py
 #: rocky/views/ooi_view.py
 msgid "Findings"
-msgstr ""
+msgstr "Résultats"
 
 #: crisis_room/templates/organization_crisis_room.html
 msgid "Options for dashboard"
-msgstr ""
+msgstr "Options du tableau de bord"
 
 #: crisis_room/templates/organization_crisis_room.html
 msgid "Show all descriptions"
-msgstr ""
+msgstr "Afficher toutes les descriptions"
 
 #: crisis_room/templates/organization_crisis_room.html
 msgid "Hide all descriptions"
-msgstr ""
+msgstr "Masquer toutes les descriptions"
 
 #: crisis_room/templates/organization_crisis_room.html
 #: crisis_room/templates/partials/delete_dashboard_modal.html
 msgid "Delete dashboard"
-msgstr ""
+msgstr "Supprimer le tableau de bord"
 
 #: crisis_room/templates/organization_crisis_room.html
 msgid ""
 "There are no dashboards yet. Click on \"Add dashboard\" to create a new "
 "dashboard."
 msgstr ""
+"Il n'y a pas encore de tableaux de bord. Cliquez sur \"Ajouter un tableau de"
+" bord\" pour créer un nouveau tableau de bord."
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 #: katalogus/templates/partials/objects_to_scan.html
 #: rocky/templates/forms/widgets/checkbox_group_table.html
 #: rocky/templates/oois/ooi_list.html
 msgid "Object list"
-msgstr ""
+msgstr "Liste d'objets"
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid "Finding list"
-msgstr ""
+msgstr "Liste de recherche"
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 #: crisis_room/templates/partials/new_dashboard_item_action_button.html
 msgid "Report section"
-msgstr ""
+msgstr "Section rapport"
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid "There are no dashboard items added yet."
-msgstr ""
+msgstr "Aucun élément du tableau de bord n'a encore été ajouté."
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid ""
-"You can add dashboard items via the filters on the objects and findings page "
-"or you can add a report section."
+"You can add dashboard items via the filters on the objects and findings page"
+" or you can add a report section."
 msgstr ""
+"Vous pouvez ajouter des éléments de tableau de bord via les filtres sur la "
+"page des objets et des résultats ou vous pouvez ajouter une section de "
+"rapport."
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid "Add objects"
-msgstr ""
+msgstr "Ajouter des objets"
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid "Add findings"
-msgstr ""
+msgstr "Ajouter des résultats"
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid "Add report section"
-msgstr ""
+msgstr "Ajouter une section de rapport"
 
 #: crisis_room/templates/organization_crisis_room_header.html
 #: crisis_room/templates/partials/new_dashboard_modal.html
 msgid "Add dashboard"
-msgstr ""
+msgstr "Ajouter un tableau de bord"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid "Findings per organization overview"
-msgstr ""
+msgstr "Aperçu des résultats par organisation"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: reports/templates/partials/report_findings_table.html
 #: reports/templates/partials/report_severity_totals_table.html
 #: tools/forms/finding_type.py
 msgid "Finding types"
-msgstr ""
+msgstr "Recherche de types"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: reports/report_types/dns_report/report.html
@@ -897,15 +983,15 @@ msgstr ""
 #: rocky/templates/partials/ooi_report_findings_block_table.html
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "Occurrences"
-msgstr ""
+msgstr "Occurrences"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid "Highest risk level"
-msgstr ""
+msgstr "Niveau de risque le plus élevé"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid "Critical finding types"
-msgstr ""
+msgstr "Types de résultats critiques"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
@@ -919,7 +1005,7 @@ msgstr ""
 #: rocky/templates/tasks/ooi_detail_task_list.html
 #: rocky/templates/tasks/plugin_detail_task_list.html
 msgid "Details"
-msgstr ""
+msgstr "Détails"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
@@ -934,7 +1020,7 @@ msgstr ""
 #: rocky/templates/tasks/ooi_detail_task_list.html
 #: rocky/templates/tasks/plugin_detail_task_list.html
 msgid "Close details"
-msgstr ""
+msgstr "Fermer les détails"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
@@ -949,67 +1035,75 @@ msgstr ""
 #: rocky/templates/tasks/ooi_detail_task_list.html
 #: rocky/templates/tasks/plugin_detail_task_list.html
 msgid "Open details"
-msgstr ""
+msgstr "Ouvrir les détails"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid ""
-"This overview shows the total number of findings per severity that have been "
-"identified for this organization."
+"This overview shows the total number of findings per severity that have been"
+" identified for this organization."
 msgstr ""
+"Cet aperçu montre le nombre total de résultats par gravité qui ont été "
+"identifiés pour cette organisation."
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: reports/report_types/findings_report/report.html
 msgid "Critical and high findings"
-msgstr ""
+msgstr "Résultats critiques et élevés"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: reports/report_types/findings_report/report.html
 msgid ""
 "This table shows the top 25 critical and high findings that have been "
-"identified for this organization, grouped by finding types. A table with all "
-"the identified findings can be found in the Findings Report."
+"identified for this organization, grouped by finding types. A table with all"
+" the identified findings can be found in the Findings Report."
 msgstr ""
+"Ce tableau présente les 25 principaux résultats critiques et élevés "
+"identifiés pour cette organisation, regroupés par types de résultats. Un "
+"tableau avec toutes les conclusions identifiées se trouve dans le rapport "
+"sur les conclusions."
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid "No findings have been identified. Check report for more details."
 msgstr ""
+"Aucune découverte n’a été identifiée. Consultez le rapport pour plus de "
+"détails."
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid "View findings report"
-msgstr ""
+msgstr "Afficher le rapport des résultats"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Edit report recipe"
-msgstr ""
+msgstr "Modifier la recette du rapport"
 
 #: crisis_room/templates/partials/dashboard_finding_list.html
 #, python-format
 msgid "Showing %(length)s findings"
-msgstr ""
+msgstr "Affichage des résultats %(length)s"
 
 #: crisis_room/templates/partials/dashboard_finding_list.html
 msgid "Go to findings"
-msgstr ""
+msgstr "Aller aux résultats"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
 msgid "Findings table "
-msgstr ""
+msgstr "Tableau des résultats"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: crisis_room/templates/partials/dashboard_ooi_list_table.html
 #: rocky/templates/findings/finding_list.html
 #: rocky/templates/oois/ooi_list.html
 msgid "column headers with buttons are sortable"
-msgstr ""
+msgstr "les en-têtes de colonnes avec des boutons peuvent être triés"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
 #, python-format
 msgid "Show details for %(finding)s"
-msgstr ""
+msgstr "Afficher les détails pour %(finding)s"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
@@ -1018,7 +1112,7 @@ msgstr ""
 #: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
 #: rocky/views/mixins.py
 msgid "Tree"
-msgstr ""
+msgstr "Arbre"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
@@ -1027,14 +1121,15 @@ msgstr ""
 #: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
 #: rocky/views/mixins.py
 msgid "Graph"
-msgstr ""
+msgstr "Graphique"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: reports/report_types/dns_report/report.html
 #: rocky/templates/oois/ooi_detail_findings_list.html
-#: rocky/templates/oois/ooi_detail_findings_overview.html rocky/views/mixins.py
+#: rocky/templates/oois/ooi_detail_findings_overview.html
+#: rocky/views/mixins.py
 msgid "Severity"
-msgstr ""
+msgstr "Gravité"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: reports/report_types/dns_report/report.html
@@ -1042,45 +1137,45 @@ msgstr ""
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 #: rocky/views/mixins.py
 msgid "Finding"
-msgstr ""
+msgstr "Trouver"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
 #: rocky/templates/partials/ooi_report_findings_block_table.html
 msgid "Finding type"
-msgstr ""
+msgstr "Type de recherche"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
 #, python-format
 msgid "Show details for %(finding_type)s"
-msgstr ""
+msgstr "Afficher les détails pour %(finding_type)s"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
 msgid "OOI type"
-msgstr ""
+msgstr "Type OOI"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
 #, python-format
 msgid "Show %(ooi_type)s objects"
-msgstr ""
+msgstr "Afficher les objets %(ooi_type)s"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/views/mixins.py
 msgid "Location"
-msgstr ""
+msgstr "Emplacement"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #, python-format
 msgid "Show details for %(ooi)s"
-msgstr ""
+msgstr "Afficher les détails pour %(ooi)s"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
 msgid "Risk score"
-msgstr ""
+msgstr "Score de risque"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: katalogus/templates/normalizer_detail.html
@@ -1091,9 +1186,10 @@ msgstr ""
 #: reports/templates/summary/report_asset_overview.html tools/forms/boefje.py
 #: tools/forms/finding_type.py rocky/templates/findings/finding_list.html
 #: rocky/templates/oois/ooi_detail.html
-#: rocky/templates/oois/ooi_detail_findings_list.html rocky/templates/scan.html
+#: rocky/templates/oois/ooi_detail_findings_list.html
+#: rocky/templates/scan.html
 msgid "Description"
-msgstr ""
+msgstr "Description"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: reports/report_types/multi_organization_report/recommendations.html
@@ -1101,7 +1197,7 @@ msgstr ""
 #: reports/templates/partials/report_severity_totals_table.html
 #: rocky/templates/findings/finding_list.html
 msgid "Recommendation"
-msgstr ""
+msgstr "Recommandation"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: reports/report_types/vulnerability_report/report.py
@@ -1111,61 +1207,62 @@ msgstr ""
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "Source"
-msgstr ""
+msgstr "Source"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: reports/templates/partials/report_findings_table.html
 #: rocky/templates/findings/finding_list.html
 msgid "Impact"
-msgstr ""
+msgstr "Impact"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Options for dashboard items"
-msgstr ""
+msgstr "Options pour les éléments du tableau de bord"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Show description"
-msgstr ""
+msgstr "Afficher la description"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Hide description"
-msgstr ""
+msgstr "Masquer la description"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Position up"
-msgstr ""
+msgstr "Positionner vers le haut"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Position down"
-msgstr ""
+msgstr "Position vers le bas"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Rerun report"
-msgstr ""
+msgstr "Réexécuter le rapport"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 #: crisis_room/templates/partials/delete_dashboard_item_modal.html
 msgid "Delete item"
-msgstr ""
+msgstr "Supprimer l'élément"
 
 #: crisis_room/templates/partials/dashboard_ooi_list.html
 #, python-format
 msgid "Showing %(length)s objects"
-msgstr ""
+msgstr "Affichage des objets %(length)s"
 
 #: crisis_room/templates/partials/dashboard_ooi_list.html
 msgid "Go to objects"
-msgstr ""
+msgstr "Aller aux objets"
 
 #: crisis_room/templates/partials/dashboard_ooi_list_table.html
 #: rocky/templates/oois/ooi_list.html
 msgid "Objects "
-msgstr ""
+msgstr "Objets"
 
 #: crisis_room/templates/partials/delete_dashboard_item_modal.html
 #, python-format
 msgid "Are you sure you want to delete '%(name)s' from this dashboard?"
 msgstr ""
+"Êtes-vous sûr de vouloir supprimer « %(name)s » de ce tableau de bord ?"
 
 #: crisis_room/templates/partials/delete_dashboard_item_modal.html
 #: crisis_room/templates/partials/delete_dashboard_modal.html
@@ -1178,7 +1275,7 @@ msgstr ""
 #: rocky/templates/oois/ooi_list.html
 #: rocky/templates/partials/delete_ooi_modal.html rocky/views/ooi_delete.py
 msgid "Delete"
-msgstr ""
+msgstr "Supprimer"
 
 #: crisis_room/templates/partials/delete_dashboard_modal.html
 #, python-format
@@ -1186,14 +1283,16 @@ msgid ""
 "Are you sure you want to delete dashboard '%(dashboard)s'? All the items on "
 "the dashboard will be deleted as well."
 msgstr ""
+"Êtes-vous sûr de vouloir supprimer le tableau de bord « %(dashboard)s » ? "
+"Tous les éléments du tableau de bord seront également supprimés."
 
 #: crisis_room/templates/partials/new_dashboard_item_action_button.html
 msgid "Actions for adding dashboard items"
-msgstr ""
+msgstr "Actions pour ajouter des éléments au tableau de bord"
 
 #: crisis_room/templates/partials/new_dashboard_item_action_button.html
 msgid "Add item"
-msgstr ""
+msgstr "Ajouter un article"
 
 #: crisis_room/templates/partials/new_dashboard_item_action_button.html
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
@@ -1202,26 +1301,32 @@ msgstr ""
 #: reports/templates/summary/ooi_selection.html tools/forms/ooi.py
 #: tools/view_helpers.py rocky/templates/admin/delete_confirmation.html
 #: rocky/templates/admin/delete_selected_confirmation.html
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
-#: rocky/templates/header.html rocky/views/ooi_add.py rocky/views/ooi_list.py
-#: rocky/views/ooi_view.py rocky/views/upload_csv.py rocky/views/upload_raw.py
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
+#: rocky/views/ooi_add.py rocky/views/ooi_list.py rocky/views/ooi_view.py
+#: rocky/views/upload_csv.py rocky/views/upload_raw.py
 msgid "Objects"
-msgstr ""
+msgstr "Objets"
 
 #: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
 msgid "Add dashboard item"
-msgstr ""
+msgstr "Ajouter un élément de tableau de bord"
 
 #: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
 msgid ""
-"To  add a <strong>report section</strong>, go to the history page and open a "
-"report. Then go to the section that you want to add to your dashboard and "
-"press the options button next to the section name to create a dashboard item."
+"To  add a <strong>report section</strong>, go to the history page and open a"
+" report. Then go to the section that you want to add to your dashboard and "
+"press the options button next to the section name to create a dashboard "
+"item."
 msgstr ""
+"Pour ajouter une section de rapport <strong></strong>, accédez à la page "
+"d'historique et ouvrez un rapport. Accédez ensuite à la section que vous "
+"souhaitez ajouter à votre tableau de bord et appuyez sur le bouton options à"
+" côté du nom de la section pour créer un élément de tableau de bord."
 
 #: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
 msgid "Go to report history"
-msgstr ""
+msgstr "Accéder à l'historique des rapports"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #, python-format
@@ -1229,6 +1334,8 @@ msgid ""
 "\n"
 "    Add %(item_type)s to dashboard\n"
 msgstr ""
+"\n"
+"Ajouter %(item_type)s au tableau de bord\n"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #, python-format
@@ -1236,6 +1343,8 @@ msgid ""
 "Add these %(item_type)s with the selected filters to the dashboard of your "
 "choice."
 msgstr ""
+"Ajoutez ces %(item_type)s avec les filtres sélectionnés au tableau de bord "
+"de votre choix."
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
@@ -1246,61 +1355,73 @@ msgstr ""
 #: rocky/templates/partials/notifications_block.html
 #: rocky/templates/two_factor/core/login.html
 msgid "explanation"
-msgstr ""
+msgstr "explication"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid "You do not have a custom dashboard yet"
-msgstr ""
+msgstr "Vous n'avez pas encore de tableau de bord personnalisé"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #, python-format
 msgid ""
-"In order to add these %(item_type)s to a dashboard, you first need to create "
-"a dashboard. Please add a dashboard in the crisis room of your organization."
+"In order to add these %(item_type)s to a dashboard, you first need to create"
+" a dashboard. Please add a dashboard in the crisis room of your "
+"organization."
 msgstr ""
+"Afin d'ajouter ces %(item_type)s à un tableau de bord, vous devez d'abord "
+"créer un tableau de bord. Veuillez ajouter un tableau de bord dans la salle "
+"de crise de votre organisation."
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 #: rocky/templates/findings/finding_list.html
 #: rocky/templates/oois/ooi_list.html
 msgid "Add to dashboard"
-msgstr ""
+msgstr "Ajouter au tableau de bord"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid "Go to crisis room"
-msgstr ""
+msgstr "Aller en salle de crise"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid "Add report section to dashboard"
-msgstr ""
+msgstr "Ajouter une section de rapport au tableau de bord"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid ""
-"In order to add this report section to a dashboard, you first need to create "
-"a dashboard. Please create a dashboard in the crisis room of your "
+"In order to add this report section to a dashboard, you first need to create"
+" a dashboard. Please create a dashboard in the crisis room of your "
 "organization."
 msgstr ""
+"Afin d'ajouter cette section de rapport à un tableau de bord, vous devez "
+"d'abord créer un tableau de bord. Veuillez créer un tableau de bord dans la "
+"salle de crise de votre organisation."
 
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid "Report must be scheduled for dashboard items"
-msgstr ""
+msgstr "Le rapport doit être planifié pour les éléments du tableau de bord"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid ""
 "In order for dashboard information to be updated on a regular basis instead "
-"of showing static data, the report should be scheduled. The frequency of the "
-"schedules recurrence determines how fresh the data on the dashboard will be."
+"of showing static data, the report should be scheduled. The frequency of the"
+" schedules recurrence determines how fresh the data on the dashboard will "
+"be."
 msgstr ""
+"Pour que les informations du tableau de bord soient mises à jour "
+"régulièrement au lieu d'afficher des données statiques, le rapport doit être"
+" planifié. La fréquence de récurrence des planifications détermine la "
+"fraîcheur des données sur le tableau de bord."
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 msgid "Applied filters"
-msgstr ""
+msgstr "Filtres appliqués"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 msgid "Object types"
-msgstr ""
+msgstr "Types d'objets"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 #: katalogus/templates/change_clearance_level.html onboarding/forms.py
@@ -1308,16 +1429,17 @@ msgstr ""
 #: reports/templates/summary/ooi_selection.html tools/forms/boefje.py
 #: tools/forms/ooi.py rocky/templates/oois/ooi_page_tabs.html
 #: rocky/templates/partials/explanations.html
-#: rocky/templates/scan_profiles/scan_profile_detail.html rocky/views/mixins.py
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+#: rocky/views/mixins.py
 msgid "Clearance level"
-msgstr ""
+msgstr "Niveau de dégagement"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 #: reports/templates/partials/report_ooi_list.html
 #: reports/templates/summary/ooi_selection.html tools/forms/ooi.py
 #: rocky/views/mixins.py
 msgid "Clearance type"
-msgstr ""
+msgstr "Type de dégagement"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 #: reports/templates/report_overview/modal_partials/delete_modal.html
@@ -1325,86 +1447,92 @@ msgstr ""
 #: reports/templates/report_overview/report_history_table.html
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Input objects"
-msgstr ""
+msgstr "Objets d'entrée"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 msgid "Show all objects"
-msgstr ""
+msgstr "Afficher tous les objets"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 #: reports/templates/partials/report_types_selection.html
 msgid "No filters applied"
-msgstr ""
+msgstr "Aucun filtre appliqué"
 
 #: crisis_room/templates/partials/report_section_action_button.html
 msgid "Add section to dashboard"
-msgstr ""
+msgstr "Ajouter une section au tableau de bord"
 
 #: katalogus/client.py
 msgid ""
 "The KATalogus has an unexpected error. Check the logs for further details."
 msgstr ""
+"Le KATalogus a une erreur inattendue. Consultez les journaux pour plus de "
+"détails."
 
 #: katalogus/client.py
 #, python-format
 msgid "An HTTP %d error occurred. Check logs for more info."
 msgstr ""
+"Une erreur HTTP %d s'est produite. Consultez les journaux pour plus "
+"d’informations."
 
 #: katalogus/client.py
 msgid "An HTTP error occurred. Check logs for more info."
 msgstr ""
+"Une erreur HTTP s'est produite. Consultez les journaux pour plus "
+"d’informations."
 
 #: katalogus/client.py
 msgid "Boefje with this name already exists."
-msgstr ""
+msgstr "Boefje portant ce nom existe déjà."
 
 #: katalogus/client.py
 msgid "Boefje with this ID already exists."
-msgstr ""
+msgstr "Boefje avec cet ID existe déjà."
 
 #: katalogus/client.py
 msgid "Access to resource not allowed"
-msgstr ""
+msgstr "Accès à la ressource non autorisé"
 
 #: katalogus/client.py
 msgid "User is not allowed to see plugin settings"
-msgstr ""
+msgstr "L'utilisateur n'est pas autorisé à voir les paramètres du plugin"
 
 #: katalogus/client.py
 msgid "User is not allowed to set plugin settings"
-msgstr ""
+msgstr "L'utilisateur n'est pas autorisé à définir les paramètres du plugin"
 
 #: katalogus/client.py
 msgid "User is not allowed to delete plugin settings"
-msgstr ""
+msgstr "L'utilisateur n'est pas autorisé à supprimer les paramètres du plugin"
 
 #: katalogus/client.py
 msgid "User is not allowed to view plugin settings"
-msgstr ""
+msgstr "L'utilisateur n'est pas autorisé à afficher les paramètres du plugin"
 
 #: katalogus/client.py
 msgid "User is not allowed to access the other organization"
-msgstr ""
+msgstr "L'utilisateur n'est pas autorisé à accéder à l'autre organisation"
 
 #: katalogus/client.py
 msgid "User is not allowed to enable plugins"
-msgstr ""
+msgstr "L'utilisateur n'est pas autorisé à activer les plugins"
 
 #: katalogus/client.py
 msgid "User is not allowed to disable plugins"
-msgstr ""
+msgstr "L'utilisateur n'est pas autorisé à désactiver les plugins"
 
 #: katalogus/client.py
 msgid "User is not allowed to create plugins"
-msgstr ""
+msgstr "L'utilisateur n'est pas autorisé à créer des plugins"
 
 #: katalogus/client.py
 msgid "User is not allowed to edit plugins"
-msgstr ""
+msgstr "L'utilisateur n'est pas autorisé à modifier les plugins"
 
 #: katalogus/forms/katalogus_filter.py
 msgid "Show all"
-msgstr ""
+msgstr "Afficher tout"
 
 #: katalogus/forms/katalogus_filter.py
 #: katalogus/templates/partials/enable_disable_plugin.html
@@ -1413,7 +1541,7 @@ msgstr ""
 #: reports/report_types/dns_report/report.html
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Enabled"
-msgstr ""
+msgstr "Activé"
 
 #: katalogus/forms/katalogus_filter.py
 #: katalogus/templates/partials/enable_disable_plugin.html
@@ -1422,39 +1550,43 @@ msgstr ""
 #: reports/templates/report_overview/scheduled_reports_table.html
 #: reports/templates/summary/selected_plugins.html
 msgid "Disabled"
-msgstr ""
+msgstr "Désactivé"
 
 #: katalogus/forms/katalogus_filter.py
 msgid "Enabled-Disabled"
-msgstr ""
+msgstr "Activé-Désactivé"
 
 #: katalogus/forms/katalogus_filter.py
 msgid "Disabled-Enabled"
-msgstr ""
+msgstr "Désactivé-Activé"
 
 #: katalogus/forms/katalogus_filter.py
 msgid "Filter options"
-msgstr ""
+msgstr "Options de filtrage"
 
 #: katalogus/forms/katalogus_filter.py
 msgid "Sorting options"
-msgstr ""
+msgstr "Options de tri"
 
 #: katalogus/forms/plugin_settings.py
 msgid "This field is required."
-msgstr ""
+msgstr "Ce champ est obligatoire."
 
 #: katalogus/templates/about_plugins.html
 #: katalogus/templates/partials/plugins_navigation.html
 msgid "About plugins"
-msgstr ""
+msgstr "À propos des plugins"
 
 #: katalogus/templates/about_plugins.html katalogus/templates/katalogus.html
 msgid ""
-"Plugins gather data, objects and insight. Each plugin has its own focus area "
-"and strengths and may be able to work with other plugins to gain even more "
+"Plugins gather data, objects and insight. Each plugin has its own focus area"
+" and strengths and may be able to work with other plugins to gain even more "
 "insights."
 msgstr ""
+"Les plugins collectent des données, des objets et des informations. Chaque "
+"plugin a son propre domaine d'intervention et ses propres atouts et peut "
+"être capable de fonctionner avec d'autres plugins pour obtenir encore plus "
+"d'informations."
 
 #: katalogus/templates/about_plugins.html katalogus/templates/boefjes.html
 msgid ""
@@ -1462,120 +1594,132 @@ msgid ""
 "issues, and give insight. Each boefje is a separate scan that can run on a "
 "selection of objects."
 msgstr ""
+"Les Boefjes sont utilisés pour rechercher des objets. Ils détectent les "
+"vulnérabilités, les problèmes de sécurité et donnent des informations. "
+"Chaque boefje est une analyse distincte qui peut s'exécuter sur une "
+"sélection d'objets."
 
 #: katalogus/templates/about_plugins.html katalogus/templates/normalizers.html
 msgid ""
 "Normalizers analyze the information and turn it into objects for the data "
 "model in Octopoes."
 msgstr ""
+"Normalizers analyse les informations et les transforme en objets pour le "
+"modèle de données dans Octopoes."
 
 #: katalogus/templates/about_plugins.html
 msgid ""
-"Bits are business rules that look for insight within the current dataset and "
-"search for specific insight and draw conclusions."
+"Bits are business rules that look for insight within the current dataset and"
+" search for specific insight and draw conclusions."
 msgstr ""
+"Les bits sont des règles métier qui recherchent des informations dans "
+"l'ensemble de données actuel, recherchent des informations spécifiques et "
+"tirent des conclusions."
 
 #: katalogus/templates/boefje_detail.html
 #: katalogus/templates/partials/plugin_tile_modal.html
 #: katalogus/templates/plugin_container_image.html
 msgid "Scan level"
-msgstr ""
+msgstr "Niveau de numérisation"
 
 #: katalogus/templates/boefje_detail.html
 #: katalogus/templates/normalizer_detail.html
 msgid "Consumes"
-msgstr ""
+msgstr "Consomme"
 
 #: katalogus/templates/boefje_detail.html
 #, python-format
 msgid "%(plugin_name)s is able to scan the following object types:"
-msgstr ""
+msgstr "%(plugin_name)s est capable d'analyser les types d'objets suivants :"
 
 #: katalogus/templates/boefje_detail.html
 #: katalogus/templates/normalizer_detail.html
 #, python-format
 msgid "%(plugin_name)s does not need any input objects."
-msgstr ""
+msgstr "%(plugin_name)s n’a besoin d’aucun objet d’entrée."
 
 #: katalogus/templates/boefje_detail.html
 #: katalogus/templates/normalizer_detail.html
 #: katalogus/templates/partials/plugin_tile_modal.html
 msgid "Produces"
-msgstr ""
+msgstr "Produit"
 
 #: katalogus/templates/boefje_detail.html
 #: katalogus/templates/normalizer_detail.html
 #: katalogus/templates/partials/plugin_tile_modal.html
 #, python-format
 msgid "%(plugin_name)s can produce the following output:"
-msgstr ""
+msgstr "%(plugin_name)s peut produire le résultat suivant :"
 
 #: katalogus/templates/boefje_detail.html
 #, python-format
 msgid "%(plugin_name)s doesn't produce any output mime types."
-msgstr ""
+msgstr "%(plugin_name)s ne produit aucun type MIME de sortie."
 
 #: katalogus/templates/boefje_setup.html
 msgid "Boefje variant setup"
-msgstr ""
+msgstr "Configuration de la variante Boefje"
 
 #: katalogus/templates/boefje_setup.html
 #: rocky/templates/organizations/organization_member_list.html
 #: rocky/templates/organizations/organization_settings.html
 #: rocky/views/ooi_edit.py rocky/views/organization_edit.py
 msgid "Edit"
-msgstr ""
+msgstr "Modifier"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Boefje setup"
-msgstr ""
+msgstr "Configuration du Boefje"
 
 #: katalogus/templates/boefje_setup.html
 msgid ""
 "You can create a new Boefje. If you want more information on this, you can "
-"check out the <a href=\"https://docs.openkat.nl/developer_documentation/"
-"development_tutorial/creating_a_boefje.html\">documentation</a>."
+"check out the <a "
+"href=\"https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html\">documentation</a>."
 msgstr ""
+"Vous pouvez créer un nouveau Boefje. Si vous souhaitez plus d'informations à"
+" ce sujet, vous pouvez consulter la documentation <a "
+"href=\"https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html\"></a>."
 
 #: katalogus/templates/boefje_setup.html
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 msgid "Save changes"
-msgstr ""
+msgstr "Enregistrer les modifications"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Discard changes"
-msgstr ""
+msgstr "Ignorer les modifications"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Create variant"
-msgstr ""
+msgstr "Créer une variante"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Discard variant"
-msgstr ""
+msgstr "Supprimer la variante"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Create new Boefje"
-msgstr ""
+msgstr "Créer un nouveau Boefje"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Discard new Boefje"
-msgstr ""
+msgstr "Jeter le nouveau Boefje"
 
 #: katalogus/templates/boefjes.html
 msgid "Add Boefje"
-msgstr ""
+msgstr "Ajouter Boefje"
 
 #: katalogus/templates/boefjes.html katalogus/templates/katalogus.html
 #: katalogus/templates/normalizers.html
 msgid "available"
-msgstr ""
+msgstr "disponible"
 
 #: katalogus/templates/change_clearance_level.html
 #: katalogus/templates/partials/objects_to_scan.html
 #: reports/templates/partials/report_setup_scan.html
 msgid "scan level warning"
-msgstr ""
+msgstr "avertissement de niveau d'analyse"
 
 #: katalogus/templates/change_clearance_level.html
 #, python-format
@@ -1583,10 +1727,13 @@ msgid ""
 "%(plugin_name)s will only scan objects with a corresponding clearance level "
 "of <strong>L%(scan_level)s</strong> or higher."
 msgstr ""
+"%(plugin_name)s analysera uniquement les objets avec un niveau "
+"d'autorisation correspondant de <strong>L%(scan_level)s</strong> ou "
+"supérieur."
 
 #: katalogus/templates/change_clearance_level.html
 msgid "Scan object"
-msgstr ""
+msgstr "Scanner un objet"
 
 #: katalogus/templates/change_clearance_level.html
 #, python-format
@@ -1595,115 +1742,124 @@ msgid ""
 "be advised that by continuing you will declare a level %(scan_level)s on "
 "these objects."
 msgstr ""
+"Les objets suivants ne sont pas encore autorisés pour le niveau "
+"%(scan_level)s, veuillez noter qu'en continuant, vous déclarerez un niveau "
+"%(scan_level)s sur ces objets."
 
 #: katalogus/templates/change_clearance_level.html
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/summary/report_asset_overview.html
 msgid "Selected objects"
-msgstr ""
+msgstr "Objets sélectionnés"
 
 #: katalogus/templates/change_clearance_level.html
 #: reports/templates/report_overview/report_history_table.html
 #: reports/templates/summary/ooi_selection.html rocky/views/mixins.py
 msgid "Object"
-msgstr ""
+msgstr "Objet"
 
 #: katalogus/templates/change_clearance_level.html
 msgid "Are you sure you want to scan anyways?"
-msgstr ""
+msgstr "Etes-vous sûr de vouloir quand même scanner ?"
 
 #: katalogus/templates/change_clearance_level.html
 #: rocky/templates/oois/ooi_detail.html
 msgid "Scan"
-msgstr ""
+msgstr "Balayage"
 
 #: katalogus/templates/clone_settings.html
 #: katalogus/templates/confirmation_clone_settings.html
 msgid "Clone settings"
-msgstr ""
+msgstr "Paramètres de clonage"
 
 #: katalogus/templates/clone_settings.html
 #, python-format
 msgid ""
 "Use the form below to clone the settings from "
-"<strong>%(current_organization)s</strong> to the selected organization. This "
-"includes both the KAT-alogus settings as well as enabled and disabled "
+"<strong>%(current_organization)s</strong> to the selected organization. This"
+" includes both the KAT-alogus settings as well as enabled and disabled "
 "plugins."
 msgstr ""
+"Utilisez le formulaire ci-dessous pour cloner les paramètres de "
+"<strong>%(current_organization)s</strong> vers l'organisation sélectionnée. "
+"Cela inclut à la fois les paramètres homologues KAT ainsi que les plugins "
+"activés et désactivés."
 
 #: katalogus/templates/confirmation_clone_settings.html
 msgid "Clone"
-msgstr ""
+msgstr "Cloner"
 
 #: katalogus/templates/katalogus.html
 msgid "All plugins"
-msgstr ""
+msgstr "Tous les plugins"
 
 #: katalogus/templates/katalogus_settings.html
 msgid "KAT-alogus settings"
-msgstr ""
+msgstr "Paramètres analogues à KAT"
 
 #: katalogus/templates/katalogus_settings.html
 msgid ""
 "There are currently no settings defined. Add settings at the plugin detail "
 "page."
 msgstr ""
+"Aucun paramètre n'est actuellement défini. Ajoutez des paramètres sur la "
+"page de détails du plugin."
 
 #: katalogus/templates/katalogus_settings.html
 #: rocky/templates/two_factor/core/otp_required.html
 msgid "Go back"
-msgstr ""
+msgstr "Retourner"
 
 #: katalogus/templates/katalogus_settings.html
 msgid "This is an overview of the latest settings of all plugins."
-msgstr ""
+msgstr "Ceci est un aperçu des derniers paramètres de tous les plugins."
 
 #: katalogus/templates/katalogus_settings.html
 msgid "Latest plugin settings"
-msgstr ""
+msgstr "Derniers paramètres du plugin"
 
 #: katalogus/templates/katalogus_settings.html
 #: rocky/templates/tasks/ooi_detail_task_list.html
 msgid "Plugin"
-msgstr ""
+msgstr "Plugin"
 
 #: katalogus/templates/katalogus_settings.html
 #: katalogus/templates/plugin_settings_list.html
 #: rocky/templates/oois/ooi_delete.html
 msgid "Value"
-msgstr ""
+msgstr "Valeur"
 
 #: katalogus/templates/normalizer_detail.html
 #, python-format
 msgid "%(plugin_name)s is able to process the following mime types:"
-msgstr ""
+msgstr "%(plugin_name)s est capable de traiter les types MIME suivants :"
 
 #: katalogus/templates/partials/boefje_tile.html
 msgid "This object type is required"
-msgstr ""
+msgstr "Ce type d'objet est obligatoire"
 
 #: katalogus/templates/partials/boefje_tile.html
 msgid "Scan level:"
-msgstr ""
+msgstr "Niveau de numérisation :"
 
 #: katalogus/templates/partials/boefje_tile.html
 msgid "Publisher:"
-msgstr ""
+msgstr "Éditeur:"
 
 #: katalogus/templates/partials/boefje_tile.html
 #: katalogus/templates/partials/plugin_tile.html
 #: katalogus/templates/partials/plugin_tile_modal.html
 msgid "See details"
-msgstr ""
+msgstr "Voir les détails"
 
 #: katalogus/templates/partials/enable_disable_plugin.html
 msgid "Enable"
-msgstr ""
+msgstr "Activer"
 
 #: katalogus/templates/partials/enable_disable_plugin.html
 #: rocky/templates/two_factor/profile/disable.html
 msgid "Disable"
-msgstr ""
+msgstr "Désactiver"
 
 #: katalogus/templates/partials/katalogus_filter.html
 #: rocky/templates/findings/findings_filter.html
@@ -1711,7 +1867,7 @@ msgstr ""
 #: rocky/templates/partials/organization_member_list_filters.html
 #: rocky/templates/tasks/partials/task_filter.html
 msgid "Hide filters"
-msgstr ""
+msgstr "Masquer les filtres"
 
 #: katalogus/templates/partials/katalogus_filter.html
 #: rocky/templates/findings/findings_filter.html
@@ -1719,7 +1875,7 @@ msgstr ""
 #: rocky/templates/partials/organization_member_list_filters.html
 #: rocky/templates/tasks/partials/task_filter.html
 msgid "Show filters"
-msgstr ""
+msgstr "Afficher les filtres"
 
 #: katalogus/templates/partials/katalogus_filter.html
 #: rocky/templates/findings/findings_filter.html
@@ -1727,29 +1883,29 @@ msgstr ""
 #: rocky/templates/partials/organization_member_list_filters.html
 #: rocky/templates/tasks/partials/task_filter.html
 msgid "applied"
-msgstr ""
+msgstr "appliqué"
 
 #: katalogus/templates/partials/katalogus_filter.html
 msgid "Filter plugins"
-msgstr ""
+msgstr "Plugins de filtrage"
 
 #: katalogus/templates/partials/katalogus_filter.html
 msgid "Clear filter"
-msgstr ""
+msgstr "Effacer le filtre"
 
 #: katalogus/templates/partials/katalogus_header.html
 #: katalogus/views/change_clearance_level.py katalogus/views/katalogus.py
 #: katalogus/views/katalogus_settings.py katalogus/views/plugin_detail.py
 #: katalogus/views/plugin_settings_add.py
 #: katalogus/views/plugin_settings_delete.py
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
-#: rocky/templates/header.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
 msgid "KAT-alogus"
-msgstr ""
+msgstr "KAT-équivalent"
 
 #: katalogus/templates/partials/katalogus_header.html
 msgid "An overview of all available plugins."
-msgstr ""
+msgstr "Un aperçu de tous les plugins disponibles."
 
 #: katalogus/templates/partials/katalogus_header.html
 #: katalogus/templates/plugin_settings_list.html
@@ -1758,35 +1914,35 @@ msgstr ""
 #: rocky/templates/organizations/organization_list.html
 #: rocky/templates/organizations/organization_settings.html
 msgid "Settings"
-msgstr ""
+msgstr "Paramètres"
 
 #: katalogus/templates/partials/katalogus_toolbar.html
 msgid "Gridview"
-msgstr ""
+msgstr "Vue en grille"
 
 #: katalogus/templates/partials/katalogus_toolbar.html
 msgid "Tableview"
-msgstr ""
+msgstr "Vue de table"
 
 #: katalogus/templates/partials/modal_report_types.html
 msgid "Required for"
-msgstr ""
+msgstr "Requis pour"
 
 #: katalogus/templates/partials/modal_report_types.html
 msgid "report types"
-msgstr ""
+msgstr "types de rapports"
 
 #: katalogus/templates/partials/modal_report_types.html
 msgid "Report types for "
-msgstr ""
+msgstr "Types de rapports pour"
 
 #: katalogus/templates/partials/no_enabling_permission_message.html
 msgid "No permission to enable/disable plugins"
-msgstr ""
+msgstr "Aucune autorisation pour activer/désactiver les plugins"
 
 #: katalogus/templates/partials/no_enabling_permission_message.html
 msgid "Contact your administrator to request permission."
-msgstr ""
+msgstr "Contactez votre administrateur pour demander l'autorisation."
 
 #: katalogus/templates/partials/objects_to_scan.html
 #, python-format
@@ -1797,10 +1953,16 @@ msgid ""
 "<strong>L%(scan_level)s</strong>. Use the filter to show OOI's with a lower "
 "clearance level."
 msgstr ""
+"Ce Boefje numérisera uniquement les objets avec un niveau d'autorisation "
+"correspondant de <strong>L%(scan_level)s</strong> ou supérieur. Il n'y a "
+"aucune indemnisation pour ce Boefje pour scanner un OOI avec un niveau "
+"d'autorisation inférieur à celui du <strong>L%(scan_level)s</strong>. "
+"Utilisez le filtre pour afficher les OOI avec un niveau de dégagement "
+"inférieur."
 
 #: katalogus/templates/partials/objects_to_scan.html
 msgid "Warning scan level:"
-msgstr ""
+msgstr "Niveau d'analyse d'avertissement :"
 
 #: katalogus/templates/partials/objects_to_scan.html
 msgid ""
@@ -1809,6 +1971,12 @@ msgid ""
 "now on out, until it manually gets set to something else again. This means "
 "that all other enabled Boefjes will use this higher clearance level aswel."
 msgstr ""
+"La numérisation des OOI avec un niveau d'autorisation inférieur entraînera "
+"une augmentation du niveau d'autorisation de OpenKAT sur ce OOI, non "
+"seulement pour cette analyse, mais à partir de maintenant, jusqu'à ce qu'il "
+"soit à nouveau réglé manuellement sur autre chose. Cela signifie que tous "
+"les autres Boefjes activés utiliseront également ce niveau d'autorisation "
+"plus élevé."
 
 #: katalogus/templates/partials/objects_to_scan.html
 #, python-format
@@ -1817,6 +1985,9 @@ msgid ""
 "Add objects with a complying clearance level, or alter the clearance level "
 "of existing objects."
 msgstr ""
+"Vous n’avez actuellement aucun objet répondant au niveau d’analyse de "
+"%(name)s. Ajoutez des objets avec un niveau d'autorisation conforme ou "
+"modifiez le niveau d'autorisation des objets existants."
 
 #: katalogus/templates/partials/objects_to_scan.html
 #, python-format
@@ -1824,59 +1995,62 @@ msgid ""
 "You currently don't have scannable objects for %(name)s. Add objects to use "
 "this Boefje. This Boefje is able to scan objects of the following types:"
 msgstr ""
+"Vous ne disposez actuellement d’aucun objet numérisable pour %(name)s. "
+"Ajoutez des objets pour utiliser ce Boefje. Ce Boefje est capable de "
+"numériser des objets des types suivants :"
 
 #: katalogus/templates/partials/plugin_settings_required.html
 msgid "The form could not be initialized."
-msgstr ""
+msgstr "Le formulaire n'a pas pu être initialisé."
 
 #: katalogus/templates/partials/plugin_settings_required.html
 msgid "Required settings"
-msgstr ""
+msgstr "Paramètres requis"
 
 #: katalogus/templates/partials/plugin_settings_required.html
 #: rocky/templates/partials/ooi_list_toolbar.html
 msgid "Add"
-msgstr ""
+msgstr "Ajouter"
 
 #: katalogus/templates/partials/plugin_tile.html
 msgid "Required for:"
-msgstr ""
+msgstr "Requis pour :"
 
 #: katalogus/templates/partials/plugin_tile_modal.html
 msgid "Boefje details"
-msgstr ""
+msgstr "Détails du Boefje"
 
 #: katalogus/templates/partials/plugin_tile_modal.html reports/forms.py
 #: reports/templates/report_overview/report_history_table.html
 msgid "Report types"
-msgstr ""
+msgstr "Types de rapports"
 
 #: katalogus/templates/partials/plugin_tile_modal.html
 msgid "This boefje is required by the following report types."
-msgstr ""
+msgstr "Ce boefje est requis par les types de rapports suivants."
 
 #: katalogus/templates/partials/plugin_tile_modal.html
 msgid "Go to boefje detail page"
-msgstr ""
+msgstr "Aller à la page de détails du boefje"
 
 #: katalogus/templates/partials/plugins.html
 msgid "Plugins overview:"
-msgstr ""
+msgstr "Aperçu des plugins :"
 
 #: katalogus/templates/partials/plugins.html
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugin name"
-msgstr ""
+msgstr "Nom du plugin"
 
 #: katalogus/templates/partials/plugins.html
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugin type"
-msgstr ""
+msgstr "Type de plugin"
 
 #: katalogus/templates/partials/plugins.html
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugin description"
-msgstr ""
+msgstr "Description du plugin"
 
 #: katalogus/templates/partials/plugins.html
 #: reports/templates/partials/report_header.html
@@ -1884,73 +2058,76 @@ msgstr ""
 #: rocky/templates/organizations/organization_list.html
 #: rocky/templates/organizations/organization_settings.html
 msgid "Actions"
-msgstr ""
+msgstr "Actes"
 
 #: katalogus/templates/partials/plugins.html
 msgid "Detail page"
-msgstr ""
+msgstr "Page de détail"
 
 #: katalogus/templates/partials/plugins_navigation.html
 #: reports/templates/report_overview/report_overview_navigation.html
 msgid "Plugins Navigation"
-msgstr ""
+msgstr "Navigation des plugins"
 
 #: katalogus/templates/partials/plugins_navigation.html
 #: rocky/templates/scan.html rocky/templates/tasks/boefjes.html
 #: rocky/templates/tasks/partials/tab_navigation.html rocky/views/tasks.py
 msgid "Boefjes"
-msgstr ""
+msgstr "Boefjes"
 
 #: katalogus/templates/partials/plugins_navigation.html
 #: rocky/templates/tasks/normalizers.html
 #: rocky/templates/tasks/partials/tab_navigation.html rocky/views/tasks.py
 msgid "Normalizers"
-msgstr ""
+msgstr "Normalizers"
 
 #: katalogus/templates/partials/plugins_navigation.html
 #: tools/forms/scheduler.py
 msgid "All"
-msgstr ""
+msgstr "Tous"
 
 #: katalogus/templates/plugin_container_image.html tools/forms/boefje.py
 msgid "Container image"
-msgstr ""
+msgstr "Image du conteneur"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "The container image for this Boefje is:"
-msgstr ""
+msgstr "L'image du conteneur pour ce Boefje est :"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Variants"
-msgstr ""
+msgstr "Variantes"
 
 #: katalogus/templates/plugin_container_image.html
 msgid ""
 "Boefje variants that use the same container image. For more information "
 "about Boefje variants you can read the documentation."
 msgstr ""
+"Variantes Boefje qui utilisent la même image de conteneur. Pour plus "
+"d'informations sur les variantes Boefje, vous pouvez lire la documentation."
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Add variant"
-msgstr ""
+msgstr "Ajouter une variante"
 
 #: katalogus/templates/plugin_container_image.html
 #: rocky/templates/partials/notifications_block.html
 msgid "confirmation"
-msgstr ""
+msgstr "confirmation"
 
 #: katalogus/templates/plugin_container_image.html
 #, python-format
 msgid "Variant %(plugin.name)s created."
-msgstr ""
+msgstr "Variante %(plugin.name)s créée."
 
 #: katalogus/templates/plugin_container_image.html
 msgid "The Boefje variant is successfully created and can now be used."
 msgstr ""
+"La variante Boefje est créée avec succès et peut désormais être utilisée."
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Overview of variants"
-msgstr ""
+msgstr "Aperçu des variantes"
 
 #: katalogus/templates/plugin_container_image.html
 #: reports/report_types/tls_report/report.html
@@ -1961,36 +2138,36 @@ msgstr ""
 #: rocky/templates/tasks/plugin_detail_task_list.html
 #: rocky/templates/tasks/reports.html
 msgid "Status"
-msgstr ""
+msgstr "Statut"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Age"
-msgstr ""
+msgstr "Âge"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Scan interval"
-msgstr ""
+msgstr "Intervalle d'analyse"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Run on"
-msgstr ""
+msgstr "Courir"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "current"
-msgstr ""
+msgstr "actuel"
 
 #: katalogus/templates/plugin_container_image.html
 #: reports/report_types/dns_report/report.html
 msgid "minutes"
-msgstr ""
+msgstr "minutes"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Default system scan frequency"
-msgstr ""
+msgstr "Fréquence d'analyse du système par défaut"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Boefje ID"
-msgstr ""
+msgstr "ID Boefje"
 
 #: katalogus/templates/plugin_container_image.html
 #: reports/templates/report_overview/modal_partials/delete_modal.html
@@ -1999,222 +2176,256 @@ msgstr ""
 #: reports/templates/report_overview/subreports_table.html
 #: rocky/templates/tasks/reports.html
 msgid "Creation date"
-msgstr ""
+msgstr "Date de création"
 
 #: katalogus/templates/plugin_container_image.html tools/forms/boefje.py
 msgid "Arguments"
-msgstr ""
+msgstr "Arguments"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "The following arguments are used for this Boefje variant:"
-msgstr ""
+msgstr "Les arguments suivants sont utilisés pour cette variante Boefje :"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "There are no arguments used for this Boefje variant."
-msgstr ""
+msgstr "Aucun argument n'est utilisé pour cette variante Boefje."
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Edit variant"
-msgstr ""
+msgstr "Modifier la variante"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "This Boefje has no variants yet."
-msgstr ""
+msgstr "Ce Boefje n'a pas encore de variantes."
 
 #: katalogus/templates/plugin_container_image.html
 msgid ""
-"You can make a variant and change the arguments and JSON Schema to customize "
-"it to fit your needs."
+"You can make a variant and change the arguments and JSON Schema to customize"
+" it to fit your needs."
 msgstr ""
+"Vous pouvez créer une variante et modifier les arguments et le schéma JSON "
+"pour le personnaliser en fonction de vos besoins."
 
 #: katalogus/templates/plugin_settings_add.html
 msgid "Add setting"
 msgid_plural "Add settings"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Ajouter des paramètres"
+msgstr[1] "Ajouter des paramètres"
 
 #: katalogus/templates/plugin_settings_add.html
 msgid "Setting"
 msgid_plural "Settings"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Paramètres"
+msgstr[1] "Paramètres"
 
 #: katalogus/templates/plugin_settings_add.html
 msgid "Add setting and enable boefje"
 msgid_plural "Add settings and enable boefje"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Ajouter des paramètres et activer boefje"
+msgstr[1] "Ajouter des paramètres et activer boefje"
 
 #: katalogus/templates/plugin_settings_delete.html
 msgid "Delete settings"
-msgstr ""
+msgstr "Supprimer les paramètres"
 
 #: katalogus/templates/plugin_settings_delete.html
 #, python-format
 msgid ""
 "Are you sure you want to delete all settings for the plugin %(plugin_name)s?"
 msgstr ""
+"Etes-vous sûr de vouloir supprimer tous les paramètres du plugin "
+"%(plugin_name)s ?"
 
 #: katalogus/templates/plugin_settings_list.html
 msgid ""
-"In the table below the settings for this specific Boefje can be seen. Set or "
-"change the value of the variables by editing the settings."
+"In the table below the settings for this specific Boefje can be seen. Set or"
+" change the value of the variables by editing the settings."
 msgstr ""
+"Dans le tableau ci-dessous, les paramètres de ce Boefje spécifique peuvent "
+"être vus. Définissez ou modifiez la valeur des variables en modifiant les "
+"paramètres."
 
 #: katalogus/templates/plugin_settings_list.html
 msgid "Configure Settings"
-msgstr ""
+msgstr "Configurer les paramètres"
 
 #: katalogus/templates/plugin_settings_list.html
 msgid "Overview of settings"
-msgstr ""
+msgstr "Aperçu des paramètres"
 
 #: katalogus/templates/plugin_settings_list.html
 msgid "Variable"
-msgstr ""
+msgstr "Variable"
 
 #: katalogus/views/change_clearance_level.py
 msgid "Session has terminated, please select objects again."
-msgstr ""
+msgstr "La session est terminée, veuillez sélectionner à nouveau les objets."
 
 #: katalogus/views/change_clearance_level.py
 msgid "Change clearance level"
-msgstr ""
+msgstr "Modifier le niveau d'autorisation"
 
 #: katalogus/views/katalogus_settings.py
 msgid "Settings from {} to {} successfully cloned."
-msgstr ""
+msgstr "Paramètres de {} à {} clonés avec succès."
 
 #: katalogus/views/katalogus_settings.py
 #: katalogus/views/plugin_settings_list.py
 msgid "Failed getting settings for boefje {}"
-msgstr ""
+msgstr "Échec de l'obtention des paramètres pour boefje {}"
 
 #: katalogus/views/mixins.py
 msgid ""
 "Getting information for plugin {} failed. Please check the KATalogus logs."
 msgstr ""
+"L'obtention d'informations sur le plugin {} a échoué. Veuillez vérifier les "
+"journaux KATalogus."
 
 #: katalogus/views/plugin_detail.py
 msgid ""
 "Some selected OOIs needs an increase of clearance level to perform scans. "
 "You do not have the permission to change clearance level."
 msgstr ""
+"Certains OOIs sélectionnés nécessitent une augmentation du niveau "
+"d'autorisation pour effectuer des analyses. Vous n'êtes pas autorisé à "
+"modifier le niveau d'autorisation."
 
 #: katalogus/views/plugin_enable_disable.py
 msgid "{} '{}' disabled."
-msgstr ""
+msgstr "{} '{}' désactivé."
 
 #: katalogus/views/plugin_enable_disable.py
 msgid "{} '{}' enabled."
-msgstr ""
+msgstr "{} '{}' activé."
 
 #: katalogus/views/plugin_enable_disable.py
 msgid ""
 "You have not acknowledged your clearance level. Go to your profile page to "
 "acknowledge your clearance level."
 msgstr ""
+"Vous n'avez pas reconnu votre niveau d'habilitation. Accédez à votre page de"
+" profil pour reconnaître votre niveau d’autorisation."
 
 #: katalogus/views/plugin_enable_disable.py
 msgid ""
 "Your clearance level is not set. Go to your profile page to see your "
 "clearance or contact the administrator to set a clearance level."
 msgstr ""
+"Votre niveau d'autorisation n'est pas défini. Accédez à votre page de profil"
+" pour voir votre autorisation ou contactez l'administrateur pour définir un "
+"niveau d'autorisation."
 
 #: katalogus/views/plugin_enable_disable.py
 msgid ""
 "Your clearance level is L{}. Contact your administrator to get a higher "
 "clearance level."
 msgstr ""
+"Votre niveau d'autorisation est L{}. Contactez votre administrateur pour "
+"obtenir un niveau d'autorisation plus élevé."
 
 #: katalogus/views/plugin_enable_disable.py
 msgid "To enable {} you need at least a clearance level of L{}. "
 msgstr ""
+"Pour activer {}, vous avez besoin d'au moins un niveau d'autorisation de "
+"L{}."
 
 #: katalogus/views/plugin_settings_add.py
 msgid "Trying to add settings to boefje without schema"
-msgstr ""
+msgstr "Essayer d'ajouter des paramètres à boefje sans schéma"
 
 #: katalogus/views/plugin_settings_add.py
 msgid "No changes to the settings added: no form data present"
 msgstr ""
+"Aucune modification des paramètres ajoutée : aucune donnée de formulaire "
+"présente"
 
 #: katalogus/views/plugin_settings_add.py
 msgid "Added settings for '{}'"
-msgstr ""
+msgstr "Paramètres ajoutés pour '{}'"
 
 #: katalogus/views/plugin_settings_add.py
 msgid "Failed adding settings"
-msgstr ""
+msgstr "Échec de l'ajout des paramètres"
 
 #: katalogus/views/plugin_settings_add.py
 msgid "Enabling {} failed"
-msgstr ""
+msgstr "L'activation de {} a échoué"
 
 #: katalogus/views/plugin_settings_add.py
 msgid "Boefje '{}' enabled."
-msgstr ""
+msgstr "Boefje '{}' activé."
 
 #: katalogus/views/plugin_settings_add.py
 msgid "Add settings"
-msgstr ""
+msgstr "Ajouter des paramètres"
 
 #: katalogus/views/plugin_settings_delete.py
 msgid "Settings for plugin {} successfully deleted."
-msgstr ""
+msgstr "Paramètres du plugin {} supprimés avec succès."
 
 #: katalogus/views/plugin_settings_delete.py
 msgid "Plugin {} has no settings."
-msgstr ""
+msgstr "Le plugin {} n'a aucun paramètre."
 
 #: katalogus/views/plugin_settings_delete.py
 msgid ""
 "Failed deleting Settings for plugin {}. Check the Katalogus logs for more "
 "info."
 msgstr ""
+"Échec de la suppression des paramètres du plug-in {}. Consultez les journaux"
+" Katalogus pour plus d’informations."
 
 #: onboarding/forms.py
 msgid ""
 "The clearance level determines how aggressive the object can be scanned by "
 "plugins. A higher clearance level means more aggressive scans are allowed."
 msgstr ""
+"Le niveau d'autorisation détermine le degré d'agressivité avec lequel "
+"l'objet peut être analysé par les plugins. Un niveau d'autorisation plus "
+"élevé signifie que des analyses plus agressives sont autorisées."
 
 #: onboarding/forms.py tools/forms/ooi.py
 msgid "explanation-clearance-level"
-msgstr ""
+msgstr "niveau d'autorisation-explication"
 
 #: onboarding/forms.py
 msgid "Please enter a valid URL starting with 'http://' or 'https://'."
 msgstr ""
+"Veuillez saisir un URL valide commençant par « http:// » ou « https:// »."
 
 #: onboarding/templates/partials/onboarding_header.html
 msgid "Onboarding"
-msgstr ""
+msgstr "Intégration"
 
 #: onboarding/templates/partials/step_1_introduction_text.html
 msgid "Welcome to OpenKAT!"
-msgstr ""
+msgstr "Bienvenue sur OpenKAT !"
 
 #: onboarding/templates/partials/step_1_introduction_text.html
 msgid ""
-"Welcome to the onboarding of OpenKAT. We will walk you through some steps to "
-"set everything up."
+"Welcome to the onboarding of OpenKAT. We will walk you through some steps to"
+" set everything up."
 msgstr ""
+"Bienvenue à l'intégration de OpenKAT. Nous vous guiderons à travers quelques"
+" étapes pour tout configurer."
 
 #: onboarding/templates/partials/step_1_introduction_text.html
 msgid ""
-"At the end of this onboarding you have added your first object, created your "
-"first DNS report and learned about some basic concepts used within OpenKAT."
+"At the end of this onboarding you have added your first object, created your"
+" first DNS report and learned about some basic concepts used within OpenKAT."
 msgstr ""
+"À la fin de cette intégration, vous avez ajouté votre premier objet, créé "
+"votre premier rapport DNS et découvert certains concepts de base utilisés "
+"dans OpenKAT."
 
 #: onboarding/templates/partials/step_1_introduction_text.html
 msgid "The full documentation for OpenKAT can be found at:"
-msgstr ""
+msgstr "La documentation complète du OpenKAT est disponible à l'adresse :"
 
 #: onboarding/templates/partials/step_2_organization_text.html
 #: rocky/templates/organizations/organization_add.html
 msgid "Organization setup"
-msgstr ""
+msgstr "Configuration de l'organisation"
 
 #: onboarding/templates/partials/step_2_organization_text.html
 msgid ""
@@ -2222,36 +2433,44 @@ msgid ""
 "be changed later in the interface. The organization code cannot be changed "
 "as this is used by the database."
 msgstr ""
+"Veuillez saisir les détails suivants de l'organisation. Le nom de "
+"l'organisation peut être modifié ultérieurement dans l'interface. Le code de"
+" l'organisation ne peut pas être modifié car il est utilisé par la base de "
+"données."
 
 #: onboarding/templates/step_10_report.html
 #: reports/report_types/concatenated_report/report.py
 msgid "Report"
-msgstr ""
+msgstr "Rapport"
 
 #: onboarding/templates/step_10_report.html
 msgid "Boefjes are scanning"
-msgstr ""
+msgstr "Boefjes scanne"
 
 #: onboarding/templates/step_10_report.html
 msgid ""
 "The enabled Boefjes are running in the background to gather the data for "
 "your DNS Report. This may take a few minutes."
 msgstr ""
+"Les Boefjes activés s'exécutent en arrière-plan pour collecter les données "
+"de votre rapport DNS. Cela peut prendre quelques minutes."
 
 #: onboarding/templates/step_10_report.html
 msgid ""
 "In the meantime you can explore OpenKAT and view your DNS Report on the "
 "Reports page once it has been generated."
 msgstr ""
+"En attendant, vous pouvez explorer OpenKAT et consulter votre rapport DNS "
+"sur la page Rapports une fois qu'il a été généré."
 
 #: onboarding/templates/step_10_report.html
 msgid "Continue to OpenKAT"
-msgstr ""
+msgstr "Continuer vers OpenKAT"
 
 #: onboarding/templates/step_1_introduction_registration.html
 #: onboarding/templates/step_1a_introduction.html
 msgid "Let's get started"
-msgstr ""
+msgstr "Commençons"
 
 #: onboarding/templates/step_2a_organization_setup.html
 #: onboarding/templates/step_2b_organization_update.html
@@ -2259,7 +2478,7 @@ msgstr ""
 #: rocky/templates/organizations/organization_settings.html
 #: rocky/templates/partials/organization_properties_table.html
 msgid "Organization details"
-msgstr ""
+msgstr "Détails de l'organisation"
 
 #: onboarding/templates/step_2a_organization_setup.html
 #: rocky/templates/forms/json_schema_form.html
@@ -2271,54 +2490,65 @@ msgstr ""
 #: rocky/templates/partials/form/indemnification_add_form.html
 #: rocky/templates/two_factor/_wizard_actions.html
 msgid "Submit"
-msgstr ""
+msgstr "Soumettre"
 
 #: onboarding/templates/step_2b_organization_update.html
 msgid "Submit changes"
-msgstr ""
+msgstr "Soumettre les modifications"
 
 #: onboarding/templates/step_2b_organization_update.html
 #: onboarding/templates/step_3_indemnification_setup.html
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 #: onboarding/templates/step_7_clearance_level_introduction.html
 msgid "Continue"
-msgstr ""
+msgstr "Continuer"
 
 #: onboarding/templates/step_3_indemnification_setup.html
 msgid "Indemnification setup"
-msgstr ""
+msgstr "Configuration de l'indemnisation"
 
 #: onboarding/templates/step_3_indemnification_setup.html
 msgid "Indemnification on the organization is already present."
-msgstr ""
+msgstr "L'indemnisation de l'organisation est déjà présente."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 msgid "User clearance level"
-msgstr ""
+msgstr "Niveau d'autorisation de l'utilisateur"
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 msgid ""
-"The user clearance level specifies the maximum scan level for security scans "
-"and the maximum clearance level you can assign to objects (e.g. a URL)."
+"The user clearance level specifies the maximum scan level for security scans"
+" and the maximum clearance level you can assign to objects (e.g. a URL)."
 msgstr ""
+"Le niveau d'autorisation utilisateur spécifie le niveau d'analyse maximum "
+"pour les analyses de sécurité et le niveau d'autorisation maximum que vous "
+"pouvez attribuer aux objets (par exemple, un URL)."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 msgid ""
 "The administrator assigns a maximum user clearance level to each user. This "
 "will make sure that only trusted users can start more aggressive scans."
 msgstr ""
+"L'administrateur attribue un niveau d'autorisation utilisateur maximum à "
+"chaque utilisateur. Cela garantira que seuls les utilisateurs de confiance "
+"pourront lancer des analyses plus agressives."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 msgid ""
 "A user must accept a clearance level, before they perform actions in "
 "OpenKAT. Here you may accept the maximum trusted clearance level, as "
-"assigned by your administrator. On your user settings page you can choose to "
-"lower your accepted clearance level after completing the onboarding."
+"assigned by your administrator. On your user settings page you can choose to"
+" lower your accepted clearance level after completing the onboarding."
 msgstr ""
+"Un utilisateur doit accepter un niveau d'autorisation avant d'effectuer des "
+"actions dans OpenKAT. Ici, vous pouvez accepter le niveau d'autorisation de "
+"confiance maximum, tel qu'attribué par votre administrateur. Sur la page de "
+"vos paramètres utilisateur, vous pouvez choisir de réduire votre niveau "
+"d'autorisation accepté après avoir terminé l'intégration."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 msgid "What is my clearance level?"
-msgstr ""
+msgstr "Quel est mon niveau d'autorisation ?"
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 #, python-format
@@ -2330,6 +2560,12 @@ msgid ""
 "<strong>%(ooi)s</strong> </br> Contact your administrator to receive a "
 "higher clearance."
 msgstr ""
+"Malheureusement, vous ne pouvez pas poursuivre l'intégration. </br> Votre "
+"administrateur vous a accordé un niveau d'autorisation "
+"<strong>L%(tcl)s</strong>. </br> Vous avez besoin d'au moins un niveau "
+"d'autorisation <strong>L%(dns_report_least_clearance_level)s</strong> pour "
+"numériser <strong>%(ooi)s</strong> </br> Contactez votre administrateur pour"
+" recevoir une autorisation plus élevée."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 #: onboarding/templates/step_5_add_scan_ooi.html
@@ -2339,7 +2575,7 @@ msgstr ""
 #: onboarding/templates/step_9_choose_report_type.html
 #: rocky/templates/partials/form/boefje_tiles_form.html
 msgid "Skip onboarding"
-msgstr ""
+msgstr "Passer l'intégration"
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 #, python-format
@@ -2348,6 +2584,9 @@ msgid ""
 "<strong>L%(tcl)s</strong>. </br> You must first accept this clearance level "
 "to continue."
 msgstr ""
+"Votre administrateur vous a accordé un niveau d'autorisation "
+"<strong>L%(tcl)s</strong>. </br> Vous devez d'abord accepter ce niveau "
+"d'autorisation pour continuer."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 #, python-format
@@ -2355,10 +2594,12 @@ msgid ""
 "Your administrator has <strong>trusted</strong> you with a clearance level "
 "of <strong>L%(tcl)s</strong>."
 msgstr ""
+"Votre administrateur vous a fait confiance <strong></strong> avec un niveau "
+"d'autorisation de <strong>L%(tcl)s</strong>."
 
 #: onboarding/templates/step_5_add_scan_ooi.html
 msgid "Add an object"
-msgstr ""
+msgstr "Ajouter un objet"
 
 #: onboarding/templates/step_5_add_scan_ooi.html
 msgid ""
@@ -2366,11 +2607,14 @@ msgid ""
 "URLs. In the onboarding we will add an URL object, such as our vulnerable "
 "OpenKAT website: https://mispo.es."
 msgstr ""
+"OpenKAT utilise différents types d'objets, comme les adresses IP, les noms "
+"d'hôte et URLs. Lors de l'intégration, nous ajouterons un objet URL, tel que"
+" notre site Web vulnérable OpenKAT : https://mispo.es."
 
 #: onboarding/templates/step_5_add_scan_ooi.html
 #: rocky/templates/partials/ooi_detail_related_object.html
 msgid "Related objects"
-msgstr ""
+msgstr "Objets associés"
 
 #: onboarding/templates/step_5_add_scan_ooi.html
 msgid ""
@@ -2380,22 +2624,33 @@ msgid ""
 "collects and adds these related objects by running scans. Objects can also "
 "be manually added."
 msgstr ""
+"La plupart des objets dépendent de l'existence d'objets associés. Par "
+"exemple, un URL doit être connecté à un réseau, un nom d'hôte, un nom de "
+"domaine complet (nom de domaine complet) et une adresse IP. Lorsque cela est"
+" possible, OpenKAT collecte et ajoute automatiquement ces objets associés en"
+" exécutant des analyses. Les objets peuvent également être ajoutés "
+"manuellement."
 
 #: onboarding/templates/step_5_add_scan_ooi.html
 msgid "Create object"
-msgstr ""
+msgstr "Créer un objet"
 
 #: onboarding/templates/step_6_set_clearance_level.html
 msgid "Set object clearance level"
-msgstr ""
+msgstr "Définir le niveau d'autorisation des objets"
 
 #: onboarding/templates/step_6_set_clearance_level.html
 msgid ""
-"After creating a new object you can set a clearance level for this object. A "
-"clearance level determines how aggressive the object can be scanned. A "
+"After creating a new object you can set a clearance level for this object. A"
+" clearance level determines how aggressive the object can be scanned. A "
 "higher clearance level, means that more aggressive scans are allowed. "
 "Clearance levels can always be adjusted later on."
 msgstr ""
+"Après avoir créé un nouvel objet, vous pouvez définir un niveau "
+"d'autorisation pour cet objet. Un niveau d'autorisation détermine le degré "
+"d'agressivité de l'objet qui peut être scanné. Un niveau d’autorisation plus"
+" élevé signifie que des analyses plus agressives sont autorisées. Les "
+"niveaux de dégagement peuvent toujours être ajustés ultérieurement."
 
 #: onboarding/templates/step_6_set_clearance_level.html
 #, python-format
@@ -2404,22 +2659,30 @@ msgid ""
 "L%(dns_report_least_clearance_level)s, meaning only informational scans are "
 "allowed."
 msgstr ""
+"Pour l'intégration, nous utilisons un niveau d'autorisation de "
+"L%(dns_report_least_clearance_level)s, ce qui signifie que seules les "
+"analyses informatives sont autorisées."
 
 #: onboarding/templates/step_6_set_clearance_level.html
 msgid "Set clearance level"
-msgstr ""
+msgstr "Définir le niveau de dégagement"
 
 #: onboarding/templates/step_7_clearance_level_introduction.html
 msgid "Plugin introduction"
-msgstr ""
+msgstr "Présentation du plugin"
 
 #: onboarding/templates/step_7_clearance_level_introduction.html
 msgid ""
 "OpenKAT uses plugins to scan your objects. Each plugin has a scan level to "
-"specify how aggressive the scan is. Plugins can only scan those objects with "
-"a clearance level that is equal to, or higher than the scan level of the "
+"specify how aggressive the scan is. Plugins can only scan those objects with"
+" a clearance level that is equal to, or higher than the scan level of the "
 "plugin. Plugin scan level are indicated by the number of cat paws."
 msgstr ""
+"OpenKAT utilise des plugins pour analyser vos objets. Chaque plugin dispose "
+"d'un niveau d'analyse pour spécifier le degré d'agressivité de l'analyse. "
+"Les plugins ne peuvent analyser que les objets dont le niveau d'autorisation"
+" est égal ou supérieur au niveau d'analyse du plugin. Le niveau d'analyse du"
+" plugin est indiqué par le nombre de pattes de chat."
 
 #: onboarding/templates/step_7_clearance_level_introduction.html
 msgid ""
@@ -2427,6 +2690,10 @@ msgid ""
 "performs non-intrusive scans which look for publicly available information. "
 "It scans objects with a clearance level of 1 or higher."
 msgstr ""
+"Le plugin <strong>DNS Zone</strong> a un niveau d'analyse de 1, ce qui "
+"signifie qu'il effectue des analyses non intrusives qui recherchent des "
+"informations accessibles au public. Il scanne les objets avec un niveau "
+"d'autorisation de 1 ou plus."
 
 #: onboarding/templates/step_7_clearance_level_introduction.html
 msgid ""
@@ -2434,46 +2701,63 @@ msgid ""
 "more aggressive and could potentially break things. It scans objects with a "
 "clearance level of 3 or higher."
 msgstr ""
+"Le plugin <strong>Fierce</strong> a un niveau d'analyse de 3, ce qui "
+"signifie qu'il est plus agressif et pourrait potentiellement casser des "
+"choses. Il scanne les objets avec un niveau d'autorisation de 3 ou plus."
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid "Enabling plugins and start scanning"
-msgstr ""
+msgstr "Activer les plugins et lancer la numérisation"
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid ""
 "OpenKAT uses plugins to scan, check and analyze. There are three types of "
 "plugins."
 msgstr ""
+"OpenKAT utilise des plugins pour numériser, vérifier et analyser. Il existe "
+"trois types de plugins."
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid ""
 "The first plugin are <b>Boefjes</b>, which scan objects for data. These are "
 "security tools like nmap, LeakIX and WPscan. </p>"
 msgstr ""
+"Le premier plugin est <b>Boefjes</b>, qui analyse les objets à la recherche "
+"de données. Ce sont des outils de sécurité comme nmap, LeakIX et WPscan. "
+"</p>"
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid ""
-"The other two plugins are <b>Normalizers</b> and <b>Bits</b>, which are used "
-"to process the output of Boefjes. They can create findings and related "
+"The other two plugins are <b>Normalizers</b> and <b>Bits</b>, which are used"
+" to process the output of Boefjes. They can create findings and related "
 "objects. Bits are also used to create organization specific findings, based "
 "on policy requirements. </p>"
 msgstr ""
+"Les deux autres plugins sont <b>Normalizers</b> et <b>Bits</b>, qui sont "
+"utilisés pour traiter la sortie de Boefjes. Ils peuvent créer des "
+"découvertes et des objets associés. Les bits sont également utilisés pour "
+"créer des résultats spécifiques à l'organisation, basés sur les exigences de"
+" la politique. </p>"
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid ""
 "For the onboarding we will enable the Boefjes shown below. Once enabled "
-"these Boefjes gather publicly available information on suitable objects with "
-"a clearance level of 1 or higher. Normalizers and Bits are enabled by "
+"these Boefjes gather publicly available information on suitable objects with"
+" a clearance level of 1 or higher. Normalizers and Bits are enabled by "
 "default."
 msgstr ""
+"Pour l'intégration, nous activerons le Boefjes indiqué ci-dessous. Une fois "
+"activés, ces Boefjes collectent des informations accessibles au public sur "
+"les objets appropriés avec un niveau d'autorisation de 1 ou supérieur. "
+"Normalizers et Bits sont activés par défaut."
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid "Enable and continue"
-msgstr ""
+msgstr "Activer et continuer"
 
 #: onboarding/templates/step_9_choose_report_type.html
 msgid "Generate a report"
-msgstr ""
+msgstr "Générer un rapport"
 
 #: onboarding/templates/step_9_choose_report_type.html
 msgid ""
@@ -2481,79 +2765,87 @@ msgid ""
 "can generate different types of reports in OpenKAT. Each report may require "
 "one or more plugins that provide the input for the report."
 msgstr ""
+"Les rapports peuvent être utilisés pour obtenir plus d’informations sur les "
+"actifs de votre organisation. Vous pouvez générer différents types de "
+"rapports dans OpenKAT. Chaque rapport peut nécessiter un ou plusieurs "
+"plugins qui fournissent les données d'entrée du rapport."
 
 #: onboarding/templates/step_9_choose_report_type.html
 msgid ""
 "For the onboarding we will generate a DNS report for your added URL. In the "
 "previous step you enabled the required plugins for this report."
 msgstr ""
+"Pour l'intégration, nous générerons un rapport DNS pour votre URL ajouté. À "
+"l'étape précédente, vous avez activé les plugins requis pour ce rapport."
 
 #: onboarding/templates/step_9_choose_report_type.html
 msgid "Generate DNS Report"
-msgstr ""
+msgstr "Générer le rapport DNS"
 
 #: onboarding/view_helpers.py
 msgid "1: Welcome"
-msgstr ""
+msgstr "1 : Bienvenue"
 
 #: onboarding/view_helpers.py
 msgid "2: Organization setup"
-msgstr ""
+msgstr "2 : Configuration de l'organisation"
 
 #: onboarding/view_helpers.py
 msgid "3: Add object"
-msgstr ""
+msgstr "3 : Ajouter un objet"
 
 #: onboarding/view_helpers.py
 msgid "4: Plugins"
-msgstr ""
+msgstr "4 : Plugins"
 
 #: onboarding/view_helpers.py
 msgid "5: Generating report"
-msgstr ""
+msgstr "5 : Génération du rapport"
 
 #: onboarding/views.py
 #, python-brace-format
 msgid "{org_name} successfully created."
-msgstr ""
+msgstr "{org_name} créé avec succès."
 
 #: onboarding/views.py
 #, python-brace-format
 msgid "{org_name} successfully updated."
-msgstr ""
+msgstr "{org_name} mis à jour avec succès."
 
 #: onboarding/views.py
 msgid "Creating an object"
-msgstr ""
+msgstr "Créer un objet"
 
 #: onboarding/views.py
 msgid "Fetch the parent DNS zone of a hostname"
-msgstr ""
+msgstr "Récupérer la zone parent DNS d'un nom d'hôte"
 
 #: onboarding/views.py
 msgid "Finds subdomains by brute force"
-msgstr ""
+msgstr "Recherche les sous-domaines par force brute"
 
 #: onboarding/views.py
 msgid "Please select a plugin to proceed."
-msgstr ""
+msgstr "Veuillez sélectionner un plugin pour continuer."
 
 #: onboarding/views.py
 msgid "Please select all required plugins to proceed."
-msgstr ""
+msgstr "Veuillez sélectionner tous les plugins requis pour continuer."
 
 #: onboarding/views.py reports/views/aggregate_report.py
 #: reports/views/generate_report.py
 msgid "An error occurred while enabling {}. The plugin is not available."
 msgstr ""
+"Une erreur s'est produite lors de l'activation de {}. Le plugin n'est pas "
+"disponible."
 
 #: onboarding/views.py
 msgid "Plugins successfully enabled."
-msgstr ""
+msgstr "Plugins activés avec succès."
 
 #: onboarding/views.py
 msgid "Web URL not found."
-msgstr ""
+msgstr "Web URL introuvable."
 
 #: onboarding/views.py
 msgid ""
@@ -2561,111 +2853,114 @@ msgid ""
 "waiting for Boefjes to complete. In the meantime get familiar with OpenKAT "
 "and visit the Reports History tab later."
 msgstr ""
+"La génération de votre rapport est prévue dans environ 3 minutes, car nous "
+"attendons la fin de Boefjes. En attendant, familiarisez-vous avec OpenKAT et"
+" visitez l'onglet Historique des rapports plus tard."
 
 #: reports/forms.py tools/forms/ooi_form.py
 msgid "Filter by OOI types"
-msgstr ""
+msgstr "Filtrer par types de OOI"
 
 #: reports/forms.py
 msgid "Today"
-msgstr ""
+msgstr "Aujourd'hui"
 
 #: reports/forms.py
 msgid "Different date"
-msgstr ""
+msgstr "Date différente"
 
 #: reports/forms.py
 msgid "No, just once"
-msgstr ""
+msgstr "Non, juste une fois"
 
 #: reports/forms.py
 msgid "Yes, repeat"
-msgstr ""
+msgstr "Oui, je répète"
 
 #: reports/forms.py
 msgid "Start date"
-msgstr ""
+msgstr "Date de début"
 
 #: reports/forms.py
 msgid "Start time (UTC)"
-msgstr ""
+msgstr "Heure de début (UTC)"
 
 #: reports/forms.py
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Recurrence"
-msgstr ""
+msgstr "Récurrence"
 
 #: reports/forms.py
 msgid "No recurrence, just once"
-msgstr ""
+msgstr "Pas de récidive, juste une fois"
 
 #: reports/forms.py
 msgid "Daily"
-msgstr ""
+msgstr "Tous les jours"
 
 #: reports/forms.py
 msgid "Weekly"
-msgstr ""
+msgstr "Hebdomadaire"
 
 #: reports/forms.py
 msgid "Monthly"
-msgstr ""
+msgstr "Mensuel"
 
 #: reports/forms.py
 msgid "Yearly"
-msgstr ""
+msgstr "Annuel"
 
 #: reports/forms.py
 msgid "day"
-msgstr ""
+msgstr "jour"
 
 #: reports/forms.py
 msgid "week"
-msgstr ""
+msgstr "semaine"
 
 #: reports/forms.py
 msgid "month"
-msgstr ""
+msgstr "mois"
 
 #: reports/forms.py
 msgid "year"
-msgstr ""
+msgstr "année"
 
 #: reports/forms.py
 msgid "Never"
-msgstr ""
+msgstr "Jamais"
 
 #: reports/forms.py
 msgid "On"
-msgstr ""
+msgstr "Sur"
 
 #: reports/forms.py
 msgid "After"
-msgstr ""
+msgstr "Après"
 
 #: reports/forms.py
 msgid "Report name format"
-msgstr ""
+msgstr "Format du nom du rapport"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/report_types/multi_organization_report/appendix.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Appendix"
-msgstr ""
+msgstr "Appendice"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Currently filtered on"
-msgstr ""
+msgstr "Actuellement filtré sur"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/partials/report_sidemenu.html
 #: reports/templates/summary/report_asset_overview.html
 msgid "Selected Report Types"
-msgstr ""
+msgstr "Types de rapports sélectionnés"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Selected report types"
-msgstr ""
+msgstr "Types de rapports sélectionnés"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/partials/plugin_overview_table.html
@@ -2675,65 +2970,65 @@ msgstr ""
 #: reports/templates/report_overview/subreports_table.html
 #: reports/templates/summary/report_asset_overview.html
 msgid "Report type"
-msgstr ""
+msgstr "Type de rapport"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Service Versions and Health"
-msgstr ""
+msgstr "Versions et santé du service"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Service, version and health"
-msgstr ""
+msgstr "Service, version et état de santé"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/summary/service_health.html rocky/templates/footer.html
 #: rocky/templates/health.html
 msgid "Service"
-msgstr ""
+msgstr "Service"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/summary/service_health.html rocky/templates/health.html
 msgid "Version"
-msgstr ""
+msgstr "Version"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: rocky/templates/footer.html rocky/views/health.py
 msgid "Health"
-msgstr ""
+msgstr "Santé"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: rocky/templates/health.html
 msgid "Healthy"
-msgstr ""
+msgstr "En bonne santé"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Unhealthy"
-msgstr ""
+msgstr "Malsain"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Used Config objects"
-msgstr ""
+msgstr "Objets de configuration utilisés"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Used config objects"
-msgstr ""
+msgstr "Objets de configuration utilisés"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Primary Key"
-msgstr ""
+msgstr "Clé primaire"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Bit ID"
-msgstr ""
+msgstr "ID de bit"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Config"
-msgstr ""
+msgstr "Configuration"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "No config objects found."
-msgstr ""
+msgstr "Aucun objet de configuration trouvé."
 
 #: reports/report_types/aggregate_organisation_report/asset_overview.html
 #: reports/report_types/multi_organization_report/asset_overview.html
@@ -2741,20 +3036,23 @@ msgstr ""
 #: reports/templates/partials/report_sidemenu.html
 #: reports/templates/summary/report_asset_overview.html
 msgid "Asset overview"
-msgstr ""
+msgstr "Aperçu des actifs"
 
 #: reports/report_types/aggregate_organisation_report/asset_overview.html
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid ""
-"An overview of the manually released scanned assets. Assets in <strong>bold</"
-"strong> are taken as a starting point, assets that are not in bold were "
-"found by OpenKAT itself."
+"An overview of the manually released scanned assets. Assets in "
+"<strong>bold</strong> are taken as a starting point, assets that are not in "
+"bold were found by OpenKAT itself."
 msgstr ""
+"Un aperçu des ressources numérisées publiées manuellement. Les actifs en "
+"<strong>bold</strong> sont pris comme point de départ, les actifs qui ne "
+"sont pas en gras ont été trouvés par OpenKAT lui-même."
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 #: reports/report_types/aggregate_organisation_report/report.html
 msgid "Overview of the basic security status"
-msgstr ""
+msgstr "Aperçu de l'état de sécurité de base"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 msgid ""
@@ -2762,39 +3060,42 @@ msgid ""
 "assets. Basic security in order. In principle, all values in this table "
 "should be checked off."
 msgstr ""
+"Ce tableau donne un aperçu de l'état de sécurité de base des actifs connus. "
+"Sécurité de base en ordre. En principe, toutes les valeurs de ce tableau "
+"doivent être cochées."
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 msgid "Basic security status"
-msgstr ""
+msgstr "Statut de sécurité de base"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 #: reports/report_types/ipv6_report/report.html
 #: reports/report_types/multi_organization_report/ipv6.html
 #: reports/report_types/systems_report/report.html
 msgid "System type"
-msgstr ""
+msgstr "Type de système"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Safe connections"
-msgstr ""
+msgstr "Connexions sécurisées"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 msgid "System Specific"
-msgstr ""
+msgstr "Spécifique au système"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 msgid "RPKI"
-msgstr ""
+msgstr "RPKI"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/rpki_report/report.html
 #: reports/report_types/safe_connections_report/report.html
 msgid "server"
-msgstr ""
+msgstr "serveur"
 
 #: reports/report_types/aggregate_organisation_report/findings.html
 #: reports/report_types/aggregate_organisation_report/report.html
@@ -2802,53 +3103,58 @@ msgid ""
 "This chapter contains information about the findings that have been "
 "identified for this organization."
 msgstr ""
+"Ce chapitre contient des informations sur les résultats qui ont été "
+"identifiés pour cette organisation."
 
 #: reports/report_types/aggregate_organisation_report/recommendations.html
 #: reports/report_types/multi_organization_report/recommendations.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Recommendations"
-msgstr ""
+msgstr "Recommandations"
 
 #: reports/report_types/aggregate_organisation_report/recommendations.html
 #, python-format
 msgid "There is <i>%(total_findings)s</i> vulnerability"
 msgid_plural "There are <i>%(total_findings)s</i> vulnerabilities"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Il existe des vulnérabilités <i>%(total_findings)s</i>"
+msgstr[1] "Il existe des vulnérabilités <i>%(total_findings)s</i>"
 
 #: reports/report_types/aggregate_organisation_report/recommendations.html
 #, python-format
 msgid "found on <i>%(total_systems)s</i> system."
 msgid_plural "found on <i>%(total_systems)s</i> systems."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "trouvé sur les systèmes <i>%(total_systems)s</i>."
+msgstr[1] "trouvé sur les systèmes <i>%(total_systems)s</i>."
 
 #: reports/report_types/aggregate_organisation_report/recommendations.html
 #: reports/report_types/multi_organization_report/recommendations.html
 msgid "There are no recommendations."
-msgstr ""
+msgstr "Il n'y a aucune recommandation."
 
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Basic security"
-msgstr ""
+msgstr "Sécurité de base"
 
 #: reports/report_types/aggregate_organisation_report/report.html
 msgid ""
 "In this chapter, first a table of compliance checks is displayed, followed "
 "by a detailed examination of compliance issues for each component."
 msgstr ""
+"Dans ce chapitre, un tableau des contrôles de conformité est d'abord "
+"affiché, suivi d'un examen détaillé des problèmes de conformité pour chaque "
+"composant."
 
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "System specific"
-msgstr ""
+msgstr "Spécifique au système"
 
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Resource Public Key Infrastructure"
-msgstr ""
+msgstr "Infrastructure à clé publique de ressources"
 
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/report_types/aggregate_organisation_report/vulnerabilities.html
@@ -2856,16 +3162,16 @@ msgstr ""
 #: reports/report_types/vulnerability_report/report.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Vulnerabilities"
-msgstr ""
+msgstr "Vulnérabilités"
 
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/report_types/aggregate_organisation_report/vulnerabilities.html
 msgid "Vulnerabilities found are grouped per system."
-msgstr ""
+msgstr "Les vulnérabilités trouvées sont regroupées par système."
 
 #: reports/report_types/aggregate_organisation_report/report.py
 msgid "Aggregate Organisation Report"
-msgstr ""
+msgstr "Rapport global sur l'organisation"
 
 #: reports/report_types/aggregate_organisation_report/rpki.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
@@ -2876,6 +3182,13 @@ msgid ""
 "misconfigurations and malicious route intercepts through verified route "
 "announcements, ensuring reliable server access and secure internet traffic."
 msgstr ""
+"Cette section contient des informations de sécurité de base sur "
+"l'infrastructure à clé publique des ressources. Si votre serveur Web utilise"
+" RPKI pour ses adresses IP et les serveurs de noms associés, il améliore "
+"alors la protection des visiteurs contre les erreurs de configuration et les"
+" interceptions d'itinéraires malveillantes grâce à des annonces d'itinéraire"
+" vérifiées, garantissant ainsi un accès fiable au serveur et un trafic "
+"Internet sécurisé."
 
 #: reports/report_types/aggregate_organisation_report/safe_connections.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
@@ -2886,41 +3199,49 @@ msgid ""
 "strong encryption which protects the data from interception during "
 "communiction."
 msgstr ""
+"Dans ce chapitre, nous vérifions si les connexions de tous les ports IP du "
+"système sont sécurisées. Des connexions sécurisées sont importantes pour "
+"empêcher les accès non autorisés et les violations de données. Les "
+"chiffrements forts sont cruciaux car ils garantissent un cryptage fort qui "
+"protège les données de toute interception lors de la communication."
 
 #: reports/report_types/aggregate_organisation_report/summary.html
 #: reports/report_types/multi_organization_report/summary.html
 #: rocky/views/ooi_tree.py
 msgid "Summary"
-msgstr ""
+msgstr "Résumé"
 
 #: reports/report_types/aggregate_organisation_report/summary.html
 msgid "Critical Vulnerabilities"
-msgstr ""
+msgstr "Vulnérabilités critiques"
 
 #: reports/report_types/aggregate_organisation_report/summary.html
 msgid "IPs scanned"
-msgstr ""
+msgstr "IPs numérisé"
 
 #: reports/report_types/aggregate_organisation_report/summary.html
 msgid "Hostnames scanned"
-msgstr ""
+msgstr "Noms d'hôtes analysés"
 
 #: reports/report_types/aggregate_organisation_report/summary.html
 msgid "Terms in report"
-msgstr ""
+msgstr "Termes du rapport"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/rpki_report/report.html
 #: reports/report_types/safe_connections_report/report.html
 #, python-format
 msgid ""
-"This table shows which checks were performed. Following that, the compliance "
-"issues, if any, are shown for each %(type)s Server."
+"This table shows which checks were performed. Following that, the compliance"
+" issues, if any, are shown for each %(type)s Server."
 msgstr ""
+"Ce tableau montre quelles vérifications ont été effectuées. Ensuite, les "
+"problèmes de conformité, le cas échéant, sont affichés pour chaque serveur "
+"%(type)s."
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 msgid "Check overview"
-msgstr ""
+msgstr "Vérifier l'aperçu"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/mail_report/report.html
@@ -2930,7 +3251,7 @@ msgstr ""
 #: reports/report_types/safe_connections_report/report.html
 #: reports/report_types/web_system_report/report.html
 msgid "Check"
-msgstr ""
+msgstr "Vérifier"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/mail_report/report.html
@@ -2939,18 +3260,18 @@ msgstr ""
 #: reports/report_types/safe_connections_report/report.html
 #: reports/report_types/web_system_report/report.html
 msgid "Compliance"
-msgstr ""
+msgstr "Conformité"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/rpki_report/report.html
 msgid "IPs are compliant"
-msgstr ""
+msgstr "Les IPs sont conformes"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/safe_connections_report/report.html
 #: reports/report_types/vulnerability_report/report.html
 msgid "Host:"
-msgstr ""
+msgstr "Hôte:"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/mail_report/report.html
@@ -2959,7 +3280,7 @@ msgstr ""
 #: reports/report_types/safe_connections_report/report.html
 #: reports/report_types/web_system_report/report.html
 msgid "Compliance issue"
-msgstr ""
+msgstr "Problème de conformité"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/mail_report/report.html
@@ -2973,7 +3294,7 @@ msgstr ""
 #: rocky/templates/partials/ooi_report_findings_block_table.html
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "Risk level"
-msgstr ""
+msgstr "Niveau de risque"
 
 #: reports/report_types/aggregate_organisation_report/system_specific_overview.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
@@ -2982,28 +3303,43 @@ msgid ""
 "security and compliance issues come into play for different systems. They "
 "are listed here under each other."
 msgstr ""
+"C'est ici que sont effectuées les vérifications spécifiques aux types de "
+"systèmes. Différents problèmes de sécurité et de conformité entrent en jeu "
+"pour différents systèmes. Ils sont répertoriés ici les uns sous les autres."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Term Overview"
-msgstr ""
+msgstr "Aperçu des termes"
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid "For definitions of terms used in this chapter, see the glossary below."
 msgstr ""
+"Pour les définitions des termes utilisés dans ce chapitre, consultez le "
+"glossaire ci-dessous."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
 "Web servers and domains are examples of digital assets within this "
-"framework. Web servers are essential for hosting and serving websites or web "
-"applications, while domains represent the online addresses used to access "
-"these resources. Other examples of assets in the IT realm include databases, "
-"user accounts, software applications, and networking infrastructure. Asset "
+"framework. Web servers are essential for hosting and serving websites or web"
+" applications, while domains represent the online addresses used to access "
+"these resources. Other examples of assets in the IT realm include databases,"
+" user accounts, software applications, and networking infrastructure. Asset "
 "management is a critical aspect of cybersecurity, involving the "
 "identification, classification, and protection of these assets to safeguard "
 "against threats and ensure the overall security and functionality of an "
 "organization's IT environment."
 msgstr ""
+"Les serveurs et domaines Web sont des exemples d’actifs numériques dans ce "
+"cadre. Les serveurs Web sont essentiels pour héberger et servir des sites "
+"Web ou des applications Web, tandis que les domaines représentent les "
+"adresses en ligne utilisées pour accéder à ces ressources. D'autres exemples"
+" d'actifs dans le domaine informatique incluent les bases de données, les "
+"comptes d'utilisateurs, les applications logicielles et l'infrastructure "
+"réseau. La gestion des actifs est un aspect essentiel de la cybersécurité, "
+"impliquant l'identification, la classification et la protection de ces "
+"actifs pour se prémunir contre les menaces et garantir la sécurité et la "
+"fonctionnalité globales de l'environnement informatique d'une organisation."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
@@ -3011,13 +3347,20 @@ msgid ""
 "hostnames or the IP address has a declared scan level that is at least L1. "
 "Type systems are web servers, mail servers and name servers (DNS)."
 msgstr ""
+"Plusieurs noms d'hôte résolus en une adresse IP où au moins l'un des noms "
+"d'hôte ou l'adresse IP a un niveau d'analyse déclaré qui est au moins L1. "
+"Les systèmes de types sont des serveurs Web, des serveurs de messagerie et "
+"des serveurs de noms (DNS)."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
 "A fundamental component of the client-server model. A web server uses "
-"protocols like HTTP or HTTPS to facilitate communication between clients and "
-"the server."
+"protocols like HTTP or HTTPS to facilitate communication between clients and"
+" the server."
 msgstr ""
+"Un élément fondamental du modèle client-serveur. Un serveur Web utilise des "
+"protocoles tels que HTTP ou HTTPS pour faciliter la communication entre les "
+"clients et le serveur."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
@@ -3031,16 +3374,33 @@ msgid ""
 "emails, handling tasks such as authentication, spam filtering, and message "
 "storage."
 msgstr ""
+"Un serveur de messagerie est une application logicielle ou un périphérique "
+"matériel spécialisé qui facilite l'envoi, la réception et le stockage de "
+"courriers électroniques au sein d'un réseau informatique. Fonctionnant sur "
+"le protocole de transfert de courrier simple (SMTP) pour les messages "
+"sortants et sur le protocole d'accès aux messages Internet (IMAP) ou sur le "
+"protocole de bureau de poste (POP) pour les messages entrants, un serveur de"
+" messagerie gère la communication par courrier électronique en acheminant "
+"les messages entre les utilisateurs et en les stockant jusqu'à leur "
+"récupération. Le serveur assure le transfert efficace et sécurisé des "
+"e-mails, en gérant des tâches telles que l'authentification, le filtrage du "
+"spam et le stockage des messages."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
-"A nameserver, or Domain Name System (DNS) server, is a critical component of "
-"the internet infrastructure responsible for translating human-readable "
-"domain names into IP addresses, enabling the seamless navigation of the web. "
-"When a user enters a domain name in a web browser, the nameserver is queried "
-"to obtain the corresponding IP address of the server hosting the associated "
-"website or service."
+"A nameserver, or Domain Name System (DNS) server, is a critical component of"
+" the internet infrastructure responsible for translating human-readable "
+"domain names into IP addresses, enabling the seamless navigation of the web."
+" When a user enters a domain name in a web browser, the nameserver is "
+"queried to obtain the corresponding IP address of the server hosting the "
+"associated website or service."
 msgstr ""
+"Un serveur de noms, ou serveur Domain Name System (DNS), est un composant "
+"essentiel de l'infrastructure Internet chargé de traduire les noms de "
+"domaine lisibles par l'homme en adresses IP, permettant une navigation "
+"transparente sur le Web. Lorsqu'un utilisateur saisit un nom de domaine dans"
+" un navigateur Web, le serveur de noms est interrogé pour obtenir l'adresse "
+"IP correspondante du serveur hébergeant le site Web ou le service associé."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
@@ -3055,15 +3415,26 @@ msgid ""
 "medical images, like X-rays, CT scans, and MRIs, utilizing a standardized "
 "format."
 msgstr ""
+"Un serveur DICOM, qui signifie Digital Imaging and Communications in "
+"Medicine, est un serveur spécialisé conçu pour le stockage, la récupération "
+"et l'échange d'images médicales et d'informations associées dans le secteur "
+"de la santé. DICOM est une norme largement adoptée qui garantit "
+"l'interopérabilité et la cohérence dans la communication d'images médicales "
+"et de données associées entre différents appareils et systèmes, tels que les"
+" équipements d'imagerie médicale, les systèmes d'archivage et de "
+"communication d'images (PACS) et les systèmes d'information radiologique "
+"(RIS). Les serveurs DICOM stockent et gèrent les images médicales "
+"spécifiques au patient, telles que les radiographies, les tomodensitogrammes"
+" et les IRM, en utilisant un format standardisé."
 
 #: reports/report_types/aggregate_organisation_report/vulnerabilities.html
 #: reports/report_types/multi_organization_report/vulnerabilities.html
 msgid "No CVEs have been found."
-msgstr ""
+msgstr "Aucun CVE n'a été trouvé."
 
 #: reports/report_types/dns_report/report.html
 msgid "Records found"
-msgstr ""
+msgstr "Enregistrements trouvés"
 
 #: reports/report_types/dns_report/report.html
 msgid ""
@@ -3071,42 +3442,52 @@ msgid ""
 "DNSZone. Additionally the security measures table shows whether or not DNS "
 "relating security measures are enabled."
 msgstr ""
+"Le rapport DNS donne un aperçu des enregistrements DNS trouvés pour la "
+"DNSZone. De plus, le tableau des mesures de sécurité indique si les mesures "
+"de sécurité associées au DNS sont activées ou non."
 
 #: reports/report_types/dns_report/report.html
 msgid ""
 "<strong>Disclaimer:</strong> Not all DNSRecords are parsed in OpenKAT. DNS "
 "record types that are parsed and could be displayed in the table are:"
 msgstr ""
+"<strong>Avertissement :</strong> Tous les enregistrements DNS ne sont pas "
+"analysés dans OpenKAT. Les types d'enregistrement DNS analysés et pouvant "
+"être affichés dans le tableau sont :"
 
 #: reports/report_types/dns_report/report.html
 msgid "All existing DNS record types can be found here:"
 msgstr ""
+"Tous les types d'enregistrement DNS existants peuvent être trouvés ici :"
 
 #: reports/report_types/dns_report/report.html
 msgid "Record"
-msgstr ""
+msgstr "Enregistrer"
 
 #: reports/report_types/dns_report/report.html
 msgid "TTL"
-msgstr ""
+msgstr "TTL"
 
 #: reports/report_types/dns_report/report.html
 msgid "Data"
-msgstr ""
+msgstr "Données"
 
 #: reports/report_types/dns_report/report.html
 msgid "No records have been found."
-msgstr ""
+msgstr "Aucun enregistrement n'a été trouvé."
 
 #: reports/report_types/dns_report/report.html
 msgid "Security measures"
-msgstr ""
+msgstr "Mesures de sécurité"
 
 #: reports/report_types/dns_report/report.html
 msgid ""
-"The security measures table below shows which DNS relating security measures "
-"are enabled based on the contents of the DNS records."
+"The security measures table below shows which DNS relating security measures"
+" are enabled based on the contents of the DNS records."
 msgstr ""
+"Le tableau des mesures de sécurité ci-dessous indique quelles mesures de "
+"sécurité liées au DNS sont activées en fonction du contenu des "
+"enregistrements DNS."
 
 #: reports/report_types/dns_report/report.html
 #: reports/templates/partials/report_ooi_list.html
@@ -3119,48 +3500,52 @@ msgstr ""
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 #: rocky/views/mixins.py
 msgid "Type"
-msgstr ""
+msgstr "Taper"
 
 #: reports/report_types/dns_report/report.html
 msgid "Yes"
-msgstr ""
+msgstr "Oui"
 
 #: reports/report_types/dns_report/report.html
 msgid "No"
-msgstr ""
+msgstr "Non"
 
 #: reports/report_types/dns_report/report.html
 #: reports/templates/partials/report_findings_table.html
 msgid "Other findings found"
-msgstr ""
+msgstr "Autres résultats trouvés"
 
 #: reports/report_types/dns_report/report.html
 msgid "Findings information"
-msgstr ""
+msgstr "Informations sur les résultats"
 
 #: reports/report_types/dns_report/report.py
 msgid "DNS Report"
-msgstr ""
+msgstr "Rapport DNS"
 
 #: reports/report_types/dns_report/report.py
 msgid ""
 "DNS reports focus on domain name system configuration and potential "
 "weaknesses."
 msgstr ""
+"Les rapports DNS se concentrent sur la configuration du système de noms de "
+"domaine et les faiblesses potentielles."
 
 #: reports/report_types/findings_report/report.html
 msgid ""
 "The Findings Report contains information about the findings that have been "
 "identified for the selected asset and organization."
 msgstr ""
+"Le rapport des résultats contient des informations sur les résultats qui ont"
+" été identifiés pour l'actif et l'organisation sélectionnés."
 
 #: reports/report_types/findings_report/report.py
 msgid "Findings Report"
-msgstr ""
+msgstr "Rapport sur les résultats"
 
 #: reports/report_types/findings_report/report.py
 msgid "Shows all the finding types and their occurrences."
-msgstr ""
+msgstr "Affiche tous les types de résultats et leurs occurrences."
 
 #: reports/report_types/ipv6_report/report.html
 msgid ""
@@ -3169,204 +3554,226 @@ msgid ""
 "over IPv6 or not. A green compliance check is shown if this is the case. A "
 "grey compliance cross is shown if no IPv6 address was detected."
 msgstr ""
+"Le rapport IPv6 fournit un aperçu de l'état actuel IPv6 du système "
+"identifié. Le tableau ci-dessous indique si le domaine est accessible via "
+"IPv6 ou non. Un contrôle de conformité vert s'affiche si tel est le cas. Une"
+" croix de conformité grise s'affiche si aucune adresse IPv6 n'a été "
+"détectée."
 
 #: reports/report_types/ipv6_report/report.html
 msgid "IPv6 overview"
-msgstr ""
+msgstr "IPv6 en aperçu"
 
 #: reports/report_types/ipv6_report/report.html
 #: reports/report_types/systems_report/report.html
 msgid "Domain"
-msgstr ""
+msgstr "Domaine"
 
 #: reports/report_types/ipv6_report/report.py
 msgid "IPv6 Report"
-msgstr ""
+msgstr "Rapport IPv6"
 
 #: reports/report_types/ipv6_report/report.py
 msgid "Check whether hostnames point to IPv6 addresses."
-msgstr ""
+msgstr "Vérifiez si les noms d'hôtes pointent vers des adresses IPv6."
 
 #: reports/report_types/mail_report/report.html
 msgid ""
 "The Mail Report provides an overview of the compliance checks associated "
 "with email servers. The current compliance checks the presence of SPF, DKIM "
 "and DMARC records. The table below shows for each of these checks how many "
-"of the identified mail servers are compliant, and if applicable a compliance "
-"issue description and risk level. The risk level may be different for your "
+"of the identified mail servers are compliant, and if applicable a compliance"
+" issue description and risk level. The risk level may be different for your "
 "specific environment."
 msgstr ""
+"Le rapport de messagerie fournit un aperçu des contrôles de conformité "
+"associés aux serveurs de messagerie. La conformité actuelle vérifie la "
+"présence des enregistrements SPF, DKIM et DMARC. Le tableau ci-dessous "
+"indique pour chacune de ces vérifications combien de serveurs de messagerie "
+"identifiés sont conformes et, le cas échéant, une description du problème de"
+" conformité et un niveau de risque. Le niveau de risque peut être différent "
+"selon votre environnement spécifique."
 
 #: reports/report_types/mail_report/report.html
 msgid "Mailserver compliance"
-msgstr ""
+msgstr "Conformité du serveur de messagerie"
 
 #: reports/report_types/mail_report/report.html
 msgid "mailservers compliant"
-msgstr ""
+msgstr "serveurs de messagerie conformes"
 
 #: reports/report_types/mail_report/report.html
 msgid "No mailservers have been found on this system."
-msgstr ""
+msgstr "Aucun serveur de messagerie n'a été trouvé sur ce système."
 
 #: reports/report_types/mail_report/report.py
 msgid "Mail Report"
-msgstr ""
+msgstr "Rapport de courrier"
 
 #: reports/report_types/mail_report/report.py
 msgid ""
 "System specific Mail Report that focusses on IP addresses and hostnames."
 msgstr ""
+"Rapport de messagerie spécifique au système qui se concentre sur les "
+"adresses et les noms d'hôte IP."
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Overview of included assets"
-msgstr ""
+msgstr "Aperçu des actifs inclus"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Asset"
-msgstr ""
+msgstr "Actif"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
 msgid "Amount"
-msgstr ""
+msgstr "Montant"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "IP addresses"
-msgstr ""
+msgstr "Adresses IP"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Domain names"
-msgstr ""
+msgstr "Noms de domaine"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Assets with most critical vulnerabilities"
-msgstr ""
+msgstr "Actifs présentant les vulnérabilités les plus critiques"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Vulnerability"
-msgstr ""
+msgstr "Vulnérabilité"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Organisation"
-msgstr ""
+msgstr "Organisation"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "No vulnerabilities found."
-msgstr ""
+msgstr "Aucune vulnérabilité trouvée."
 
 #: reports/report_types/multi_organization_report/basic_security_details.html
 msgid "Overview of safe connections"
-msgstr ""
+msgstr "Aperçu des connexions sécurisées"
 
 #: reports/report_types/multi_organization_report/basic_security_details.html
 #: reports/report_types/safe_connections_report/report.html
 msgid "Only Safe Ciphers"
-msgstr ""
+msgstr "Uniquement des chiffres sécurisés"
 
 #: reports/report_types/multi_organization_report/basic_security_details.html
 #: reports/report_types/safe_connections_report/report.html
 msgid "services are compliant"
-msgstr ""
+msgstr "les services sont conformes"
 
 #: reports/report_types/multi_organization_report/basic_security_details.html
 msgid "System specific checks"
-msgstr ""
+msgstr "Vérifications spécifiques au système"
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid "IPv6"
-msgstr ""
+msgstr "IPv6"
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid ""
-"IPv6 includes improvements in security features compared to IPv4. While IPv4 "
-"can implement security measures, IPv6 was designed with security in mind, "
+"IPv6 includes improvements in security features compared to IPv4. While IPv4"
+" can implement security measures, IPv6 was designed with security in mind, "
 "and its adoption can contribute to a more secure internet."
 msgstr ""
+"IPv6 inclut des améliorations des fonctionnalités de sécurité par rapport au"
+" IPv4. Alors que le IPv4 peut mettre en œuvre des mesures de sécurité, le "
+"IPv6 a été conçu dans un souci de sécurité, et son adoption peut contribuer "
+"à un Internet plus sécurisé."
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid "In total "
-msgstr ""
+msgstr "En tout"
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid " out of "
-msgstr ""
+msgstr "de"
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid " systems have an IPv6 connection."
-msgstr ""
+msgstr "les systèmes ont une connexion IPv6."
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid "Overview of IP version compliance"
-msgstr ""
+msgstr "Présentation de la conformité de la version IP"
 
 #: reports/report_types/multi_organization_report/open_ports.html
 msgid ""
 "See an overview of open ports found over all systems and the services these "
 "systems provide."
 msgstr ""
+"Consultez un aperçu des ports ouverts trouvés sur tous les systèmes et des "
+"services fournis par ces systèmes."
 
 #: reports/report_types/multi_organization_report/open_ports.html
 msgid "Overview of detected open ports"
-msgstr ""
+msgstr "Aperçu des ports ouverts détectés"
 
 #: reports/report_types/multi_organization_report/open_ports.html
 #: reports/report_types/open_ports_report/report.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Open ports"
-msgstr ""
+msgstr "Ports ouverts"
 
 #: reports/report_types/multi_organization_report/open_ports.html
 msgid "Occurrences (IP addresses)"
-msgstr ""
+msgstr "Occurrences (adresses IP)"
 
 #: reports/report_types/multi_organization_report/open_ports.html
 #: reports/templates/summary/service_health.html
 msgid "Services"
-msgstr ""
+msgstr "Services"
 
 #: reports/report_types/multi_organization_report/open_ports.html
 msgid "No open ports found."
-msgstr ""
+msgstr "Aucun port ouvert trouvé."
 
 #: reports/report_types/multi_organization_report/recommendations.html
 msgid "Overview of recommendations"
-msgstr ""
+msgstr "Aperçu des recommandations"
 
 #: reports/report_types/multi_organization_report/recommendations.html
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "Occurrence"
-msgstr ""
+msgstr "Occurrence"
 
 #: reports/report_types/multi_organization_report/report.html
 msgid "No findings have been identified yet."
-msgstr ""
+msgstr "Aucune découverte n’a encore été identifiée."
 
 #: reports/report_types/multi_organization_report/report.py
 msgid "Multi Organization Report"
-msgstr ""
+msgstr "Rapport multi-organisation"
 
 #: reports/report_types/multi_organization_report/summary.html
 msgid "Best scoring security check"
-msgstr ""
+msgstr "Meilleur contrôle de sécurité"
 
 #: reports/report_types/multi_organization_report/summary.html
 msgid "Worst scoring security check"
-msgstr ""
+msgstr "Contrôle de sécurité avec le pire score"
 
 #: reports/report_types/multi_organization_report/vulnerabilities.html
 msgid ""
 "Vulnerabilities found are grouped per system. Here, we only consider CVE "
 "vulnerabilities."
 msgstr ""
+"Les vulnérabilités trouvées sont regroupées par système. Ici, nous "
+"considérons uniquement les vulnérabilités CVE."
 
 #: reports/report_types/multi_organization_report/vulnerabilities.html
 msgid "Vulnerabilities grouped per system"
-msgstr ""
+msgstr "Vulnérabilités regroupées par système"
 
 #: reports/report_types/multi_organization_report/vulnerabilities.html
 msgid "total"
-msgstr ""
+msgstr "total"
 
 #: reports/report_types/name_server_report/report.html
 msgid ""
@@ -3379,73 +3786,90 @@ msgid ""
 "identified are shown too. The risk level may be different for your specific "
 "environment."
 msgstr ""
+"Le rapport sur les serveurs de noms fournit un aperçu des contrôles de "
+"conformité qui ont été effectués sur les serveurs de noms de domaine "
+"identifiés (DNS). Les contrôles de conformité vérifient la présence et la "
+"validité de DNSSEC et si aucun port inutile n'a été identifié comme étant "
+"ouvert. Le tableau ci-dessous donne un aperçu des contrôles disponibles, y "
+"compris si le système a réussi les contrôles effectués. Le niveau de risque "
+"et le raisonnement pour lequel un problème a été identifié sont également "
+"affichés. Le niveau de risque peut être différent selon votre environnement "
+"spécifique."
 
 #: reports/report_types/name_server_report/report.html
 msgid "Name server compliance"
-msgstr ""
+msgstr "Conformité du serveur de noms"
 
 #: reports/report_types/name_server_report/report.html
 msgid "DNSSEC Present"
-msgstr ""
+msgstr "DNSSEC Présent"
 
 #: reports/report_types/name_server_report/report.html
 msgid "name servers compliant"
-msgstr ""
+msgstr "serveurs de noms conformes"
 
 #: reports/report_types/name_server_report/report.html
 msgid "Valid DNSSEC"
-msgstr ""
+msgstr "Valide DNSSEC"
 
 #: reports/report_types/name_server_report/report.html
 #: reports/report_types/web_system_report/report.html
 msgid "No unnecessary ports open"
-msgstr ""
+msgstr "Aucun port inutile ouvert"
 
 #: reports/report_types/name_server_report/report.html
 msgid "No nameservers have been found on this system."
-msgstr ""
+msgstr "Aucun serveur de noms n'a été trouvé sur ce système."
 
 #: reports/report_types/name_server_report/report.py
 msgid "Name Server Report"
-msgstr ""
+msgstr "Rapport du serveur de noms"
 
 #: reports/report_types/name_server_report/report.py
 msgid "Name Server Report checks name servers on basic security standards."
 msgstr ""
+"Name Server Report vérifie les serveurs de noms selon les normes de sécurité"
+" de base."
 
 #: reports/report_types/open_ports_report/report.html
 msgid ""
-"The Open Ports Report provides an overview of the open ports identified on a "
-"system. The ports that are marked as <b>bold</b> were identified by direct "
-"scans performed by OpenKAT (such as nmap). Ports that are not marked in bold "
-"were identified through external services and/or scans (such as Shodan). "
+"The Open Ports Report provides an overview of the open ports identified on a"
+" system. The ports that are marked as <b>bold</b> were identified by direct "
+"scans performed by OpenKAT (such as nmap). Ports that are not marked in bold"
+" were identified through external services and/or scans (such as Shodan). "
 "Scans with the same hostnames, ports and IPs are merged."
 msgstr ""
+"Le rapport sur les ports ouverts fournit un aperçu des ports ouverts "
+"identifiés sur un système. Les ports marqués comme <b>bold</b> ont été "
+"identifiés par des analyses directes effectuées par OpenKAT (telles que "
+"nmap). Les ports qui ne sont pas marqués en gras ont été identifiés via des "
+"services externes et/ou des analyses (tels que Shodan). Les analyses avec "
+"les mêmes noms d'hôte, ports et IPs sont fusionnées."
 
 #: reports/report_types/open_ports_report/report.html
 msgid "Overview of open ports found for the scanned assets"
-msgstr ""
+msgstr "Aperçu des ports ouverts trouvés pour les ressources analysées"
 
 #: reports/report_types/open_ports_report/report.html
 #: reports/report_types/systems_report/report.html
 msgid "IP address"
-msgstr ""
+msgstr "Adresse IP"
 
 #: reports/report_types/open_ports_report/report.html
 msgid "Hostnames"
-msgstr ""
+msgstr "Noms d'hôtes"
 
 #: reports/report_types/open_ports_report/report.html
 msgid "Direct scan"
-msgstr ""
+msgstr "Analyse directe"
 
 #: reports/report_types/open_ports_report/report.py
 msgid "Open Ports Report"
-msgstr ""
+msgstr "Rapport sur les ports ouverts"
 
 #: reports/report_types/open_ports_report/report.py
 msgid "Find open ports of IP addresses"
-msgstr ""
+msgstr "Rechercher les ports ouverts des adresses IP"
 
 #: reports/report_types/rpki_report/report.html
 msgid ""
@@ -3455,167 +3879,205 @@ msgid ""
 "misconfigurations and malicious route intercepts through verified route "
 "announcements, ensuring reliable server access and secure internet traffic."
 msgstr ""
+"Cette section contient des informations de sécurité de base sur "
+"l'infrastructure à clé publique de ressources (RPKI). Si votre serveur Web "
+"utilise RPKI pour ses adresses IP et les serveurs de noms associés, il "
+"améliore la protection des visiteurs contre les erreurs de configuration et "
+"les interceptions d'itinéraires malveillantes grâce à des annonces "
+"d'itinéraire vérifiées, garantissant ainsi un accès fiable au serveur et un "
+"trafic Internet sécurisé."
 
 #: reports/report_types/rpki_report/report.html
 msgid ""
 "The RPKI Report shows if an RPKI route announcement was available for the "
 "system and if this announcement is not expired."
 msgstr ""
+"Le rapport RPKI indique si une annonce d'itinéraire RPKI était disponible "
+"pour le système et si cette annonce n'a pas expiré."
 
 #: reports/report_types/rpki_report/report.html
 msgid "RPKI compliance"
-msgstr ""
+msgstr "Conformité RPKI"
 
 #: reports/report_types/rpki_report/report.html
 msgid "RPKI Available"
-msgstr ""
+msgstr "RPKI Disponible"
 
 #: reports/report_types/rpki_report/report.html
 msgid "RPKI valid"
-msgstr ""
+msgstr "RPKI valide"
 
 #: reports/report_types/rpki_report/report.html
 msgid "RPKI record is not valid."
-msgstr ""
+msgstr "L'enregistrement RPKI n'est pas valide."
 
 #: reports/report_types/rpki_report/report.html
 msgid "RPKI record does not exist."
-msgstr ""
+msgstr "L'enregistrement RPKI n'existe pas."
 
 #: reports/report_types/rpki_report/report.html
 #: reports/report_types/safe_connections_report/report.html
 msgid "No IPs have been found on this system."
-msgstr ""
+msgstr "Aucun IPs n'a été trouvé sur ce système."
 
 #: reports/report_types/rpki_report/report.py
 msgid "RPKI Report"
-msgstr ""
+msgstr "Rapport RPKI"
 
 #: reports/report_types/rpki_report/report.py
 msgid ""
-"Shows whether the IP is covered by a valid RPKI ROA. For a hostname it shows "
-"the IP addresses and whether they are covered by a valid RPKI ROA."
+"Shows whether the IP is covered by a valid RPKI ROA. For a hostname it shows"
+" the IP addresses and whether they are covered by a valid RPKI ROA."
 msgstr ""
+"Indique si le IP est couvert par un RPKI ROA valide. Pour un nom d'hôte, il "
+"affiche les adresses IP et si elles sont couvertes par un RPKI ROA valide."
 
 #: reports/report_types/safe_connections_report/report.html
 msgid ""
 "The Safe Connections report provides an overview of the performed checks "
 "with regard to encrypted communication channels such as HTTPS. The table "
-"below gives an overview of the available checks including whether the system "
-"passed the performed checks. The risk level and reasoning as to why an issue "
-"was identified are shown too. The risk level may be different for your "
-"specific environment."
+"below gives an overview of the available checks including whether the system"
+" passed the performed checks. The risk level and reasoning as to why an "
+"issue was identified are shown too. The risk level may be different for your"
+" specific environment."
 msgstr ""
+"Le rapport Connexions sécurisées fournit un aperçu des contrôles effectués "
+"concernant les canaux de communication cryptés tels que HTTPS. Le tableau "
+"ci-dessous donne un aperçu des contrôles disponibles, y compris si le "
+"système a réussi les contrôles effectués. Le niveau de risque et le "
+"raisonnement pour lequel un problème a été identifié sont également "
+"affichés. Le niveau de risque peut être différent selon votre environnement "
+"spécifique."
 
 #: reports/report_types/safe_connections_report/report.html
 msgid "Safe connections compliance"
-msgstr ""
+msgstr "Conformité des connexions sécurisées"
 
 #: reports/report_types/safe_connections_report/report.py
 msgid "Safe Connections Report"
-msgstr ""
+msgstr "Rapport de connexions sécurisées"
 
 #: reports/report_types/safe_connections_report/report.py
 msgid "Shows whether the IPService contains safe ciphers."
-msgstr ""
+msgstr "Indique si l'IPService contient des chiffrements sécurisés."
 
 #: reports/report_types/systems_report/report.html
 msgid ""
-"The System Report provides an overview of the system types (types of similar "
-"services) that were identified for each system. The following system types "
+"The System Report provides an overview of the system types (types of similar"
+" services) that were identified for each system. The following system types "
 "can be identified: DNS servers, Web servers, Mail servers and those "
 "classified as 'Other' servers. Each hostname and/or IP address is given one "
 "or more system types depending on the identified ports and services. The "
 "table below gives an overview of these results."
 msgstr ""
+"Le rapport système fournit un aperçu des types de systèmes (types de "
+"services similaires) identifiés pour chaque système. Les types de systèmes "
+"suivants peuvent être identifiés : serveurs DNS, serveurs Web, serveurs de "
+"messagerie et ceux classés comme serveurs « Autres ». Chaque nom d'hôte "
+"et/ou adresse IP se voit attribuer un ou plusieurs types de système en "
+"fonction des ports et services identifiés. Le tableau ci-dessous donne un "
+"aperçu de ces résultats."
 
 #: reports/report_types/systems_report/report.html
 msgid "Selected assets"
-msgstr ""
+msgstr "Actifs sélectionnés"
 
 #: reports/report_types/systems_report/report.html
 msgid "No system types have been identified on this system."
-msgstr ""
+msgstr "Aucun type de système n'a été identifié sur ce système."
 
 #: reports/report_types/systems_report/report.py
 msgid "System Report"
-msgstr ""
+msgstr "Rapport système"
 
 #: reports/report_types/systems_report/report.py
 msgid "Combine IP addresses, hostnames and services into systems."
 msgstr ""
+"Combinez les adresses IP, les noms d’hôtes et les services dans des "
+"systèmes."
 
 #: reports/report_types/tls_report/report.html
 msgid ""
 "The TLS Report shows which TLS protocols and ciphers were identified on the "
 "host for the provided port."
 msgstr ""
+"Le rapport TLS indique quels protocoles et chiffrements TLS ont été "
+"identifiés sur l'hôte pour le port fourni."
 
 #: reports/report_types/tls_report/report.html
 msgid ""
 "The table below provides an overview of the identified TLS protocols and "
 "ciphers, including a status suggestion."
 msgstr ""
+"Le tableau ci-dessous donne un aperçu des protocoles et chiffrements TLS "
+"identifiés, y compris une suggestion d'état."
 
 #: reports/report_types/tls_report/report.html
 msgid "Ciphers"
-msgstr ""
+msgstr "Chiffres"
 
 #: reports/report_types/tls_report/report.html
 msgid "Protocol"
-msgstr ""
+msgstr "Protocole"
 
 #: reports/report_types/tls_report/report.html
 msgid "Encryption Algorithm"
-msgstr ""
+msgstr "Algorithme de cryptage"
 
 #: reports/report_types/tls_report/report.html
 msgid "Bits"
-msgstr ""
+msgstr "Morceaux"
 
 #: reports/report_types/tls_report/report.html
 msgid "Key Size"
-msgstr ""
+msgstr "Taille de la clé"
 
 #: reports/report_types/tls_report/report.html
 #: rocky/templates/organizations/organization_list.html
 #: rocky/templates/organizations/organization_settings.html
 msgid "Code"
-msgstr ""
+msgstr "Code"
 
 #: reports/report_types/tls_report/report.html
 msgid "Phase out"
-msgstr ""
+msgstr "Élimination progressive"
 
 #: reports/report_types/tls_report/report.html
 msgid "Good"
-msgstr ""
+msgstr "Bien"
 
 #: reports/report_types/tls_report/report.html
 msgid ""
 "No ciphers were found for this combination of IP address, port and service."
 msgstr ""
+"Aucun chiffre n'a été trouvé pour cette combinaison d'adresse, de port et de"
+" service IP."
 
 #: reports/report_types/tls_report/report.html
 msgid ""
-"The list below gives an overview of the findings based on the identified TLS "
-"protocols and ciphers. This includes the reasoning why the cipher or "
+"The list below gives an overview of the findings based on the identified TLS"
+" protocols and ciphers. This includes the reasoning why the cipher or "
 "protocol is marked as a finding."
 msgstr ""
+"La liste ci-dessous donne un aperçu des résultats basés sur les protocoles "
+"et chiffrements TLS identifiés. Cela inclut le raisonnement pour lequel le "
+"chiffre ou le protocole est marqué comme un résultat."
 
 #: reports/report_types/tls_report/report.py
 msgid "TLS Report"
-msgstr ""
+msgstr "Rapport TLS"
 
 #: reports/report_types/tls_report/report.py
 msgid ""
 "TLS Report assesses the security of data encryption and transmission "
 "protocols."
 msgstr ""
+"Le rapport TLS évalue la sécurité des protocoles de cryptage et de "
+"transmission des données."
 
 #: reports/report_types/vulnerability_report/report.html
 msgid "No vulnerabilities have been found on this system."
-msgstr ""
+msgstr "Aucune vulnérabilité n'a été trouvée sur ce système."
 
 #: reports/report_types/vulnerability_report/report.html
 msgid ""
@@ -3624,302 +4086,347 @@ msgid ""
 "the table shows the CVE scoring, the number of occurrences, and the CVE "
 "details."
 msgstr ""
+"Le rapport de vulnérabilité fournit un aperçu de toutes les vulnérabilités "
+"CVE identifiées sur les systèmes sélectionnés. Pour chaque CVE, le tableau "
+"affiche le score CVE, le nombre d'occurrences et les détails de CVE."
 
 #: reports/report_types/vulnerability_report/report.html
 msgid "vulnerabilities on this system"
-msgstr ""
+msgstr "vulnérabilités sur ce système"
 
 #: reports/report_types/vulnerability_report/report.html
 msgid "Advice"
-msgstr ""
+msgstr "Conseil"
 
 #: reports/report_types/vulnerability_report/report.py
 msgid "Vulnerability Report"
-msgstr ""
+msgstr "Rapport de vulnérabilité"
 
 #: reports/report_types/vulnerability_report/report.py
 msgid "Vulnerabilities found are grouped for each system."
-msgstr ""
+msgstr "Les vulnérabilités trouvées sont regroupées pour chaque système."
 
 #: reports/report_types/vulnerability_report/report.py
 msgid "First seen"
-msgstr ""
+msgstr "Vu pour la première fois"
 
 #: reports/report_types/vulnerability_report/report.py
 msgid "Last seen"
-msgstr ""
+msgstr "Vu pour la dernière fois"
 
 #: reports/report_types/vulnerability_report/report.py
 msgid "Evidence"
-msgstr ""
+msgstr "Preuve"
 
 #: reports/report_types/web_system_report/report.html
 msgid ""
-"The Web System Report provides an overview of various web server checks that "
-"were performed against the scanned system(s). For each performed check the "
+"The Web System Report provides an overview of various web server checks that"
+" were performed against the scanned system(s). For each performed check the "
 "table below shows whether or not the server is compliant with the checks. A "
 "description of why this compliant check failed is also shown, including an "
 "general risk level. The risk level may be different for your specific "
 "environment."
 msgstr ""
+"Le rapport du système Web fournit un aperçu des différentes vérifications du"
+" serveur Web effectuées sur le(s) système(s) analysé(s). Pour chaque "
+"vérification effectuée, le tableau ci-dessous indique si le serveur est "
+"conforme ou non aux vérifications. Une description des raisons pour "
+"lesquelles cette vérification de conformité a échoué est également affichée,"
+" y compris un niveau de risque général. Le niveau de risque peut être "
+"différent selon votre environnement spécifique."
 
 #: reports/report_types/web_system_report/report.html
 msgid "Web system compliance"
-msgstr ""
+msgstr "Conformité du système Web"
 
 #: reports/report_types/web_system_report/report.html
 msgid "CSP Present"
-msgstr ""
+msgstr "CSP Présent"
 
 #: reports/report_types/web_system_report/report.html
 msgid "webservers compliant"
-msgstr ""
+msgstr "serveurs Web conformes"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Secure CSP Header"
-msgstr ""
+msgstr "En-tête sécurisé CSP"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Redirects HTTP to HTTPS"
-msgstr ""
+msgstr "Redirige HTTP vers HTTPS"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Offers HTTPS"
-msgstr ""
+msgstr "Offres HTTPS"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Has a Security.txt"
-msgstr ""
+msgstr "Possède un fichier Security.txt"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Has a certificate"
-msgstr ""
+msgstr "Possède un certificat"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Certificate is valid"
-msgstr ""
+msgstr "Le certificat est valide"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Certificate is not expiring soon"
-msgstr ""
+msgstr "Le certificat n'expire pas de sitôt"
 
 #: reports/report_types/web_system_report/report.html
 msgid "No webservers have been found on this system."
-msgstr ""
+msgstr "Aucun serveur Web n'a été trouvé sur ce système."
 
 #: reports/report_types/web_system_report/report.py
 msgid "Web System Report"
-msgstr ""
+msgstr "Rapport du système Web"
 
 #: reports/report_types/web_system_report/report.py
 msgid "Web System Reports check web systems on basic security standards."
 msgstr ""
+"Les rapports du système Web vérifient les systèmes Web selon les normes de "
+"sécurité de base."
 
 #: reports/templates/partials/export_report_settings.html
 msgid "Report schedule"
-msgstr ""
+msgstr "Calendrier du rapport"
 
 #: reports/templates/partials/export_report_settings.html
 msgid ""
 "When scheduling your report, you have two options. You can either choose to "
 "generate it just once now, or set it to run automatically at regular "
-"intervals, like daily, weekly, or monthly. If you need the report just for a "
-"single occasion, select the one-time option."
+"intervals, like daily, weekly, or monthly. If you need the report just for a"
+" single occasion, select the one-time option."
 msgstr ""
+"Lors de la planification de votre rapport, vous disposez de deux options. "
+"Vous pouvez soit choisir de le générer une seule fois maintenant, soit le "
+"configurer pour qu'il s'exécute automatiquement à intervalles réguliers, par"
+" exemple quotidiennement, hebdomadairement ou mensuellement. Si vous n’avez "
+"besoin du rapport qu’une seule fois, sélectionnez l’option unique."
 
 #: reports/templates/partials/export_report_settings.html
 #: reports/templates/report_overview/report_history_table.html
 msgid "Report name"
-msgstr ""
+msgstr "Nom du rapport"
 
 #: reports/templates/partials/export_report_settings.html
 #, python-format, python-brace-format
 msgid ""
 "When generating reports, it is possible to give the report a name. The name "
-"can be static or dynamic. The default format for a report is '${report_type} "
-"for ${oois_count} objects'. These placeholders automatically adapt based on "
-"the report details. This format could for example return 'Aggregate Report "
+"can be static or dynamic. The default format for a report is '${report_type}"
+" for ${oois_count} objects'. These placeholders automatically adapt based on"
+" the report details. This format could for example return 'Aggregate Report "
 "for 15 objects'. Another placeholder that can be used is '${ooi}', which "
-"will show the name of the object when there is only one object. You can also "
-"customize the name by adding prefixes, suffixes, or other formats like '%%W' "
-"for the week number, using options from <a href=\"https://strftime.org/\" "
-"target=\"_blank\" rel=\"noopener\">Python strftime code</a>."
+"will show the name of the object when there is only one object. You can also"
+" customize the name by adding prefixes, suffixes, or other formats like "
+"'%%W' for the week number, using options from <a "
+"href=\"https://strftime.org/\" target=\"_blank\" rel=\"noopener\">Python "
+"strftime code</a>."
 msgstr ""
+"Lors de la génération de rapports, il est possible de donner un nom au "
+"rapport. Le nom peut être statique ou dynamique. Le format par défaut d'un "
+"rapport est « ${report_type} pour les objets ${oois_count} ». Ces espaces "
+"réservés s’adaptent automatiquement en fonction des détails du rapport. Ce "
+"format pourrait par exemple renvoyer un « Rapport agrégé pour 15 objets ». "
+"Un autre espace réservé qui peut être utilisé est « ${ooi} », qui affichera "
+"le nom de l'objet lorsqu'il n'y a qu'un seul objet. Vous pouvez également "
+"personnaliser le nom en ajoutant des préfixes, des suffixes ou d'autres "
+"formats tels que « %%W » pour le numéro de semaine, à l'aide des options de "
+"<a href=\"https://strftime.org/\" target=\"_blank\" rel=\"noopener\">Python "
+"strftime code</a>."
 
 #: reports/templates/partials/export_report_settings.html
 #: reports/templates/partials/generate_report_header.html
 #: reports/templates/partials/new_report_action_button.html
 #: reports/views/generate_report.py
 msgid "Generate report"
-msgstr ""
+msgstr "Générer un rapport"
 
 #: reports/templates/partials/generate_report_header.html
 msgid "To generate an aggregate report, complete the following steps."
-msgstr ""
+msgstr "Pour générer un rapport global, procédez comme suit."
 
 #: reports/templates/partials/generate_report_header.html
 msgid "To generate a multi report, complete the following steps."
-msgstr ""
+msgstr "Pour générer un rapport multiple, procédez comme suit."
 
 #: reports/templates/partials/generate_report_header.html
 msgid "To generate separate report(s), complete the following steps."
-msgstr ""
+msgstr "Pour générer des rapports distincts, procédez comme suit."
 
 #: reports/templates/partials/generate_report_sidemenu.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Table of contents"
-msgstr ""
+msgstr "Table des matières"
 
 #: reports/templates/partials/new_report_action_button.html
 msgid "Actions for creating a new report"
-msgstr ""
+msgstr "Actions pour créer un nouveau rapport"
 
 #: reports/templates/partials/new_report_action_button.html
 msgid "Separate report(s)"
-msgstr ""
+msgstr "Rapport(s) séparé(s)"
 
 #: reports/templates/partials/new_report_action_button.html
 #: reports/views/aggregate_report.py
 msgid "Aggregate report"
-msgstr ""
+msgstr "Rapport global"
 
 #: reports/templates/partials/new_report_action_button.html
 #: reports/views/multi_report.py
 msgid "Multi report"
-msgstr ""
+msgstr "Rapport multiple"
 
 #: reports/templates/partials/plugin_overview_table.html
 #: reports/templates/partials/report_sidemenu.html
 #: rocky/templates/oois/ooi_page_tabs.html
 msgid "Overview"
-msgstr ""
+msgstr "Aperçu"
 
 #: reports/templates/partials/plugin_overview_table.html
 msgid "Plugin overview table"
-msgstr ""
+msgstr "Tableau de présentation des plugins"
 
 #: reports/templates/partials/plugin_overview_table.html
 #: reports/templates/partials/report_setup_scan.html
 msgid "Required plugins"
-msgstr ""
+msgstr "Plugins requis"
 
 #: reports/templates/partials/plugin_overview_table.html
 #: reports/templates/partials/report_setup_scan.html
 msgid "Suggested plugins"
-msgstr ""
+msgstr "Plugins suggérés"
 
 #: reports/templates/partials/plugin_overview_table.html
 msgid "Action required"
-msgstr ""
+msgstr "Action requise"
 
 #: reports/templates/partials/plugin_overview_table.html
 msgid "Ready"
-msgstr ""
+msgstr "Prêt"
 
 #: reports/templates/partials/report_findings_table.html
 msgid ""
 "This table provides an overview of the identified findings on the scanned "
 "systems. For each finding type it shows the risk level, the number of "
 "occurrences and the first known occurrence of the finding. The risk level "
-"may be different for your specific environment. The details can be seen when "
-"expanding a row. A description, the source, impact and recommendation of the "
-"finding can be found here. It also shows in which findings the finding type "
-"occurred."
+"may be different for your specific environment. The details can be seen when"
+" expanding a row. A description, the source, impact and recommendation of "
+"the finding can be found here. It also shows in which findings the finding "
+"type occurred."
 msgstr ""
+"Ce tableau donne un aperçu des résultats identifiés sur les systèmes "
+"analysés. Pour chaque type de résultat, il indique le niveau de risque, le "
+"nombre d'occurrences et la première occurrence connue du résultat. Le niveau"
+" de risque peut être différent selon votre environnement spécifique. Les "
+"détails peuvent être vus lors du développement d’une ligne. Une description,"
+" la source, l’impact et la recommandation de la découverte peuvent être "
+"trouvés ici. Il montre également dans quelles découvertes le type de "
+"découverte s'est produit."
 
 #: reports/templates/partials/report_findings_table.html
 msgid "First known occurrence"
-msgstr ""
+msgstr "Premier événement connu"
 
 #: reports/templates/partials/report_findings_table.html
 msgid "Open in report"
-msgstr ""
+msgstr "Ouvrir dans le rapport"
 
 #: reports/templates/partials/report_findings_table.html
 msgid ""
 "No critical and high findings have been identified for this organization."
 msgstr ""
+"Aucune constatation critique ou élevée n’a été identifiée pour cette "
+"organisation."
 
 #: reports/templates/partials/report_findings_table.html
 msgid "No findings have been identified for this organization."
-msgstr ""
+msgstr "Aucune constatation n’a été identifiée pour cette organisation."
 
 #: reports/templates/partials/report_header.html
 msgid "Download as PDF"
-msgstr ""
+msgstr "Télécharger en tant que PDF"
 
 #: reports/templates/partials/report_header.html
 #: rocky/templates/partials/ooi_list_toolbar.html
 msgid "Download as JSON"
-msgstr ""
+msgstr "Télécharger en tant que JSON"
 
 #: reports/templates/partials/report_header.html
 msgid "Open asset reports"
-msgstr ""
+msgstr "Ouvrir des rapports sur les actifs"
 
 #: reports/templates/partials/report_header.html
 msgid "This is the OpenKAT report for organization"
-msgstr ""
+msgstr "Il s'agit du rapport OpenKAT pour l'organisation"
 
 #: reports/templates/partials/report_header.html
 msgid ""
 "All selected report types for the selected objects are displayed one below "
 "the other."
 msgstr ""
+"Tous les types de rapport sélectionnés pour les objets sélectionnés sont "
+"affichés les uns en dessous des autres."
 
 #: reports/templates/partials/report_header.html
 msgid "Created with data from:"
-msgstr ""
+msgstr "Créé avec les données de :"
 
 #: reports/templates/partials/report_header.html
 msgid "Created on:"
-msgstr ""
+msgstr "Créé le :"
 
 #: reports/templates/partials/report_header.html
 msgid "Created from recipe:"
-msgstr ""
+msgstr "Créé à partir de la recette :"
 
 #: reports/templates/partials/report_header.html
 msgid "Recipe created by:"
-msgstr ""
+msgstr "Recette créée par :"
 
 #: reports/templates/partials/report_header.html
 #, python-format
 msgid "This sector contains %(length)s scanned organizations."
-msgstr ""
+msgstr "Ce secteur contient les organisations analysées %(length)s."
 
 #: reports/templates/partials/report_header.html
 msgid "Of these organizations"
-msgstr ""
+msgstr "De ces organisations"
 
 #: reports/templates/partials/report_header.html
 msgid "organizations have tag"
-msgstr ""
+msgstr "les organisations ont une étiquette"
 
 #: reports/templates/partials/report_header.html
 msgid "The basic security scores are around "
-msgstr ""
+msgstr "Les scores de sécurité de base sont d'environ"
 
 #: reports/templates/partials/report_header.html
 #, python-format
 msgid "A total of %(total)s critical vulnerabilities have been identified."
-msgstr ""
+msgstr "Au total, des vulnérabilités critiques %(total)s ont été identifiées."
 
 #: reports/templates/partials/report_introduction.html
 msgid "Introduction"
-msgstr ""
+msgstr "Introduction"
 
 #: reports/templates/partials/report_introduction.html
 msgid ""
 "This report gives an overview of the current state of security for your "
-"organisation for the selected date. The summary section provides an overview "
-"of the selected systems (objects), plugins and reports. This is followed "
+"organisation for the selected date. The summary section provides an overview"
+" of the selected systems (objects), plugins and reports. This is followed "
 "with the findings for each report."
 msgstr ""
+"Ce rapport donne un aperçu de l'état actuel de la sécurité de votre "
+"organisation pour la date sélectionnée. La section récapitulative fournit un"
+" aperçu des systèmes (objets), plugins et rapports sélectionnés. Viennent "
+"ensuite les conclusions de chaque rapport."
 
 #: reports/templates/partials/report_names_form.html
 msgid "Report names:"
-msgstr ""
+msgstr "Noms des rapports :"
 
 #: reports/templates/partials/report_names_form.html
 #: rocky/templates/forms/widgets/checkbox_group_table.html
@@ -3930,40 +4437,40 @@ msgstr ""
 #: rocky/templates/partials/form/field_input_multiselect.html
 #: rocky/templates/partials/form/field_input_radio.html
 msgid "Required"
-msgstr ""
+msgstr "Requis"
 
 #: reports/templates/partials/report_names_form.html
 msgid "Add reference date"
-msgstr ""
+msgstr "Ajouter une date de référence"
 
 #: reports/templates/partials/report_names_form.html
 #: reports/templates/report_overview/modal_partials/rename_modal.html
 msgid "Reset"
-msgstr ""
+msgstr "Réinitialiser"
 
 #: reports/templates/partials/report_names_form.html
 msgid "No reference date"
-msgstr ""
+msgstr "Pas de date de référence"
 
 #: reports/templates/partials/report_names_form.html
 msgid "Day"
-msgstr ""
+msgstr "Jour"
 
 #: reports/templates/partials/report_names_form.html
 msgid "Week"
-msgstr ""
+msgstr "Semaine"
 
 #: reports/templates/partials/report_names_form.html
 msgid "Month"
-msgstr ""
+msgstr "Mois"
 
 #: reports/templates/partials/report_names_form.html
 msgid "Year"
-msgstr ""
+msgstr "Année"
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "Object selection"
-msgstr ""
+msgstr "Sélection d'objet"
 
 #: reports/templates/partials/report_ooi_list.html
 msgid ""
@@ -3971,52 +4478,68 @@ msgid ""
 "continue with a live set or you can select the objects manually from the "
 "table below."
 msgstr ""
+"Sélectionnez les objets que vous souhaitez inclure dans votre rapport. Vous "
+"pouvez soit continuer avec un live set, soit sélectionner les objets "
+"manuellement dans le tableau ci-dessous."
 
 #: reports/templates/partials/report_ooi_list.html
 msgid ""
-"A live set is a set of objects based on the applied filters. Any object that "
-"matches this applied filter (now or in the future) will be used as input for "
-"the scheduled report. If your live set filter (e.g. 'hostnames' with 'L2 "
-"clearance' that are 'declared') shows 2 hostnames that match the filter "
+"A live set is a set of objects based on the applied filters. Any object that"
+" matches this applied filter (now or in the future) will be used as input "
+"for the scheduled report. If your live set filter (e.g. 'hostnames' with 'L2"
+" clearance' that are 'declared') shows 2 hostnames that match the filter "
 "today, the scheduled report will run for those 2 hostnames. If you add 3 "
-"more hostnames tomorrow (with the same filter criteria), your next scheduled "
-"report will contain 5 hostnames. Your live set will update as you go."
+"more hostnames tomorrow (with the same filter criteria), your next scheduled"
+" report will contain 5 hostnames. Your live set will update as you go."
 msgstr ""
+"Un live set est un ensemble d’objets basés sur les filtres appliqués. Tout "
+"objet correspondant à ce filtre appliqué (maintenant ou dans le futur) sera "
+"utilisé comme entrée pour le rapport planifié. Si votre filtre d'ensemble en"
+" direct (par exemple, « noms d'hôte » avec « autorisation L2 » qui sont « "
+"déclarés ») affiche 2 noms d'hôte qui correspondent au filtre aujourd'hui, "
+"le rapport planifié sera exécuté pour ces 2 noms d'hôte. Si vous ajoutez 3 "
+"noms d'hôtes supplémentaires demain (avec les mêmes critères de filtrage), "
+"votre prochain rapport planifié contiendra 5 noms d'hôtes. Votre live set "
+"sera mis à jour au fur et à mesure."
 
 #: reports/templates/partials/report_ooi_list.html
 msgid ""
 "Based on the current dataset, your selected filters result in the following "
 "objects."
 msgstr ""
+"Sur la base de l'ensemble de données actuel, vos filtres sélectionnés "
+"génèrent les objets suivants."
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "objects selected"
-msgstr ""
+msgstr "objets sélectionnés"
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "Deselect all objects"
-msgstr ""
+msgstr "Désélectionner tous les objets"
 
 #: reports/templates/partials/report_ooi_list.html
 #: rocky/templates/oois/ooi_list.html
 #, python-format
 msgid "Showing %(length)s of %(total)s objects"
-msgstr ""
+msgstr "Affichage de %(length)s des objets %(total)s"
 
 #: reports/templates/partials/report_ooi_list.html
 #, python-format
 msgid "Select all %(total_oois)s object"
 msgid_plural "Select all %(total_oois)s objects"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Sélectionnez tous les objets %(total_oois)s"
+msgstr[1] "Sélectionnez tous les objets %(total_oois)s"
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "Object name"
-msgstr ""
+msgstr "Nom de l'objet"
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "Report(s) may be empty due to no objects in the selected filters."
 msgstr ""
+"Les rapports peuvent être vides car aucun objet ne figure dans les filtres "
+"sélectionnés."
 
 #: reports/templates/partials/report_ooi_list.html
 msgid ""
@@ -4024,53 +4547,63 @@ msgid ""
 "Future reports may contain data. It is still possible to generate the "
 "(potentially empty) report."
 msgstr ""
+"Les rapports correspondant aux filtres sélectionnés seront vides à ce "
+"moment-là. Les futurs rapports peuvent contenir des données. Il est toujours"
+" possible de générer le rapport (potentiellement vide)."
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "Continue with live set"
-msgstr ""
+msgstr "Continuer avec le live set"
 
 #: reports/templates/partials/report_ooi_list.html
 #: reports/templates/partials/report_types_selection.html
 msgid "Continue with selection"
-msgstr ""
+msgstr "Continuer la sélection"
 
 #: reports/templates/partials/report_setup_scan.html
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 #: reports/views/multi_report.py
 msgid "Configuration"
-msgstr ""
+msgstr "Configuration"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Set up the required plugins for this report."
-msgstr ""
+msgstr "Configurez les plugins requis pour ce rapport."
 
 #: reports/templates/partials/report_setup_scan.html
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugins"
-msgstr ""
+msgstr "Plugins"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid ""
 "KAT will be able to generate a full report when all the required and "
 "suggested boefjes are enabled."
 msgstr ""
+"KAT pourra générer un rapport complet lorsque tous les boefjes requis et "
+"suggérés seront activés."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid ""
 "If you choose not to enable a plugin, the data that plugin would collect or "
-"produce will be left out of the report which will then be generated based on "
-"the available data collected by the enabled plugins."
+"produce will be left out of the report which will then be generated based on"
+" the available data collected by the enabled plugins."
 msgstr ""
+"Si vous choisissez de ne pas activer un plugin, les données que ce plugin "
+"collecterait ou produirait seront exclues du rapport qui sera ensuite généré"
+" sur la base des données disponibles collectées par les plugins activés."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid ""
 "Some plugins are mandatory as they are crucial for a report type. Reports "
 "that don't have their requirements met will be skipped."
 msgstr ""
+"Certains plugins sont obligatoires car cruciaux pour un type de rapport. Les"
+" rapports dont les exigences ne sont pas remplies seront ignorés."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Warning! Before you proceed read the following points:"
-msgstr ""
+msgstr "Avertissement! Avant de continuer, lisez les points suivants :"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid ""
@@ -4078,57 +4611,64 @@ msgid ""
 "enabled plugins and set clearance levels. This means that scans will run "
 "automatically. Be patient; plugins may take some time before they have "
 "collected all their data. Enabling them just before report generation will "
-"likely result in inaccurate reports, as plugins have not finished collecting "
-"data."
+"likely result in inaccurate reports, as plugins have not finished collecting"
+" data."
 msgstr ""
+"OpenKAT est conçu pour analyser régulièrement tous les objets connus à "
+"l'aide des plugins activés et définir des niveaux d'autorisation. Cela "
+"signifie que les analyses s'exécuteront automatiquement. Sois patient; les "
+"plugins peuvent prendre un certain temps avant d’avoir collecté toutes leurs"
+" données. Les activer juste avant la génération du rapport entraînera "
+"probablement des rapports inexacts, car les plugins n'ont pas fini de "
+"collecter des données."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Good job! All required plugins are enabled."
-msgstr ""
+msgstr "Bon travail! Tous les plugins requis sont activés."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "This report type requires the following plugins to be enabled:"
-msgstr ""
+msgstr "Ce type de rapport nécessite l'activation des plugins suivants :"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Toggle all required plugins"
-msgstr ""
+msgstr "Basculer tous les plugins requis"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Show enabled plugins"
-msgstr ""
+msgstr "Afficher les plugins activés"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "There are no required plugins."
-msgstr ""
+msgstr "Il n’y a aucun plugin requis."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Good job! All suggested plugins are enabled."
-msgstr ""
+msgstr "Bon travail! Tous les plugins suggérés sont activés."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "The following plugins are optional to generate the report:"
-msgstr ""
+msgstr "Les plugins suivants sont facultatifs pour générer le rapport :"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Toggle all optional plugins"
-msgstr ""
+msgstr "Basculer tous les plugins facultatifs"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Hide suggested plugins"
-msgstr ""
+msgstr "Masquer les plugins suggérés"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Show more suggested plugins"
-msgstr ""
+msgstr "Afficher plus de plugins suggérés"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "There are no optional plugins."
-msgstr ""
+msgstr "Il n'y a pas de plugins optionnels."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Enable selected plugins and continue"
-msgstr ""
+msgstr "Activer les plugins sélectionnés et continuer"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid ""
@@ -4137,72 +4677,82 @@ msgid ""
 "            severity that have been identified for this organization.\n"
 "        "
 msgstr ""
+"\n"
+"Cet aperçu montre le nombre total de résultats par\n"
+"            gravité qui ont été identifiées pour cette organisation."
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Total per severity overview"
-msgstr ""
+msgstr "Aperçu du total par gravité"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Critical"
-msgstr ""
+msgstr "Critique"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "High"
-msgstr ""
+msgstr "Haut"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Medium"
-msgstr ""
+msgstr "Moyen"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Low"
-msgstr ""
+msgstr "Faible"
 
 #: reports/templates/partials/report_severity_totals_table.html
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Pending"
-msgstr ""
+msgstr "En attente"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Unknown"
-msgstr ""
+msgstr "Inconnu"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Total"
-msgstr ""
+msgstr "Total"
 
 #: reports/templates/partials/report_sidemenu.html
 msgid "Selected Objects"
-msgstr ""
+msgstr "Objets sélectionnés"
 
 #: reports/templates/partials/report_sidemenu.html
 msgid "Selected Plugins"
-msgstr ""
+msgstr "Plugins sélectionnés"
 
 #: reports/templates/partials/report_sidemenu.html
 msgid "Used Config Objects"
-msgstr ""
+msgstr "Objets de configuration utilisés"
 
 #: reports/templates/partials/report_types_selection.html
 msgid "Choose report types"
-msgstr ""
+msgstr "Choisir les types de rapports"
 
 #: reports/templates/partials/report_types_selection.html
 msgid ""
-"Various types of reports, such as DNS reports and TLS reports, are essential "
-"for identifying vulnerabilities in different aspects of a system's security. "
-"DNS reports focus on domain name system configuration and potential "
-"weaknesses, while TLS reports assess the security of data encryption and "
-"transmission protocols, helping organizations pinpoint areas where security "
-"improvements are needed."
+"Various types of reports, such as DNS reports and TLS reports, are essential"
+" for identifying vulnerabilities in different aspects of a system's "
+"security. DNS reports focus on domain name system configuration and "
+"potential weaknesses, while TLS reports assess the security of data "
+"encryption and transmission protocols, helping organizations pinpoint areas "
+"where security improvements are needed."
 msgstr ""
+"Différents types de rapports, tels que les rapports DNS et les rapports TLS,"
+" sont essentiels pour identifier les vulnérabilités dans différents aspects "
+"de la sécurité d'un système. Les rapports DNS se concentrent sur la "
+"configuration du système de noms de domaine et les faiblesses potentielles, "
+"tandis que les rapports TLS évaluent la sécurité des protocoles de cryptage "
+"et de transmission des données, aidant ainsi les organisations à identifier "
+"les domaines dans lesquels des améliorations de sécurité sont nécessaires."
 
 #: reports/templates/partials/report_types_selection.html
 #, python-format
 msgid "Selected object (%(total_oois)s)"
 msgid_plural "Selected objects (%(total_oois)s)"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Objets sélectionnés (%(total_oois)s)"
+msgstr[1] "Objets sélectionnés (%(total_oois)s)"
 
 #: reports/templates/partials/report_types_selection.html
 #, python-format
@@ -4210,43 +4760,48 @@ msgid ""
 "You have selected a live set in the previous step. Based on the current "
 "dataset, this live set results in %(total_oois)s objects."
 msgstr ""
+"Vous avez sélectionné un live set à l’étape précédente. Sur la base de "
+"l'ensemble de données actuel, cet ensemble dynamique génère des objets "
+"%(total_oois)s."
 
 #: reports/templates/partials/report_types_selection.html
 msgid "Applied filters:"
-msgstr ""
+msgstr "Filtres appliqués :"
 
 #: reports/templates/partials/report_types_selection.html
 #, python-format
 msgid "You have selected %(total_oois)s object in the previous step."
 msgid_plural "You have selected %(total_oois)s objects in the previous step."
 msgstr[0] ""
+"Vous avez sélectionné des objets %(total_oois)s à l'étape précédente."
 msgstr[1] ""
+"Vous avez sélectionné des objets %(total_oois)s à l'étape précédente."
 
 #: reports/templates/partials/report_types_selection.html
 msgid "Change selection"
-msgstr ""
+msgstr "Modifier la sélection"
 
 #: reports/templates/partials/report_types_selection.html
 msgid "Available report types"
-msgstr ""
+msgstr "Types de rapports disponibles"
 
 #: reports/templates/partials/report_types_selection.html
 msgid "All report types that are available for your selection."
-msgstr ""
+msgstr "Tous les types de rapports disponibles pour votre sélection."
 
 #: reports/templates/partials/report_types_selection.html
 msgid "Toggle all report types"
-msgstr ""
+msgstr "Basculer tous les types de rapports"
 
 #: reports/templates/partials/return_button.html
 #, python-format
 msgid "%(btn_text)s"
-msgstr ""
+msgstr "%(btn_text)s"
 
 #: reports/templates/report_overview/modal_partials/delete_modal.html
 #: reports/templates/report_overview/modal_partials/share_modal.html
 msgid "Delete the following report(s):"
-msgstr ""
+msgstr "Supprimez le(s) rapport(s) suivant(s) :"
 
 #: reports/templates/report_overview/modal_partials/delete_modal.html
 #: reports/templates/report_overview/modal_partials/share_modal.html
@@ -4255,6 +4810,10 @@ msgid ""
 "report can still be accessed on timestamps before the deletion. Only the "
 "report is removed from the view, not the data it is based on."
 msgstr ""
+"Les rapports supprimés sont supprimés de la vue dès leur suppression. Le "
+"rapport est toujours accessible sur les horodatages avant la suppression. "
+"Seul le rapport est supprimé de la vue, et non les données sur lesquelles il"
+" est basé."
 
 #: reports/templates/report_overview/modal_partials/delete_modal.html
 #: reports/templates/report_overview/modal_partials/share_modal.html
@@ -4263,6 +4822,9 @@ msgid ""
 "is part of a combined report, it will remain available in the combined "
 "report."
 msgstr ""
+"Il est toujours possible de générer un nouveau rapport pour la même date. Si"
+" le rapport fait partie d'un rapport combiné, il restera disponible dans le "
+"rapport combiné."
 
 #: reports/templates/report_overview/modal_partials/delete_modal.html
 #: reports/templates/report_overview/modal_partials/rerun_modal.html
@@ -4270,81 +4832,88 @@ msgstr ""
 #: reports/templates/report_overview/scheduled_reports_table.html
 #: reports/templates/report_overview/subreports_table.html
 msgid "Reference date"
-msgstr ""
+msgstr "Date de référence"
 
 #: reports/templates/report_overview/modal_partials/enable_disable_schedule_modal.html
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Disable schedule"
-msgstr ""
+msgstr "Désactiver le planning"
 
 #: reports/templates/report_overview/modal_partials/enable_disable_schedule_modal.html
 #, python-format
 msgid ""
-"Are you sure you want to disable the schedule for <strong>%(report_name)s</"
-"strong>? The recipe will still exist and the schedule can be enabled later "
-"on."
+"Are you sure you want to disable the schedule for "
+"<strong>%(report_name)s</strong>? The recipe will still exist and the "
+"schedule can be enabled later on."
 msgstr ""
+"Êtes-vous sûr de vouloir désactiver la planification pour "
+"<strong>%(report_name)s</strong> ? La recette existera toujours et la "
+"programmation pourra être activée ultérieurement."
 
 #: reports/templates/report_overview/modal_partials/rename_modal.html
 msgid "Rename the following report(s):"
-msgstr ""
+msgstr "Renommez le(s) rapport(s) suivant(s) :"
 
 #: reports/templates/report_overview/modal_partials/rename_modal.html
 #: reports/templates/report_overview/report_history_table.html
 msgid "Rename"
-msgstr ""
+msgstr "Rebaptiser"
 
 #: reports/templates/report_overview/modal_partials/rerun_modal.html
 msgid "Rerun the following report(s):"
-msgstr ""
+msgstr "Réexécutez le(s) rapport(s) suivant(s) :"
 
 #: reports/templates/report_overview/modal_partials/rerun_modal.html
 msgid ""
 "By submitting you're generating the selected reports again, using the "
 "current data."
 msgstr ""
+"En soumettant, vous générez à nouveau les rapports sélectionnés, en "
+"utilisant les données actuelles."
 
 #: reports/templates/report_overview/modal_partials/rerun_modal.html
 #: reports/templates/report_overview/report_history_table.html
 msgid "Rerun"
-msgstr ""
+msgstr "Rediffusion"
 
 #: reports/templates/report_overview/report_history.html
 msgid "Reports history"
-msgstr ""
+msgstr "Historique des rapports"
 
 #: reports/templates/report_overview/report_history.html
 msgid ""
 "On this page you can see all the reports that have been generated in the "
 "past. To create a new report, click the 'Generate Report' button."
 msgstr ""
+"Sur cette page, vous pouvez voir tous les rapports générés dans le passé. "
+"Pour créer un nouveau rapport, cliquez sur le bouton « Générer un rapport »."
 
 #: reports/templates/report_overview/report_history_table.html
 #: reports/templates/report_overview/subreports.html
 #, python-format
 msgid "Showing %(length)s of %(total)s reports"
-msgstr ""
+msgstr "Affichage des rapports %(length)s sur %(total)s"
 
 #: reports/templates/report_overview/report_history_table.html
 #: rocky/templates/tasks/reports.html
 msgid "Reports:"
-msgstr ""
+msgstr "Rapports :"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "Shows parent report details"
-msgstr ""
+msgstr "Affiche les détails du rapport parent"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "Close asset report object details"
-msgstr ""
+msgstr "Fermer les détails de l'objet du rapport sur les actifs"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "Open asset report object details"
-msgstr ""
+msgstr "Ouvrir les détails de l'objet du rapport sur les actifs"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "Asset reports details"
-msgstr ""
+msgstr "Détails des rapports sur les actifs"
 
 #: reports/templates/report_overview/report_history_table.html
 #, python-format
@@ -4355,129 +4924,137 @@ msgid_plural ""
 "This report consists of %(counter)s asset reports with the following report "
 "types and objects:"
 msgstr[0] ""
+"Ce rapport se compose de rapports d'actifs %(counter)s avec les types de "
+"rapport et les objets suivants :"
 msgstr[1] ""
+"Ce rapport se compose de rapports d'actifs %(counter)s avec les types de "
+"rapport et les objets suivants :"
 
 #: reports/templates/report_overview/report_history_table.html
 #: reports/templates/report_overview/subreports_header.html
 #: reports/templates/report_overview/subreports_table.html
 #: reports/views/report_overview.py
 msgid "Asset reports"
-msgstr ""
+msgstr "Rapports sur les actifs"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "Shows asset report details"
-msgstr ""
+msgstr "Affiche les détails du rapport sur les actifs"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "View all asset reports"
-msgstr ""
+msgstr "Afficher tous les rapports sur les actifs"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "No reports have been generated yet."
-msgstr ""
+msgstr "Aucun rapport n'a encore été généré."
 
 #: reports/templates/report_overview/report_overview_header.html
 #: reports/views/base.py rocky/templates/header.html
 #: rocky/templates/tasks/partials/tab_navigation.html
 #: rocky/templates/tasks/reports.html rocky/views/tasks.py
 msgid "Reports"
-msgstr ""
+msgstr "Rapports"
 
 #: reports/templates/report_overview/report_overview_header.html
 msgid "An overview of reports that are scheduled or have been generated."
-msgstr ""
+msgstr "Un aperçu des rapports planifiés ou générés."
 
 #: reports/templates/report_overview/report_overview_navigation.html
 msgid "Scheduled"
-msgstr ""
+msgstr "Programmé"
 
 #: reports/templates/report_overview/report_overview_navigation.html
 msgid "History"
-msgstr ""
+msgstr "Histoire"
 
 #: reports/templates/report_overview/scheduled_reports.html
 msgid "Scheduled reports"
-msgstr ""
+msgstr "Rapports planifiés"
 
 #: reports/templates/report_overview/scheduled_reports.html
 msgid ""
-"On this page you can see all the reports that are or have been scheduled. To "
-"schedule a report, select a start date and recurrence while generating a "
+"On this page you can see all the reports that are or have been scheduled. To"
+" schedule a report, select a start date and recurrence while generating a "
 "report."
 msgstr ""
+"Sur cette page, vous pouvez voir tous les rapports qui sont ou ont été "
+"planifiés. Pour planifier un rapport, sélectionnez une date de début et une "
+"récurrence lors de la génération d'un rapport."
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 #, python-format
 msgid "Showing %(length)s of %(total)s schedules"
-msgstr ""
+msgstr "Affichage des programmes %(length)s sur %(total)s"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Scheduled reports:"
-msgstr ""
+msgstr "Rapports programmés :"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Scheduled for"
-msgstr ""
+msgstr "Prévu pour"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Schedule status"
-msgstr ""
+msgstr "Statut de planification"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Once"
-msgstr ""
+msgstr "Une fois"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Recent reports"
-msgstr ""
+msgstr "Rapports récents"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Scheduled Reports:"
-msgstr ""
+msgstr "Rapports programmés :"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Show report details"
-msgstr ""
+msgstr "Afficher les détails du rapport"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "objects"
-msgstr ""
+msgstr "objets"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Enable schedule"
-msgstr ""
+msgstr "Activer le calendrier"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "No scheduled reports have been generated yet."
-msgstr ""
+msgstr "Aucun rapport planifié n'a encore été généré."
 
 #: reports/templates/report_overview/subreports_header.html
 msgid "Back to Reports History"
-msgstr ""
+msgstr "Retour à l'historique des rapports"
 
 #: reports/templates/report_overview/subreports_header.html
 msgid "An overview of all underlying reports of"
-msgstr ""
+msgstr "Un aperçu de tous les rapports sous-jacents de"
 
 #: reports/templates/report_overview/subreports_header.html
 #: reports/templates/report_overview/subreports_table.html
 msgid "Shows report details"
-msgstr ""
+msgstr "Affiche les détails du rapport"
 
 #: reports/templates/report_overview/subreports_table.html
 #: rocky/templates/tasks/boefjes.html
 #: rocky/templates/tasks/plugin_detail_task_list.html
 msgid "Input Object"
-msgstr ""
+msgstr "Objet d'entrée"
 
 #: reports/templates/report_schedules/delete_recipe_modal.html
 msgid "Delete report recipe"
-msgstr ""
+msgstr "Supprimer la recette du rapport"
 
 #: reports/templates/report_schedules/delete_recipe_modal.html
 #, python-format
 msgid "Are you sure you want to delete report recipe \"%(name)s\"?"
 msgstr ""
+"Etes-vous sûr de vouloir supprimer la recette de rapport « %(name)s » ?"
 
 #: reports/templates/report_schedules/delete_recipe_modal.html
 msgid ""
@@ -4485,164 +5062,192 @@ msgid ""
 "not be possible anymore to see or enable the schedule. You will find "
 "previously generated reports in the report history tab."
 msgstr ""
+"La suppression de cette recette de rapport signifie qu'elle sera "
+"définitivement supprimée. Il ne sera plus possible de voir ou d'activer le "
+"planning. Vous trouverez les rapports générés précédemment dans l'onglet "
+"Historique des rapports."
 
 #: reports/templates/summary/report_asset_overview.html
 msgid ""
-"The objects listed in the table below were used to generate this report. For "
-"each object in the table it additionally shows the clearance level and "
+"The objects listed in the table below were used to generate this report. For"
+" each object in the table it additionally shows the clearance level and "
 "whether or not the object was added by a user ('Declared') or indirectly "
 "identified through another service or system ('Inherited')."
 msgstr ""
+"Les objets répertoriés dans le tableau ci-dessous ont été utilisés pour "
+"générer ce rapport. Pour chaque objet du tableau, il indique en outre le "
+"niveau d'autorisation et si l'objet a été ajouté ou non par un utilisateur "
+"(« Déclaré ») ou indirectement identifié via un autre service ou système (« "
+"Hérité »)."
 
 #: reports/templates/summary/report_asset_overview.html
 msgid "No objects found."
-msgstr ""
+msgstr "Aucun objet trouvé."
 
 #: reports/templates/summary/report_asset_overview.html
 msgid ""
 "The table below shows which reports were chosen to generate this report, "
 "including a report description."
 msgstr ""
+"Le tableau ci-dessous montre quels rapports ont été choisis pour générer ce "
+"rapport, y compris une description du rapport."
 
 #: reports/templates/summary/report_asset_overview.html
 msgid "No report types found."
-msgstr ""
+msgstr "Aucun type de rapport trouvé."
 
 #: reports/templates/summary/selected_plugins.html
 msgid ""
 "The table below shows all required or optional plugins for the selected "
 "reports."
 msgstr ""
+"Le tableau ci-dessous montre tous les plugins requis ou facultatifs pour les"
+" rapports sélectionnés."
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Required and optional plugins"
-msgstr ""
+msgstr "Plugins obligatoires et facultatifs"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugin enabled"
-msgstr ""
+msgstr "Plugin activé"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugin options"
-msgstr ""
+msgstr "Options du plugin"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugin scan level"
-msgstr ""
+msgstr "Niveau d'analyse du plugin"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Enabled."
-msgstr ""
+msgstr "Activé."
 
 #: reports/templates/summary/selected_plugins.html
 msgid "required"
-msgstr ""
+msgstr "requis"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "optional"
-msgstr ""
+msgstr "facultatif"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugin extra info"
-msgstr ""
+msgstr "Informations supplémentaires sur le plugin"
 
 #: reports/templates/summary/selected_plugins.html
 msgid ""
 "There are no required or optional plugins needed for the selected report "
 "types."
 msgstr ""
+"Aucun plug-in obligatoire ou facultatif n'est requis pour les types de "
+"rapports sélectionnés."
 
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 #: reports/views/multi_report.py
 msgid "Select objects"
-msgstr ""
+msgstr "Sélectionner des objets"
 
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 #: reports/views/multi_report.py
 msgid "Select report types"
-msgstr ""
+msgstr "Sélectionnez les types de rapports"
 
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 #: reports/views/multi_report.py
 msgid "Export setup"
-msgstr ""
+msgstr "Exporter la configuration"
 
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 msgid "Save report"
-msgstr ""
+msgstr "Enregistrer le rapport"
 
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 msgid "You do not have the required permissions to enable plugins."
 msgstr ""
+"Vous ne disposez pas des autorisations requises pour activer les plugins."
 
 #: reports/views/base.py
 msgid "Select at least one OOI to proceed."
-msgstr ""
+msgstr "Sélectionnez au moins un OOI pour continuer."
 
 #: reports/views/base.py
 msgid "Select at least one report type to proceed."
-msgstr ""
+msgstr "Sélectionnez au moins un type de rapport pour continuer."
 
 #: reports/views/mixins.py
 msgid ""
 "No data could be found for %(report_types). Object(s) did not exist on "
 "%(date)s."
 msgstr ""
+"Aucune donnée n'a pu être trouvée pour %(report_types). Les objets "
+"n'existaient pas sur %(date)s."
 
 #: reports/views/multi_report.py
 msgid "View report"
-msgstr ""
+msgstr "Afficher le rapport"
 
 #: reports/views/report_overview.py
 msgid "Not enough permissions"
-msgstr ""
+msgstr "Pas assez d'autorisations"
 
 #: reports/views/report_overview.py
 msgid "Recipe '{}' deleted successfully"
-msgstr ""
+msgstr "La recette '{}' a été supprimée avec succès"
 
 #: reports/views/report_overview.py
 msgid "Recipe not found."
-msgstr ""
+msgstr "Recette introuvable."
 
 #: reports/views/report_overview.py
 msgid "No schedule or recipe selected"
-msgstr ""
+msgstr "Aucun horaire ni recette sélectionné"
 
 #: reports/views/report_overview.py
 msgid ""
 "Schedule disabled successfully. '{}' will not be generated automatically "
 "until the schedule is enabled again."
 msgstr ""
+"Planification désactivée avec succès. '{}' ne sera pas généré "
+"automatiquement tant que la planification n'est pas réactivée."
 
 #: reports/views/report_overview.py
 msgid ""
 "Schedule enabled successfully. '{}' will be generated according to schedule."
 msgstr ""
+"Planification activée avec succès. '{}' sera généré selon le calendrier."
 
 #: reports/views/report_overview.py
 msgid "An unexpected error occurred, please check logs for more info."
 msgstr ""
+"Une erreur inattendue s'est produite. Veuillez consulter les journaux pour "
+"plus d'informations."
 
 #: reports/views/report_overview.py
 msgid "Other OOI type selected than Report"
-msgstr ""
+msgstr "Autre type OOI sélectionné que Rapport"
 
 #: reports/views/report_overview.py
 msgid "Deletion successful."
-msgstr ""
+msgstr "Suppression réussie."
 
 #: reports/views/report_overview.py
 msgid ""
 "Multi organization reports cannot be rescheduled. It consists of imported "
 "data from different organizations and is not based on newly generated data."
 msgstr ""
+"Les rapports multi-organisations ne peuvent pas être reprogrammés. Il se "
+"compose de données importées de différentes organisations et n'est pas basé "
+"sur des données nouvellement générées."
 
 #: reports/views/report_overview.py
 msgid ""
 "Rerun successful. It may take a moment before the new report has been "
 "generated."
 msgstr ""
+"Réexécution réussie. Cela peut prendre un moment avant que le nouveau "
+"rapport soit généré."
 
 #: reports/views/report_overview.py
 #, python-format
@@ -4650,379 +5255,393 @@ msgid ""
 "Couldn't rerun %s, since the recipe for this report has been disabled or "
 "deleted."
 msgstr ""
+"Impossible de réexécuter %s, car la recette de ce rapport a été désactivée "
+"ou supprimée."
 
 #: reports/views/report_overview.py
 msgid "Renaming failed. Empty report name found."
-msgstr ""
+msgstr "Le changement de nom a échoué. Nom de rapport vide trouvé."
 
 #: reports/views/report_overview.py
 msgid "Report names and reports does not match."
-msgstr ""
+msgstr "Les noms des rapports et les rapports ne correspondent pas."
 
 #: reports/views/report_overview.py
 msgid "Reports successfully renamed."
-msgstr ""
+msgstr "Rapports renommés avec succès."
 
 #: reports/views/report_overview.py
 msgid "Report {} could not be renamed."
-msgstr ""
+msgstr "Le rapport {} n'a pas pu être renommé."
 
 #: reports/views/view_helpers.py
 msgid "1: Select objects"
-msgstr ""
+msgstr "1 : Sélectionner des objets"
 
 #: reports/views/view_helpers.py
 msgid "2: Choose report types"
-msgstr ""
+msgstr "2 : Choisissez les types de rapports"
 
 #: reports/views/view_helpers.py
 msgid "3: Configuration"
-msgstr ""
+msgstr "3 : Configuration"
 
 #: reports/views/view_helpers.py
 msgid "4: Export setup"
-msgstr ""
+msgstr "4 : Exporter la configuration"
 
 #: reports/views/view_helpers.py
 msgid "3: Export setup"
-msgstr ""
+msgstr "3 : Exporter la configuration"
 
 #: tools/forms/base.py
 msgid "Date"
-msgstr ""
-
-#: tools/forms/base.py tools/forms/scheduler.py
-msgid "The selected date is in the future. Please select a different date."
-msgstr ""
+msgstr "Date"
 
 #: tools/forms/boefje.py
 msgid "For example: -sTU --top-ports 1000"
-msgstr ""
+msgstr "Par exemple : -sTU --top-ports 1000"
 
 #: tools/forms/boefje.py
 msgid "JSON Schema"
-msgstr ""
+msgstr "Schéma JSON"
 
 #: tools/forms/boefje.py
 msgid "Input object type"
-msgstr ""
+msgstr "Type d'objet d'entrée"
 
 #: tools/forms/boefje.py
 msgid "Output mime types"
-msgstr ""
+msgstr "Types MIME de sortie"
 
 #: tools/forms/boefje.py
 msgid "Scan type"
-msgstr ""
+msgstr "Type de numérisation"
 
 #: tools/forms/boefje.py
 msgid "Interval amount"
-msgstr ""
+msgstr "Montant de l'intervalle"
 
 #: tools/forms/boefje.py
 msgid ""
 "Specify the scanning interval for this Boefje. The default is 24 hours. For "
 "example: 5 minutes will let the Boefje scan every 5 minutes."
 msgstr ""
+"Spécifiez l'intervalle d'analyse pour ce Boefje. La valeur par défaut est de"
+" 24 heures. Par exemple : 5 minutes permettront au Boefje d'analyser toutes "
+"les 5 minutes."
 
 #: tools/forms/boefje.py
 msgid "Interval frequency"
-msgstr ""
+msgstr "Fréquence d'intervalle"
 
 #: tools/forms/boefje.py
 msgid "Object creation/change"
-msgstr ""
+msgstr "Création/modification d'objet"
 
 #: tools/forms/boefje.py
 msgid ""
 "Choose weather the Boefje should run after creating and/or changing an "
 "object. "
 msgstr ""
+"Choisissez la météo dans laquelle le Boefje doit s'exécuter après la "
+"création et/ou la modification d'un objet."
 
 #: tools/forms/finding_type.py
 msgid "KAT-ID"
-msgstr ""
+msgstr "KAT-ID"
 
 #: tools/forms/finding_type.py
 msgid "Unique ID within OpenKAT, for this type"
-msgstr ""
+msgstr "ID unique dans OpenKAT, pour ce type"
 
 #: tools/forms/finding_type.py
 msgid "Title"
-msgstr ""
+msgstr "Titre"
 
 #: tools/forms/finding_type.py
 msgid "Give the finding type a fitting title"
-msgstr ""
+msgstr "Donnez au type de résultat un titre approprié"
 
 #: tools/forms/finding_type.py
 msgid "Describe the finding type"
-msgstr ""
+msgstr "Décrire le type de résultat"
 
 #: tools/forms/finding_type.py
 msgid "Risk"
-msgstr ""
+msgstr "Risque"
 
 #: tools/forms/finding_type.py
 msgid "Solution"
-msgstr ""
+msgstr "Solution"
 
 #: tools/forms/finding_type.py
 msgid "How can this be solved?"
-msgstr ""
+msgstr "Comment résoudre ce problème ?"
 
 #: tools/forms/finding_type.py
 msgid "Describe how this type of finding can be solved"
-msgstr ""
+msgstr "Décrire comment ce type de constatation peut être résolu"
 
 #: tools/forms/finding_type.py
 msgid "References"
-msgstr ""
+msgstr "Références"
 
 #: tools/forms/finding_type.py
 msgid "Please give some references on the solution"
-msgstr ""
+msgstr "Veuillez donner quelques références sur la solution"
 
 #: tools/forms/finding_type.py
 msgid "Please give sources and references on the suggested solution"
 msgstr ""
+"Veuillez donner des sources et des références sur la solution suggérée"
 
 #: tools/forms/finding_type.py
 msgid "Impact description"
-msgstr ""
+msgstr "Description des impacts"
 
 #: tools/forms/finding_type.py
 msgid "Describe the solutions impact"
-msgstr ""
+msgstr "Décrire l'impact des solutions"
 
 #: tools/forms/finding_type.py
 msgid "Solution chance"
-msgstr ""
+msgstr "Chance de solution"
 
 #: tools/forms/finding_type.py
 msgid "Solution impact"
-msgstr ""
+msgstr "Impact des solutions"
 
 #: tools/forms/finding_type.py
 msgid "Solution effort"
-msgstr ""
+msgstr "Effort de solution"
 
 #: tools/forms/finding_type.py
 msgid "ID should start with "
-msgstr ""
+msgstr "L'identifiant doit commencer par"
 
 #: tools/forms/finding_type.py
 msgid "Finding type already exists"
-msgstr ""
+msgstr "Le type de recherche existe déjà"
 
 #: tools/forms/finding_type.py
 msgid "Click to select one of the available options"
-msgstr ""
+msgstr "Cliquez pour sélectionner l'une des options disponibles"
 
 #: tools/forms/finding_type.py
 #: rocky/templates/partials/finding_occurrence_definition_list.html
 msgid "Proof"
-msgstr ""
+msgstr "Preuve"
 
 #: tools/forms/finding_type.py
 msgid "Provide evidence of your finding"
-msgstr ""
+msgstr "Fournissez la preuve de votre découverte"
 
 #: tools/forms/finding_type.py
 msgid "Describe your finding"
-msgstr ""
+msgstr "Décrivez votre découverte"
 
 #: tools/forms/finding_type.py
 msgid "Reproduce finding"
-msgstr ""
+msgstr "Reproduire le résultat"
 
 #: tools/forms/finding_type.py
 msgid "Please explain how to reproduce your finding"
-msgstr ""
+msgstr "Veuillez expliquer comment reproduire votre découverte"
 
 #: tools/forms/finding_type.py tools/forms/upload_raw.py
 msgid "Date/Time (UTC)"
-msgstr ""
+msgstr "Date/heure (UTC)"
 
 #: tools/forms/finding_type.py tools/forms/upload_raw.py
 msgid "Doc! I'm from the future, I'm here to take you back!"
-msgstr ""
+msgstr "Docteur ! Je viens du futur, je suis là pour te ramener !"
 
 #: tools/forms/finding_type.py
 msgid "OOI doesn't exist"
-msgstr ""
+msgstr "OOI n'existe pas"
 
 #: tools/forms/findings.py
 msgid "Show non-muted findings"
-msgstr ""
+msgstr "Afficher les résultats non masqués"
 
 #: tools/forms/findings.py
 msgid "Show muted findings"
-msgstr ""
+msgstr "Afficher les résultats masqués"
 
 #: tools/forms/findings.py
 msgid "Show muted and non-muted findings"
-msgstr ""
+msgstr "Afficher les résultats masqués et non masqués"
 
 #: tools/forms/findings.py
 msgid "Filter by severity"
-msgstr ""
+msgstr "Filtrer par gravité"
 
 #: tools/forms/findings.py
 msgid "Filter by muted findings"
-msgstr ""
+msgstr "Filtrer par résultats masqués"
 
 #: tools/forms/findings.py tools/forms/ooi_form.py tools/forms/scheduler.py
 msgid "Search"
-msgstr ""
+msgstr "Recherche"
 
 #: tools/forms/findings.py
 msgid "Object ID contains (case sensitive)"
-msgstr ""
+msgstr "L'ID d'objet contient (sensible à la casse)"
 
 #: tools/forms/ooi.py
 msgid "Filter types"
-msgstr ""
+msgstr "Types de filtres"
 
 #: tools/forms/ooi.py
 msgid "Clearance Level"
-msgstr ""
+msgstr "Niveau de dégagement"
 
 #: tools/forms/ooi.py
 msgid "Next scan"
-msgstr ""
+msgstr "Analyse suivante"
 
 #: tools/forms/ooi.py
 msgid "Show objects that don't meet the Boefjes scan level."
 msgstr ""
+"Afficher les objets qui ne correspondent pas au niveau d'analyse Boefjes."
 
 #: tools/forms/ooi.py
 msgid "Show Boefjes that exceed the objects clearance level."
 msgstr ""
+"Afficher les Boefjes qui dépassent le niveau de dégagement des objets."
 
 #: tools/forms/ooi.py
 msgid ""
-"All the boefjes with a scan level below or equal to the clearance level will "
-"be allowed to scan this object."
+"All the boefjes with a scan level below or equal to the clearance level will"
+" be allowed to scan this object."
 msgstr ""
+"Tous les boefjes avec un niveau de scan inférieur ou égal au niveau "
+"d'autorisation seront autorisés à scanner cet objet."
 
 #: tools/forms/ooi.py
 msgid "Expires by (UTC)"
-msgstr ""
+msgstr "Expire le (UTC)"
 
 #: tools/forms/ooi_form.py
 msgid "option"
-msgstr ""
+msgstr "option"
 
 #: tools/forms/ooi_form.py
 #, python-brace-format
 msgid "Optionally choose a {option_label}"
-msgstr ""
+msgstr "Choisissez éventuellement un {option_label}"
 
 #: tools/forms/ooi_form.py
 #, python-brace-format
 msgid "Please choose a {option_label}"
-msgstr ""
+msgstr "Veuillez choisir un {option_label}"
 
 #: tools/forms/ooi_form.py
 msgid "Filter by clearance level"
-msgstr ""
+msgstr "Filtrer par niveau d'autorisation"
 
 #: tools/forms/ooi_form.py
 msgid "Filter by clearance type"
-msgstr ""
+msgstr "Filtrer par type de dégagement"
 
 #: tools/forms/scheduler.py
 msgid "From"
-msgstr ""
+msgstr "Depuis"
 
 #: tools/forms/scheduler.py
 msgid "To"
-msgstr ""
+msgstr "À"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Cancelled"
-msgstr ""
+msgstr "Annulé"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Completed"
-msgstr ""
+msgstr "Complété"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Dispatched"
-msgstr ""
+msgstr "Expédié"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Failed"
-msgstr ""
+msgstr "Échoué"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Queued"
-msgstr ""
+msgstr "En file d'attente"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Running"
-msgstr ""
+msgstr "En cours d'exécution"
 
 #: tools/forms/scheduler.py
 msgid "Search by object name"
+msgstr "Rechercher par nom d'objet"
+
+#: tools/forms/scheduler.py
+msgid "The selected date is in the future. Please select a different date."
 msgstr ""
+"La date sélectionnée est dans le futur. Veuillez sélectionner une autre "
+"date."
 
 #: tools/forms/settings.py
 msgid "--- Show all ----"
-msgstr ""
+msgstr "--- Afficher tout ----"
 
 #: tools/forms/settings.py
 msgid "recommendation"
-msgstr ""
+msgstr "recommandation"
 
 #: tools/forms/settings.py
 msgid "low"
-msgstr ""
+msgstr "faible"
 
 #: tools/forms/settings.py
 msgid "medium"
-msgstr ""
+msgstr "moyen"
 
 #: tools/forms/settings.py
 msgid "high"
-msgstr ""
+msgstr "haut"
 
 #: tools/forms/settings.py
 msgid "very high"
-msgstr ""
+msgstr "très élevé"
 
 #: tools/forms/settings.py
 msgid "critical"
-msgstr ""
+msgstr "critique"
 
 #: tools/forms/settings.py
 msgid "quickfix"
-msgstr ""
+msgstr "solution rapide"
 
 #: tools/forms/settings.py
 msgid "Declared"
-msgstr ""
+msgstr "Déclaré"
 
 #: tools/forms/settings.py
 msgid "Inherited"
-msgstr ""
+msgstr "Hérité"
 
 #: tools/forms/settings.py
 msgid "Empty"
-msgstr ""
+msgstr "Vide"
 
 #: tools/forms/settings.py
 msgid "Add one finding type ID per line."
-msgstr ""
+msgstr "Ajoutez un ID de type de résultat par ligne."
 
 #: tools/forms/settings.py
 msgid "Add the date and time of your finding (UTC)"
-msgstr ""
+msgstr "Ajoutez la date et l'heure de votre découverte (UTC)"
 
 #: tools/forms/settings.py
 msgid "Add the date and time of when the raw file was generated (UTC)"
-msgstr ""
+msgstr "Ajoutez la date et l'heure de génération du fichier brut (UTC)"
 
 #: tools/forms/settings.py
 msgid ""
@@ -5030,20 +5649,30 @@ msgid ""
 "to see the status of your network through time. Select a datetime to change "
 "the view to represent that moment in time."
 msgstr ""
+"Le OpenKAT stocke une indication horaire avec chaque observation, il est "
+"donc possible de voir l'état de votre réseau au fil du temps. Sélectionnez "
+"une date/heure pour modifier la vue afin de représenter ce moment dans le "
+"temps."
 
 #: tools/forms/settings.py
 msgid ""
-"<p>The name of the Docker image. For example: <i>'ghcr.io/minvws/openkat/"
-"nmap'</i>. In OpenKAT, all Boefjes with the same container image will be "
-"seen as 'variants' and will be shown together on the Boefje detail page. </"
-"p> "
+"<p>The name of the Docker image. For example: "
+"<i>'ghcr.io/minvws/openkat/nmap'</i>. In OpenKAT, all Boefjes with the same "
+"container image will be seen as 'variants' and will be shown together on the"
+" Boefje detail page. </p> "
 msgstr ""
+"<p>Le nom de l’image Docker. Par exemple : "
+"<i>'ghcr.io/minvws/openkat/nmap'</i>. Dans OpenKAT, tous les Boefjes avec la"
+" même image de conteneur seront considérés comme des « variantes » et seront"
+" affichés ensemble sur la page de détails de Boefje. </p>"
 
 #: tools/forms/settings.py
 msgid ""
 "A description of the Boefje explaining in short what it can do. This will "
 "both be displayed inside the KAT-alogus and on the Boefje details page."
 msgstr ""
+"Une description du Boefje expliquant en bref ce qu'il peut faire. Ceci sera "
+"à la fois affiché dans l'alogus KAT et sur la page de détails du Boefje."
 
 #: tools/forms/settings.py
 msgid ""
@@ -5051,164 +5680,201 @@ msgid ""
 "objects, press and hold the 'ctrl'/'command' key and then click the items "
 "you want to select. "
 msgstr ""
+"Sélectionnez le(s) type(s) d'objet consommé(s) par votre Boefje. Pour "
+"sélectionner plusieurs objets, appuyez et maintenez la touche « ctrl »/« "
+"commande », puis cliquez sur les éléments que vous souhaitez sélectionner."
 
 #: tools/forms/settings.py
 msgid ""
 "<p>If any other settings are needed for your Boefje, add these as a JSON "
 "Schema, otherwise, leave the field empty or 'null'.</p> <p> This JSON is "
-"used as the basis for a form for the user. When the user enables this Boefje "
-"they can get the option to give extra information. For example, it can "
+"used as the basis for a form for the user. When the user enables this Boefje"
+" they can get the option to give extra information. For example, it can "
 "contain an API key that the script requires.</p> <p>More information about "
-"what the schema.json file looks like can be found <a href='https://docs."
-"openkat.nl/developer_documentation/development_tutorial/creating_a_boefje."
-"html'> here</a>.</p> "
+"what the schema.json file looks like can be found <a "
+"href='https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html'>"
+" here</a>.</p> "
 msgstr ""
+"<p>Si d'autres paramètres sont nécessaires pour votre Boefje, ajoutez-les en"
+" tant que schéma JSON, sinon laissez le champ vide ou « nul ».</p> <p> Ce "
+"JSON est utilisé comme base pour un formulaire pour l'utilisateur. Lorsque "
+"l'utilisateur active ce Boefje, il peut avoir la possibilité de donner des "
+"informations supplémentaires. Par exemple, il peut contenir une clé API "
+"requise par le script.</p> <p>Plus d'informations sur l'apparence du fichier"
+" schema.json peuvent être trouvées <a "
+"href='https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html'>"
+" ici</a>.</p>"
 
 #: tools/forms/settings.py
 msgid ""
 "<p>Add a set of mime types that are produced by this Boefje, separated by "
-"commas. For example: <i>'text/html'</i>, <i>'image/jpeg'</i> or <i>'boefje/"
-"{boefje-id}'</i></p> <p>These output mime types will be shown on the Boefje "
-"detail page as information for other users. </p> "
+"commas. For example: <i>'text/html'</i>, <i>'image/jpeg'</i> or "
+"<i>'boefje/{boefje-id}'</i></p> <p>These output mime types will be shown on "
+"the Boefje detail page as information for other users. </p> "
 msgstr ""
+"<p>Ajoutez un ensemble de types MIME produits par ce Boefje, séparés par des"
+" virgules. Par exemple : <i>'text/html'</i>, <i>'image/jpeg'</i> ou "
+"<i>'boefje/{boefje-id}'</i></p> <p>Ces types MIME de sortie seront affichés "
+"sur le Page de détails Boefje à titre d'information pour les autres "
+"utilisateurs. </p>"
 
 #: tools/forms/settings.py
 msgid ""
 "<p>Select a clearance level for your Boefje. For more information about the "
-"different clearance levels please check the <a href='https://docs.openkat.nl/"
-"manual/usermanual.html#scan-levels-clearance-indemnities'> documentation</a>."
-"</p> "
+"different clearance levels please check the <a "
+"href='https://docs.openkat.nl/manual/usermanual.html#scan-levels-clearance-"
+"indemnities'> documentation</a>.</p> "
 msgstr ""
+"<p>Sélectionnez un niveau de dégagement pour votre Boefje. Pour plus "
+"d'informations sur les différents niveaux de dégagement, veuillez consulter "
+"la documentation <a "
+"href='https://docs.openkat.nl/manual/usermanual.html#scan-levels-clearance-"
+"indemnities'></a>.</p>"
 
 #: tools/forms/settings.py
 msgid ""
-"Choose when this Boefje will scan objects. It can run on a given interval or "
-"it can run every time an object has been created or changed. "
+"Choose when this Boefje will scan objects. It can run on a given interval or"
+" it can run every time an object has been created or changed. "
 msgstr ""
+"Choisissez quand ce Boefje analysera les objets. Il peut s'exécuter à un "
+"intervalle donné ou à chaque fois qu'un objet est créé ou modifié."
 
 #: tools/forms/settings.py
 msgid "Depth of the tree."
-msgstr ""
+msgstr "Profondeur de l'arbre."
 
 #: tools/forms/upload_csv.py
 msgid "Only CSV file supported"
-msgstr ""
+msgstr "Seul le fichier CSV est pris en charge"
 
 #: tools/forms/upload_csv.py
 msgid "File could not be decoded"
-msgstr ""
+msgstr "Le fichier n'a pas pu être décodé"
 
 #: tools/forms/upload_csv.py
 msgid "No file selected"
-msgstr ""
+msgstr "Aucun fichier sélectionné"
 
 #: tools/forms/upload_csv.py
 msgid "The uploaded file is empty."
-msgstr ""
+msgstr "Le fichier téléchargé est vide."
 
 #: tools/forms/upload_csv.py
 msgid "The number of columns do not meet the requirements."
-msgstr ""
+msgstr "Le nombre de colonnes ne répond pas aux exigences."
 
 #: tools/forms/upload_csv.py
 msgid "OOI Type in CSV does not meet the criteria."
-msgstr ""
+msgstr "OOI Le type dans CSV ne répond pas aux critères."
 
 #: tools/forms/upload_csv.py
 msgid "An error has occurred during the parsing of the csv file:"
-msgstr ""
+msgstr "Une erreur s'est produite lors de l'analyse du fichier csv :"
 
 #: tools/forms/upload_csv.py
 msgid "Upload CSV file"
-msgstr ""
+msgstr "Téléchargez le fichier CSV"
 
 #: tools/forms/upload_csv.py
 msgid "Only accepts CSV file."
-msgstr ""
+msgstr "N'accepte que le fichier CSV."
 
 #: tools/forms/upload_oois.py rocky/templates/partials/explanations.html
 msgid "Object Type"
-msgstr ""
+msgstr "Type d'objet"
 
 #: tools/forms/upload_oois.py
 msgid "Choose a type of which objects are added."
-msgstr ""
+msgstr "Choisissez un type d'objets à ajouter."
 
 #: tools/forms/upload_raw.py
 msgid "Mime types"
-msgstr ""
+msgstr "Types de mimes"
 
 #: tools/forms/upload_raw.py
 msgid ""
-"<p>Add a set of mime types, separated by commas, for example:</"
-"p><p><i>\"text/html, image/jpeg\"</i> or <i>\"boefje/dns-records\"</i>.</"
-"p><p>Mime types are used to match the correct normalizer to a raw file. When "
-"the mime type \"boefje/dns-records\" is added, the normalizer expects the "
-"raw file to contain dns scan information.</p>"
+"<p>Add a set of mime types, separated by commas, for "
+"example:</p><p><i>\"text/html, image/jpeg\"</i> or <i>\"boefje/dns-"
+"records\"</i>.</p><p>Mime types are used to match the correct normalizer to "
+"a raw file. When the mime type \"boefje/dns-records\" is added, the "
+"normalizer expects the raw file to contain dns scan information.</p>"
 msgstr ""
+"<p>Ajoutez un ensemble de types MIME, séparés par des virgules, par "
+"exemple :</p><p><i>\"text/html, image/jpeg\"</i> ou Les types "
+"<i>\"boefje/dns-records\"</i>.</p><p>Mime sont utilisés pour faire "
+"correspondre le normalisateur correct à un fichier brut. Lorsque le type "
+"MIME « boefje/dns-records » est ajouté, le normaliseur s'attend à ce que le "
+"fichier brut contienne des informations d'analyse DNS.</p>"
 
 #: tools/forms/upload_raw.py rocky/templates/partials/ooi_list_toolbar.html
 #: rocky/templates/upload_raw.html
 msgid "Upload raw file"
-msgstr ""
+msgstr "Télécharger le fichier brut"
 
 #: tools/forms/upload_raw.py
 msgid "Input or Scan OOI"
-msgstr ""
+msgstr "Saisir ou numériser OOI"
 
 #: tools/forms/upload_raw.py
 msgid "Click to select one of the available options, or type one yourself"
 msgstr ""
+"Cliquez pour sélectionner l'une des options disponibles ou saisissez-en une "
+"vous-même"
 
 #: tools/forms/upload_raw.py
 msgid "OOI doesn't exist, try another valid time"
-msgstr ""
+msgstr "OOI n'existe pas, essayez une autre heure valide"
 
 #: tools/models.py
 msgid ""
-"A short code containing only lower-case unicode letters, numbers, hyphens or "
-"underscores that will be used in URLs and paths."
+"A short code containing only lower-case unicode letters, numbers, hyphens or"
+" underscores that will be used in URLs and paths."
 msgstr ""
+"Un code court contenant uniquement des lettres Unicode minuscules, des "
+"chiffres, des traits d'union ou des traits de soulignement qui seront "
+"utilisés dans URLs et les chemins."
 
 #: tools/models.py
 msgid ""
 "This organization code is reserved by OpenKAT and cannot be used. Choose "
 "another organization code."
 msgstr ""
+"Ce code d'organisation est réservé par OpenKAT et ne peut pas être utilisé. "
+"Choisissez un autre code d'organisation."
 
 #: tools/models.py
 msgid "new"
-msgstr ""
+msgstr "nouveau"
 
 #: tools/templatetags/ooi_extra.py
 msgid "Unknown user"
-msgstr ""
+msgstr "Utilisateur inconnu"
 
 #: tools/view_helpers.py rocky/templates/header.html
 #: rocky/templates/organizations/organization_member_list.html
 #: rocky/views/organization_member_edit.py
 msgid "Members"
-msgstr ""
+msgstr "Membres"
 
 #: rocky/forms.py
 msgid "Current status"
-msgstr ""
+msgstr "Statut actuel"
 
 #: rocky/forms.py rocky/templates/organizations/organization_member_list.html
 msgid "Active"
-msgstr ""
+msgstr "Actif"
 
 #: rocky/forms.py rocky/templates/organizations/organization_member_list.html
 msgid "New"
-msgstr ""
+msgstr "Nouveau"
 
 #: rocky/forms.py
 msgid "Account status"
-msgstr ""
+msgstr "Statut du compte"
 
 #: rocky/forms.py
 msgid "Not blocked"
-msgstr ""
+msgstr "Non bloqué"
 
 #: rocky/messaging.py
 msgid ""
@@ -5216,242 +5882,261 @@ msgid ""
 "needs at least a clearance level of L{} in order to do a proper onboarding. "
 "Edit this member and change the clearance level if necessary."
 msgstr ""
+"Vous avez fait confiance à ce membre avec un niveau d'autorisation L{}. Ce "
+"membre a besoin d'au moins un niveau d'autorisation L{} afin de procéder à "
+"une intégration appropriée. Modifiez ce membre et modifiez le niveau "
+"d'autorisation si nécessaire."
 
 #: rocky/paginator.py
 msgid "That page number is not an integer"
-msgstr ""
+msgstr "Ce numéro de page n'est pas un entier"
 
 #: rocky/paginator.py
 msgid "That page number is less than 1"
-msgstr ""
+msgstr "Ce numéro de page est inférieur à 1"
 
 #: rocky/paginator.py
 msgid "That page contains no results"
-msgstr ""
+msgstr "Cette page ne contient aucun résultat"
 
 #: rocky/scheduler.py
 msgid ""
 "The Scheduler has an unexpected error. Check the Scheduler logs for further "
 "details."
 msgstr ""
+"Le planificateur a une erreur inattendue. Consultez les journaux du "
+"planificateur pour plus de détails."
 
 #: rocky/scheduler.py
 msgid "Could not connect to Scheduler. Service is possibly down."
 msgstr ""
+"Impossible de se connecter au planificateur. Le service est peut-être en "
+"panne."
 
 #: rocky/scheduler.py
 msgid "Your request could not be validated."
-msgstr ""
+msgstr "Votre demande n'a pas pu être validée."
 
 #: rocky/scheduler.py
 msgid "Task could not be found."
-msgstr ""
+msgstr "La tâche est introuvable."
 
 #: rocky/scheduler.py
 msgid ""
 "Scheduler is receiving too many requests. Increase SCHEDULER_PQ_MAXSIZE or "
 "wait for task to finish."
 msgstr ""
+"Le planificateur reçoit trop de demandes. Augmentez SCHEDULER_PQ_MAXSIZE ou "
+"attendez la fin de la tâche."
 
 #: rocky/scheduler.py
 msgid "Bad request. Your request could not be interpreted by the Scheduler."
 msgstr ""
+"Mauvaise demande. Votre demande n'a pas pu être interprétée par le "
+"planificateur."
 
 #: rocky/scheduler.py
 msgid "The Scheduler has received a conflict. Your task is already in queue."
 msgstr ""
+"Le planificateur a reçu un conflit. Votre tâche est déjà en file d'attente."
 
 #: rocky/scheduler.py
 msgid "A HTTPError occurred. See Scheduler logs for more info."
 msgstr ""
+"Une erreur HTTP s'est produite. Voir Journaux du planificateur pour plus "
+"d'informations."
 
 #: rocky/scheduler.py
 msgid "Schedule list: "
-msgstr ""
+msgstr "Liste des horaires :"
 
 #: rocky/scheduler.py
 msgid "Task list: "
-msgstr ""
+msgstr "Liste des tâches :"
 
 #: rocky/settings.py
 msgid "Blue light"
-msgstr ""
+msgstr "Lumière bleue"
 
 #: rocky/settings.py
 msgid "Blue medium"
-msgstr ""
+msgstr "Bleu moyen"
 
 #: rocky/settings.py
 msgid "Blue dark"
-msgstr ""
+msgstr "Bleu foncé"
 
 #: rocky/settings.py
 msgid "Green light"
-msgstr ""
+msgstr "Feu vert"
 
 #: rocky/settings.py
 msgid "Green medium"
-msgstr ""
+msgstr "Médium vert"
 
 #: rocky/settings.py
 msgid "Green dark"
-msgstr ""
+msgstr "Vert foncé"
 
 #: rocky/settings.py
 msgid "Yellow light"
-msgstr ""
+msgstr "Lumière jaune"
 
 #: rocky/settings.py
 msgid "Yellow medium"
-msgstr ""
+msgstr "Jaune moyen"
 
 #: rocky/settings.py
 msgid "Yellow dark"
-msgstr ""
+msgstr "Jaune foncé"
 
 #: rocky/settings.py
 msgid "Orange light"
-msgstr ""
+msgstr "Lumière orange"
 
 #: rocky/settings.py
 msgid "Orange medium"
-msgstr ""
+msgstr "Orange moyen"
 
 #: rocky/settings.py
 msgid "Orange dark"
-msgstr ""
+msgstr "Orange foncé"
 
 #: rocky/settings.py
 msgid "Red light"
-msgstr ""
+msgstr "Feu rouge"
 
 #: rocky/settings.py
 msgid "Red medium"
-msgstr ""
+msgstr "Médium rouge"
 
 #: rocky/settings.py
 msgid "Red dark"
-msgstr ""
+msgstr "Rouge foncé"
 
 #: rocky/settings.py
 msgid "Violet light"
-msgstr ""
+msgstr "Lumière violette"
 
 #: rocky/settings.py
 msgid "Violet medium"
-msgstr ""
+msgstr "Violette médium"
 
 #: rocky/settings.py
 msgid "Violet dark"
-msgstr ""
+msgstr "Violet foncé"
 
 #: rocky/settings.py
 msgid "Plain"
-msgstr ""
+msgstr "Plaine"
 
 #: rocky/settings.py
 msgid "Solid"
-msgstr ""
+msgstr "Solide"
 
 #: rocky/settings.py
 msgid "Dashed"
-msgstr ""
+msgstr "En pointillés"
 
 #: rocky/settings.py
 msgid "Dotted"
-msgstr ""
+msgstr "Pointé"
 
 #: rocky/templates/403.html
 msgid "Error code 403: Unauthorized"
-msgstr ""
+msgstr "Code d'erreur 403 : non autorisé"
 
 #: rocky/templates/403.html
 msgid "Your account is not authorized to access this page or organization."
 msgstr ""
+"Votre compte n'est pas autorisé à accéder à cette page ou à cette "
+"organisation."
 
 #: rocky/templates/403.html
 msgid "Please contact your system administrator."
-msgstr ""
+msgstr "Veuillez contacter votre administrateur système."
 
 #: rocky/templates/403.html rocky/templates/404.html
 msgid "You may want to go back to the"
-msgstr ""
+msgstr "Vous voudrez peut-être revenir au"
 
 #: rocky/templates/403.html rocky/templates/404.html
 msgid "Crisis Room"
-msgstr ""
+msgstr "Salle de crise"
 
 #: rocky/templates/404.html
 msgid "Error code 404: Page not found"
-msgstr ""
+msgstr "Code d'erreur 404 : page introuvable"
 
 #: rocky/templates/404.html
 msgid ""
 "The page you wanted to see or the file you wanted to view was not found."
 msgstr ""
+"La page que vous vouliez voir ou le fichier que vous vouliez voir n'a pas "
+"été trouvé."
 
 #: rocky/templates/admin/base.html
 msgid "Skip to main content"
-msgstr ""
+msgstr "Passer au contenu principal"
 
 #: rocky/templates/admin/base.html
 msgid "Welcome,"
-msgstr ""
+msgstr "Accueillir,"
 
 #: rocky/templates/admin/base.html
 msgid "View site"
-msgstr ""
+msgstr "Voir le site"
 
 #: rocky/templates/admin/base.html
 msgid "Documentation"
-msgstr ""
+msgstr "Documentation"
 
 #: rocky/templates/admin/base.html
 msgid "Change password"
-msgstr ""
+msgstr "Changer le mot de passe"
 
 #: rocky/templates/admin/base.html
 msgid "Log out"
-msgstr ""
+msgstr "Se déconnecter"
 
 #: rocky/templates/admin/base.html rocky/templates/header.html
 msgid "Breadcrumbs"
-msgstr ""
+msgstr "Fil d'Ariane"
 
 #: rocky/templates/admin/base.html rocky/templates/admin/change_form.html
 #: rocky/templates/admin/change_list.html
 #: rocky/templates/admin/delete_confirmation.html
 #: rocky/templates/admin/delete_selected_confirmation.html
 msgid "Home"
-msgstr ""
+msgstr "Maison"
 
 #: rocky/templates/admin/change_form.html
 #, python-format
 msgid "Add %(name)s"
-msgstr ""
+msgstr "Ajouter %(name)s"
 
 #: rocky/templates/admin/change_form.html
 #: rocky/templates/admin/change_list.html
 msgid "Please correct the error below."
 msgid_plural "Please correct the errors below."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Veuillez corriger les erreurs ci-dessous."
+msgstr[1] "Veuillez corriger les erreurs ci-dessous."
 
 #: rocky/templates/admin/change_list.html
 msgid "Filter"
-msgstr ""
+msgstr "Filtre"
 
 #: rocky/templates/admin/change_list.html
 msgid "Hide counts"
-msgstr ""
+msgstr "Masquer les décomptes"
 
 #: rocky/templates/admin/change_list.html
 msgid "Show counts"
-msgstr ""
+msgstr "Afficher les décomptes"
 
 #: rocky/templates/admin/change_list.html
 msgid "Clear all filters"
-msgstr ""
+msgstr "Supprimer tous les filtres"
 
 #: rocky/templates/admin/delete_confirmation.html
 #, python-format
@@ -5460,13 +6145,18 @@ msgid ""
 "related objects, but your account doesn't have permission to delete the "
 "following types of objects"
 msgstr ""
+"La suppression du %(object_name)s « %(escaped_object)s » entraînerait la "
+"suppression des objets associés, mais votre compte n'est pas autorisé à "
+"supprimer les types d'objets suivants"
 
 #: rocky/templates/admin/delete_confirmation.html
 #, python-format
 msgid ""
-"Deleting the %(object_name)s '%(escaped_object)s' would require deleting the "
-"following protected related objects"
+"Deleting the %(object_name)s '%(escaped_object)s' would require deleting the"
+" following protected related objects"
 msgstr ""
+"La suppression du %(object_name)s '%(escaped_object)s' nécessiterait la "
+"suppression des objets associés protégés suivants"
 
 #: rocky/templates/admin/delete_confirmation.html
 #, python-format
@@ -5474,20 +6164,23 @@ msgid ""
 "Are you sure you want to delete the %(object_name)s \"%(escaped_object)s\"? "
 "All of the following related items will be deleted"
 msgstr ""
+"Êtes-vous sûr de vouloir supprimer le %(object_name)s "
+"« %(escaped_object)s » ? Tous les éléments associés suivants seront "
+"supprimés"
 
 #: rocky/templates/admin/delete_confirmation.html
 #: rocky/templates/admin/delete_selected_confirmation.html
 msgid "Yes, I’m sure"
-msgstr ""
+msgstr "Oui, je suis sûr"
 
 #: rocky/templates/admin/delete_confirmation.html
 #: rocky/templates/admin/delete_selected_confirmation.html
 msgid "No, take me back"
-msgstr ""
+msgstr "Non, ramène-moi"
 
 #: rocky/templates/admin/delete_selected_confirmation.html
 msgid "Delete multiple objects"
-msgstr ""
+msgstr "Supprimer plusieurs objets"
 
 #: rocky/templates/admin/delete_selected_confirmation.html
 #, python-format
@@ -5496,6 +6189,9 @@ msgid ""
 "objects, but your account doesn't have permission to delete the following "
 "types of objects"
 msgstr ""
+"La suppression du %(objects_name)s sélectionné entraînerait la suppression "
+"des objets associés, mais votre compte n'est pas autorisé à supprimer les "
+"types d'objets suivants"
 
 #: rocky/templates/admin/delete_selected_confirmation.html
 #, python-format
@@ -5503,6 +6199,8 @@ msgid ""
 "Deleting the selected %(objects_name)s would require deleting the following "
 "protected related objects"
 msgstr ""
+"La suppression du %(objects_name)s sélectionné nécessiterait la suppression "
+"des objets associés protégés suivants"
 
 #: rocky/templates/admin/delete_selected_confirmation.html
 #, python-format
@@ -5510,64 +6208,69 @@ msgid ""
 "Are you sure you want to delete the selected %(objects_name)s? All of the "
 "following objects and their related items will be deleted"
 msgstr ""
+"Etes-vous sûr de vouloir supprimer le %(objects_name)s sélectionné ? Tous "
+"les objets suivants et leurs éléments associés seront supprimés"
 
 #: rocky/templates/admin/popup_response.html
 msgid "Popup closing…"
-msgstr ""
+msgstr "Fermeture de la popup…"
 
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
-#: rocky/templates/header.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
 msgid "Close menu"
-msgstr ""
+msgstr "Fermer le menu"
 
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
-#: rocky/templates/header.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
 msgid "Main navigation"
-msgstr ""
+msgstr "Navigation principale"
 
 #: rocky/templates/dashboard_client.html
 msgid "Indemnifications"
-msgstr ""
+msgstr "Indemnisations"
 
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html
 #: rocky/templates/partials/secondary-menu.html
 msgid "Logout"
-msgstr ""
+msgstr "Déconnexion"
 
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html
 msgid "Welcome"
-msgstr ""
+msgstr "Accueillir"
 
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html
 msgid "User overview"
-msgstr ""
+msgstr "Aperçu des utilisateurs"
 
 #: rocky/templates/dashboard_redteam.html
 #: rocky/templates/partials/notifications_block.html
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "warning"
-msgstr ""
+msgstr "avertissement"
 
 #: rocky/templates/dashboard_redteam.html
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 #: rocky/templates/partials/notifications_block.html
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "Warning:"
-msgstr ""
+msgstr "Avertissement:"
 
 #: rocky/templates/dashboard_redteam.html
 msgid "Organization code missing"
-msgstr ""
+msgstr "Code d'organisation manquant"
 
 #: rocky/templates/finding_type_add.html
 #: rocky/templates/partials/findings_list_toolbar.html
 #: rocky/views/finding_type_add.py
 msgid "Add finding type"
-msgstr ""
+msgstr "Ajouter un type de recherche"
 
 #: rocky/templates/finding_type_add.html
 msgid "Finding Type"
-msgstr ""
+msgstr "Type de recherche"
 
 #: rocky/templates/findings/finding_add.html
 #: rocky/templates/oois/ooi_detail_findings_list.html
@@ -5575,11 +6278,11 @@ msgstr ""
 #: rocky/templates/partials/findings_list_toolbar.html
 #: rocky/views/finding_add.py
 msgid "Add finding"
-msgstr ""
+msgstr "Ajouter un résultat"
 
 #: rocky/templates/findings/finding_list.html
-msgid "Findings @ "
-msgstr ""
+msgid "Findings "
+msgstr "Résultats"
 
 #: rocky/templates/findings/finding_list.html
 #, python-format
@@ -5588,107 +6291,115 @@ msgid ""
 "<strong>%(organization_name)s</strong>. Each finding relates to an object. "
 "Click a finding for additional information."
 msgstr ""
+"Présentation de tous les résultats OpenKAT trouvés pour l'organisation "
+"<strong>%(organization_name)s</strong>. Chaque trouvaille concerne un objet."
+" Cliquez sur un résultat pour obtenir des informations supplémentaires."
 
 #: rocky/templates/findings/finding_list.html
 #, python-format
 msgid "Showing %(length)s of %(total)s findings"
-msgstr ""
+msgstr "Affichage des résultats %(length)s sur %(total)s"
 
 #: rocky/templates/findings/finding_list.html
 #: rocky/templates/partials/mute_findings_modal.html
 msgid "Mute findings"
-msgstr ""
+msgstr "Résultats muets"
 
 #: rocky/templates/findings/finding_list.html
 msgid "Unmute findings"
-msgstr ""
+msgstr "Réactiver les résultats"
 
 #: rocky/templates/findings/findings_filter.html
 #: rocky/templates/partials/elements/ooi_list_settings_form.html
 #: rocky/templates/tasks/partials/task_filter.html
 msgid "Set filters"
-msgstr ""
+msgstr "Définir des filtres"
 
 #: rocky/templates/findings/findings_filter.html
 #: rocky/templates/partials/elements/ooi_list_settings_form.html
 #: rocky/templates/tasks/partials/task_filter.html
 msgid "Clear filters"
-msgstr ""
+msgstr "Effacer les filtres"
 
 #: rocky/templates/footer.html rocky/views/privacy_statement.py
 msgid "Privacy Statement"
-msgstr ""
+msgstr "Déclaration de confidentialité"
 
 #: rocky/templates/forms/json_schema_form.html
 msgid "Fill out this form to answer the Question (again):"
-msgstr ""
+msgstr "Remplissez ce formulaire pour répondre (à nouveau) à la question :"
 
 #: rocky/templates/graph-d3.html
 msgid ""
 "Click a circle to collapse / expand the tree, click the text to view the "
 "tree from that OOI and hover over the text to see details."
 msgstr ""
+"Cliquez sur un cercle pour réduire/développer l'arborescence, cliquez sur le"
+" texte pour afficher l'arborescence de ce OOI et survolez le texte pour voir"
+" les détails."
 
 #: rocky/templates/graph-d3.html
 msgid "Tree graph"
-msgstr ""
+msgstr "Graphique en arbre"
 
 #: rocky/templates/header.html
 msgid "Menu"
-msgstr ""
+msgstr "Menu"
 
 #: rocky/templates/header.html
 msgid "OpenKAT logo, go to the homepage of OpenKAT"
-msgstr ""
+msgstr "Logo OpenKAT, accédez à la page d'accueil de OpenKAT"
 
 #: rocky/templates/header.html rocky/templates/tasks/ooi_detail_task_list.html
 #: rocky/templates/tasks/partials/tasks_overview_header.html
 #: rocky/templates/tasks/plugin_detail_task_list.html
 #: rocky/views/task_detail.py rocky/views/tasks.py
 msgid "Tasks"
-msgstr ""
+msgstr "Tâches"
 
 #: rocky/templates/health.html
 msgid "Health Checks"
-msgstr ""
+msgstr "Bilans de santé"
 
 #: rocky/templates/health.html
 msgid "Health checks"
-msgstr ""
+msgstr "Bilans de santé"
 
 #: rocky/templates/health.html
 msgid "Additional"
-msgstr ""
+msgstr "Supplémentaire"
 
 #: rocky/templates/indemnification_present.html
 msgid "Indemnification"
-msgstr ""
+msgstr "Indemnité"
 
 #: rocky/templates/indemnification_present.html
 msgid ""
 "Indemnification on the organization present. You may now add objects and "
 "start scans."
 msgstr ""
+"Indemnisation sur l'organisation présente. Vous pouvez maintenant ajouter "
+"des objets et lancer des analyses."
 
 #: rocky/templates/indemnification_present.html
 msgid "Go to Objects"
-msgstr ""
+msgstr "Aller aux objets"
 
 #: rocky/templates/indemnification_present.html
 msgid "Go to"
-msgstr ""
+msgstr "Aller à"
 
 #: rocky/templates/landing_page.html
 msgid "Welcome to OpenKAT"
-msgstr ""
+msgstr "Bienvenue sur OpenKAT"
 
 #: rocky/templates/landing_page.html
 msgid "Kwetsbaarheden Analyse Tool"
-msgstr ""
+msgstr "Outil d'analyse Kwetsbaarheden"
 
 #: rocky/templates/landing_page.html
 msgid "What is OpenKAT?"
-msgstr ""
+msgstr "Qu'est-ce que OpenKAT ?"
 
 #: rocky/templates/landing_page.html
 msgid ""
@@ -5696,261 +6407,301 @@ msgid ""
 "by the Ministry of Health, Welfare and Sport to make your and our world "
 "safer."
 msgstr ""
+"OpenKAT est un outil d'analyse de vulnérabilité. Un projet Open Source "
+"développé par le ministère de la Santé, du Bien-être et des Sports pour "
+"rendre votre monde et notre monde plus sûrs."
 
 #: rocky/templates/landing_page.html
 msgid "OpenKAT sees"
-msgstr ""
+msgstr "OpenKAT voit"
 
 #: rocky/templates/landing_page.html
 msgid ""
 "Dozens of tools are integrated in OpenKAT to view the world (digital and "
 "analog)."
 msgstr ""
+"Des dizaines d'outils sont intégrés dans OpenKAT pour visualiser le monde "
+"(numérique et analogique)."
 
 #: rocky/templates/landing_page.html
 msgid "Our motto is therefore: I see, I see, what you do not see."
-msgstr ""
+msgstr "Notre devise est donc : je vois, je vois, ce que vous ne voyez pas."
 
 #: rocky/templates/landing_page.html
 msgid "OpenKAT knows"
-msgstr ""
+msgstr "OpenKAT sait"
 
 #: rocky/templates/landing_page.html
 msgid ""
 "OpenKAT does not forget (just like that), and can be queried without "
 "scanning again. Also about a historical situation."
 msgstr ""
+"OpenKAT n'oublie pas (juste comme ça) et peut être interrogé sans scanner à "
+"nouveau. Aussi sur une situation historique."
 
 #: rocky/templates/landing_page.html
 msgid "OpenKAT is secure"
-msgstr ""
+msgstr "OpenKAT est sécurisé"
 
 #: rocky/templates/landing_page.html
 msgid ""
 "Forensically secured storage of evidence is one of the basic ingredients of "
 "OpenKAT."
 msgstr ""
+"Le stockage médico-légal des preuves est l’un des ingrédients de base du "
+"OpenKAT."
 
 #: rocky/templates/landing_page.html
 msgid "OpenKAT is sweet"
-msgstr ""
+msgstr "OpenKAT est doux"
 
 #: rocky/templates/landing_page.html
 msgid ""
-"OpenKAT thinks about privacy, and stores what is necessary, within the rules "
-"of your organization and the law."
+"OpenKAT thinks about privacy, and stores what is necessary, within the rules"
+" of your organization and the law."
 msgstr ""
+"OpenKAT pense à la confidentialité et stocke ce qui est nécessaire, dans le "
+"respect des règles de votre organisation et de la loi."
 
 #: rocky/templates/landing_page.html
 msgid "A wide playing field"
-msgstr ""
+msgstr "Un large terrain de jeu"
 
 #: rocky/templates/landing_page.html
 msgid ""
-"OpenKAT makes a copy of the actual reality by means of the integrated tools. "
-"Within this copy you can search for answers to countless security and policy "
-"questions. Expected and unexpected changes in the world are made visible, "
-"and where necessary reported or made known directly to the right people."
+"OpenKAT makes a copy of the actual reality by means of the integrated tools."
+" Within this copy you can search for answers to countless security and "
+"policy questions. Expected and unexpected changes in the world are made "
+"visible, and where necessary reported or made known directly to the right "
+"people."
 msgstr ""
+"OpenKAT réalise une copie de la réalité réelle grâce aux outils intégrés. "
+"Dans cette copie, vous pouvez rechercher des réponses à d'innombrables "
+"questions de sécurité et de politique. Les changements attendus et "
+"inattendus dans le monde sont rendus visibles et, si nécessaire, signalés ou"
+" portés à la connaissance directement des personnes compétentes."
 
 #: rocky/templates/legal/privacy_statement.html
 msgid "OpenKAT Privacy Statement"
-msgstr ""
+msgstr "Déclaration de confidentialité OpenKAT"
 
 #: rocky/templates/legal/privacy_statement.html
 msgid ""
 "OpenKAT is dedicated to protecting the confidentiality and privacy of "
-"information entrusted to it. As part of this fundamental obligation, OpenKAT "
-"is committed to the appropriate protection and use of personal information "
+"information entrusted to it. As part of this fundamental obligation, OpenKAT"
+" is committed to the appropriate protection and use of personal information "
 "(sometimes referred to as \"personal data\", \"personally identifiable "
 "information\" or \"PII\") that has been collected online."
 msgstr ""
+"OpenKAT is dedicated to protecting the confidentiality and privacy of "
+"information entrusted to it. Dans le cadre de cette obligation fondamentale,"
+" OpenKAT s'engage à protéger et à utiliser de manière appropriée les "
+"informations personnelles (parfois appelées « données personnelles », « "
+"informations personnellement identifiables » ou « PII ») qui ont été "
+"collectées en ligne."
 
 #: rocky/templates/oois/error.html
 msgid "Object List"
-msgstr ""
+msgstr "Liste d'objets"
 
 #: rocky/templates/oois/error.html
 msgid "An error occurred. Please contact a system administrator."
 msgstr ""
+"Une erreur s'est produite. Veuillez contacter un administrateur système."
 
 #: rocky/templates/oois/ooi_add.html
 #, python-format
 msgid "Add a %(display_type)s"
-msgstr ""
+msgstr "Ajouter un %(display_type)s"
 
 #: rocky/templates/oois/ooi_add.html
 msgid ""
 "Here you can add the asset of the client. Findings can be added to these in "
 "the findings page."
 msgstr ""
+"Ici, vous pouvez ajouter l'actif du client. Des résultats peuvent y être "
+"ajoutés dans la page des résultats."
 
 #: rocky/templates/oois/ooi_add.html
 #, python-format
 msgid "Add %(display_type)s"
-msgstr ""
+msgstr "Ajouter %(display_type)s"
 
 #: rocky/templates/oois/ooi_add_type_select.html
 #: rocky/templates/oois/ooi_detail_add_related_object.html
 #: rocky/templates/partials/elements/ooi_add_type_select_form.html
 #: rocky/templates/partials/ooi_list_toolbar.html rocky/views/ooi_add.py
 msgid "Add object"
-msgstr ""
+msgstr "Ajouter un objet"
 
 #: rocky/templates/oois/ooi_add_type_select.html
 msgid "Select the type of object you want to create."
-msgstr ""
+msgstr "Sélectionnez le type d'objet que vous souhaitez créer."
 
 #: rocky/templates/oois/ooi_delete.html
 #, python-format
 msgid "Delete %(primary_key)s"
-msgstr ""
+msgstr "Supprimer %(primary_key)s"
 
 #: rocky/templates/oois/ooi_delete.html
 msgid "Are you sure?"
-msgstr ""
+msgstr "Es-tu sûr?"
 
 #: rocky/templates/oois/ooi_delete.html
 #, python-format
 msgid "Here you can delete the %(display_type)s."
-msgstr ""
+msgstr "Ici, vous pouvez supprimer le %(display_type)s."
 
 #: rocky/templates/oois/ooi_delete.html
 msgid "To be deleted object(s)"
-msgstr ""
+msgstr "Objet(s) à supprimer"
 
 #: rocky/templates/oois/ooi_delete.html
 #: rocky/templates/partials/elements/ooi_tree_condensed_table.html
 msgid "Key"
-msgstr ""
+msgstr "Clé"
 
 #: rocky/templates/oois/ooi_delete.html
 #: rocky/templates/partials/ooi_detail_toolbar.html
 #, python-format
 msgid "Delete %(display_type)s"
-msgstr ""
+msgstr "Supprimer %(display_type)s"
 
 #: rocky/templates/oois/ooi_delete.html
 msgid "Deletion not possible for types: KATFindingType and CVEFindingType"
 msgstr ""
+"Suppression impossible pour les types : KATFindingType et CVEFindingType"
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "using boefjes"
-msgstr ""
+msgstr "utiliser des boefjes"
 
 #: rocky/templates/oois/ooi_detail.html
 #: rocky/templates/organizations/organization_settings.html
 msgid "indemnification warning"
-msgstr ""
+msgstr "avertissement d'indemnisation"
 
 #: rocky/templates/oois/ooi_detail.html
 #, python-format
 msgid ""
-"<strong>Warning:</strong> There is no indemnification for this organization. "
-"Go to the <a href=\"%(organization_settings)s\">organization settings page</"
-"a> to add one."
+"<strong>Warning:</strong> There is no indemnification for this organization."
+" Go to the <a href=\"%(organization_settings)s\">organization settings "
+"page</a> to add one."
 msgstr ""
+"<strong>Avertissement :</strong> Il n'y a aucune indemnisation pour cette "
+"organisation. Accédez à la page des paramètres de l'organisation <a "
+"href=\"%(organization_settings)s\"></a> pour en ajouter un."
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "Permission warning"
-msgstr ""
+msgstr "Avertissement d'autorisation"
 
 #: rocky/templates/oois/ooi_detail.html
 msgid ""
 "<strong>Warning:</strong> You don't have the proper permission at the "
 "organizational level to scan objects. Contact your administrator."
 msgstr ""
+"<strong>Avertissement :</strong> Vous ne disposez pas de l'autorisation "
+"appropriée au niveau de l'organisation pour analyser des objets. Contactez "
+"votre administrateur."
 
 #: rocky/templates/oois/ooi_detail.html
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Scan warning"
-msgstr ""
+msgstr "Avertissement d'analyse"
 
 #: rocky/templates/oois/ooi_detail.html
 #, python-format
 msgid ""
-"<strong>Warning:</strong> You are not allowed to scan this OOI. Your maximum "
-"clearance level is %(member_clearance_level)s and this OOI has level "
+"<strong>Warning:</strong> You are not allowed to scan this OOI. Your maximum"
+" clearance level is %(member_clearance_level)s and this OOI has level "
 "%(boefje_scan_level)s. Go to your <a href=\"%(account_details)s\">account "
 "details</a> to manage your clearance level."
 msgstr ""
+"<strong>Avertissement : </strong> Vous n'êtes pas autorisé à numériser ce "
+"OOI. Votre niveau de dégagement maximum est %(member_clearance_level)s et ce"
+" OOI a le niveau %(boefje_scan_level)s. Accédez aux détails de votre compte "
+"<a href=\"%(account_details)s\"></a> pour gérer votre niveau d'autorisation."
 
 #: rocky/templates/oois/ooi_detail.html rocky/templates/scan.html
 msgid "Boefjes overview"
-msgstr ""
+msgstr "Boefjes en aperçu"
 
 #: rocky/templates/oois/ooi_detail.html
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 #: rocky/templates/scan.html rocky/templates/tasks/boefjes.html
 #: rocky/templates/tasks/normalizers.html
 msgid "Boefje"
-msgstr ""
+msgstr "Boefje"
 
 #: rocky/templates/oois/ooi_detail.html rocky/templates/scan.html
 msgid "Scan profile"
-msgstr ""
+msgstr "Profil de numérisation"
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "Unable to start scan. See the warning for more details."
 msgstr ""
+"Impossible de démarrer l'analyse. Voir l'avertissement pour plus de détails."
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "Start scan"
-msgstr ""
+msgstr "Démarrer l'analyse"
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "There are no boefjes enabled to scan an OOI of type"
-msgstr ""
+msgstr "Il n'y a aucun boefjes activé pour scanner un OOI de type"
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "See"
-msgstr ""
+msgstr "Voir"
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "to find and enable boefjes that can scan within the current level."
 msgstr ""
+"pour trouver et activer les boefjes qui peuvent scanner dans le niveau "
+"actuel."
 
 #: rocky/templates/oois/ooi_detail_add_related_object.html
 #: rocky/templates/partials/ooi_detail_related_object.html
 msgid "Add related object"
-msgstr ""
+msgstr "Ajouter un objet associé"
 
 #: rocky/templates/oois/ooi_detail_add_related_object.html
 #: rocky/templates/oois/ooi_detail_object.html
 msgid "Object details"
-msgstr ""
+msgstr "Détails de l'objet"
 
 #: rocky/templates/oois/ooi_detail_add_related_object.html
 #: rocky/templates/partials/elements/ooi_add_type_select_form.html
 msgid "Object type"
-msgstr ""
+msgstr "Type d'objet"
 
 #: rocky/templates/oois/ooi_detail_add_related_object.html
 #: rocky/templates/partials/elements/ooi_add_type_select_form.html
 msgid "Choose an object type to add"
-msgstr ""
+msgstr "Choisissez un type d'objet à ajouter"
 
 #: rocky/templates/oois/ooi_detail_add_related_object.html
 #: rocky/templates/partials/elements/ooi_add_type_select_form.html
 msgid "Select an object type to add."
-msgstr ""
+msgstr "Sélectionnez un type d'objet à ajouter."
 
 #: rocky/templates/oois/ooi_detail_findings_list.html
 msgid "Overview of findings for"
-msgstr ""
+msgstr "Aperçu des résultats pour"
 
 #: rocky/templates/oois/ooi_detail_findings_list.html
 msgid "Score"
-msgstr ""
+msgstr "Score"
 
 #: rocky/templates/oois/ooi_detail_findings_list.html
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "Finding details"
-msgstr ""
+msgstr "Trouver des détails"
 
 #: rocky/templates/oois/ooi_detail_findings_overview.html
 msgid "Overview of the number of findings and their severity found on"
-msgstr ""
+msgstr "Aperçu du nombre de constatations et de leur gravité constatées sur"
 
 #: rocky/templates/oois/ooi_detail_findings_overview.html
 msgid ""
@@ -5958,206 +6709,225 @@ msgid ""
 "table shows the number of unique findings found as well as the number of "
 "occurrences."
 msgstr ""
+"Les résultats peuvent se produire plusieurs fois. Pour donner un meilleur "
+"aperçu, le tableau suivant montre le nombre de résultats uniques trouvés "
+"ainsi que le nombre d'occurrences."
 
 #: rocky/templates/oois/ooi_detail_findings_overview.html
 msgid "See finding details"
-msgstr ""
+msgstr "Voir les détails de la recherche"
 
 #: rocky/templates/oois/ooi_detail_findings_overview.html
 msgid "Total findings"
-msgstr ""
+msgstr "Résultats totaux"
 
 #: rocky/templates/oois/ooi_detail_object.html
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Inactive"
-msgstr ""
+msgstr "Inactif"
 
 #: rocky/templates/oois/ooi_detail_origins_declarations.html
 msgid "Declarations"
-msgstr ""
+msgstr "Déclarations"
 
 #: rocky/templates/oois/ooi_detail_origins_inference.html
 msgid "Inferred by"
-msgstr ""
+msgstr "Déduit par"
 
 #: rocky/templates/oois/ooi_detail_origins_inference.html
 msgid "Bit"
-msgstr ""
+msgstr "Peu"
 
 #: rocky/templates/oois/ooi_detail_origins_inference.html
 msgid "Parameters"
-msgstr ""
+msgstr "Paramètres"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "Last observed by"
-msgstr ""
+msgstr "Observé pour la dernière fois par"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "Task ID"
-msgstr ""
+msgstr "ID de tâche"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "When"
-msgstr ""
+msgstr "Quand"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 #: rocky/templates/tasks/normalizers.html
 msgid "Normalizer"
-msgstr ""
+msgstr "Normalizer"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "This scan was manually created."
-msgstr ""
+msgstr "Cette analyse a été créée manuellement."
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "The boefje has since been deleted or disabled."
-msgstr ""
+msgstr "Le boefje a depuis été supprimé ou désactivé."
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "No Raw file could be found, this might point to an error in OpenKAT"
 msgstr ""
+"Aucun fichier brut n'a pu être trouvé, cela peut indiquer une erreur dans "
+"OpenKAT."
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Warning"
-msgstr ""
+msgstr "Avertissement"
 
 #: rocky/templates/oois/ooi_edit.html
 #, python-format
 msgid "Edit %(type)s: %(ooi_human_readable)s"
-msgstr ""
+msgstr "Modifier %(type)s : %(ooi_human_readable)s"
 
 #: rocky/templates/oois/ooi_edit.html
 msgid "Primary key fields cannot be edited."
-msgstr ""
+msgstr "Les champs de clé primaire ne peuvent pas être modifiés."
 
 #: rocky/templates/oois/ooi_edit.html
 #, python-format
 msgid "Save %(display_type)s"
-msgstr ""
+msgstr "Enregistrer %(display_type)s"
 
 #: rocky/templates/oois/ooi_findings.html
 msgid "Currently no findings have been identified for OOI"
-msgstr ""
+msgstr "Actuellement, aucun résultat n'a été identifié pour OOI."
 
 #: rocky/templates/oois/ooi_list.html
 #, python-format
 msgid ""
-"An overview of objects found for organization <strong>%(organization_name)s</"
-"strong>. Objects can be added manually or by running Boefjes. Click an "
-"object for additional information."
+"An overview of objects found for organization "
+"<strong>%(organization_name)s</strong>. Objects can be added manually or by "
+"running Boefjes. Click an object for additional information."
 msgstr ""
+"Présentation des objets trouvés pour l'organisation "
+"<strong>%(organization_name)s</strong>. Les objets peuvent être ajoutés "
+"manuellement ou en exécutant Boefjes. Cliquez sur un objet pour obtenir des "
+"informations supplémentaires."
 
 #: rocky/templates/oois/ooi_list.html
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Edit clearance level"
-msgstr ""
+msgstr "Modifier le niveau d'autorisation"
 
 #: rocky/templates/oois/ooi_mute_finding.html
 msgid "Mute finding:"
-msgstr ""
+msgstr "Résultat muet :"
 
 #: rocky/templates/oois/ooi_mute_finding.html
 msgid "Give a reason below why you want to mute this finding."
 msgstr ""
+"Donnez ci-dessous la raison pour laquelle vous souhaitez ignorer ce "
+"résultat."
 
 #: rocky/templates/oois/ooi_mute_finding.html
 #: rocky/templates/partials/mute_findings_modal.html
 #: rocky/templates/partials/ooi_detail_toolbar.html
 msgid "Mute finding"
-msgstr ""
+msgstr "Recherche muette"
 
 #: rocky/templates/oois/ooi_mute_finding.html
 msgid "Mute"
-msgstr ""
+msgstr "Muet"
 
 #: rocky/templates/oois/ooi_page_tabs.html
 msgid "List of views for OOI"
-msgstr ""
+msgstr "Liste des vues pour OOI"
 
 #: rocky/templates/oois/ooi_past_due_warning.html
 msgid "This object is past due"
-msgstr ""
+msgstr "Cet objet est en souffrance"
 
 #: rocky/templates/oois/ooi_past_due_warning.html
 msgid "This object is past due and has been deleted"
-msgstr ""
+msgstr "Cet objet est en souffrance et a été supprimé"
 
 #: rocky/templates/oois/ooi_past_due_warning.html
 msgid ""
 "This object is past due. You are viewing the object state in a past state."
 msgstr ""
+"Cet objet est en souffrance. Vous visualisez l’état de l’objet dans un état "
+"passé."
 
 #: rocky/templates/oois/ooi_past_due_warning.html
 msgid ""
 "You will not be able to add Findings or other OOI's to past due objects."
 msgstr ""
+"Vous ne pourrez pas ajouter des résultats ou d'autres OOI aux objets en "
+"souffrance."
 
 #: rocky/templates/oois/ooi_past_due_warning.html
 #: rocky/templates/partials/hyperlink_ooi_id.html
 #, python-format
 msgid "Show details for %(name)s"
-msgstr ""
+msgstr "Afficher les détails pour %(name)s"
 
 #: rocky/templates/oois/ooi_past_due_warning.html
 msgid "View the current state"
-msgstr ""
+msgstr "Afficher l'état actuel"
 
 #: rocky/templates/oois/ooi_past_due_warning.html
 msgid ""
 "You will not be able to add Findings or other OOI's, this object has been "
 "deleted and is no longer available."
 msgstr ""
+"Vous ne pourrez pas ajouter de résultats ou d'autres OOI, cet objet a été "
+"supprimé et n'est plus disponible."
 
 #: rocky/templates/oois/ooi_summary.html
 msgid "Summary for"
-msgstr ""
+msgstr "Résumé pour"
 
 #: rocky/templates/oois/ooi_summary.html
 msgid "Below you can see findings that were found for"
-msgstr ""
+msgstr "Ci-dessous vous pouvez voir les résultats trouvés pour"
 
 #: rocky/templates/oois/ooi_summary.html
 msgid "and direct  children of this"
-msgstr ""
+msgstr "et diriger les enfants de ceci"
 
 #: rocky/templates/oois/ooi_summary.html
 msgid "This"
-msgstr ""
+msgstr "Ce"
 
 #: rocky/templates/oois/ooi_summary.html
 msgid "tree view"
-msgstr ""
+msgstr "vue arborescente"
 
 #: rocky/templates/oois/ooi_summary.html
 msgid "of the"
-msgstr ""
+msgstr "de la"
 
 #: rocky/templates/oois/ooi_summary.html
 msgid "shows the same objects."
-msgstr ""
+msgstr "montre les mêmes objets."
 
 #: rocky/templates/organizations/organization_add.html
 msgid ""
-"Please enter the following organization details. These details can be edited "
-"within the organization page within OpenKAT when necessary."
+"Please enter the following organization details. These details can be edited"
+" within the organization page within OpenKAT when necessary."
 msgstr ""
+"Veuillez saisir les détails suivants de l'organisation. Ces détails peuvent "
+"être modifiés dans la page de l'organisation dans OpenKAT si nécessaire."
 
 #: rocky/templates/organizations/organization_edit.html
 msgid "Edit organization"
-msgstr ""
+msgstr "Modifier l'organisation"
 
 #: rocky/templates/organizations/organization_edit.html
 msgid "Save organization"
-msgstr ""
+msgstr "Enregistrer l'organisation"
 
 #: rocky/templates/organizations/organization_list.html
 msgid "An overview of all organizations you are a member of."
-msgstr ""
+msgstr "Un aperçu de toutes les organisations dont vous êtes membre."
 
 #: rocky/templates/organizations/organization_list.html
 msgid "Add new organization"
-msgstr ""
+msgstr "Ajouter une nouvelle organisation"
 
 #: rocky/templates/organizations/organization_list.html
 #, python-format
@@ -6166,72 +6936,79 @@ msgid ""
 "                            Showing %(total)s organizations\n"
 "                        "
 msgstr ""
+"\n"
+"Affichage des organisations %(total)s"
 
 #: rocky/templates/organizations/organization_list.html
 msgid "Organization overview:"
-msgstr ""
+msgstr "Aperçu de l'organisation :"
 
 #: rocky/templates/organizations/organization_list.html
 #: rocky/templates/organizations/organization_settings.html
 msgid "Tags"
-msgstr ""
+msgstr "Balises"
 
 #: rocky/templates/organizations/organization_list.html
 msgid "There were no organizations found for your user account"
-msgstr ""
+msgstr "Aucune organisation n'a été trouvée pour votre compte utilisateur"
 
 #: rocky/templates/organizations/organization_list.html
 msgid "Actions to perform for all of your organizations."
-msgstr ""
+msgstr "Des actions à réaliser pour l'ensemble de vos organisations."
 
 #: rocky/templates/organizations/organization_list.html
 #: rocky/templates/organizations/organization_settings.html
 msgid "Rerun all bits"
-msgstr ""
+msgstr "Réexécutez tous les bits"
 
 #: rocky/templates/organizations/organization_member_add.html
 msgid "Change account type"
-msgstr ""
+msgstr "Changer le type de compte"
 
 #: rocky/templates/organizations/organization_member_add_header.html
 #: rocky/views/organization_member_add.py
 msgid "Add member"
-msgstr ""
+msgstr "Ajouter un membre"
 
 #: rocky/templates/organizations/organization_member_add_header.html
 #, python-format
 msgid ""
-"Creating a new member of organization <strong>%(organization)s</strong>. For "
-"detailed information about the different account types, check the <a "
+"Creating a new member of organization <strong>%(organization)s</strong>. For"
+" detailed information about the different account types, check the <a "
 "href=\"https://docs.openkat.nl/basics/users-and-organisations.html#users\" "
 "target=\"_blank\" rel=\"noopener\">documentation</a>."
 msgstr ""
+"Création d'un nouveau membre de l'organisation "
+"<strong>%(organization)s</strong>. Pour des informations détaillées sur les "
+"différents types de comptes, consultez la documentation <a "
+"href=\"https://docs.openkat.nl/basics/users-and-organisations.html#users\" "
+"target=\"_blank\" rel=\"noopener\"></a>."
 
 #: rocky/templates/organizations/organization_member_edit.html
 #: rocky/views/organization_member_edit.py
 msgid "Edit member"
-msgstr ""
+msgstr "Modifier le membre"
 
 #: rocky/templates/organizations/organization_member_edit.html
 msgid "Save member"
-msgstr ""
+msgstr "Enregistrer le membre"
 
 #: rocky/templates/organizations/organization_member_list.html
 #, python-format
 msgid "An overview of members of <strong>%(organization_name)s</strong>."
-msgstr ""
+msgstr "Un aperçu des membres de <strong>%(organization_name)s</strong>."
 
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Add member(s)"
-msgstr ""
+msgstr "Ajouter des membres"
 
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Manually"
-msgstr ""
+msgstr "Manuellement"
 
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Upload a CSV"
-msgstr ""
+msgstr "Téléchargez un CSV"
 
 #: rocky/templates/organizations/organization_member_list.html
 #, python-format
@@ -6240,27 +7017,29 @@ msgid ""
 "                        Showing %(total)s members\n"
 "                    "
 msgstr ""
+"\n"
+"Affichage des membres %(total)s"
 
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Member overview:"
-msgstr ""
+msgstr "Aperçu des membres :"
 
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Role"
-msgstr ""
+msgstr "Rôle"
 
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Assigned clearance level"
-msgstr ""
+msgstr "Niveau d'autorisation attribué"
 
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Super user"
-msgstr ""
+msgstr "Super utilisateur"
 
 #: rocky/templates/organizations/organization_member_upload.html
 #: rocky/views/organization_member_add.py
 msgid "Add members"
-msgstr ""
+msgstr "Ajouter des membres"
 
 #: rocky/templates/organizations/organization_member_upload.html
 #, python-format
@@ -6268,14 +7047,19 @@ msgid ""
 "To upload multiple members at once, you can upload a CSV file or you can <a "
 "href=\"%(download_url)s\">download the template</a>."
 msgstr ""
+"Pour télécharger plusieurs membres à la fois, vous pouvez télécharger un "
+"fichier CSV ou <a href=\"%(download_url)s\">télécharger le modèle </a>."
 
 #: rocky/templates/organizations/organization_member_upload.html
-msgid "To create a custom CSV file, make sure it meets the following criteria:"
+msgid ""
+"To create a custom CSV file, make sure it meets the following criteria:"
 msgstr ""
+"Pour créer un fichier CSV personnalisé, assurez-vous qu'il répond aux "
+"critères suivants :"
 
 #: rocky/templates/organizations/organization_member_upload.html
 msgid "Upload"
-msgstr ""
+msgstr "Télécharger"
 
 #: rocky/templates/organizations/organization_settings.html
 #, python-format
@@ -6283,177 +7067,203 @@ msgid ""
 "An overview of general information and settings for "
 "<strong>%(organization_name)s</strong>."
 msgstr ""
+"Présentation des informations générales et des paramètres pour "
+"<strong>%(organization_name)s</strong>."
 
 #: rocky/templates/organizations/organization_settings.html
 msgid ""
 "<strong>Warning:</strong> Indemnification is not set for this organization."
 msgstr ""
+"<strong>Avertissement : </strong> L'indemnisation n'est pas définie pour "
+"cette organisation."
 
 #: rocky/templates/organizations/organization_settings.html
 #: rocky/views/indemnification_add.py
 msgid "Add indemnification"
-msgstr ""
+msgstr "Ajouter une indemnisation"
 
 #: rocky/templates/partials/current_config.html
 msgid "Current configuration"
-msgstr ""
+msgstr "Configuration actuelle"
 
 #: rocky/templates/partials/delete_ooi_modal.html
 msgid "Delete objects"
-msgstr ""
+msgstr "Supprimer des objets"
 
 #: rocky/templates/partials/delete_ooi_modal.html
 msgid ""
-"Are you sure you want to delete all the selected objects? The history of the "
-"deleted objects will still be available."
+"Are you sure you want to delete all the selected objects? The history of the"
+" deleted objects will still be available."
 msgstr ""
+"Êtes-vous sûr de vouloir supprimer tous les objets sélectionnés ? "
+"L'historique des objets supprimés sera toujours disponible."
 
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 msgid "Edit clearance level settings"
-msgstr ""
+msgstr "Modifier les paramètres du niveau d'autorisation"
 
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 msgid "You are editing clearance level of all the selected objects."
 msgstr ""
+"Vous modifiez le niveau d'autorisation de tous les objets sélectionnés."
 
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 msgid "Switching between declare and inherit"
-msgstr ""
+msgstr "Basculer entre déclarer et hériter"
 
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 msgid ""
 "Clearance levels can be automatically inherited or you can manually declare "
-"the clearance level for an object. Switching to inherit clearance level will "
-"also recalculate the clearance levels of objects that inherit from these "
+"the clearance level for an object. Switching to inherit clearance level will"
+" also recalculate the clearance levels of objects that inherit from these "
 "clearance levels."
 msgstr ""
+"Les niveaux d'autorisation peuvent être automatiquement hérités ou vous "
+"pouvez déclarer manuellement le niveau d'autorisation pour un objet. Le "
+"passage au niveau d'autorisation hérité recalculera également les niveaux "
+"d'autorisation des objets qui héritent de ces niveaux d'autorisation."
 
 #: rocky/templates/partials/elements/ooi_detail_settings.html
 msgid "Observed at"
-msgstr ""
+msgstr "Observé à"
 
 #: rocky/templates/partials/elements/ooi_detail_settings.html
 #: rocky/templates/partials/elements/ooi_report_settings.html
 msgid "Show settings"
-msgstr ""
+msgstr "Afficher les paramètres"
 
 #: rocky/templates/partials/elements/ooi_detail_settings.html
 #: rocky/templates/partials/elements/ooi_report_settings.html
 msgid "Hide settings"
-msgstr ""
+msgstr "Masquer les paramètres"
 
 #: rocky/templates/partials/elements/ooi_list_settings_form.html
 msgid "Toggle all OOI types"
-msgstr ""
+msgstr "Basculer tous les types OOI"
 
 #: rocky/templates/partials/elements/ooi_tree_condensed_table.html
 msgid "Children"
-msgstr ""
+msgstr "Enfants"
 
 #: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
 #, python-format
 msgid "Show details for %(object_id)s, with %(child_count)s children."
 msgstr ""
+"Afficher les détails pour %(object_id)s, avec les enfants %(child_count)s."
 
 #: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
 #, python-format
 msgid ""
 "Show tree for %(object_id)s with only children of type %(object_ooi_type)s"
 msgstr ""
+"Afficher l'arborescence pour %(object_id)s avec uniquement les enfants de "
+"type %(object_ooi_type)s"
 
 #: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
 #, python-format
 msgid "Unfold %(object_id)s with %(child_count)s children"
-msgstr ""
+msgstr "Dépliez %(object_id)s avec les enfants %(child_count)s"
 
 #: rocky/templates/partials/elements/ooi_tree_table.html
 msgid "go to:"
-msgstr ""
+msgstr "allez à:"
 
 #: rocky/templates/partials/elements/ooi_tree_table.html
 msgid "Go to detailpage"
-msgstr ""
+msgstr "Aller à la page de détail"
 
 #: rocky/templates/partials/elements/ooi_tree_table.html
 msgid "detail"
-msgstr ""
+msgstr "détail"
 
 #: rocky/templates/partials/elements/ooi_tree_table.html
 msgid "Go to tree view"
-msgstr ""
+msgstr "Aller à l'arborescence"
 
 #: rocky/templates/partials/elements/ooi_tree_table.html
 msgid "tree"
-msgstr ""
+msgstr "arbre"
 
 #: rocky/templates/partials/elements/ooi_tree_table.html
 msgid "Go to graph view"
-msgstr ""
+msgstr "Aller à la vue graphique"
 
 #: rocky/templates/partials/elements/ooi_tree_table.html
 msgid "graph"
-msgstr ""
+msgstr "graphique"
 
 #: rocky/templates/partials/explanations.html
 msgid "Clearance level inheritance"
-msgstr ""
+msgstr "Héritage du niveau d'autorisation"
 
 #: rocky/templates/partials/explanations.html
 msgid "OOI"
-msgstr ""
+msgstr "OOI"
+
+#: rocky/templates/partials/explanations.html
+msgid "This OOI"
+msgstr "Ce OOI"
 
 #: rocky/templates/partials/explanations.html
 msgid "Origin"
-msgstr ""
+msgstr "Origine"
+
+#: rocky/templates/partials/explanations.html
+msgid "declared"
+msgstr "déclaré"
+
+#: rocky/templates/partials/explanations.html
+msgid "inherited from ↓"
+msgstr "hérité de ↓"
 
 #: rocky/templates/partials/explanations.html
 msgid "Show clearance level inheritance"
-msgstr ""
+msgstr "Afficher l'héritage du niveau d'autorisation"
 
 #: rocky/templates/partials/finding_occurrence_definition_list.html
 msgid "Reproduction"
-msgstr ""
+msgstr "Reproduction"
 
 #: rocky/templates/partials/form/checkbox_group_table_form.html
 msgid "Please enable plugin to start scanning."
-msgstr ""
+msgstr "Veuillez activer le plugin pour lancer la numérisation."
 
 #: rocky/templates/partials/form/field_input.html
 msgid "Not set"
-msgstr ""
+msgstr "Non défini"
 
 #: rocky/templates/partials/form/field_input.html
 msgid "Forgot email"
-msgstr ""
+msgstr "E-mail oublié"
 
 #: rocky/templates/partials/form/field_input.html
 msgid "Forgot password"
-msgstr ""
+msgstr "Mot de passe oublié"
 
 #: rocky/templates/partials/form/field_input_errors.html
 #: rocky/templates/partials/notifications_block.html
 msgid "error"
-msgstr ""
+msgstr "erreur"
 
 #: rocky/templates/partials/form/field_input_errors.html
 #: rocky/templates/partials/form/form_errors.html
 #: rocky/templates/partials/notifications_block.html
 msgid "Error:"
-msgstr ""
+msgstr "Erreur:"
 
 #: rocky/templates/partials/form/field_input_help_text.html
 msgid "Open explanation"
-msgstr ""
+msgstr "Explication ouverte"
 
 #: rocky/templates/partials/form/field_input_help_text.html
 msgid "Close explanation"
-msgstr ""
+msgstr "Fermer l'explication"
 
 #: rocky/templates/partials/form/field_input_help_text.html
 #: rocky/templates/partials/notifications_block.html
 #: rocky/templates/two_factor/core/login.html
 msgid "Explanation:"
-msgstr ""
+msgstr "Explication:"
 
 #: rocky/templates/partials/form/indemnification_add_form.html
 msgid ""
@@ -6462,218 +7272,233 @@ msgid ""
 "negative impact on (your) assets. Therefore it is important to know and be "
 "aware of the impact of security scans."
 msgstr ""
+"L'exécution d'analyses de sécurité sur les actifs n'est généralement "
+"autorisée que si vous êtes autorisé à analyser ces actifs. Certaines "
+"analyses peuvent également avoir un impact négatif sur (vos) actifs. Il est "
+"donc important de connaître et d’être conscient de l’impact des analyses de "
+"sécurité."
 
 #: rocky/templates/partials/form/indemnification_add_form.html
 msgid ""
-"An organization indemnification is required before you can use OpenKAT. With "
-"the indemnification you declare that you, as a person, can be held "
+"An organization indemnification is required before you can use OpenKAT. With"
+" the indemnification you declare that you, as a person, can be held "
 "accountable."
 msgstr ""
+"Une indemnisation de l'organisation est requise avant de pouvoir utiliser "
+"OpenKAT. Avec l'indemnisation, vous déclarez que vous, en tant que personne,"
+" pouvez être tenu responsable."
 
 #: rocky/templates/partials/form/indemnification_add_form.html
 msgid "Set an indemnification"
-msgstr ""
+msgstr "Fixer une indemnisation"
 
 #: rocky/templates/partials/hyperlink_ooi_type.html
 #, python-format
 msgid "Only show objects of type %(type)s"
-msgstr ""
+msgstr "Afficher uniquement les objets de type %(type)s"
 
 #: rocky/templates/partials/list_filters.html
 msgid "Hide filter options"
-msgstr ""
+msgstr "Masquer les options de filtre"
 
 #: rocky/templates/partials/list_filters.html
 msgid "Show filter options"
-msgstr ""
+msgstr "Afficher les options de filtre"
 
 #: rocky/templates/partials/list_paginator.html
 msgid "List pagination"
-msgstr ""
+msgstr "Pagination de la liste"
 
 #: rocky/templates/partials/list_paginator.html
 msgid "Previous Page"
-msgstr ""
+msgstr "Page précédente"
 
 #: rocky/templates/partials/list_paginator.html
 msgid "Previous"
-msgstr ""
+msgstr "Précédent"
 
 #: rocky/templates/partials/list_paginator.html
 msgid "Five Pages Back"
-msgstr ""
+msgstr "Cinq pages en arrière"
 
 #: rocky/templates/partials/list_paginator.html
 #: rocky/templates/partials/pagination.html
 msgid "Page"
-msgstr ""
+msgstr "Page"
+
+#: rocky/templates/partials/list_paginator.html
+msgid "Current"
+msgstr "Actuel"
 
 #: rocky/templates/partials/list_paginator.html
 msgid "Five Pages Forward"
-msgstr ""
+msgstr "Cinq pages en avant"
 
 #: rocky/templates/partials/list_paginator.html
 msgid "Next Page"
-msgstr ""
+msgstr "Page suivante"
 
 #: rocky/templates/partials/list_paginator.html
 msgid "Next"
-msgstr ""
+msgstr "Suivant"
 
 #: rocky/templates/partials/mute_findings_modal.html
 msgid "You are muting the selected findings."
-msgstr ""
+msgstr "Vous désactivez les résultats sélectionnés."
 
 #: rocky/templates/partials/mute_findings_modal.html
 msgid "Reason:"
-msgstr ""
+msgstr "Raison:"
 
 #: rocky/templates/partials/mute_findings_modal.html
 msgid "Expires by (UTC):"
-msgstr ""
+msgstr "Expire le (UTC) :"
 
 #: rocky/templates/partials/notifications_block.html
 msgid "Confirmation:"
-msgstr ""
+msgstr "Confirmation:"
 
 #: rocky/templates/partials/ooi_detail_related_object.html
 msgid "No related object known for"
-msgstr ""
+msgstr "Aucun objet associé connu pour"
 
 #: rocky/templates/partials/ooi_detail_toolbar.html
 msgid "Generate Report"
-msgstr ""
+msgstr "Générer un rapport"
 
 #: rocky/templates/partials/ooi_detail_toolbar.html
 #, python-format
 msgid "Edit %(display_type)s"
-msgstr ""
+msgstr "Modifier %(display_type)s"
 
 #: rocky/templates/partials/ooi_head.html
-#, python-format
-msgid ""
-"An overview of \"%(ooi)s\", object type \"%(type)s\". This shows general "
-"information and its related objects. It also gives the possibility to add "
-"additional related objects, or to scan for them."
-msgstr ""
+msgid "Data from:"
+msgstr "Données de :"
+
+#: rocky/templates/partials/ooi_head.html
+msgid "(Now)"
+msgstr "(Maintenant)"
 
 #: rocky/templates/partials/ooi_list_toolbar.html
 msgid "Scan for objects"
-msgstr ""
+msgstr "Rechercher des objets"
 
 #: rocky/templates/partials/ooi_list_toolbar.html
 #: rocky/templates/upload_csv.html rocky/views/upload_csv.py
 msgid "Upload CSV"
-msgstr ""
+msgstr "Téléchargez CSV"
 
 #: rocky/templates/partials/ooi_list_toolbar.html
 msgid "Export"
-msgstr ""
+msgstr "Exporter"
 
 #: rocky/templates/partials/ooi_list_toolbar.html
 msgid "Download as CSV"
-msgstr ""
+msgstr "Télécharger en tant que CSV"
 
 #: rocky/templates/partials/ooi_report_findings_block.html
 #, python-format
 msgid "%(total)s findings on %(name)s"
-msgstr ""
+msgstr "Résultats %(total)s sur %(name)s"
 
 #: rocky/templates/partials/ooi_report_findings_block_table.html
 #, python-format
 msgid "Findings for %(type)s %(name)s on %(observed_at)s:"
-msgstr ""
+msgstr "Résultats pour %(type)s %(name)s sur %(observed_at)s :"
 
 #: rocky/templates/partials/ooi_report_findings_block_table.html
 msgid "Open finding details"
-msgstr ""
+msgstr "Ouvrir les détails de la recherche"
 
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 #, python-format
 msgid "Details of %(object_id)s"
-msgstr ""
+msgstr "Détails de %(object_id)s"
 
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid ""
 "The severity of this findingtype has not (yet) been determined by the data "
 "source. This situation requires manual investigation of the severity."
 msgstr ""
+"La gravité de ce type de constatation n’a pas (encore) été déterminée par la"
+" source de données. Cette situation nécessite une enquête manuelle sur la "
+"gravité."
 
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "Total occurrences"
-msgstr ""
+msgstr "Nombre total d'occurrences"
 
 #: rocky/templates/partials/ooi_tree_toolbar_bottom.html
 msgid "Tree - dense view"
-msgstr ""
+msgstr "Arbre - vue dense"
 
 #: rocky/templates/partials/ooi_tree_toolbar_bottom.html
 msgid "Tree - table view"
-msgstr ""
+msgstr "Arbre - vue tableau"
 
 #: rocky/templates/partials/organization_member_list_filters.html
 msgid "Update List"
-msgstr ""
+msgstr "Mettre à jour la liste"
 
 #: rocky/templates/partials/organization_properties_table.html
 msgid "Organization name"
-msgstr ""
+msgstr "Nom de l'organisation"
 
 #: rocky/templates/partials/organization_properties_table.html
 msgid "Organization code"
-msgstr ""
+msgstr "Code de l'organisation"
 
 #: rocky/templates/partials/organizations_menu_dropdown.html
 msgid "Select organization"
-msgstr ""
+msgstr "Sélectionnez une organisation"
 
 #: rocky/templates/partials/organizations_menu_dropdown.html
 msgid "All organizations"
-msgstr ""
+msgstr "Toutes les organisations"
 
 #: rocky/templates/partials/page-meta.html
 msgid "Logged in as:"
-msgstr ""
+msgstr "Connecté en tant que :"
 
 #: rocky/templates/partials/pagination.html
 msgid "of"
-msgstr ""
+msgstr "de"
 
 #: rocky/templates/partials/pagination.html
 msgid "first"
-msgstr ""
+msgstr "d'abord"
 
 #: rocky/templates/partials/pagination.html
 msgid "previous"
-msgstr ""
+msgstr "précédent"
 
 #: rocky/templates/partials/pagination.html
 msgid "next"
-msgstr ""
+msgstr "suivant"
 
 #: rocky/templates/partials/pagination.html
 msgid "last"
-msgstr ""
+msgstr "dernier"
 
 #: rocky/templates/partials/secondary-menu.html
 msgid "User navigation"
-msgstr ""
+msgstr "Navigation utilisateur"
 
 #: rocky/templates/partials/secondary-menu.html
 msgid "Close user navigation"
-msgstr ""
+msgstr "Fermer la navigation utilisateur"
 
 #: rocky/templates/partials/secondary-menu.html
 msgid "My organizations"
-msgstr ""
+msgstr "Mes organisations"
 
 #: rocky/templates/partials/secondary-menu.html
 msgid "Profile"
-msgstr ""
+msgstr "Profil"
 
 #: rocky/templates/partials/skip-to-content.html
 msgid "Go to content"
-msgstr ""
+msgstr "Aller au contenu"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid ""
@@ -6682,50 +7507,59 @@ msgid ""
 "This means that the clearance level might stay the same, increase or "
 "decrease, depending on other declared clearance levels."
 msgstr ""
+"Le niveau d'autorisation détermine le niveau d'analyses boefje autorisées "
+"sur cet objet. Un objet hérite de son niveau d'autorisation des objets "
+"voisins. Cela signifie que le niveau d'autorisation peut rester le même, "
+"augmenter ou diminuer, en fonction des autres niveaux d'autorisation "
+"déclarés."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Empty clearance level explanation"
-msgstr ""
+msgstr "Explication du niveau de dégagement vide"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Empty:"
-msgstr ""
+msgstr "Vide:"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid ""
 "This object has a clearance level of \"empty\". This means that this object "
 "has no clearance level."
 msgstr ""
+"Cet objet a un niveau de sécurité « vide ». Cela signifie que cet objet n'a "
+"pas de niveau d'autorisation."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Indemnification warning"
-msgstr ""
+msgstr "Avertissement d’indemnisation"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Indemnification is not set for this organization."
-msgstr ""
+msgstr "Aucune indemnisation n’est fixée pour cette organisation."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Go to the"
-msgstr ""
+msgstr "Allez au"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "organization settings page"
-msgstr ""
+msgstr "page des paramètres de l'organisation"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "to add one."
-msgstr ""
+msgstr "pour en ajouter un."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Set clearance level warning"
-msgstr ""
+msgstr "Définir l'avertissement du niveau de dégagement"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid ""
 "You don't have permissions to set the clearance level. Contact your "
 "administrator."
 msgstr ""
+"Vous n'êtes pas autorisé à définir le niveau d'autorisation. Contactez votre"
+" administrateur."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 #, python-format
@@ -6734,115 +7568,128 @@ msgid ""
 "clearance level is %(member_clearance_level)s and this OOI has level "
 "%(boefje_scan_level)s."
 msgstr ""
+"Vous n'êtes pas autorisé à définir le niveau d'autorisation de ce OOI. Votre"
+" niveau de dégagement maximum est %(member_clearance_level)s et ce OOI a le "
+"niveau %(boefje_scan_level)s."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Go to your"
-msgstr ""
+msgstr "Allez à votre"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "account details"
-msgstr ""
+msgstr "détails du compte"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "to manage your clearance level."
-msgstr ""
+msgstr "pour gérer votre niveau d'autorisation."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Current clearance level"
-msgstr ""
+msgstr "Niveau d'autorisation actuel"
 
 #: rocky/templates/tasks/boefje_task_detail.html
 msgid ""
 "An overview of the boefje task, the input OOI and the RAW data it generated."
 msgstr ""
+"Un aperçu de la tâche boefje, de l'entrée OOI et des données RAW qu'elle a "
+"générées."
 
 #: rocky/templates/tasks/boefje_task_detail.html
 #: rocky/templates/tasks/partials/task_actions.html
 msgid "Download meta and raw data"
-msgstr ""
+msgstr "Télécharger des métadonnées et des données brutes"
 
 #: rocky/templates/tasks/boefje_task_detail.html
 msgid "Download meta data"
-msgstr ""
+msgstr "Télécharger les métadonnées"
 
 #: rocky/templates/tasks/boefje_task_detail.html
 msgid "Input object"
-msgstr ""
+msgstr "Objet d'entrée"
 
 #: rocky/templates/tasks/boefjes.html
 msgid "There are no tasks for boefjes."
-msgstr ""
+msgstr "Il n'y a pas de tâches pour les boefjes."
 
 #: rocky/templates/tasks/boefjes.html
 msgid "List of tasks for boefjes."
-msgstr ""
+msgstr "Liste des tâches pour les boefjes."
 
 #: rocky/templates/tasks/boefjes.html rocky/templates/tasks/reports.html
 msgid "Organization Code"
-msgstr ""
+msgstr "Code de l'organisation"
 
 #: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
 #: rocky/templates/tasks/ooi_detail_task_list.html
 #: rocky/templates/tasks/plugin_detail_task_list.html
 msgid "Created date"
-msgstr ""
+msgstr "Date de création"
 
 #: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
 #: rocky/templates/tasks/reports.html
 msgid "Modified date"
-msgstr ""
+msgstr "Date de modification"
 
 #: rocky/templates/tasks/normalizers.html
 msgid "There are no tasks for normalizers."
-msgstr ""
+msgstr "Il n'y a aucune tâche pour les normalisateurs."
 
 #: rocky/templates/tasks/normalizers.html
 msgid "List of tasks for normalizers."
-msgstr ""
+msgstr "Liste des tâches pour les normalisateurs."
 
 #: rocky/templates/tasks/normalizers.html
 msgid "Boefje input OOI"
-msgstr ""
+msgstr "Entrée Boefje OOI"
 
 #: rocky/templates/tasks/normalizers.html
 msgid "Manually added"
-msgstr ""
+msgstr "Ajouté manuellement"
 
 #: rocky/templates/tasks/ooi_detail_task_list.html
 msgid "There have been no tasks."
-msgstr ""
+msgstr "Il n'y a eu aucune tâche."
 
 #: rocky/templates/tasks/partials/stats.html
 msgid "Task statistics - Last 24 hours"
-msgstr ""
+msgstr "Statistiques des tâches - Dernières 24 heures"
 
 #: rocky/templates/tasks/partials/stats.html
 msgid "All times in UTC, blocks of 1 hour."
-msgstr ""
+msgstr "Toutes les heures en UTC, par blocs de 1 heure."
 
 #: rocky/templates/tasks/partials/stats.html
 msgid "Timeslot"
-msgstr ""
+msgstr "Plage horaire"
 
 #: rocky/templates/tasks/partials/stats.html
 msgid "Could not load stats, Scheduler error."
-msgstr ""
+msgstr "Impossible de charger les statistiques, erreur du planificateur."
 
 #: rocky/templates/tasks/partials/tab_navigation.html
 msgid "List of tasks"
-msgstr ""
+msgstr "Liste des tâches"
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Loading..."
+msgstr "Chargement..."
 
 #: rocky/templates/tasks/partials/task_actions.html
 msgid "Yielded objects"
-msgstr ""
+msgstr "Objets cédés"
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Yielded raw files"
+msgstr "Fichiers bruts générés"
 
 #: rocky/templates/tasks/partials/task_actions.html
 msgid "Reschedule"
-msgstr ""
+msgstr "Reprogrammer"
 
 #: rocky/templates/tasks/partials/task_actions.html
 msgid "Download task data"
-msgstr ""
+msgstr "Télécharger les données de tâche"
 
 #: rocky/templates/tasks/partials/tasks_overview_header.html
 #, python-format
@@ -6853,39 +7700,44 @@ msgid ""
 "Report tasks. This task aggregates and presents findings from both Boefjes "
 "and Normalizers."
 msgstr ""
+"Présentation des tâches pour <strong>%(organization)s</strong>. Les tâches "
+"sont divisées en Boefjes, Normalizers et Rapports. Boefjes analyse les "
+"objets et Normalizers envoie sur le type MIME de sortie. De plus, il existe "
+"des tâches de rapport. Cette tâche regroupe et présente les résultats de "
+"Boefjes et Normalizers."
 
 #: rocky/templates/tasks/plugin_detail_task_list.html
 msgid "There are no tasks for"
-msgstr ""
+msgstr "Il n'y a aucune tâche pour"
 
 #: rocky/templates/tasks/plugin_detail_task_list.html
 msgid "List of tasks for"
-msgstr ""
+msgstr "Liste des tâches pour"
 
 #: rocky/templates/tasks/reports.html
 msgid "There are no tasks for reports."
-msgstr ""
+msgstr "Il n'y a aucune tâche pour les rapports."
 
 #: rocky/templates/tasks/reports.html
 msgid "List of tasks for reports."
-msgstr ""
+msgstr "Liste des tâches pour les rapports."
 
 #: rocky/templates/tasks/reports.html
 msgid "Recipe ID"
-msgstr ""
+msgstr "ID de recette"
 
 #: rocky/templates/two_factor/_wizard_actions.html
 msgid "Log in"
-msgstr ""
+msgstr "Se connecter"
 
 #: rocky/templates/two_factor/_wizard_actions.html
 msgid "Authenticate"
-msgstr ""
+msgstr "Authentifier"
 
 #: rocky/templates/two_factor/core/backup_tokens.html
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Backup Tokens"
-msgstr ""
+msgstr "Jetons de sauvegarde"
 
 #: rocky/templates/two_factor/core/backup_tokens.html
 msgid ""
@@ -6894,45 +7746,53 @@ msgid ""
 "you've used up all your backup tokens, you can generate a new set of backup "
 "tokens. Only the backup tokens shown below will be valid."
 msgstr ""
+"Les jetons de sauvegarde peuvent être utilisés lorsque vos numéros de "
+"téléphone principal et de secours ne sont pas disponibles. Les jetons de "
+"sauvegarde ci-dessous peuvent être utilisés pour la vérification de la "
+"connexion. Si vous avez utilisé tous vos jetons de sauvegarde, vous pouvez "
+"générer un nouvel ensemble de jetons de sauvegarde. Seuls les jetons de "
+"sauvegarde indiqués ci-dessous seront valides."
 
 #: rocky/templates/two_factor/core/backup_tokens.html
 msgid "Print these tokens and keep them somewhere safe."
-msgstr ""
+msgstr "Imprimez ces jetons et conservez-les dans un endroit sûr."
 
 #: rocky/templates/two_factor/core/backup_tokens.html
 msgid "You don't have any backup codes yet."
-msgstr ""
+msgstr "Vous n'avez pas encore de codes de secours."
 
 #: rocky/templates/two_factor/core/backup_tokens.html
 msgid "Generate Tokens"
-msgstr ""
+msgstr "Générer des jetons"
 
 #: rocky/templates/two_factor/core/backup_tokens.html
 #: rocky/templates/two_factor/core/setup_complete.html
 msgid "Back to Account Security"
-msgstr ""
+msgstr "Retour à la sécurité du compte"
 
 #: rocky/templates/two_factor/core/login.html
 msgid "You are logged in."
-msgstr ""
+msgstr "Vous êtes connecté."
 
 #: rocky/templates/two_factor/core/login.html
 msgid "Two factor authentication is enabled for your account."
-msgstr ""
+msgstr "L'authentification à deux facteurs est activée pour votre compte."
 
 #: rocky/templates/two_factor/core/login.html
 msgid ""
 "Two factor authentication is not enabled for your account. Enable it to "
 "continue."
 msgstr ""
+"L'authentification à deux facteurs n'est pas activée pour votre compte. "
+"Permettez-lui de continuer."
 
 #: rocky/templates/two_factor/core/login.html
 msgid "Setup two factor authentication"
-msgstr ""
+msgstr "Configurer l'authentification à deux facteurs"
 
 #: rocky/templates/two_factor/core/login.html
 msgid "Credentials"
-msgstr ""
+msgstr "Informations d'identification"
 
 #: rocky/templates/two_factor/core/login.html
 msgid ""
@@ -6940,18 +7800,22 @@ msgid ""
 "been generated for you to print and keep safe. Please enter one of these "
 "backup tokens to login to your account."
 msgstr ""
+"Utilisez ce formulaire pour saisir des jetons de sauvegarde pour vous "
+"connecter. Ces jetons ont été générés pour que vous puissiez les imprimer et"
+" les conserver en sécurité. Veuillez saisir l'un de ces jetons de sauvegarde"
+" pour vous connecter à votre compte."
 
 #: rocky/templates/two_factor/core/login.html
 msgid "As a last resort, you can use a backup token:"
-msgstr ""
+msgstr "En dernier recours, vous pouvez utiliser un token de sauvegarde :"
 
 #: rocky/templates/two_factor/core/login.html
 msgid "Use Backup Token"
-msgstr ""
+msgstr "Utiliser le jeton de sauvegarde"
 
 #: rocky/templates/two_factor/core/otp_required.html
 msgid "Permission Denied"
-msgstr ""
+msgstr "Autorisation refusée"
 
 #: rocky/templates/two_factor/core/otp_required.html
 msgid ""
@@ -6959,242 +7823,301 @@ msgid ""
 "authentication for security reasons. You need to enable these security "
 "features in order to access this page."
 msgstr ""
+"La page que vous avez demandée oblige les utilisateurs à vérifier à l'aide "
+"d'une authentification à deux facteurs pour des raisons de sécurité. Vous "
+"devez activer ces fonctionnalités de sécurité pour accéder à cette page."
 
 #: rocky/templates/two_factor/core/otp_required.html
 #: rocky/templates/two_factor/profile/profile.html
 msgid ""
-"Two-factor authentication is not enabled for your account. Enable two-factor "
-"authentication for enhanced account security."
+"Two-factor authentication is not enabled for your account. Enable two-factor"
+" authentication for enhanced account security."
 msgstr ""
+"L'authentification à deux facteurs n'est pas activée pour votre compte. "
+"Activez l'authentification à deux facteurs pour une sécurité renforcée du "
+"compte."
 
 #: rocky/templates/two_factor/core/otp_required.html
 #: rocky/templates/two_factor/core/setup.html
 #: rocky/templates/two_factor/core/setup_complete.html
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Enable Two-Factor Authentication"
-msgstr ""
+msgstr "Activer l'authentification à deux facteurs"
 
 #: rocky/templates/two_factor/core/phone_register.html
 msgid "Add Backup Phone"
-msgstr ""
+msgstr "Ajouter un téléphone de secours"
 
 #: rocky/templates/two_factor/core/phone_register.html
 msgid ""
 "You'll be adding a backup phone number to your account. This number will be "
 "used if your primary method of registration is not available."
 msgstr ""
+"Vous ajouterez un numéro de téléphone de secours à votre compte. Ce numéro "
+"sera utilisé si votre méthode d'inscription principale n'est pas disponible."
 
 #: rocky/templates/two_factor/core/phone_register.html
 msgid ""
 "We've sent a token to your phone number. Please enter the token you've "
 "received."
 msgstr ""
+"Nous avons envoyé un jeton à votre numéro de téléphone. Veuillez saisir le "
+"jeton que vous avez reçu."
 
 #: rocky/templates/two_factor/core/setup.html
 msgid ""
 "To start using a token generator, please use your smartphone to scan the QR "
-"code below or use the setup key. For example, use GoogleAuthenticator. Then, "
-"enter the token generated by the app."
+"code below or use the setup key. For example, use GoogleAuthenticator. Then,"
+" enter the token generated by the app."
 msgstr ""
+"Pour commencer à utiliser un générateur de jetons, veuillez utiliser votre "
+"smartphone pour scanner le code QR ci-dessous ou utiliser la clé de "
+"configuration. Par exemple, utilisez GoogleAuthenticator. Ensuite, saisissez"
+" le jeton généré par l'application."
 
 #: rocky/templates/two_factor/core/setup.html
 msgid "QR code"
-msgstr ""
+msgstr "Code QR"
 
 #: rocky/templates/two_factor/core/setup.html
 msgid "Setup key"
-msgstr ""
+msgstr "Clé de configuration"
 
 #: rocky/templates/two_factor/core/setup.html
 msgid ""
-"The secret key is a 32 characters representation of the QR code. There are 2 "
-"options to setup the two factor authtentication. You can scan the QR code "
+"The secret key is a 32 characters representation of the QR code. There are 2"
+" options to setup the two factor authtentication. You can scan the QR code "
 "above or you can insert this key using the secret key option of the "
 "authenticator app."
 msgstr ""
+"La clé secrète est une représentation de 32 caractères du code QR. Il existe"
+" 2 options pour configurer l'authentification à deux facteurs. Vous pouvez "
+"scanner le code QR ci-dessus ou insérer cette clé en utilisant l'option de "
+"clé secrète de l'application d'authentification."
 
 #: rocky/templates/two_factor/core/setup_complete.html
-msgid "Congratulations, you've successfully enabled two-factor authentication."
+msgid ""
+"Congratulations, you've successfully enabled two-factor authentication."
 msgstr ""
+"Félicitations, vous avez activé avec succès l'authentification à deux "
+"facteurs."
 
 #: rocky/templates/two_factor/core/setup_complete.html
 msgid "Start using OpenKAT"
-msgstr ""
+msgstr "Commencez à utiliser OpenKAT"
 
 #: rocky/templates/two_factor/core/setup_complete.html
 msgid ""
 "However, it might happen that you don't have access to your primary token "
 "device. To enable account recovery, add a phone number."
 msgstr ""
+"Cependant, il peut arriver que vous n'ayez pas accès à votre périphérique à "
+"jeton principal. Pour activer la récupération de compte, ajoutez un numéro "
+"de téléphone."
 
 #: rocky/templates/two_factor/core/setup_complete.html
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Add Phone Number"
-msgstr ""
+msgstr "Ajouter un numéro de téléphone"
 
 #: rocky/templates/two_factor/profile/disable.html
 msgid "Disable Two-factor Authentication"
-msgstr ""
+msgstr "Désactiver l'authentification à deux facteurs"
 
 #: rocky/templates/two_factor/profile/disable.html
 msgid ""
 "You are about to disable two-factor authentication. This weakens your "
 "account security, are you sure?"
 msgstr ""
+"Vous êtes sur le point de désactiver l'authentification à deux facteurs. "
+"Cela affaiblit la sécurité de votre compte, en êtes-vous sûr ?"
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Account Security"
-msgstr ""
+msgstr "Sécurité du compte"
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Tokens will be generated by your token generator."
-msgstr ""
+msgstr "Les jetons seront générés par votre générateur de jetons."
 
 #: rocky/templates/two_factor/profile/profile.html
 #, python-format
 msgid "Primary method: %(primary)s"
-msgstr ""
+msgstr "Méthode principale : %(primary)s"
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Tokens will be generated by your YubiKey."
-msgstr ""
+msgstr "Les jetons seront générés par votre YubiKey."
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Backup Phone Numbers"
-msgstr ""
+msgstr "Numéros de téléphone de sauvegarde"
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid ""
 "If your primary method is not available, we are able to send backup tokens "
 "to the phone numbers listed below."
 msgstr ""
+"Si votre méthode principale n'est pas disponible, nous sommes en mesure "
+"d'envoyer des jetons de secours aux numéros de téléphone répertoriés ci-"
+"dessous."
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Unregister"
-msgstr ""
+msgstr "Se désinscrire"
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid ""
 "If you don't have any device with you, you can access your account using "
 "backup tokens."
 msgstr ""
+"Si vous n'avez aucun appareil avec vous, vous pouvez accéder à votre compte "
+"à l'aide de jetons de sauvegarde."
 
 #: rocky/templates/two_factor/profile/profile.html
 #, python-format
 msgid "You have only one backup token remaining."
 msgid_plural "You have %(counter)s backup tokens remaining."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Il vous reste des jetons de sauvegarde %(counter)s."
+msgstr[1] "Il vous reste des jetons de sauvegarde %(counter)s."
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Show Codes"
-msgstr ""
+msgstr "Afficher les codes"
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Disable Two-Factor Authentication"
-msgstr ""
+msgstr "Désactiver l'authentification à deux facteurs"
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid ""
-"However we strongly discourage you to do so, you can also disable two-factor "
-"authentication for your account."
+"However we strongly discourage you to do so, you can also disable two-factor"
+" authentication for your account."
 msgstr ""
+"Cependant, nous vous déconseillons fortement de le faire, vous pouvez "
+"également désactiver l'authentification à deux facteurs pour votre compte."
 
 #: rocky/templates/two_factor/twilio/sms_message.html
 #, python-format
 msgid "Your OTP token is %(token)s"
-msgstr ""
+msgstr "Votre jeton OTP est %(token)s"
 
 #: rocky/templates/upload_csv.html
 msgid "Automate the creation of multiple objects by uploading a CSV file."
 msgstr ""
+"Automatisez la création de plusieurs objets en téléchargeant un fichier CSV."
 
 #: rocky/templates/upload_csv.html
 msgid "These are the criteria for CSV upload:"
-msgstr ""
+msgstr "Voici les critères pour le téléchargement de CSV :"
 
 #: rocky/templates/upload_raw.html
 msgid "Automate the creation of multiple objects by uploading a raw file."
 msgstr ""
+"Automatisez la création de plusieurs objets en téléchargeant un fichier "
+"brut."
 
 #: rocky/templates/upload_raw.html
 msgid ""
-"An input OOI can be selected for the normalizer to attach newly yielded OOIs "
-"to. If no input OOI was used for the raw file, a placeholder ExternalScan "
+"An input OOI can be selected for the normalizer to attach newly yielded OOIs"
+" to. If no input OOI was used for the raw file, a placeholder ExternalScan "
 "OOI can be used. ExternalScan OOIs can be created from the objects page. "
 "When a new version of the raw file is generated, the same ExternalScan OOI "
 "should be chosen to ensure that old results are overwritten."
 msgstr ""
+"Une entrée OOI peut être sélectionnée pour que le normalisateur puisse "
+"attacher le OOIs nouvellement généré. Si aucune entrée OOI n’a été utilisée "
+"pour le fichier brut, un espace réservé ExternalScan OOI peut être utilisé. "
+"ExternalScan OOIs peut être créé à partir de la page des objets. Lorsqu'une "
+"nouvelle version du fichier brut est générée, le même ExternalScan OOI doit "
+"être choisi pour garantir que les anciens résultats sont écrasés."
 
 #: rocky/templates/upload_raw.html rocky/views/upload_raw.py
 msgid "Upload raw"
-msgstr ""
+msgstr "Télécharger brut"
 
 #: rocky/views/bytes_raw.py
 msgid "Getting raw data failed."
-msgstr ""
+msgstr "L'obtention des données brutes a échoué."
 
 #: rocky/views/bytes_raw.py
 msgid "The task does not have any raw data."
-msgstr ""
+msgstr "La tâche ne contient aucune donnée brute."
 
 #: rocky/views/finding_list.py rocky/views/ooi_list.py
 msgid "Unknown action."
-msgstr ""
+msgstr "Action inconnue."
 
 #: rocky/views/health.py
 msgid "Beautified"
-msgstr ""
+msgstr "Embelli"
 
 #: rocky/views/indemnification_add.py
 msgid "Indemnification successfully set."
-msgstr ""
+msgstr "L'indemnisation a été établie avec succès."
 
 #: rocky/views/mixins.py
 msgid "The selected date is in the future."
-msgstr ""
+msgstr "La date sélectionnée est dans le futur."
 
 #: rocky/views/mixins.py
 msgid "Can not parse date, falling back to show current date."
 msgstr ""
+"Impossible d'analyser la date, retour à l'affichage de la date actuelle."
+
+#: rocky/views/mixins.py
+#, python-format
+msgid "Could not load origins for OOI: %s from octopoes"
+msgstr "Impossible de charger les origines pour OOI : %s à partir de poulpes"
+
+#: rocky/views/mixins.py
+msgid "Could not load normalizer metas from bytes"
+msgstr "Impossible de charger les métas du normalisateur à partir des octets"
+
+#: rocky/views/mixins.py
+#, python-format
+msgid "Could not load boefje %s from katalogus"
+msgstr "Impossible de charger le boefje %s à partir du catalogue"
 
 #: rocky/views/mixins.py
 msgid "You do not have the permission to add items to a dashboard."
-msgstr ""
+msgstr "Vous n'êtes pas autorisé à ajouter des éléments à un tableau de bord."
 
 #: rocky/views/mixins.py
 msgid "Dashboard item has been added."
-msgstr ""
+msgstr "Un élément du tableau de bord a été ajouté."
 
 #: rocky/views/ooi_add.py
 #, python-format
 msgid "Add %(ooi_type)s"
-msgstr ""
+msgstr "Ajouter %(ooi_type)s"
 
 #: rocky/views/ooi_detail.py
 msgid ""
 "Cannot set clearance level. It must be provided and must be a valid number."
 msgstr ""
+"Impossible de définir le niveau d'autorisation. Il doit être fourni et doit "
+"être un numéro valide."
 
 #: rocky/views/ooi_detail.py
 msgid "Only Question OOIs can be answered."
-msgstr ""
+msgstr "Seule la question OOIs peut recevoir une réponse."
 
 #: rocky/views/ooi_detail.py
 msgid "Question has been answered."
-msgstr ""
+msgstr "La question a reçu une réponse."
 
 #: rocky/views/ooi_detail_related_object.py
 msgid " (as "
-msgstr ""
+msgstr "(comme"
 
 #: rocky/views/ooi_findings.py
 msgid "Object findings"
-msgstr ""
+msgstr "Résultats d'objets"
 
 #: rocky/views/ooi_list.py
 msgid "No OOIs selected."
-msgstr ""
+msgstr "Aucun OOIs sélectionné."
 
 #: rocky/views/ooi_list.py
 #, python-format
@@ -7202,6 +8125,8 @@ msgid ""
 "Could not raise clearance levels to L%s. Indemnification not present at "
 "organization %s."
 msgstr ""
+"Impossible d'augmenter les niveaux d'autorisation à L%s. Indemnisation non "
+"présente dans l'organisation %s."
 
 #: rocky/views/ooi_list.py
 #, python-format
@@ -7209,6 +8134,9 @@ msgid ""
 "Could not raise clearance level to L%s. You were trusted a clearance level "
 "of L%s. Contact your administrator to receive a higher clearance."
 msgstr ""
+"Impossible d'augmenter le niveau d'autorisation à L%s. On vous a fait "
+"confiance avec un niveau d'autorisation L%s. Contactez votre administrateur "
+"pour recevoir une autorisation plus élevée."
 
 #: rocky/views/ooi_list.py
 #, python-format
@@ -7216,42 +8144,53 @@ msgid ""
 "Could not raise clearance level to L%s. You acknowledged a clearance level "
 "of L%s. Please accept the clearance level below to proceed."
 msgstr ""
+"Impossible d'augmenter le niveau d'autorisation à L%s. Vous avez reconnu un "
+"niveau d'autorisation L%s. Veuillez accepter le niveau d'autorisation ci-"
+"dessous pour continuer."
 
 #: rocky/views/ooi_list.py
 msgid "An error occurred while saving clearance levels."
 msgstr ""
+"Une erreur s'est produite lors de l'enregistrement des niveaux "
+"d'autorisation."
 
 #: rocky/views/ooi_list.py
 msgid "One of the OOI's doesn't exist"
-msgstr ""
+msgstr "L'un des OOI n'existe pas"
 
 #: rocky/views/ooi_list.py
 #, python-format
 msgid "Successfully set scan profile to %s for %d OOIs."
-msgstr ""
+msgstr "Définissez avec succès le profil de numérisation sur %s pour %d OOIs."
 
 #: rocky/views/ooi_list.py
 msgid "An error occurred while setting clearance levels to inherit."
 msgstr ""
+"Une erreur s'est produite lors de la définition des niveaux d'autorisation à"
+" hériter."
 
 #: rocky/views/ooi_list.py
 msgid ""
-"An error occurred while setting clearance levels to inherit: one of the OOIs "
-"doesn't exist."
+"An error occurred while setting clearance levels to inherit: one of the OOIs"
+" doesn't exist."
 msgstr ""
+"Une erreur s'est produite lors de la définition des niveaux d'autorisation à"
+" hériter : l'un des OOIs n'existe pas."
 
 #: rocky/views/ooi_list.py
 #, python-format
 msgid "Successfully set %d OOI(s) clearance level to inherit."
-msgstr ""
+msgstr "Définissez avec succès le niveau d'autorisation %d OOI(s) à hériter."
 
 #: rocky/views/ooi_list.py
 msgid "An error occurred while deleting oois."
-msgstr ""
+msgstr "Une erreur s'est produite lors de la suppression des oois."
 
 #: rocky/views/ooi_list.py
 msgid "An error occurred while deleting OOIs: one of the OOIs doesn't exist."
 msgstr ""
+"Une erreur s'est produite lors de la suppression de OOIs : l'un des OOIs "
+"n'existe pas."
 
 #: rocky/views/ooi_list.py
 #, python-format
@@ -7259,115 +8198,120 @@ msgid ""
 "Successfully deleted %d ooi(s). Note: Bits can recreate objects "
 "automatically."
 msgstr ""
+"%d ooi(s) supprimé(s) avec succès. Remarque : Les bits peuvent recréer "
+"automatiquement des objets."
 
 #: rocky/views/ooi_mute.py
 msgid "Please select at least one finding."
-msgstr ""
+msgstr "Veuillez sélectionner au moins un résultat."
 
 #: rocky/views/ooi_mute.py
 msgid "Finding(s) successfully unmuted."
-msgstr ""
+msgstr "Les résultats ont été réactivés avec succès."
 
 #: rocky/views/ooi_mute.py
 msgid "Finding(s) successfully muted."
-msgstr ""
+msgstr "Les résultats ont été désactivés avec succès."
 
 #: rocky/views/ooi_tree.py
 msgid "Tree Visualisation"
-msgstr ""
+msgstr "Visualisation de l'arborescence"
 
 #: rocky/views/ooi_tree.py
 msgid "Graph Visualisation"
-msgstr ""
+msgstr "Visualisation graphique"
 
 #: rocky/views/ooi_view.py
 msgid "Observed_at: "
-msgstr ""
+msgstr "Observé_à :"
 
 #: rocky/views/ooi_view.py
 msgid "OOI types: "
-msgstr ""
+msgstr "Types OOI :"
 
 #: rocky/views/ooi_view.py
 msgid "Clearance level: "
-msgstr ""
+msgstr "Niveau de dégagement :"
 
 #: rocky/views/ooi_view.py
 msgid "Clearance type: "
-msgstr ""
+msgstr "Type de dégagement :"
 
 #: rocky/views/ooi_view.py
 msgid "Searching for: "
-msgstr ""
+msgstr "Recherche de :"
 
 #: rocky/views/organization_add.py
 msgid "Setup"
-msgstr ""
+msgstr "Installation"
 
 #: rocky/views/organization_add.py
 msgid "Organization added successfully."
-msgstr ""
+msgstr "Organisation ajoutée avec succès."
 
 #: rocky/views/organization_add.py
 msgid "You are not allowed to add organizations."
-msgstr ""
+msgstr "Vous n'êtes pas autorisé à ajouter des organisations."
 
 #: rocky/views/organization_edit.py
 #, python-format
 msgid "Organization %s successfully updated."
-msgstr ""
+msgstr "L'organisation %s a été mise à jour avec succès."
 
 #: rocky/views/organization_member_add.py
 msgid "Add column titles, followed by each object on a new line."
 msgstr ""
+"Ajoutez des titres de colonnes, suivis de chaque objet sur une nouvelle "
+"ligne."
 
 #: rocky/views/organization_member_add.py
 msgid "The columns are: "
-msgstr ""
+msgstr "Les colonnes sont :"
 
 #: rocky/views/organization_member_add.py
 msgid "Clearance levels should be between -1 and 4."
-msgstr ""
+msgstr "Les niveaux de clairance doivent être compris entre -1 et 4."
 
 #: rocky/views/organization_member_add.py
 msgid "Account type can be one of: "
-msgstr ""
+msgstr "Le type de compte peut être l'un des suivants :"
 
 #: rocky/views/organization_member_add.py
 msgid "Member added successfully."
-msgstr ""
+msgstr "Membre ajouté avec succès."
 
 #: rocky/views/organization_member_add.py
 msgid "The csv file is missing required columns"
-msgstr ""
+msgstr "Le fichier CSV ne contient pas les colonnes requises"
 
 #: rocky/views/organization_member_add.py
 #, python-brace-format
 msgid "Invalid account type: '{account_type}'"
-msgstr ""
+msgstr "Type de compte invalide : « {account_type} »"
 
 #: rocky/views/organization_member_add.py
 #, python-brace-format
 msgid "Invalid data for: '{email}'"
-msgstr ""
+msgstr "Données invalides pour : '{email}'"
 
 #: rocky/views/organization_member_add.py
 #, python-brace-format
 msgid "Invalid email address: '{email}'"
-msgstr ""
+msgstr "Adresse e-mail invalide : '{email}'"
 
 #: rocky/views/organization_member_add.py
 msgid "Successfully processed users from csv."
-msgstr ""
+msgstr "Utilisateurs traités avec succès à partir de CSV."
 
 #: rocky/views/organization_member_add.py
 msgid "Error parsing the csv file. Please verify its contents."
 msgstr ""
+"Erreur lors de l'analyse du fichier CSV. Veuillez vérifier son contenu."
 
 #: rocky/views/organization_member_edit.py
 #, python-format
 msgid "Member %s successfully updated."
-msgstr ""
+msgstr "Le membre %s a été mis à jour avec succès."
 
 #: rocky/views/organization_member_edit.py
 #, python-format
@@ -7377,44 +8321,55 @@ msgid ""
 "level L%s. For this reason the acknowledged clearance level has been set at "
 "the same level as trusted clearance level."
 msgstr ""
+"Le niveau d'autorisation de confiance mis à jour de L%s est inférieur au "
+"niveau d'autorisation reconnu par le membre de L%s. Ce membre ne dispose que"
+" d'une autorisation pour le niveau L%s. Pour cette raison, le niveau "
+"d'autorisation reconnu a été fixé au même niveau que le niveau "
+"d'autorisation approuvé."
 
 #: rocky/views/organization_member_edit.py
 msgid ""
 "You have trusted this member with a higher trusted level than member "
 "acknowledged. Member must first accept this level to use it."
 msgstr ""
+"Vous avez fait confiance à ce membre avec un niveau de confiance plus élevé "
+"que celui reconnu par le membre. Le membre doit d'abord accepter ce niveau "
+"pour pouvoir l'utiliser."
 
 #: rocky/views/organization_member_list.py
 #, python-format
 msgid "Blocked member %s successfully."
-msgstr ""
+msgstr "Membre bloqué %s avec succès."
 
 #: rocky/views/organization_member_list.py
 #, python-format
 msgid "Unblocked member %s successfully."
-msgstr ""
+msgstr "Membre débloqué %s avec succès."
 
 #: rocky/views/organization_settings.py
 #, python-brace-format
 msgid "Recalculated {number_of_bits} bits. Duration: {duration}"
-msgstr ""
+msgstr "Bits {number_of_bits} recalculés. Durée : {duration}"
 
 #: rocky/views/page_actions.py
 msgid "Could not process your request, action required."
-msgstr ""
+msgstr "Impossible de traiter votre demande, action requise."
 
 #: rocky/views/scan_profile.py
 msgid ""
-"Cannot set clearance level. The clearance type must be inherited or declared."
+"Cannot set clearance level. The clearance type must be inherited or "
+"declared."
 msgstr ""
+"Impossible de définir le niveau d'autorisation. Le type de consignation doit"
+" être hérité ou déclaré."
 
 #: rocky/views/scans.py
 msgid "Scans"
-msgstr ""
+msgstr "Analyses"
 
 #: rocky/views/scheduler.py
 msgid "Your report has been scheduled."
-msgstr ""
+msgstr "Votre rapport a été programmé."
 
 #: rocky/views/scheduler.py
 msgid ""
@@ -7422,63 +8377,83 @@ msgid ""
 "will be added to the object list when they are in. It may take some time, a "
 "refresh of the page may be needed to show the results."
 msgstr ""
+"Votre tâche est planifiée et sera bientôt démarrée en arrière-plan. Les "
+"résultats seront ajoutés à la liste des objets lorsqu'ils y seront. Cela "
+"peut prendre un certain temps, une actualisation de la page peut être "
+"nécessaire pour afficher les résultats."
 
 #: rocky/views/tasks.py
 #, python-brace-format
 msgid "Fetching tasks failed: no connection with scheduler: {error}"
 msgstr ""
+"Échec de la récupération des tâches : aucune connexion avec le "
+"planificateur : {error}"
 
 #: rocky/views/tasks.py
 msgid "All Tasks"
-msgstr ""
+msgstr "Toutes les tâches"
 
 #: rocky/views/upload_csv.py
 msgid "Add column titles. Followed by each object on a new line."
 msgstr ""
+"Ajoutez des titres de colonnes. Suivi de chaque objet sur une nouvelle "
+"ligne."
 
 #: rocky/views/upload_csv.py
 msgid ""
 "For URL object type, a column 'raw' with URL values is required, starting "
 "with http:// or https://, optionally a second column 'network' is supported "
 msgstr ""
+"Pour le type d'objet URL, une colonne « brute » avec les valeurs URL est "
+"requise, commençant par http:// ou https://,. En option, une deuxième "
+"colonne « réseau » est prise en charge."
 
 #: rocky/views/upload_csv.py
 msgid ""
 "For Hostname object type, a column with 'name' values is required, "
 "optionally a second column 'network' is supported "
 msgstr ""
+"Pour le type d'objet Nom d'hôte, une colonne avec les valeurs « nom » est "
+"requise. En option, une deuxième colonne « réseau » est prise en charge."
 
 #: rocky/views/upload_csv.py
 msgid ""
 "For IPAddressV4 and IPAddressV6 object types, a column of 'address' is "
 "required, optionally a second column 'network' is supported "
 msgstr ""
+"Pour les types d'objet IPAddressV4 et IPAddressV6, une colonne « adresse » "
+"est requise, une deuxième colonne « réseau » est éventuellement prise en "
+"charge."
 
 #: rocky/views/upload_csv.py
 msgid ""
 "Clearance levels can be controlled by a column 'clearance' taking numerical "
-"values 0, 1, 2, 3, and 4 for the corresponding clearance level (other values "
-"are ignored) "
+"values 0, 1, 2, 3, and 4 for the corresponding clearance level (other values"
+" are ignored) "
 msgstr ""
+"Les niveaux d'autorisation peuvent être contrôlés par une colonne « "
+"autorisation » prenant les valeurs numériques 0, 1, 2, 3 et 4 pour le niveau"
+" d'autorisation correspondant (les autres valeurs sont ignorées)."
 
 #: rocky/views/upload_csv.py
 msgid "Object(s) could not be created for row number(s): "
-msgstr ""
+msgstr "Les objets n'ont pas pu être créés pour les numéros de ligne :"
 
 #: rocky/views/upload_csv.py
 msgid "Object(s) successfully added."
-msgstr ""
+msgstr "Objet(s) ajouté(s) avec succès."
 
 #: rocky/views/upload_raw.py
 #, python-format
 msgid "Raw file could not be uploaded to Bytes: status code %d"
 msgstr ""
+"Le fichier brut n'a pas pu être téléchargé vers Bytes : code d'état %d"
 
 #: rocky/views/upload_raw.py
 #, python-format
 msgid "Raw file could not be uploaded to Bytes: %s"
-msgstr ""
+msgstr "Le fichier brut n'a pas pu être téléchargé vers Bytes : %s"
 
 #: rocky/views/upload_raw.py
 msgid "Raw file successfully added."
-msgstr ""
+msgstr "Fichier brut ajouté avec succès."


### PR DESCRIPTION
## Summary
- update the French Django translation catalog from the current Weblate template
- fill previously untranslated strings using machine translation with protected placeholders and OpenKAT domain terms
- update translation metadata

## Validation
- msgfmt --statistics --check rocky/rocky/locale/fr/LC_MESSAGES/django.po

Note: these translations were machine-assisted and should be reviewed by a French speaker before release.