### PR TITLE
Update Spanish translations

### DIFF
--- a/rocky/rocky/locale/es/LC_MESSAGES/django.po
+++ b/rocky/rocky/locale/es/LC_MESSAGES/django.po
@@ -2,16 +2,14 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # andrea-finalist <andrea.flores@finalist.nl>, 2025.
-#: reports/forms.py
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: OpenKAT\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-20 07:38+0000\n"
-"PO-Revision-Date: 2025-08-22 09:39+0000\n"
-"Last-Translator: andrea-finalist <andrea.flores@finalist.nl>\n"
-"Language-Team: Spanish <https://hosted.weblate.org/projects/openkat/nl-kat-"
-"coordination/es/>\n"
+"POT-Creation-Date: 2026-03-28 14:22+0000\n"
+"PO-Revision-Date: 2026-07-14 00:00+0000\n"
+"Last-Translator: Brenno de Winter <brenno@dewinter.com>\n"
+"Language-Team: Spanish <https://hosted.weblate.org/projects/openkat/nl-kat-coordination/es/>\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -98,40 +96,40 @@ msgstr "Seleccione un nivel de acesso a este miembro."
 
 #: account/forms/account_setup.py onboarding/forms.py tools/forms/ooi.py
 msgid "Please select a clearance level to proceed."
-msgstr ""
+msgstr "Seleccione un nivel de autorización para continuar."
 
 #: account/forms/account_setup.py tools/models.py
 msgid "The name of the organization."
-msgstr ""
+msgstr "El nombre de la organización."
 
 #: account/forms/account_setup.py
 msgid "explanation-organization-name"
-msgstr ""
+msgstr "explicación-nombre-de-la-organización"
 
 #: account/forms/account_setup.py
 #, python-brace-format
 msgid "A unique code of maximum {code_length} characters in length."
-msgstr ""
+msgstr "Un código único de longitud máxima de caracteres {code_length}."
 
 #: account/forms/account_setup.py
 msgid "explanation-organization-code"
-msgstr ""
+msgstr "explicación-código-organización"
 
 #: account/forms/account_setup.py
 msgid "Organization name is required to proceed."
-msgstr ""
+msgstr "Se requiere el nombre de la organización para continuar."
 
 #: account/forms/account_setup.py
 msgid "Choose another organization."
-msgstr ""
+msgstr "Elija otra organización."
 
 #: account/forms/account_setup.py
 msgid "Organization code is required to proceed."
-msgstr ""
+msgstr "Se requiere el código de organización para continuar."
 
 #: account/forms/account_setup.py
 msgid "Choose another code for your organization."
-msgstr ""
+msgstr "Elija otro código para su organización."
 
 #: account/forms/account_setup.py
 msgid ""
@@ -139,6 +137,10 @@ msgid ""
 "have permission to scan these assets. I am aware of the implications a scan "
 "(with a higher scan level) brings on my systems."
 msgstr ""
+"Declaro que OpenKAT puede escanear los activos de mi organización y que "
+"tengo permiso para escanear estos activos. Soy consciente de las "
+"implicaciones que un escaneo (con un nivel de escaneo más alto) trae a mis "
+"sistemas."
 
 #: account/forms/account_setup.py
 msgid ""
@@ -146,123 +148,137 @@ msgid ""
 "organization. I have the experience and knowledge to know what the "
 "consequences might be and can be held responsible for them."
 msgstr ""
+"Declaro que estoy autorizado a dar esta indemnización en nombre de mi "
+"organización. Tengo la experiencia y el conocimiento para saber cuáles "
+"podrían ser las consecuencias y puedo ser responsable de ellas."
 
 #: account/forms/account_setup.py
 msgid "Trusted to change Clearance Levels."
-msgstr ""
+msgstr "Confiable para cambiar los niveles de autorización."
 
 #: account/forms/account_setup.py
 msgid "Acknowledged to change Clearance Levels."
-msgstr ""
+msgstr "Reconocido para cambiar los niveles de autorización."
 
 #: account/forms/account_setup.py rocky/forms.py
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Blocked"
-msgstr ""
+msgstr "Obstruido"
 
 #: account/forms/account_setup.py
 msgid ""
 "Set the members status to blocked, so they don't have access to the "
 "organization anymore."
 msgstr ""
+"Configure el estado de los miembros como bloqueado, para que ya no tengan "
+"acceso a la organización."
 
 #: account/forms/account_setup.py
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Accepted clearance level"
-msgstr ""
+msgstr "Nivel de autorización aceptado"
 
 #: account/forms/account_setup.py
 msgid "Enter tags separated by comma."
-msgstr ""
+msgstr "Introduzca etiquetas separadas por comas."
 
 #: account/forms/account_setup.py
 msgid "The two password fields didn’t match."
-msgstr ""
+msgstr "Los dos campos de contraseña no coincidían."
 
 #: account/forms/account_setup.py
 msgid "New password"
-msgstr ""
+msgstr "Nueva contraseña"
 
 #: account/forms/account_setup.py
 msgid "Enter a new password"
-msgstr ""
+msgstr "Ingrese una nueva contraseña"
 
 #: account/forms/account_setup.py
 msgid "New password confirmation"
-msgstr ""
+msgstr "Nueva confirmación de contraseña"
 
 #: account/forms/account_setup.py
 msgid "Repeat the new password"
-msgstr ""
+msgstr "Repita la nueva contraseña"
 
 #: account/forms/account_setup.py
 msgid "Confirm the new password"
-msgstr ""
+msgstr "Confirma la nueva contraseña"
 
 #: account/forms/login.py
 msgid "Please enter a correct email address and password."
 msgstr ""
+"Por favor ingrese una dirección de correo electrónico y contraseña "
+"correctas."
 
 #: account/forms/login.py
 msgid "This account is inactive."
-msgstr ""
+msgstr "Esta cuenta está inactiva."
 
 #: account/forms/login.py
 msgid "Insert the email you registered with or got at OpenKAT installation."
 msgstr ""
+"Inserte el correo electrónico con el que se registró o que obtuvo en la "
+"instalación de OpenKAT."
 
 #: account/forms/organization.py
 msgid "Organization is required."
-msgstr ""
+msgstr "Se requiere organización."
 
 #: account/forms/organization.py tools/view_helpers.py
 #: rocky/templates/dashboard_redteam.html
 #: rocky/templates/organizations/organization_list.html
 #: rocky/views/organization_add.py
 msgid "Organizations"
-msgstr ""
+msgstr "Organizaciones"
 
 #: account/forms/organization.py
 msgid "The organization from which to clone settings."
-msgstr ""
+msgstr "La organización desde la cual clonar la configuración."
 
 #: account/forms/password_reset.py account/templates/account_detail.html
 msgid "Email address"
-msgstr ""
+msgstr "Dirección de correo electrónico"
 
 #: account/forms/password_reset.py
 msgid "A reset link will be sent to this email"
-msgstr ""
+msgstr "Se enviará un enlace de reinicio a este correo electrónico."
 
 #: account/forms/password_reset.py
 msgid "The email address connected to your OpenKAT-account"
-msgstr ""
+msgstr "La dirección de correo electrónico conectada a su cuenta OpenKAT"
 
 #: account/forms/token.py
 msgid ""
 "Insert the token generated by the authenticator app to setup the two factor "
 "authentication."
 msgstr ""
+"Inserte el token generado por la aplicación de autenticación para configurar"
+" la autenticación de dos factores."
 
 #: account/forms/token.py
 msgid "Insert the token generated by your token authenticator app."
 msgstr ""
+"Inserte el token generado por su aplicación de autenticación de token."
 
 #: account/forms/token.py
 msgid "Backup token"
-msgstr ""
+msgstr "token de respaldo"
 
 #: account/mixins.py
 msgid "Clearance level has been set."
-msgstr ""
+msgstr "Se ha establecido el nivel de autorización."
 
 #: account/mixins.py
 #, python-format
 msgid ""
-"Could not raise clearance level of %s to L%s. Indemnification not present at "
-"organization %s."
+"Could not raise clearance level of %s to L%s. Indemnification not present at"
+" organization %s."
 msgstr ""
+"No se pudo aumentar el nivel de autorización de %s a L%s. Indemnización no "
+"presente en la organización %s."
 
 #: account/mixins.py
 #, python-format
@@ -270,6 +286,9 @@ msgid ""
 "Could not raise clearance level of %s to L%s. You were trusted a clearance "
 "level of L%s. Contact your administrator to receive a higher clearance."
 msgstr ""
+"No se pudo aumentar el nivel de autorización de %s a L%s. Se le confió un "
+"nivel de autorización de L%s. Comuníquese con su administrador para recibir "
+"una autorización mayor."
 
 #: account/mixins.py
 #, python-format
@@ -278,170 +297,188 @@ msgid ""
 "level of L%s. Please accept the clearance level first on your profile page "
 "to proceed."
 msgstr ""
+"No se pudo aumentar el nivel de autorización de %s a L%s. Usted reconoció un"
+" nivel de autorización de L%s. Acepte primero el nivel de autorización en su"
+" página de perfil para continuar."
 
 #: account/models.py
 msgid "The email must be set"
-msgstr ""
+msgstr "El correo electrónico debe estar configurado."
 
 #: account/models.py
 msgid "Superuser must have is_staff=True."
-msgstr ""
+msgstr "El superusuario debe tener is_staff=True."
 
 #: account/models.py
 msgid "Superuser must have is_superuser=True."
-msgstr ""
+msgstr "El superusuario debe tener is_superuser=True."
 
 #: account/models.py
 msgid "full name"
-msgstr ""
+msgstr "nombre completo"
 
 #: account/models.py
 msgid "email"
-msgstr ""
+msgstr "correo electrónico"
 
 #: account/models.py
 msgid "staff status"
-msgstr ""
+msgstr "estado del personal"
 
 #: account/models.py
 msgid "Designates whether the user can log into this admin site."
 msgstr ""
+"Designa si el usuario puede iniciar sesión en este sitio de administración."
 
 #: account/models.py tools/models.py
 msgid "active"
-msgstr ""
+msgstr "activo"
 
 #: account/models.py
 msgid ""
 "Designates whether this user should be treated as active. Unselect this "
 "instead of deleting accounts."
 msgstr ""
+"Designa si este usuario debe ser tratado como activo. Anule la selección de "
+"esto en lugar de eliminar cuentas."
 
 #: account/models.py
 msgid "date joined"
-msgstr ""
+msgstr "fecha de ingreso"
 
 #: account/models.py
 msgid "The clearance level of the user for all organizations."
-msgstr ""
+msgstr "El nivel de autorización del usuario para todas las organizaciones."
 
 #: account/models.py
 msgid "name"
-msgstr ""
+msgstr "nombre"
 
 #: account/templates/account_detail.html account/views/account.py
 msgid "Account details"
-msgstr ""
+msgstr "Detalles de la cuenta"
 
 #: account/templates/account_detail.html account/templates/password_reset.html
 #: account/views/password_reset.py
 msgid "Reset password"
-msgstr ""
+msgstr "Restablecer contraseña"
 
 #: account/templates/account_detail.html
 msgid "Full name"
-msgstr ""
+msgstr "nombre completo"
 
 #: account/templates/account_detail.html
 msgid "Member type"
-msgstr ""
+msgstr "Tipo de miembro"
 
 #: account/templates/account_detail.html
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: rocky/templates/tasks/normalizers.html
 msgid "Organization"
-msgstr ""
+msgstr "Organización"
 
 #: account/templates/account_detail.html
 msgid "Permission to set OOI clearance levels"
-msgstr ""
+msgstr "Permiso para establecer niveles de autorización OOI"
 
 #: account/templates/account_detail.html
 msgid "OOI clearance"
-msgstr ""
+msgstr "Liquidación OOI"
 
 #: account/templates/account_detail.html
 msgid "You don't have any clearance to scan objects."
-msgstr ""
+msgstr "No tienes autorización para escanear objetos."
 
 #: account/templates/account_detail.html
 msgid ""
 "Get in contact with the admin to give you the necessary clearance level."
 msgstr ""
+"Póngase en contacto con el administrador para darle el nivel de autorización"
+" necesario."
 
 #: account/templates/account_detail.html
 msgid "You have currently accepted clearance up to level"
-msgstr ""
+msgstr "Actualmente has aceptado autorización hasta el nivel"
 
 #: account/templates/account_detail.html
 msgid "Explanation OOI Clearance"
-msgstr ""
+msgstr "Explicación OOI Liquidación"
 
 #: account/templates/account_detail.html
 msgid ""
 "You can withdraw this at anytime you like, but know that you won't be able "
 "to change clearance levels anymore when you do."
 msgstr ""
+"Puede retirar esto en cualquier momento que desee, pero sepa que ya no podrá"
+" cambiar los niveles de autorización cuando lo haga."
 
 #: account/templates/account_detail.html
 #, python-format
 msgid "Withdraw L%(acl)s clearance and responsibility"
-msgstr ""
+msgstr "Retirar la autorización y la responsabilidad de L%(acl)s"
 
 #: account/templates/account_detail.html
 msgid "Explanation OOI clearance"
-msgstr ""
+msgstr "Explicación autorización OOI"
 
 #: account/templates/account_detail.html
 #, python-format
 msgid ""
 "You are granted clearance for level L%(tcl)s by your admin. Before you can "
 "change OOI clearance levels up to this level, you need to accept this "
-"permission. Remember: <strong>with great power comes great responsibility.</"
-"strong>"
+"permission. Remember: <strong>with great power comes great "
+"responsibility.</strong>"
 msgstr ""
+"Su administrador le concede autorización para el nivel L%(tcl)s. Antes de "
+"poder cambiar los niveles de autorización OOI hasta este nivel, debe aceptar"
+" este permiso. Recuerde: <strong> un gran poder conlleva una gran "
+"responsabilidad.</strong>"
 
 #: account/templates/account_detail.html
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 #, python-format
 msgid "Accept level L%(tcl)s clearance and responsibility"
-msgstr ""
+msgstr "Acepte el nivel de autorización y responsabilidad L%(tcl)s"
 
 #: account/templates/password_reset.html
 msgid "Use the form below to reset your password."
-msgstr ""
+msgstr "Utilice el siguiente formulario para restablecer su contraseña."
 
 #: account/templates/password_reset.html
 #: account/templates/password_reset_confirm.html
 msgid "Send"
-msgstr ""
+msgstr "Enviar"
 
 #: account/templates/password_reset.html
 #: account/templates/password_reset_confirm.html
 msgid "Back"
-msgstr ""
+msgstr "Atrás"
 
 #: account/templates/password_reset_confirm.html
 msgid "Confirm reset password"
-msgstr ""
+msgstr "Confirmar restablecer contraseña"
 
 #: account/templates/password_reset_confirm.html
 msgid "Use the form below to confirm resetting your password"
 msgstr ""
+"Utilice el siguiente formulario para confirmar el restablecimiento de su "
+"contraseña"
 
 #: account/templates/password_reset_confirm.html
 msgid "Confirm password"
-msgstr ""
+msgstr "Confirmar Contraseña"
 
 #: account/templates/password_reset_confirm.html
 msgid "The link is invalid"
-msgstr ""
+msgstr "El enlace no es válido."
 
 #: account/templates/password_reset_confirm.html
 msgid ""
 "The password reset link was invalid, possibly because it has already been "
 "used.  Please request a new password reset."
 msgstr ""
+"El enlace para restablecer la contraseña no era válido, posiblemente porque "
+"ya se había utilizado.  Solicite un nuevo restablecimiento de contraseña."
 
 #: account/templates/password_reset_email.html
 #, python-format
@@ -449,55 +486,61 @@ msgid ""
 "You're receiving this email because you requested a password reset for your "
 "user account at %(site_name)s."
 msgstr ""
+"Está recibiendo este correo electrónico porque solicitó un restablecimiento "
+"de contraseña para su cuenta de usuario en %(site_name)s."
 
 #: account/templates/password_reset_email.html
 #: account/templates/registration_email.html
 msgid "Please go to the following page and choose a new password:"
-msgstr ""
+msgstr "Vaya a la siguiente página y elija una nueva contraseña:"
 
 #: account/templates/password_reset_email.html
 #: account/templates/registration_email.html
 msgid "Sincerely,"
-msgstr ""
+msgstr "Atentamente,"
 
 #: account/templates/password_reset_email.html
 #: account/templates/registration_email.html
 msgid "The OpenKAT team"
-msgstr ""
+msgstr "El equipo OpenKAT"
 
 #: account/templates/password_reset_subject.txt
 #, python-format
 msgid "Password reset on %(site_name)s"
-msgstr ""
+msgstr "Restablecer contraseña en %(site_name)s"
 
 #: account/templates/recover_email.html account/views/recover_email.py
 msgid "Recover email address"
-msgstr ""
+msgstr "Recuperar dirección de correo electrónico"
 
 #: account/templates/recover_email.html
 msgid "Information on how to recover your connected email address"
 msgstr ""
+"Información sobre cómo recuperar su dirección de correo electrónico "
+"conectada"
 
 #: account/templates/recover_email.html
 msgid "Forgotten email address?"
-msgstr ""
+msgstr "¿Olvidaste tu dirección de correo electrónico?"
 
 #: account/templates/recover_email.html
 msgid ""
 "If you don’t remember the email address connected to your account, contact:"
 msgstr ""
+"Si no recuerda la dirección de correo electrónico conectada a su cuenta, "
+"comuníquese con:"
 
 #: account/templates/recover_email.html
 msgid "Please contact the system administrator."
-msgstr ""
+msgstr "Comuníquese con el administrador del sistema."
 
 #: account/templates/recover_email.html
 msgid "Back to login"
-msgstr ""
+msgstr "Volver a iniciar sesión"
 
 #: account/templates/recover_email.html
 msgid "Back to Home"
-msgstr ""
+msgstr "Volver a Inicio"
 
 #: account/templates/registration_email.html
 #, python-format
@@ -505,73 +548,80 @@ msgid ""
 "Welcome to OpenKAT. You're receiving this email because you have been added "
 "to organization \"%(organization)s\" at %(site_name)s."
 msgstr ""
+"Bienvenido a OpenKAT. Estás recibiendo este correo electrónico porque has "
+"sido agregado a la organización \"%(organization)s\" en %(site_name)s."
 
 #: account/templates/registration_subject.txt
 #, python-format
 msgid "Verify OpenKAT account on %(site_name)s"
-msgstr ""
+msgstr "Verificar cuenta OpenKAT en %(site_name)s"
 
 #: account/validators.py
 msgid ""
 "Your password must contain at least the following but longer passwords are "
 "recommended:"
 msgstr ""
+"Su contraseña debe contener al menos lo siguiente, pero se recomiendan "
+"contraseñas más largas:"
 
 #: account/validators.py
 msgid " characters"
-msgstr ""
+msgstr "personajes"
 
 #: account/validators.py
 msgid " digits"
-msgstr ""
+msgstr "dígitos"
 
 #: account/validators.py
 msgid " letters"
-msgstr ""
+msgstr "letras"
 
 #: account/validators.py
 msgid ""
 " special characters such as: {str(validators.get('special_characters',''))}"
 msgstr ""
+"caracteres especiales como: {str(validators.get('special_characters',''))}"
 
 #: account/validators.py
 msgid " lower case letters"
-msgstr ""
+msgstr "letras minúsculas"
 
 #: account/validators.py
 msgid " upper case letters"
-msgstr ""
+msgstr "letras mayúsculas"
 
 #: account/views/login.py
 msgid "Your session has timed out. Please login again."
-msgstr ""
+msgstr "Su sesión ha expirado. Por favor inicie sesión nuevamente."
 
 #: account/views/login.py rocky/templates/header.html
 msgid "OpenKAT"
-msgstr ""
+msgstr "OpenKAT"
 
 #: account/views/login.py account/views/password_reset.py
 #: account/views/recover_email.py rocky/templates/partials/secondary-menu.html
 #: rocky/templates/two_factor/core/login.html
 msgid "Login"
-msgstr ""
+msgstr "Acceso"
 
 #: account/views/login.py
 msgid "Two factor authentication"
-msgstr ""
+msgstr "Autenticación de dos factores"
 
 #: account/views/password_reset.py
 msgid "We couldn't send a password reset link. Contact "
-msgstr ""
+msgstr "No pudimos enviar un enlace para restablecer la contraseña. Contacto"
 
 #: account/views/password_reset.py
 msgid ""
 "We couldn't send a password reset link. Contact your system administrator."
 msgstr ""
+"No pudimos enviar un enlace para restablecer la contraseña. Póngase en "
+"contacto con el administrador de su sistema."
 
 #: components/modal/template.html
 msgid "Close modal"
-msgstr ""
+msgstr "Cerrar modal"
 
 #: components/modal/template.html
 #: crisis_room/templates/partials/delete_dashboard_item_modal.html
@@ -594,146 +644,157 @@ msgstr ""
 #: rocky/templates/partials/mute_findings_modal.html
 #: rocky/templates/two_factor/_wizard_actions.html
 msgid "Cancel"
-msgstr ""
+msgstr "Cancelar"
 
 #: crisis_room/forms.py
 msgid "Title on dashboard"
-msgstr ""
+msgstr "Título en el tablero"
 
 #: crisis_room/forms.py
 msgid "Dashboard item size"
-msgstr ""
+msgstr "Tamaño del elemento del panel"
 
 #: crisis_room/forms.py
 msgid "Full width"
-msgstr ""
+msgstr "Ancho completo"
 
 #: crisis_room/forms.py
 msgid "Half width"
-msgstr ""
+msgstr "Medio ancho"
 
 #: crisis_room/forms.py
 msgid "An item with that name already exists. Try a different title."
-msgstr ""
+msgstr "Ya existe un elemento con ese nombre. Pruebe con un título diferente."
 
 #: crisis_room/forms.py
 msgid "An error occurred while adding dashboard item."
-msgstr ""
+msgstr "Se produjo un error al agregar un elemento del panel."
 
 #: crisis_room/forms.py
 msgid "Number of rows in list"
-msgstr ""
+msgstr "Número de filas en la lista"
 
 #: crisis_room/forms.py
 msgid "List sorting by"
-msgstr ""
+msgstr "Lista ordenada por"
 
 #: crisis_room/forms.py
 msgid "Type (A-Z)"
-msgstr ""
+msgstr "Tipo (A-Z)"
 
 #: crisis_room/forms.py
 msgid "Type (Z-A)"
-msgstr ""
+msgstr "Tipo (Z-A)"
 
 #: crisis_room/forms.py
 msgid "Clearance level (Low-High)"
-msgstr ""
+msgstr "Nivel de autorización (bajo-alto)"
 
 #: crisis_room/forms.py
 msgid "Clearance level (High-Low)"
-msgstr ""
+msgstr "Nivel de autorización (alto-bajo)"
 
 #: crisis_room/forms.py
 msgid "Show table columns"
-msgstr ""
+msgstr "Mostrar columnas de la tabla"
 
 #: crisis_room/forms.py
 msgid "Severity (Low-High)"
-msgstr ""
+msgstr "Gravedad (baja-alta)"
 
 #: crisis_room/forms.py
 msgid "Severity (High-Low)"
-msgstr ""
+msgstr "Gravedad (alta-baja)"
 
 #: crisis_room/forms.py
 msgid "Finding (A-Z)"
-msgstr ""
+msgstr "Encontrar (A-Z)"
 
 #: crisis_room/forms.py
 msgid "Finding (Z-A)"
-msgstr ""
+msgstr "Encontrar (Z-A)"
 
 #: crisis_room/models.py
 msgid "Findings Dashboard"
-msgstr ""
+msgstr "Panel de resultados"
 
 #: crisis_room/models.py
 msgid ""
-"Where on the dashboard do you want to show the data? Position {} is the most "
-"top level and the max position is {}."
+"Where on the dashboard do you want to show the data? Position {} is the most"
+" top level and the max position is {}."
 msgstr ""
+"¿En qué parte del panel desea mostrar los datos? La posición {} es el nivel "
+"más alto y la posición máxima es {}."
 
 #: crisis_room/models.py
 msgid "Will be displayed on the general crisis room, for all organizations."
 msgstr ""
+"Se exhibirá en la sala de crisis general, para todas las organizaciones."
 
 #: crisis_room/models.py
 msgid "Will be displayed on a single organization dashboard"
-msgstr ""
+msgstr "Se mostrará en un único panel de la organización."
 
 #: crisis_room/models.py
 msgid "Will be displayed on the findings dashboard for all organizations"
-msgstr ""
+msgstr "Se mostrará en el panel de resultados de todas las organizaciones."
 
 #: crisis_room/models.py
 msgid "Can change position up or down of a dashboard item."
 msgstr ""
+"Puede cambiar la posición hacia arriba o hacia abajo de un elemento del "
+"tablero."
 
 #: crisis_room/models.py
 msgid "You have to choose between a recipe or a query, but not both."
-msgstr ""
+msgstr "Hay que elegir entre una receta o una consulta, pero no ambas."
 
 #: crisis_room/models.py
 msgid "You have set a query and not where it is from. Also set the source."
 msgstr ""
+"Ha establecido una consulta y no de dónde es. Configure también la fuente."
 
 #: crisis_room/models.py
 msgid ""
 "DashboardItem must contain at least a 'recipe' or a 'source' with a 'query'."
 msgstr ""
+"DashboardItem debe contener al menos una \"receta\" o una \"fuente\" con una"
+" \"consulta\"."
 
 #: crisis_room/models.py
 msgid "Max dashboard items reached."
-msgstr ""
+msgstr "Se alcanzó el número máximo de elementos del panel."
 
 #: crisis_room/templates/crisis_room.html
 #: crisis_room/templates/organization_crisis_room.html
 #: rocky/templates/header.html
 msgid "Crisis room"
-msgstr ""
+msgstr "sala de crisis"
 
 #: crisis_room/templates/crisis_room.html
 msgid "Crisis room overview for all organizations."
 msgstr ""
+"Descripción general de la sala de crisis para todas las organizaciones."
 
 #: crisis_room/templates/crisis_room_dashboards.html
 msgid "Dashboards"
-msgstr ""
+msgstr "Paneles de control"
 
 #: crisis_room/templates/crisis_room_dashboards.html
 msgid ""
 "On this page you can see an overview of the dashboards for all "
 "organizations. **More context can be written here**"
 msgstr ""
+"En esta página puede ver una descripción general de los paneles de control "
+"de todas las organizaciones. **Se puede escribir más contexto aquí**"
 
 #: crisis_room/templates/crisis_room_dashboards.html
 msgid "dashboards"
-msgstr ""
+msgstr "tableros"
 
 #: crisis_room/templates/crisis_room_dashboards.html
 msgid "There are no dashboards to display."
-msgstr ""
+msgstr "No hay paneles para mostrar."
 
 #: crisis_room/templates/crisis_room_findings.html
 #: crisis_room/templates/partials/crisis_room_findings_table.html
@@ -741,31 +802,38 @@ msgstr ""
 #: reports/templates/partials/report_findings_table.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Findings overview"
-msgstr ""
+msgstr "Resumen de los hallazgos"
 
 #: crisis_room/templates/crisis_room_findings.html
 msgid ""
 "\n"
-"                            This overview shows the total number of findings "
-"per\n"
-"                            severity that have been identified for all "
-"organizations.\n"
-"                            This data is based on the latest Crisis Room "
-"Findings Report\n"
+"                            This overview shows the total number of findings per\n"
+"                            severity that have been identified for all organizations.\n"
+"                            This data is based on the latest Crisis Room Findings Report\n"
 "                            of each organization.\n"
 "                        "
 msgstr ""
+"\n"
+"Este resumen muestra el número total de hallazgos por\n"
+"                            gravedad que se han identificado para todas las organizaciones.\n"
+"                            Estos datos se basan en el último informe de hallazgos de Crisis Room.\n"
+"                            de cada organización."
 
 #: crisis_room/templates/crisis_room_findings.html
 msgid "Findings per organization"
-msgstr ""
+msgstr "Hallazgos por organización"
 
 #: crisis_room/templates/crisis_room_findings.html
 msgid ""
 "This table shows the findings that have been identified for each "
-"organization, sorted by the finding types and grouped by organizations. This "
-"data is based on the latest Crisis Room Findings Report of each organization."
+"organization, sorted by the finding types and grouped by organizations. This"
+" data is based on the latest Crisis Room Findings Report of each "
+"organization."
 msgstr ""
+"Esta tabla muestra los hallazgos que se han identificado para cada "
+"organización, ordenados por tipos de hallazgos y agrupados por "
+"organizaciones. Estos datos se basan en el último Informe de hallazgos de "
+"salas de crisis de cada organización."
 
 #: crisis_room/templates/crisis_room_findings.html
 #: reports/report_types/findings_report/report.html
@@ -773,17 +841,21 @@ msgid ""
 "No findings have been identified yet. As soon as they have been identified, "
 "they will be shown on this page."
 msgstr ""
+"Aún no se han identificado hallazgos. Una vez identificados, se mostrarán en"
+" esta página."
 
 #: crisis_room/templates/crisis_room_findings.html
 msgid ""
 "There are no organizations yet. After creating an organization, the "
 "identified findings will be shown here."
 msgstr ""
+"Aún no hay organizaciones. Después de crear una organización, los hallazgos "
+"identificados se mostrarán aquí."
 
 #: crisis_room/templates/crisis_room_header.html
 #: crisis_room/templates/organization_crisis_room_header.html
 msgid "Crisis room navigation"
-msgstr ""
+msgstr "Navegación en la sala de crisis"
 
 #: crisis_room/templates/crisis_room_header.html
 #: crisis_room/templates/partials/new_dashboard_item_action_button.html
@@ -799,8 +871,8 @@ msgstr ""
 #: reports/report_types/web_system_report/report.html
 #: reports/templates/partials/report_findings_table.html
 #: reports/templates/partials/report_sidemenu.html
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
-#: rocky/templates/header.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
 #: rocky/templates/oois/ooi_detail_findings_list.html
 #: rocky/templates/oois/ooi_detail_findings_overview.html
 #: rocky/templates/oois/ooi_page_tabs.html
@@ -809,84 +881,88 @@ msgstr ""
 #: rocky/views/finding_list.py rocky/views/finding_type_add.py
 #: rocky/views/ooi_view.py
 msgid "Findings"
-msgstr ""
+msgstr "Recomendaciones"
 
 #: crisis_room/templates/organization_crisis_room.html
 msgid "Options for dashboard"
-msgstr ""
+msgstr "Opciones para el tablero"
 
 #: crisis_room/templates/organization_crisis_room.html
 msgid "Show all descriptions"
-msgstr ""
+msgstr "Mostrar todas las descripciones"
 
 #: crisis_room/templates/organization_crisis_room.html
 msgid "Hide all descriptions"
-msgstr ""
+msgstr "Ocultar todas las descripciones"
 
 #: crisis_room/templates/organization_crisis_room.html
 #: crisis_room/templates/partials/delete_dashboard_modal.html
 msgid "Delete dashboard"
-msgstr ""
+msgstr "Eliminar panel"
 
 #: crisis_room/templates/organization_crisis_room.html
 msgid ""
 "There are no dashboards yet. Click on \"Add dashboard\" to create a new "
 "dashboard."
 msgstr ""
+"Aún no hay paneles de control. Haga clic en \"Agregar panel\" para crear un "
+"nuevo panel."
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 #: katalogus/templates/partials/objects_to_scan.html
 #: rocky/templates/forms/widgets/checkbox_group_table.html
 #: rocky/templates/oois/ooi_list.html
 msgid "Object list"
-msgstr ""
+msgstr "Lista de objetos"
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid "Finding list"
-msgstr ""
+msgstr "Lista de búsqueda"
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 #: crisis_room/templates/partials/new_dashboard_item_action_button.html
 msgid "Report section"
-msgstr ""
+msgstr "Sección de informe"
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid "There are no dashboard items added yet."
-msgstr ""
+msgstr "Aún no se han agregado elementos del panel."
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid ""
-"You can add dashboard items via the filters on the objects and findings page "
-"or you can add a report section."
+"You can add dashboard items via the filters on the objects and findings page"
+" or you can add a report section."
 msgstr ""
+"Puede agregar elementos del panel a través de los filtros en la página de "
+"objetos y hallazgos o puede agregar una sección de informe."
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid "Add objects"
-msgstr ""
+msgstr "Agregar objetos"
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid "Add findings"
-msgstr ""
+msgstr "Agregar hallazgos"
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid "Add report section"
-msgstr ""
+msgstr "Agregar sección de informe"
 
 #: crisis_room/templates/organization_crisis_room_header.html
 #: crisis_room/templates/partials/new_dashboard_modal.html
 msgid "Add dashboard"
-msgstr ""
+msgstr "Agregar panel"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid "Findings per organization overview"
-msgstr ""
+msgstr "Resumen de hallazgos por organización"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: reports/templates/partials/report_findings_table.html
 #: reports/templates/partials/report_severity_totals_table.html
 #: tools/forms/finding_type.py
 msgid "Finding types"
-msgstr ""
+msgstr "Encontrar tipos"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: reports/report_types/dns_report/report.html
@@ -897,15 +973,15 @@ msgstr ""
 #: rocky/templates/partials/ooi_report_findings_block_table.html
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "Occurrences"
-msgstr ""
+msgstr "Ocurrencias"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid "Highest risk level"
-msgstr ""
+msgstr "Nivel de riesgo más alto"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid "Critical finding types"
-msgstr ""
+msgstr "Tipos de hallazgos críticos"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
@@ -919,7 +995,7 @@ msgstr ""
 #: rocky/templates/tasks/ooi_detail_task_list.html
 #: rocky/templates/tasks/plugin_detail_task_list.html
 msgid "Details"
-msgstr ""
+msgstr "Detalles"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
@@ -934,7 +1010,7 @@ msgstr ""
 #: rocky/templates/tasks/ooi_detail_task_list.html
 #: rocky/templates/tasks/plugin_detail_task_list.html
 msgid "Close details"
-msgstr ""
+msgstr "Cerrar detalles"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
@@ -949,67 +1025,75 @@ msgstr ""
 #: rocky/templates/tasks/ooi_detail_task_list.html
 #: rocky/templates/tasks/plugin_detail_task_list.html
 msgid "Open details"
-msgstr ""
+msgstr "Abrir detalles"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid ""
-"This overview shows the total number of findings per severity that have been "
-"identified for this organization."
+"This overview shows the total number of findings per severity that have been"
+" identified for this organization."
 msgstr ""
+"Esta descripción general muestra el número total de hallazgos por gravedad "
+"que se han identificado para esta organización."
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: reports/report_types/findings_report/report.html
 msgid "Critical and high findings"
-msgstr ""
+msgstr "Hallazgos críticos y altos."
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: reports/report_types/findings_report/report.html
 msgid ""
 "This table shows the top 25 critical and high findings that have been "
-"identified for this organization, grouped by finding types. A table with all "
-"the identified findings can be found in the Findings Report."
+"identified for this organization, grouped by finding types. A table with all"
+" the identified findings can be found in the Findings Report."
 msgstr ""
+"Esta tabla muestra los 25 principales hallazgos críticos y altos que se han "
+"identificado para esta organización, agrupados por tipos de hallazgos. Se "
+"puede encontrar una tabla con todos los hallazgos identificados en el "
+"Informe de hallazgos."
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid "No findings have been identified. Check report for more details."
 msgstr ""
+"No se han identificado hallazgos. Consulte el informe para obtener más "
+"detalles."
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid "View findings report"
-msgstr ""
+msgstr "Ver informe de resultados"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Edit report recipe"
-msgstr ""
+msgstr "Editar receta de informe"
 
 #: crisis_room/templates/partials/dashboard_finding_list.html
 #, python-format
 msgid "Showing %(length)s findings"
-msgstr ""
+msgstr "Mostrando resultados de %(length)s"
 
 #: crisis_room/templates/partials/dashboard_finding_list.html
 msgid "Go to findings"
-msgstr ""
+msgstr "Ir a hallazgos"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
 msgid "Findings table "
-msgstr ""
+msgstr "tabla de hallazgos"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: crisis_room/templates/partials/dashboard_ooi_list_table.html
 #: rocky/templates/findings/finding_list.html
 #: rocky/templates/oois/ooi_list.html
 msgid "column headers with buttons are sortable"
-msgstr ""
+msgstr "Los encabezados de columna con botones se pueden ordenar."
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
 #, python-format
 msgid "Show details for %(finding)s"
-msgstr ""
+msgstr "Mostrar detalles de %(finding)s"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
@@ -1018,7 +1102,7 @@ msgstr ""
 #: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
 #: rocky/views/mixins.py
 msgid "Tree"
-msgstr ""
+msgstr "Árbol"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
@@ -1027,14 +1111,15 @@ msgstr ""
 #: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
 #: rocky/views/mixins.py
 msgid "Graph"
-msgstr ""
+msgstr "Gráfico"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: reports/report_types/dns_report/report.html
 #: rocky/templates/oois/ooi_detail_findings_list.html
-#: rocky/templates/oois/ooi_detail_findings_overview.html rocky/views/mixins.py
+#: rocky/templates/oois/ooi_detail_findings_overview.html
+#: rocky/views/mixins.py
 msgid "Severity"
-msgstr ""
+msgstr "Gravedad"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: reports/report_types/dns_report/report.html
@@ -1042,45 +1127,45 @@ msgstr ""
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 #: rocky/views/mixins.py
 msgid "Finding"
-msgstr ""
+msgstr "Descubrimiento"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
 #: rocky/templates/partials/ooi_report_findings_block_table.html
 msgid "Finding type"
-msgstr ""
+msgstr "Tipo de hallazgo"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
 #, python-format
 msgid "Show details for %(finding_type)s"
-msgstr ""
+msgstr "Mostrar detalles de %(finding_type)s"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
 msgid "OOI type"
-msgstr ""
+msgstr "Tipo OOI"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
 #, python-format
 msgid "Show %(ooi_type)s objects"
-msgstr ""
+msgstr "Mostrar objetos %(ooi_type)s"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/views/mixins.py
 msgid "Location"
-msgstr ""
+msgstr "Ubicación"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #, python-format
 msgid "Show details for %(ooi)s"
-msgstr ""
+msgstr "Mostrar detalles de %(ooi)s"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
 msgid "Risk score"
-msgstr ""
+msgstr "Puntuación de riesgo"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: katalogus/templates/normalizer_detail.html
@@ -1091,9 +1176,10 @@ msgstr ""
 #: reports/templates/summary/report_asset_overview.html tools/forms/boefje.py
 #: tools/forms/finding_type.py rocky/templates/findings/finding_list.html
 #: rocky/templates/oois/ooi_detail.html
-#: rocky/templates/oois/ooi_detail_findings_list.html rocky/templates/scan.html
+#: rocky/templates/oois/ooi_detail_findings_list.html
+#: rocky/templates/scan.html
 msgid "Description"
-msgstr ""
+msgstr "Descripción"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: reports/report_types/multi_organization_report/recommendations.html
@@ -1101,7 +1187,7 @@ msgstr ""
 #: reports/templates/partials/report_severity_totals_table.html
 #: rocky/templates/findings/finding_list.html
 msgid "Recommendation"
-msgstr ""
+msgstr "Recomendación"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: reports/report_types/vulnerability_report/report.py
@@ -1111,61 +1197,61 @@ msgstr ""
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "Source"
-msgstr ""
+msgstr "Fuente"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: reports/templates/partials/report_findings_table.html
 #: rocky/templates/findings/finding_list.html
 msgid "Impact"
-msgstr ""
+msgstr "Impacto"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Options for dashboard items"
-msgstr ""
+msgstr "Opciones para elementos del panel"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Show description"
-msgstr ""
+msgstr "Mostrar descripción"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Hide description"
-msgstr ""
+msgstr "Ocultar descripción"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Position up"
-msgstr ""
+msgstr "Posición arriba"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Position down"
-msgstr ""
+msgstr "Posición abajo"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Rerun report"
-msgstr ""
+msgstr "Volver a ejecutar el informe"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 #: crisis_room/templates/partials/delete_dashboard_item_modal.html
 msgid "Delete item"
-msgstr ""
+msgstr "Eliminar elemento"
 
 #: crisis_room/templates/partials/dashboard_ooi_list.html
 #, python-format
 msgid "Showing %(length)s objects"
-msgstr ""
+msgstr "Mostrando objetos %(length)s"
 
 #: crisis_room/templates/partials/dashboard_ooi_list.html
 msgid "Go to objects"
-msgstr ""
+msgstr "Ir a objetos"
 
 #: crisis_room/templates/partials/dashboard_ooi_list_table.html
 #: rocky/templates/oois/ooi_list.html
 msgid "Objects "
-msgstr ""
+msgstr "Objetos"
 
 #: crisis_room/templates/partials/delete_dashboard_item_modal.html
 #, python-format
 msgid "Are you sure you want to delete '%(name)s' from this dashboard?"
-msgstr ""
+msgstr "¿Está seguro de que desea eliminar '%(name)s' de este panel?"
 
 #: crisis_room/templates/partials/delete_dashboard_item_modal.html
 #: crisis_room/templates/partials/delete_dashboard_modal.html
@@ -1178,7 +1264,7 @@ msgstr ""
 #: rocky/templates/oois/ooi_list.html
 #: rocky/templates/partials/delete_ooi_modal.html rocky/views/ooi_delete.py
 msgid "Delete"
-msgstr ""
+msgstr "Borrar"
 
 #: crisis_room/templates/partials/delete_dashboard_modal.html
 #, python-format
@@ -1186,14 +1272,16 @@ msgid ""
 "Are you sure you want to delete dashboard '%(dashboard)s'? All the items on "
 "the dashboard will be deleted as well."
 msgstr ""
+"¿Está seguro de que desea eliminar el panel '%(dashboard)s'? Todos los "
+"elementos del panel también se eliminarán."
 
 #: crisis_room/templates/partials/new_dashboard_item_action_button.html
 msgid "Actions for adding dashboard items"
-msgstr ""
+msgstr "Acciones para agregar elementos del panel"
 
 #: crisis_room/templates/partials/new_dashboard_item_action_button.html
 msgid "Add item"
-msgstr ""
+msgstr "Agregar artículo"
 
 #: crisis_room/templates/partials/new_dashboard_item_action_button.html
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
@@ -1202,26 +1290,32 @@ msgstr ""
 #: reports/templates/summary/ooi_selection.html tools/forms/ooi.py
 #: tools/view_helpers.py rocky/templates/admin/delete_confirmation.html
 #: rocky/templates/admin/delete_selected_confirmation.html
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
-#: rocky/templates/header.html rocky/views/ooi_add.py rocky/views/ooi_list.py
-#: rocky/views/ooi_view.py rocky/views/upload_csv.py rocky/views/upload_raw.py
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
+#: rocky/views/ooi_add.py rocky/views/ooi_list.py rocky/views/ooi_view.py
+#: rocky/views/upload_csv.py rocky/views/upload_raw.py
 msgid "Objects"
-msgstr ""
+msgstr "Objetos"
 
 #: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
 msgid "Add dashboard item"
-msgstr ""
+msgstr "Agregar elemento del panel"
 
 #: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
 msgid ""
-"To  add a <strong>report section</strong>, go to the history page and open a "
-"report. Then go to the section that you want to add to your dashboard and "
-"press the options button next to the section name to create a dashboard item."
+"To  add a <strong>report section</strong>, go to the history page and open a"
+" report. Then go to the section that you want to add to your dashboard and "
+"press the options button next to the section name to create a dashboard "
+"item."
 msgstr ""
+"Para agregar una sección de informe <strong></strong>, vaya a la página del "
+"historial y abra un informe. Luego vaya a la sección que desea agregar a su "
+"panel y presione el botón de opciones al lado del nombre de la sección para "
+"crear un elemento del panel."
 
 #: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
 msgid "Go to report history"
-msgstr ""
+msgstr "Ir al historial de informes"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #, python-format
@@ -1229,6 +1323,8 @@ msgid ""
 "\n"
 "    Add %(item_type)s to dashboard\n"
 msgstr ""
+"\n"
+"Agregue %(item_type)s al tablero\n"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #, python-format
@@ -1236,6 +1332,8 @@ msgid ""
 "Add these %(item_type)s with the selected filters to the dashboard of your "
 "choice."
 msgstr ""
+"Agregue estos %(item_type)s con los filtros seleccionados al tablero de su "
+"elección."
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
@@ -1246,61 +1344,71 @@ msgstr ""
 #: rocky/templates/partials/notifications_block.html
 #: rocky/templates/two_factor/core/login.html
 msgid "explanation"
-msgstr ""
+msgstr "explicación"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid "You do not have a custom dashboard yet"
-msgstr ""
+msgstr "Aún no tienes un panel personalizado"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #, python-format
 msgid ""
-"In order to add these %(item_type)s to a dashboard, you first need to create "
-"a dashboard. Please add a dashboard in the crisis room of your organization."
+"In order to add these %(item_type)s to a dashboard, you first need to create"
+" a dashboard. Please add a dashboard in the crisis room of your "
+"organization."
 msgstr ""
+"Para agregar estos %(item_type)s a un panel, primero debe crear un panel. "
+"Agregue un panel en la sala de crisis de su organización."
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 #: rocky/templates/findings/finding_list.html
 #: rocky/templates/oois/ooi_list.html
 msgid "Add to dashboard"
-msgstr ""
+msgstr "Agregar al panel"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid "Go to crisis room"
-msgstr ""
+msgstr "Ir a la sala de crisis"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid "Add report section to dashboard"
-msgstr ""
+msgstr "Agregar sección de informe al panel"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid ""
-"In order to add this report section to a dashboard, you first need to create "
-"a dashboard. Please create a dashboard in the crisis room of your "
+"In order to add this report section to a dashboard, you first need to create"
+" a dashboard. Please create a dashboard in the crisis room of your "
 "organization."
 msgstr ""
+"Para agregar esta sección de informe a un panel, primero debe crear un "
+"panel. Cree un panel en la sala de crisis de su organización."
 
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid "Report must be scheduled for dashboard items"
-msgstr ""
+msgstr "El informe debe programarse para los elementos del panel"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid ""
 "In order for dashboard information to be updated on a regular basis instead "
-"of showing static data, the report should be scheduled. The frequency of the "
-"schedules recurrence determines how fresh the data on the dashboard will be."
+"of showing static data, the report should be scheduled. The frequency of the"
+" schedules recurrence determines how fresh the data on the dashboard will "
+"be."
 msgstr ""
+"Para que la información del panel se actualice periódicamente en lugar de "
+"mostrar datos estáticos, el informe debe programarse. La frecuencia con la "
+"que se repiten los cronogramas determina qué tan actualizados estarán los "
+"datos en el tablero."
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 msgid "Applied filters"
-msgstr ""
+msgstr "Filtros aplicados"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 msgid "Object types"
-msgstr ""
+msgstr "Tipos de objetos"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 #: katalogus/templates/change_clearance_level.html onboarding/forms.py
@@ -1308,16 +1416,17 @@ msgstr ""
 #: reports/templates/summary/ooi_selection.html tools/forms/boefje.py
 #: tools/forms/ooi.py rocky/templates/oois/ooi_page_tabs.html
 #: rocky/templates/partials/explanations.html
-#: rocky/templates/scan_profiles/scan_profile_detail.html rocky/views/mixins.py
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+#: rocky/views/mixins.py
 msgid "Clearance level"
-msgstr ""
+msgstr "Nivel de liquidación"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 #: reports/templates/partials/report_ooi_list.html
 #: reports/templates/summary/ooi_selection.html tools/forms/ooi.py
 #: rocky/views/mixins.py
 msgid "Clearance type"
-msgstr ""
+msgstr "Tipo de liquidación"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 #: reports/templates/report_overview/modal_partials/delete_modal.html
@@ -1325,86 +1434,92 @@ msgstr ""
 #: reports/templates/report_overview/report_history_table.html
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Input objects"
-msgstr ""
+msgstr "Objetos de entrada"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 msgid "Show all objects"
-msgstr ""
+msgstr "Mostrar todos los objetos"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 #: reports/templates/partials/report_types_selection.html
 msgid "No filters applied"
-msgstr ""
+msgstr "No se aplicaron filtros"
 
 #: crisis_room/templates/partials/report_section_action_button.html
 msgid "Add section to dashboard"
-msgstr ""
+msgstr "Agregar sección al panel"
 
 #: katalogus/client.py
 msgid ""
 "The KATalogus has an unexpected error. Check the logs for further details."
 msgstr ""
+"El KATalogus tiene un error inesperado. Consulte los registros para obtener "
+"más detalles."
 
 #: katalogus/client.py
 #, python-format
 msgid "An HTTP %d error occurred. Check logs for more info."
 msgstr ""
+"Se produjo un error HTTP %d. Consulte los registros para obtener más "
+"información."
 
 #: katalogus/client.py
 msgid "An HTTP error occurred. Check logs for more info."
 msgstr ""
+"Se produjo un error HTTP. Consulte los registros para obtener más "
+"información."
 
 #: katalogus/client.py
 msgid "Boefje with this name already exists."
-msgstr ""
+msgstr "Boefje con este nombre ya existe."
 
 #: katalogus/client.py
 msgid "Boefje with this ID already exists."
-msgstr ""
+msgstr "Boefje con este ID ya existe."
 
 #: katalogus/client.py
 msgid "Access to resource not allowed"
-msgstr ""
+msgstr "Acceso al recurso no permitido"
 
 #: katalogus/client.py
 msgid "User is not allowed to see plugin settings"
-msgstr ""
+msgstr "El usuario no puede ver la configuración del complemento"
 
 #: katalogus/client.py
 msgid "User is not allowed to set plugin settings"
-msgstr ""
+msgstr "El usuario no puede establecer la configuración del complemento"
 
 #: katalogus/client.py
 msgid "User is not allowed to delete plugin settings"
-msgstr ""
+msgstr "El usuario no puede eliminar la configuración del complemento"
 
 #: katalogus/client.py
 msgid "User is not allowed to view plugin settings"
-msgstr ""
+msgstr "El usuario no tiene permiso para ver la configuración del complemento"
 
 #: katalogus/client.py
 msgid "User is not allowed to access the other organization"
-msgstr ""
+msgstr "El usuario no tiene permiso para acceder a la otra organización."
 
 #: katalogus/client.py
 msgid "User is not allowed to enable plugins"
-msgstr ""
+msgstr "El usuario no puede habilitar complementos"
 
 #: katalogus/client.py
 msgid "User is not allowed to disable plugins"
-msgstr ""
+msgstr "El usuario no puede deshabilitar complementos"
 
 #: katalogus/client.py
 msgid "User is not allowed to create plugins"
-msgstr ""
+msgstr "El usuario no tiene permiso para crear complementos."
 
 #: katalogus/client.py
 msgid "User is not allowed to edit plugins"
-msgstr ""
+msgstr "El usuario no puede editar complementos"
 
 #: katalogus/forms/katalogus_filter.py
 msgid "Show all"
-msgstr ""
+msgstr "Mostrar todo"
 
 #: katalogus/forms/katalogus_filter.py
 #: katalogus/templates/partials/enable_disable_plugin.html
@@ -1413,7 +1528,7 @@ msgstr ""
 #: reports/report_types/dns_report/report.html
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Enabled"
-msgstr ""
+msgstr "Activado"
 
 #: katalogus/forms/katalogus_filter.py
 #: katalogus/templates/partials/enable_disable_plugin.html
@@ -1422,39 +1537,42 @@ msgstr ""
 #: reports/templates/report_overview/scheduled_reports_table.html
 #: reports/templates/summary/selected_plugins.html
 msgid "Disabled"
-msgstr ""
+msgstr "Desactivado"
 
 #: katalogus/forms/katalogus_filter.py
 msgid "Enabled-Disabled"
-msgstr ""
+msgstr "Habilitado-Deshabilitado"
 
 #: katalogus/forms/katalogus_filter.py
 msgid "Disabled-Enabled"
-msgstr ""
+msgstr "Deshabilitado-Habilitado"
 
 #: katalogus/forms/katalogus_filter.py
 msgid "Filter options"
-msgstr ""
+msgstr "Opciones de filtro"
 
 #: katalogus/forms/katalogus_filter.py
 msgid "Sorting options"
-msgstr ""
+msgstr "Opciones de clasificación"
 
 #: katalogus/forms/plugin_settings.py
 msgid "This field is required."
-msgstr ""
+msgstr "Este campo es obligatorio."
 
 #: katalogus/templates/about_plugins.html
 #: katalogus/templates/partials/plugins_navigation.html
 msgid "About plugins"
-msgstr ""
+msgstr "Acerca de los complementos"
 
 #: katalogus/templates/about_plugins.html katalogus/templates/katalogus.html
 msgid ""
-"Plugins gather data, objects and insight. Each plugin has its own focus area "
-"and strengths and may be able to work with other plugins to gain even more "
+"Plugins gather data, objects and insight. Each plugin has its own focus area"
+" and strengths and may be able to work with other plugins to gain even more "
 "insights."
 msgstr ""
+"Los complementos recopilan datos, objetos y conocimientos. Cada complemento "
+"tiene su propia área de enfoque y fortalezas y puede funcionar con otros "
+"complementos para obtener aún más información."
 
 #: katalogus/templates/about_plugins.html katalogus/templates/boefjes.html
 msgid ""
@@ -1462,120 +1580,130 @@ msgid ""
 "issues, and give insight. Each boefje is a separate scan that can run on a "
 "selection of objects."
 msgstr ""
+"Boefjes se utilizan para buscar objetos. Detectan vulnerabilidades, "
+"problemas de seguridad y brindan información. Cada boefje es un escaneo "
+"separado que puede ejecutarse en una selección de objetos."
 
 #: katalogus/templates/about_plugins.html katalogus/templates/normalizers.html
 msgid ""
 "Normalizers analyze the information and turn it into objects for the data "
 "model in Octopoes."
 msgstr ""
+"Normalizers analiza la información y la convierte en objetos para el modelo "
+"de datos en Octopoes."
 
 #: katalogus/templates/about_plugins.html
 msgid ""
-"Bits are business rules that look for insight within the current dataset and "
-"search for specific insight and draw conclusions."
+"Bits are business rules that look for insight within the current dataset and"
+" search for specific insight and draw conclusions."
 msgstr ""
+"Los bits son reglas de negocio que buscan información dentro del conjunto de"
+" datos actual y buscan información específica y sacan conclusiones."
 
 #: katalogus/templates/boefje_detail.html
 #: katalogus/templates/partials/plugin_tile_modal.html
 #: katalogus/templates/plugin_container_image.html
 msgid "Scan level"
-msgstr ""
+msgstr "Nivel de escaneo"
 
 #: katalogus/templates/boefje_detail.html
 #: katalogus/templates/normalizer_detail.html
 msgid "Consumes"
-msgstr ""
+msgstr "Consume"
 
 #: katalogus/templates/boefje_detail.html
 #, python-format
 msgid "%(plugin_name)s is able to scan the following object types:"
-msgstr ""
+msgstr "%(plugin_name)s puede escanear los siguientes tipos de objetos:"
 
 #: katalogus/templates/boefje_detail.html
 #: katalogus/templates/normalizer_detail.html
 #, python-format
 msgid "%(plugin_name)s does not need any input objects."
-msgstr ""
+msgstr "%(plugin_name)s no necesita ningún objeto de entrada."
 
 #: katalogus/templates/boefje_detail.html
 #: katalogus/templates/normalizer_detail.html
 #: katalogus/templates/partials/plugin_tile_modal.html
 msgid "Produces"
-msgstr ""
+msgstr "produce"
 
 #: katalogus/templates/boefje_detail.html
 #: katalogus/templates/normalizer_detail.html
 #: katalogus/templates/partials/plugin_tile_modal.html
 #, python-format
 msgid "%(plugin_name)s can produce the following output:"
-msgstr ""
+msgstr "%(plugin_name)s puede producir el siguiente resultado:"
 
 #: katalogus/templates/boefje_detail.html
 #, python-format
 msgid "%(plugin_name)s doesn't produce any output mime types."
-msgstr ""
+msgstr "%(plugin_name)s no produce ningún tipo de salida MIME."
 
 #: katalogus/templates/boefje_setup.html
 msgid "Boefje variant setup"
-msgstr ""
+msgstr "Configuración de variante Boefje"
 
 #: katalogus/templates/boefje_setup.html
 #: rocky/templates/organizations/organization_member_list.html
 #: rocky/templates/organizations/organization_settings.html
 #: rocky/views/ooi_edit.py rocky/views/organization_edit.py
 msgid "Edit"
-msgstr ""
+msgstr "Editar"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Boefje setup"
-msgstr ""
+msgstr "Configuración de Boefje"
 
 #: katalogus/templates/boefje_setup.html
 msgid ""
 "You can create a new Boefje. If you want more information on this, you can "
-"check out the <a href=\"https://docs.openkat.nl/developer_documentation/"
-"development_tutorial/creating_a_boefje.html\">documentation</a>."
+"check out the <a "
+"href=\"https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html\">documentation</a>."
 msgstr ""
+"Puede crear un nuevo Boefje. Si desea obtener más información sobre esto, "
+"puede consultar la documentación <a "
+"href=\"https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html\"></a>."
 
 #: katalogus/templates/boefje_setup.html
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 msgid "Save changes"
-msgstr ""
+msgstr "Guardar cambios"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Discard changes"
-msgstr ""
+msgstr "Descartar cambios"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Create variant"
-msgstr ""
+msgstr "Crear variante"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Discard variant"
-msgstr ""
+msgstr "Descartar variante"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Create new Boefje"
-msgstr ""
+msgstr "Crear nuevo Boefje"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Discard new Boefje"
-msgstr ""
+msgstr "Desechar el nuevo Boefje"
 
 #: katalogus/templates/boefjes.html
 msgid "Add Boefje"
-msgstr ""
+msgstr "Añadir Boefje"
 
 #: katalogus/templates/boefjes.html katalogus/templates/katalogus.html
 #: katalogus/templates/normalizers.html
 msgid "available"
-msgstr ""
+msgstr "disponible"
 
 #: katalogus/templates/change_clearance_level.html
 #: katalogus/templates/partials/objects_to_scan.html
 #: reports/templates/partials/report_setup_scan.html
 msgid "scan level warning"
-msgstr ""
+msgstr "advertencia de nivel de escaneo"
 
 #: katalogus/templates/change_clearance_level.html
 #, python-format
@@ -1583,10 +1711,12 @@ msgid ""
 "%(plugin_name)s will only scan objects with a corresponding clearance level "
 "of <strong>L%(scan_level)s</strong> or higher."
 msgstr ""
+"%(plugin_name)s solo escaneará objetos con un nivel de autorización "
+"correspondiente de <strong>L%(scan_level)s</strong> o superior."
 
 #: katalogus/templates/change_clearance_level.html
 msgid "Scan object"
-msgstr ""
+msgstr "Objeto de escaneo"
 
 #: katalogus/templates/change_clearance_level.html
 #, python-format
@@ -1595,115 +1725,126 @@ msgid ""
 "be advised that by continuing you will declare a level %(scan_level)s on "
 "these objects."
 msgstr ""
+"Los siguientes objetos aún no están borrados para el nivel %(scan_level)s; "
+"tenga en cuenta que al continuar declarará un nivel %(scan_level)s en estos "
+"objetos."
 
 #: katalogus/templates/change_clearance_level.html
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/summary/report_asset_overview.html
 msgid "Selected objects"
-msgstr ""
+msgstr "Objetos seleccionados"
 
 #: katalogus/templates/change_clearance_level.html
 #: reports/templates/report_overview/report_history_table.html
 #: reports/templates/summary/ooi_selection.html rocky/views/mixins.py
 msgid "Object"
-msgstr ""
+msgstr "Objeto"
 
 #: katalogus/templates/change_clearance_level.html
 msgid "Are you sure you want to scan anyways?"
-msgstr ""
+msgstr "¿Estás seguro de que quieres escanear de todos modos?"
 
 #: katalogus/templates/change_clearance_level.html
 #: rocky/templates/oois/ooi_detail.html
 msgid "Scan"
-msgstr ""
+msgstr "Escanear"
 
 #: katalogus/templates/clone_settings.html
 #: katalogus/templates/confirmation_clone_settings.html
 msgid "Clone settings"
-msgstr ""
+msgstr "Configuración de clonación"
 
 #: katalogus/templates/clone_settings.html
 #, python-format
 msgid ""
 "Use the form below to clone the settings from "
-"<strong>%(current_organization)s</strong> to the selected organization. This "
-"includes both the KAT-alogus settings as well as enabled and disabled "
+"<strong>%(current_organization)s</strong> to the selected organization. This"
+" includes both the KAT-alogus settings as well as enabled and disabled "
 "plugins."
 msgstr ""
+"Utilice el siguiente formulario para clonar la configuración de "
+"<strong>%(current_organization)s</strong> a la organización seleccionada. "
+"Esto incluye tanto la configuración similar a KAT como los complementos "
+"habilitados y deshabilitados."
 
 #: katalogus/templates/confirmation_clone_settings.html
 msgid "Clone"
-msgstr ""
+msgstr "Clon"
 
 #: katalogus/templates/katalogus.html
 msgid "All plugins"
-msgstr ""
+msgstr "Todos los complementos"
 
 #: katalogus/templates/katalogus_settings.html
 msgid "KAT-alogus settings"
-msgstr ""
+msgstr "Configuración análoga a KAT"
 
 #: katalogus/templates/katalogus_settings.html
 msgid ""
 "There are currently no settings defined. Add settings at the plugin detail "
 "page."
 msgstr ""
+"Actualmente no hay configuraciones definidas. Agregue configuraciones en la "
+"página de detalles del complemento."
 
 #: katalogus/templates/katalogus_settings.html
 #: rocky/templates/two_factor/core/otp_required.html
 msgid "Go back"
-msgstr ""
+msgstr "Volver"
 
 #: katalogus/templates/katalogus_settings.html
 msgid "This is an overview of the latest settings of all plugins."
 msgstr ""
+"Esta es una descripción general de las últimas configuraciones de todos los "
+"complementos."
 
 #: katalogus/templates/katalogus_settings.html
 msgid "Latest plugin settings"
-msgstr ""
+msgstr "Últimas configuraciones de complementos"
 
 #: katalogus/templates/katalogus_settings.html
 #: rocky/templates/tasks/ooi_detail_task_list.html
 msgid "Plugin"
-msgstr ""
+msgstr "Complemento"
 
 #: katalogus/templates/katalogus_settings.html
 #: katalogus/templates/plugin_settings_list.html
 #: rocky/templates/oois/ooi_delete.html
 msgid "Value"
-msgstr ""
+msgstr "Valor"
 
 #: katalogus/templates/normalizer_detail.html
 #, python-format
 msgid "%(plugin_name)s is able to process the following mime types:"
-msgstr ""
+msgstr "%(plugin_name)s puede procesar los siguientes tipos de mime:"
 
 #: katalogus/templates/partials/boefje_tile.html
 msgid "This object type is required"
-msgstr ""
+msgstr "Este tipo de objeto es obligatorio"
 
 #: katalogus/templates/partials/boefje_tile.html
 msgid "Scan level:"
-msgstr ""
+msgstr "Nivel de escaneo:"
 
 #: katalogus/templates/partials/boefje_tile.html
 msgid "Publisher:"
-msgstr ""
+msgstr "Editor:"
 
 #: katalogus/templates/partials/boefje_tile.html
 #: katalogus/templates/partials/plugin_tile.html
 #: katalogus/templates/partials/plugin_tile_modal.html
 msgid "See details"
-msgstr ""
+msgstr "Ver detalles"
 
 #: katalogus/templates/partials/enable_disable_plugin.html
 msgid "Enable"
-msgstr ""
+msgstr "Permitir"
 
 #: katalogus/templates/partials/enable_disable_plugin.html
 #: rocky/templates/two_factor/profile/disable.html
 msgid "Disable"
-msgstr ""
+msgstr "Desactivar"
 
 #: katalogus/templates/partials/katalogus_filter.html
 #: rocky/templates/findings/findings_filter.html
@@ -1711,7 +1852,7 @@ msgstr ""
 #: rocky/templates/partials/organization_member_list_filters.html
 #: rocky/templates/tasks/partials/task_filter.html
 msgid "Hide filters"
-msgstr ""
+msgstr "Ocultar filtros"
 
 #: katalogus/templates/partials/katalogus_filter.html
 #: rocky/templates/findings/findings_filter.html
@@ -1719,7 +1860,7 @@ msgstr ""
 #: rocky/templates/partials/organization_member_list_filters.html
 #: rocky/templates/tasks/partials/task_filter.html
 msgid "Show filters"
-msgstr ""
+msgstr "Mostrar filtros"
 
 #: katalogus/templates/partials/katalogus_filter.html
 #: rocky/templates/findings/findings_filter.html
@@ -1727,29 +1868,29 @@ msgstr ""
 #: rocky/templates/partials/organization_member_list_filters.html
 #: rocky/templates/tasks/partials/task_filter.html
 msgid "applied"
-msgstr ""
+msgstr "aplicado"
 
 #: katalogus/templates/partials/katalogus_filter.html
 msgid "Filter plugins"
-msgstr ""
+msgstr "Complementos de filtro"
 
 #: katalogus/templates/partials/katalogus_filter.html
 msgid "Clear filter"
-msgstr ""
+msgstr "Limpiar filtro"
 
 #: katalogus/templates/partials/katalogus_header.html
 #: katalogus/views/change_clearance_level.py katalogus/views/katalogus.py
 #: katalogus/views/katalogus_settings.py katalogus/views/plugin_detail.py
 #: katalogus/views/plugin_settings_add.py
 #: katalogus/views/plugin_settings_delete.py
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
-#: rocky/templates/header.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
 msgid "KAT-alogus"
-msgstr ""
+msgstr "KAT-análogo"
 
 #: katalogus/templates/partials/katalogus_header.html
 msgid "An overview of all available plugins."
-msgstr ""
+msgstr "Una descripción general de todos los complementos disponibles."
 
 #: katalogus/templates/partials/katalogus_header.html
 #: katalogus/templates/plugin_settings_list.html
@@ -1758,35 +1899,35 @@ msgstr ""
 #: rocky/templates/organizations/organization_list.html
 #: rocky/templates/organizations/organization_settings.html
 msgid "Settings"
-msgstr ""
+msgstr "Ajustes"
 
 #: katalogus/templates/partials/katalogus_toolbar.html
 msgid "Gridview"
-msgstr ""
+msgstr "Vista de cuadrícula"
 
 #: katalogus/templates/partials/katalogus_toolbar.html
 msgid "Tableview"
-msgstr ""
+msgstr "Vista de tabla"
 
 #: katalogus/templates/partials/modal_report_types.html
 msgid "Required for"
-msgstr ""
+msgstr "Requerido para"
 
 #: katalogus/templates/partials/modal_report_types.html
 msgid "report types"
-msgstr ""
+msgstr "tipos de informes"
 
 #: katalogus/templates/partials/modal_report_types.html
 msgid "Report types for "
-msgstr ""
+msgstr "Tipos de informes para"
 
 #: katalogus/templates/partials/no_enabling_permission_message.html
 msgid "No permission to enable/disable plugins"
-msgstr ""
+msgstr "Sin permiso para habilitar/deshabilitar complementos"
 
 #: katalogus/templates/partials/no_enabling_permission_message.html
 msgid "Contact your administrator to request permission."
-msgstr ""
+msgstr "Póngase en contacto con su administrador para solicitar permiso."
 
 #: katalogus/templates/partials/objects_to_scan.html
 #, python-format
@@ -1797,10 +1938,15 @@ msgid ""
 "<strong>L%(scan_level)s</strong>. Use the filter to show OOI's with a lower "
 "clearance level."
 msgstr ""
+"Este Boefje solo escaneará objetos con un nivel de autorización "
+"correspondiente de <strong>L%(scan_level)s</strong> o superior. No existe "
+"ninguna indemnización para que este Boefje escanee un OOI con un nivel de "
+"autorización inferior al <strong>L%(scan_level)s</strong>. Utilice el filtro"
+" para mostrar OOI con un nivel de autorización inferior."
 
 #: katalogus/templates/partials/objects_to_scan.html
 msgid "Warning scan level:"
-msgstr ""
+msgstr "Nivel de escaneo de advertencia:"
 
 #: katalogus/templates/partials/objects_to_scan.html
 msgid ""
@@ -1809,6 +1955,11 @@ msgid ""
 "now on out, until it manually gets set to something else again. This means "
 "that all other enabled Boefjes will use this higher clearance level aswel."
 msgstr ""
+"Escanear OOI con un nivel de autorización más bajo dará como resultado que "
+"OpenKAT aumente el nivel de autorización en ese OOI, no solo para este "
+"escaneo sino de ahora en adelante, hasta que se configure manualmente en "
+"otra cosa nuevamente. Esto significa que todos los demás Boefjes habilitados"
+" utilizarán también este nivel de autorización más alto."
 
 #: katalogus/templates/partials/objects_to_scan.html
 #, python-format
@@ -1817,6 +1968,9 @@ msgid ""
 "Add objects with a complying clearance level, or alter the clearance level "
 "of existing objects."
 msgstr ""
+"Actualmente no tienes ningún objeto que cumpla con el nivel de escaneo de "
+"%(name)s. Agregue objetos con un nivel de autorización adecuado o modifique "
+"el nivel de autorización de los objetos existentes."
 
 #: katalogus/templates/partials/objects_to_scan.html
 #, python-format
@@ -1824,59 +1978,62 @@ msgid ""
 "You currently don't have scannable objects for %(name)s. Add objects to use "
 "this Boefje. This Boefje is able to scan objects of the following types:"
 msgstr ""
+"Actualmente no tienes objetos escaneables para %(name)s. Agregue objetos "
+"para usar este Boefje. Este Boefje es capaz de escanear objetos de los "
+"siguientes tipos:"
 
 #: katalogus/templates/partials/plugin_settings_required.html
 msgid "The form could not be initialized."
-msgstr ""
+msgstr "No se pudo inicializar el formulario."
 
 #: katalogus/templates/partials/plugin_settings_required.html
 msgid "Required settings"
-msgstr ""
+msgstr "Configuraciones requeridas"
 
 #: katalogus/templates/partials/plugin_settings_required.html
 #: rocky/templates/partials/ooi_list_toolbar.html
 msgid "Add"
-msgstr ""
+msgstr "Agregar"
 
 #: katalogus/templates/partials/plugin_tile.html
 msgid "Required for:"
-msgstr ""
+msgstr "Requerido para:"
 
 #: katalogus/templates/partials/plugin_tile_modal.html
 msgid "Boefje details"
-msgstr ""
+msgstr "Detalles de Boefje"
 
 #: katalogus/templates/partials/plugin_tile_modal.html reports/forms.py
 #: reports/templates/report_overview/report_history_table.html
 msgid "Report types"
-msgstr ""
+msgstr "Tipos de informes"
 
 #: katalogus/templates/partials/plugin_tile_modal.html
 msgid "This boefje is required by the following report types."
-msgstr ""
+msgstr "Este boefje es requerido por los siguientes tipos de informes."
 
 #: katalogus/templates/partials/plugin_tile_modal.html
 msgid "Go to boefje detail page"
-msgstr ""
+msgstr "Ir a la página de detalles de boefje"
 
 #: katalogus/templates/partials/plugins.html
 msgid "Plugins overview:"
-msgstr ""
+msgstr "Descripción general de los complementos:"
 
 #: katalogus/templates/partials/plugins.html
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugin name"
-msgstr ""
+msgstr "Nombre del complemento"
 
 #: katalogus/templates/partials/plugins.html
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugin type"
-msgstr ""
+msgstr "Tipo de complemento"
 
 #: katalogus/templates/partials/plugins.html
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugin description"
-msgstr ""
+msgstr "Descripción del complemento"
 
 #: katalogus/templates/partials/plugins.html
 #: reports/templates/partials/report_header.html
@@ -1884,73 +2041,75 @@ msgstr ""
 #: rocky/templates/organizations/organization_list.html
 #: rocky/templates/organizations/organization_settings.html
 msgid "Actions"
-msgstr ""
+msgstr "Comportamiento"
 
 #: katalogus/templates/partials/plugins.html
 msgid "Detail page"
-msgstr ""
+msgstr "Página de detalles"
 
 #: katalogus/templates/partials/plugins_navigation.html
 #: reports/templates/report_overview/report_overview_navigation.html
 msgid "Plugins Navigation"
-msgstr ""
+msgstr "Navegación de complementos"
 
 #: katalogus/templates/partials/plugins_navigation.html
 #: rocky/templates/scan.html rocky/templates/tasks/boefjes.html
 #: rocky/templates/tasks/partials/tab_navigation.html rocky/views/tasks.py
 msgid "Boefjes"
-msgstr ""
+msgstr "Boefjes"
 
 #: katalogus/templates/partials/plugins_navigation.html
 #: rocky/templates/tasks/normalizers.html
 #: rocky/templates/tasks/partials/tab_navigation.html rocky/views/tasks.py
 msgid "Normalizers"
-msgstr ""
+msgstr "Normalizers"
 
 #: katalogus/templates/partials/plugins_navigation.html
 #: tools/forms/scheduler.py
 msgid "All"
-msgstr ""
+msgstr "Todo"
 
 #: katalogus/templates/plugin_container_image.html tools/forms/boefje.py
 msgid "Container image"
-msgstr ""
+msgstr "Imagen del contenedor"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "The container image for this Boefje is:"
-msgstr ""
+msgstr "La imagen del contenedor para este Boefje es:"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Variants"
-msgstr ""
+msgstr "Variantes"
 
 #: katalogus/templates/plugin_container_image.html
 msgid ""
 "Boefje variants that use the same container image. For more information "
 "about Boefje variants you can read the documentation."
 msgstr ""
+"Variantes Boefje que utilizan la misma imagen de contenedor. Para obtener "
+"más información sobre las variantes de Boefje, puede leer la documentación."
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Add variant"
-msgstr ""
+msgstr "Agregar variante"
 
 #: katalogus/templates/plugin_container_image.html
 #: rocky/templates/partials/notifications_block.html
 msgid "confirmation"
-msgstr ""
+msgstr "confirmación"
 
 #: katalogus/templates/plugin_container_image.html
 #, python-format
 msgid "Variant %(plugin.name)s created."
-msgstr ""
+msgstr "Variante %(plugin.name)s creada."
 
 #: katalogus/templates/plugin_container_image.html
 msgid "The Boefje variant is successfully created and can now be used."
-msgstr ""
+msgstr "La variante Boefje se creó correctamente y ahora se puede utilizar."
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Overview of variants"
-msgstr ""
+msgstr "Resumen de variantes"
 
 #: katalogus/templates/plugin_container_image.html
 #: reports/report_types/tls_report/report.html
@@ -1961,36 +2120,36 @@ msgstr ""
 #: rocky/templates/tasks/plugin_detail_task_list.html
 #: rocky/templates/tasks/reports.html
 msgid "Status"
-msgstr ""
+msgstr "Estado"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Age"
-msgstr ""
+msgstr "Edad"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Scan interval"
-msgstr ""
+msgstr "Intervalo de escaneo"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Run on"
-msgstr ""
+msgstr "Seguir corriendo"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "current"
-msgstr ""
+msgstr "actual"
 
 #: katalogus/templates/plugin_container_image.html
 #: reports/report_types/dns_report/report.html
 msgid "minutes"
-msgstr ""
+msgstr "minutos"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Default system scan frequency"
-msgstr ""
+msgstr "Frecuencia de escaneo del sistema predeterminada"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Boefje ID"
-msgstr ""
+msgstr "Identificación de Boefje"
 
 #: katalogus/templates/plugin_container_image.html
 #: reports/templates/report_overview/modal_partials/delete_modal.html
@@ -1999,222 +2158,253 @@ msgstr ""
 #: reports/templates/report_overview/subreports_table.html
 #: rocky/templates/tasks/reports.html
 msgid "Creation date"
-msgstr ""
+msgstr "Fecha de creación"
 
 #: katalogus/templates/plugin_container_image.html tools/forms/boefje.py
 msgid "Arguments"
-msgstr ""
+msgstr "Argumentos"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "The following arguments are used for this Boefje variant:"
-msgstr ""
+msgstr "Se utilizan los siguientes argumentos para esta variante Boefje:"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "There are no arguments used for this Boefje variant."
-msgstr ""
+msgstr "No se utilizan argumentos para esta variante Boefje."
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Edit variant"
-msgstr ""
+msgstr "Editar variante"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "This Boefje has no variants yet."
-msgstr ""
+msgstr "Este Boefje aún no tiene variantes."
 
 #: katalogus/templates/plugin_container_image.html
 msgid ""
-"You can make a variant and change the arguments and JSON Schema to customize "
-"it to fit your needs."
+"You can make a variant and change the arguments and JSON Schema to customize"
+" it to fit your needs."
 msgstr ""
+"Puede crear una variante y cambiar los argumentos y el esquema JSON para "
+"personalizarlo y adaptarlo a sus necesidades."
 
 #: katalogus/templates/plugin_settings_add.html
 msgid "Add setting"
 msgid_plural "Add settings"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Agregar configuraciones"
+msgstr[1] "Agregar configuraciones"
 
 #: katalogus/templates/plugin_settings_add.html
 msgid "Setting"
 msgid_plural "Settings"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Ajustes"
+msgstr[1] "Ajustes"
 
 #: katalogus/templates/plugin_settings_add.html
 msgid "Add setting and enable boefje"
 msgid_plural "Add settings and enable boefje"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Agregue configuraciones y habilite boefje"
+msgstr[1] "Agregue configuraciones y habilite boefje"
 
 #: katalogus/templates/plugin_settings_delete.html
 msgid "Delete settings"
-msgstr ""
+msgstr "Eliminar configuración"
 
 #: katalogus/templates/plugin_settings_delete.html
 #, python-format
 msgid ""
 "Are you sure you want to delete all settings for the plugin %(plugin_name)s?"
 msgstr ""
+"¿Está seguro de que desea eliminar todas las configuraciones del complemento"
+" %(plugin_name)s?"
 
 #: katalogus/templates/plugin_settings_list.html
 msgid ""
-"In the table below the settings for this specific Boefje can be seen. Set or "
-"change the value of the variables by editing the settings."
+"In the table below the settings for this specific Boefje can be seen. Set or"
+" change the value of the variables by editing the settings."
 msgstr ""
+"En la siguiente tabla se pueden ver las configuraciones para este Boefje "
+"específico. Establezca o cambie el valor de las variables editando la "
+"configuración."
 
 #: katalogus/templates/plugin_settings_list.html
 msgid "Configure Settings"
-msgstr ""
+msgstr "Configurar ajustes"
 
 #: katalogus/templates/plugin_settings_list.html
 msgid "Overview of settings"
-msgstr ""
+msgstr "Descripción general de la configuración"
 
 #: katalogus/templates/plugin_settings_list.html
 msgid "Variable"
-msgstr ""
+msgstr "Variable"
 
 #: katalogus/views/change_clearance_level.py
 msgid "Session has terminated, please select objects again."
-msgstr ""
+msgstr "La sesión ha finalizado, seleccione los objetos nuevamente."
 
 #: katalogus/views/change_clearance_level.py
 msgid "Change clearance level"
-msgstr ""
+msgstr "Cambiar nivel de autorización"
 
 #: katalogus/views/katalogus_settings.py
 msgid "Settings from {} to {} successfully cloned."
-msgstr ""
+msgstr "Las configuraciones de {} a {} se clonaron correctamente."
 
 #: katalogus/views/katalogus_settings.py
 #: katalogus/views/plugin_settings_list.py
 msgid "Failed getting settings for boefje {}"
-msgstr ""
+msgstr "No se pudo obtener la configuración para boefje {}"
 
 #: katalogus/views/mixins.py
 msgid ""
 "Getting information for plugin {} failed. Please check the KATalogus logs."
 msgstr ""
+"Error al obtener información para el complemento {}. Consulte los registros "
+"de KATalogus."
 
 #: katalogus/views/plugin_detail.py
 msgid ""
 "Some selected OOIs needs an increase of clearance level to perform scans. "
 "You do not have the permission to change clearance level."
 msgstr ""
+"Algunos OOIs seleccionados necesitan un aumento del nivel de autorización "
+"para realizar escaneos. No tiene permiso para cambiar el nivel de "
+"autorización."
 
 #: katalogus/views/plugin_enable_disable.py
 msgid "{} '{}' disabled."
-msgstr ""
+msgstr "{} '{}' desactivado."
 
 #: katalogus/views/plugin_enable_disable.py
 msgid "{} '{}' enabled."
-msgstr ""
+msgstr "{} '{}' activado."
 
 #: katalogus/views/plugin_enable_disable.py
 msgid ""
 "You have not acknowledged your clearance level. Go to your profile page to "
 "acknowledge your clearance level."
 msgstr ""
+"No ha reconocido su nivel de autorización. Vaya a su página de perfil para "
+"reconocer su nivel de autorización."
 
 #: katalogus/views/plugin_enable_disable.py
 msgid ""
 "Your clearance level is not set. Go to your profile page to see your "
 "clearance or contact the administrator to set a clearance level."
 msgstr ""
+"Su nivel de autorización no está establecido. Vaya a su página de perfil "
+"para ver su autorización o comuníquese con el administrador para establecer "
+"un nivel de autorización."
 
 #: katalogus/views/plugin_enable_disable.py
 msgid ""
 "Your clearance level is L{}. Contact your administrator to get a higher "
 "clearance level."
 msgstr ""
+"Su nivel de autorización es L{}. Comuníquese con su administrador para "
+"obtener un nivel de autorización más alto."
 
 #: katalogus/views/plugin_enable_disable.py
 msgid "To enable {} you need at least a clearance level of L{}. "
-msgstr ""
+msgstr "Para habilitar {} necesita al menos un nivel de autorización de L{}."
 
 #: katalogus/views/plugin_settings_add.py
 msgid "Trying to add settings to boefje without schema"
-msgstr ""
+msgstr "Intentando agregar configuraciones a boefje sin esquema"
 
 #: katalogus/views/plugin_settings_add.py
 msgid "No changes to the settings added: no form data present"
 msgstr ""
+"No se agregaron cambios en la configuración: no hay datos de formulario "
+"presentes"
 
 #: katalogus/views/plugin_settings_add.py
 msgid "Added settings for '{}'"
-msgstr ""
+msgstr "Configuración agregada para '{}'"
 
 #: katalogus/views/plugin_settings_add.py
 msgid "Failed adding settings"
-msgstr ""
+msgstr "Error al agregar la configuración"
 
 #: katalogus/views/plugin_settings_add.py
 msgid "Enabling {} failed"
-msgstr ""
+msgstr "Error al habilitar {}"
 
 #: katalogus/views/plugin_settings_add.py
 msgid "Boefje '{}' enabled."
-msgstr ""
+msgstr "Boefje '{}' habilitado."
 
 #: katalogus/views/plugin_settings_add.py
 msgid "Add settings"
-msgstr ""
+msgstr "Agregar configuraciones"
 
 #: katalogus/views/plugin_settings_delete.py
 msgid "Settings for plugin {} successfully deleted."
-msgstr ""
+msgstr "La configuración del complemento {} se eliminó correctamente."
 
 #: katalogus/views/plugin_settings_delete.py
 msgid "Plugin {} has no settings."
-msgstr ""
+msgstr "El complemento {} no tiene configuración."
 
 #: katalogus/views/plugin_settings_delete.py
 msgid ""
 "Failed deleting Settings for plugin {}. Check the Katalogus logs for more "
 "info."
 msgstr ""
+"No se pudo eliminar la configuración del complemento {}. Consulte los "
+"registros Katalogus para obtener más información."
 
 #: onboarding/forms.py
 msgid ""
 "The clearance level determines how aggressive the object can be scanned by "
 "plugins. A higher clearance level means more aggressive scans are allowed."
 msgstr ""
+"El nivel de autorización determina la agresividad con la que los "
+"complementos pueden escanear el objeto. Un nivel de autorización más alto "
+"significa que se permiten exploraciones más agresivas."
 
 #: onboarding/forms.py tools/forms/ooi.py
 msgid "explanation-clearance-level"
-msgstr ""
+msgstr "nivel de autorización de explicación"
 
 #: onboarding/forms.py
 msgid "Please enter a valid URL starting with 'http://' or 'https://'."
-msgstr ""
+msgstr "Ingrese un URL válido que comience con 'http://' o 'https://'."
 
 #: onboarding/templates/partials/onboarding_header.html
 msgid "Onboarding"
-msgstr ""
+msgstr "Incorporación"
 
 #: onboarding/templates/partials/step_1_introduction_text.html
 msgid "Welcome to OpenKAT!"
-msgstr ""
+msgstr "¡Bienvenido a OpenKAT!"
 
 #: onboarding/templates/partials/step_1_introduction_text.html
 msgid ""
-"Welcome to the onboarding of OpenKAT. We will walk you through some steps to "
-"set everything up."
+"Welcome to the onboarding of OpenKAT. We will walk you through some steps to"
+" set everything up."
 msgstr ""
+"Bienvenido a la incorporación de OpenKAT. Le guiaremos a través de algunos "
+"pasos para configurar todo."
 
 #: onboarding/templates/partials/step_1_introduction_text.html
 msgid ""
-"At the end of this onboarding you have added your first object, created your "
-"first DNS report and learned about some basic concepts used within OpenKAT."
+"At the end of this onboarding you have added your first object, created your"
+" first DNS report and learned about some basic concepts used within OpenKAT."
 msgstr ""
+"Al final de esta incorporación, agregó su primer objeto, creó su primer "
+"informe DNS y aprendió sobre algunos conceptos básicos utilizados en "
+"OpenKAT."
 
 #: onboarding/templates/partials/step_1_introduction_text.html
 msgid "The full documentation for OpenKAT can be found at:"
-msgstr ""
+msgstr "La documentación completa para OpenKAT se puede encontrar en:"
 
 #: onboarding/templates/partials/step_2_organization_text.html
 #: rocky/templates/organizations/organization_add.html
 msgid "Organization setup"
-msgstr ""
+msgstr "Configuración de la organización"
 
 #: onboarding/templates/partials/step_2_organization_text.html
 msgid ""
@@ -2222,36 +2412,43 @@ msgid ""
 "be changed later in the interface. The organization code cannot be changed "
 "as this is used by the database."
 msgstr ""
+"Por favor ingrese los siguientes detalles de la organización. El nombre de "
+"la organización se puede cambiar más adelante en la interfaz. El código de "
+"la organización no se puede cambiar ya que lo utiliza la base de datos."
 
 #: onboarding/templates/step_10_report.html
 #: reports/report_types/concatenated_report/report.py
 msgid "Report"
-msgstr ""
+msgstr "Informe"
 
 #: onboarding/templates/step_10_report.html
 msgid "Boefjes are scanning"
-msgstr ""
+msgstr "Boefjes están escaneando"
 
 #: onboarding/templates/step_10_report.html
 msgid ""
 "The enabled Boefjes are running in the background to gather the data for "
 "your DNS Report. This may take a few minutes."
 msgstr ""
+"Los Boefjes habilitados se ejecutan en segundo plano para recopilar los "
+"datos para su informe DNS. Esto puede tardar unos minutos."
 
 #: onboarding/templates/step_10_report.html
 msgid ""
 "In the meantime you can explore OpenKAT and view your DNS Report on the "
 "Reports page once it has been generated."
 msgstr ""
+"Mientras tanto, puede explorar OpenKAT y ver su informe DNS en la página "
+"Informes una vez que se haya generado."
 
 #: onboarding/templates/step_10_report.html
 msgid "Continue to OpenKAT"
-msgstr ""
+msgstr "Continuar a OpenKAT"
 
 #: onboarding/templates/step_1_introduction_registration.html
 #: onboarding/templates/step_1a_introduction.html
 msgid "Let's get started"
-msgstr ""
+msgstr "Empecemos"
 
 #: onboarding/templates/step_2a_organization_setup.html
 #: onboarding/templates/step_2b_organization_update.html
@@ -2259,7 +2456,7 @@ msgstr ""
 #: rocky/templates/organizations/organization_settings.html
 #: rocky/templates/partials/organization_properties_table.html
 msgid "Organization details"
-msgstr ""
+msgstr "Detalles de la organización"
 
 #: onboarding/templates/step_2a_organization_setup.html
 #: rocky/templates/forms/json_schema_form.html
@@ -2271,54 +2468,65 @@ msgstr ""
 #: rocky/templates/partials/form/indemnification_add_form.html
 #: rocky/templates/two_factor/_wizard_actions.html
 msgid "Submit"
-msgstr ""
+msgstr "Entregar"
 
 #: onboarding/templates/step_2b_organization_update.html
 msgid "Submit changes"
-msgstr ""
+msgstr "Enviar cambios"
 
 #: onboarding/templates/step_2b_organization_update.html
 #: onboarding/templates/step_3_indemnification_setup.html
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 #: onboarding/templates/step_7_clearance_level_introduction.html
 msgid "Continue"
-msgstr ""
+msgstr "Continuar"
 
 #: onboarding/templates/step_3_indemnification_setup.html
 msgid "Indemnification setup"
-msgstr ""
+msgstr "Configuración de indemnización"
 
 #: onboarding/templates/step_3_indemnification_setup.html
 msgid "Indemnification on the organization is already present."
-msgstr ""
+msgstr "La indemnización a la organización ya está presente."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 msgid "User clearance level"
-msgstr ""
+msgstr "Nivel de autorización del usuario"
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 msgid ""
-"The user clearance level specifies the maximum scan level for security scans "
-"and the maximum clearance level you can assign to objects (e.g. a URL)."
+"The user clearance level specifies the maximum scan level for security scans"
+" and the maximum clearance level you can assign to objects (e.g. a URL)."
 msgstr ""
+"El nivel de autorización del usuario especifica el nivel máximo de escaneo "
+"para escaneos de seguridad y el nivel de autorización máximo que puede "
+"asignar a los objetos (por ejemplo, un URL)."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 msgid ""
 "The administrator assigns a maximum user clearance level to each user. This "
 "will make sure that only trusted users can start more aggressive scans."
 msgstr ""
+"El administrador asigna un nivel máximo de autorización de usuario a cada "
+"usuario. Esto garantizará que sólo los usuarios de confianza puedan iniciar "
+"análisis más agresivos."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 msgid ""
 "A user must accept a clearance level, before they perform actions in "
 "OpenKAT. Here you may accept the maximum trusted clearance level, as "
-"assigned by your administrator. On your user settings page you can choose to "
-"lower your accepted clearance level after completing the onboarding."
+"assigned by your administrator. On your user settings page you can choose to"
+" lower your accepted clearance level after completing the onboarding."
 msgstr ""
+"Un usuario debe aceptar un nivel de autorización antes de realizar acciones "
+"en OpenKAT. Aquí puede aceptar el nivel de autorización máximo de confianza,"
+" asignado por su administrador. En su página de configuración de usuario, "
+"puede optar por reducir su nivel de autorización aceptado después de "
+"completar la incorporación."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 msgid "What is my clearance level?"
-msgstr ""
+msgstr "¿Cuál es mi nivel de autorización?"
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 #, python-format
@@ -2330,6 +2538,12 @@ msgid ""
 "<strong>%(ooi)s</strong> </br> Contact your administrator to receive a "
 "higher clearance."
 msgstr ""
+"Lamentablemente no puedes continuar con la incorporación. </br> Su "
+"administrador le ha confiado un nivel de autorización de "
+"<strong>L%(tcl)s</strong>. </br> Necesita al menos un nivel de autorización "
+"de <strong>L%(dns_report_least_clearance_level)s</strong> para escanear "
+"<strong>%(ooi)s</strong> </br> Comuníquese con su administrador para recibir"
+" una autorización mayor."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 #: onboarding/templates/step_5_add_scan_ooi.html
@@ -2339,7 +2553,7 @@ msgstr ""
 #: onboarding/templates/step_9_choose_report_type.html
 #: rocky/templates/partials/form/boefje_tiles_form.html
 msgid "Skip onboarding"
-msgstr ""
+msgstr "Saltar incorporación"
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 #, python-format
@@ -2348,6 +2562,9 @@ msgid ""
 "<strong>L%(tcl)s</strong>. </br> You must first accept this clearance level "
 "to continue."
 msgstr ""
+"Su administrador le ha confiado un nivel de autorización de "
+"<strong>L%(tcl)s</strong>. </br> Primero debe aceptar este nivel de "
+"autorización para continuar."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 #, python-format
@@ -2355,10 +2572,12 @@ msgid ""
 "Your administrator has <strong>trusted</strong> you with a clearance level "
 "of <strong>L%(tcl)s</strong>."
 msgstr ""
+"Su administrador tiene <strong> de confianza</strong> con un nivel de "
+"autorización de <strong>L%(tcl)s</strong>."
 
 #: onboarding/templates/step_5_add_scan_ooi.html
 msgid "Add an object"
-msgstr ""
+msgstr "Agregar un objeto"
 
 #: onboarding/templates/step_5_add_scan_ooi.html
 msgid ""
@@ -2366,11 +2585,14 @@ msgid ""
 "URLs. In the onboarding we will add an URL object, such as our vulnerable "
 "OpenKAT website: https://mispo.es."
 msgstr ""
+"OpenKAT utiliza varios tipos de objetos, como direcciones IP, nombres de "
+"host y URLs. En la incorporación agregaremos un objeto URL, como nuestro "
+"sitio web vulnerable OpenKAT: https://mispo.es.."
 
 #: onboarding/templates/step_5_add_scan_ooi.html
 #: rocky/templates/partials/ooi_detail_related_object.html
 msgid "Related objects"
-msgstr ""
+msgstr "Objetos relacionados"
 
 #: onboarding/templates/step_5_add_scan_ooi.html
 msgid ""
@@ -2380,22 +2602,33 @@ msgid ""
 "collects and adds these related objects by running scans. Objects can also "
 "be manually added."
 msgstr ""
+"La mayoría de los objetos dependen de la existencia de objetos relacionados."
+" Por ejemplo, un URL debe estar conectado a una red, un nombre de host, un "
+"fqdn (nombre de dominio completo) y una dirección IP. Cuando es posible, "
+"OpenKAT recopila y agrega automáticamente estos objetos relacionados "
+"mediante la ejecución de análisis. Los objetos también se pueden agregar "
+"manualmente."
 
 #: onboarding/templates/step_5_add_scan_ooi.html
 msgid "Create object"
-msgstr ""
+msgstr "Crear objeto"
 
 #: onboarding/templates/step_6_set_clearance_level.html
 msgid "Set object clearance level"
-msgstr ""
+msgstr "Establecer el nivel de separación de objetos"
 
 #: onboarding/templates/step_6_set_clearance_level.html
 msgid ""
-"After creating a new object you can set a clearance level for this object. A "
-"clearance level determines how aggressive the object can be scanned. A "
+"After creating a new object you can set a clearance level for this object. A"
+" clearance level determines how aggressive the object can be scanned. A "
 "higher clearance level, means that more aggressive scans are allowed. "
 "Clearance levels can always be adjusted later on."
 msgstr ""
+"Después de crear un nuevo objeto, puede establecer un nivel de autorización "
+"para este objeto. Un nivel de autorización determina qué tan agresivo se "
+"puede escanear el objeto. Un nivel de autorización más alto significa que se"
+" permiten exploraciones más agresivas. Los niveles de autorización siempre "
+"se pueden ajustar más adelante."
 
 #: onboarding/templates/step_6_set_clearance_level.html
 #, python-format
@@ -2404,22 +2637,30 @@ msgid ""
 "L%(dns_report_least_clearance_level)s, meaning only informational scans are "
 "allowed."
 msgstr ""
+"Para la incorporación utilizamos un nivel de autorización de "
+"L%(dns_report_least_clearance_level)s, lo que significa que solo se permiten"
+" escaneos informativos."
 
 #: onboarding/templates/step_6_set_clearance_level.html
 msgid "Set clearance level"
-msgstr ""
+msgstr "Establecer nivel de autorización"
 
 #: onboarding/templates/step_7_clearance_level_introduction.html
 msgid "Plugin introduction"
-msgstr ""
+msgstr "Introducción al complemento"
 
 #: onboarding/templates/step_7_clearance_level_introduction.html
 msgid ""
 "OpenKAT uses plugins to scan your objects. Each plugin has a scan level to "
-"specify how aggressive the scan is. Plugins can only scan those objects with "
-"a clearance level that is equal to, or higher than the scan level of the "
+"specify how aggressive the scan is. Plugins can only scan those objects with"
+" a clearance level that is equal to, or higher than the scan level of the "
 "plugin. Plugin scan level are indicated by the number of cat paws."
 msgstr ""
+"OpenKAT utiliza complementos para escanear sus objetos. Cada complemento "
+"tiene un nivel de escaneo para especificar qué tan agresivo es el escaneo. "
+"Los complementos solo pueden escanear aquellos objetos con un nivel de "
+"autorización igual o superior al nivel de escaneo del complemento. El nivel "
+"de escaneo del complemento se indica por la cantidad de patas de gato."
 
 #: onboarding/templates/step_7_clearance_level_introduction.html
 msgid ""
@@ -2427,6 +2668,10 @@ msgid ""
 "performs non-intrusive scans which look for publicly available information. "
 "It scans objects with a clearance level of 1 or higher."
 msgstr ""
+"El complemento <strong>DNS Zone</strong> tiene un nivel de escaneo 1, lo que"
+" significa que realiza escaneos no intrusivos que buscan información "
+"disponible públicamente. Escanea objetos con un nivel de autorización de 1 o"
+" superior."
 
 #: onboarding/templates/step_7_clearance_level_introduction.html
 msgid ""
@@ -2434,46 +2679,63 @@ msgid ""
 "more aggressive and could potentially break things. It scans objects with a "
 "clearance level of 3 or higher."
 msgstr ""
+"El complemento <strong>Fierce</strong> tiene un nivel de escaneo de 3, lo "
+"que significa que es más agresivo y potencialmente podría romper cosas. "
+"Escanea objetos con un nivel de autorización de 3 o superior."
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid "Enabling plugins and start scanning"
-msgstr ""
+msgstr "Habilitar complementos y comenzar a escanear"
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid ""
 "OpenKAT uses plugins to scan, check and analyze. There are three types of "
 "plugins."
 msgstr ""
+"OpenKAT utiliza complementos para escanear, verificar y analizar. Hay tres "
+"tipos de complementos."
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid ""
 "The first plugin are <b>Boefjes</b>, which scan objects for data. These are "
 "security tools like nmap, LeakIX and WPscan. </p>"
 msgstr ""
+"El primer complemento es <b>Boefjes</b>, que escanea objetos en busca de "
+"datos. Se trata de herramientas de seguridad como nmap, LeakIX y WPscan. "
+"</p>"
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid ""
-"The other two plugins are <b>Normalizers</b> and <b>Bits</b>, which are used "
-"to process the output of Boefjes. They can create findings and related "
+"The other two plugins are <b>Normalizers</b> and <b>Bits</b>, which are used"
+" to process the output of Boefjes. They can create findings and related "
 "objects. Bits are also used to create organization specific findings, based "
 "on policy requirements. </p>"
 msgstr ""
+"Los otros dos complementos son <b>Normalizers</b> y <b>Bits</b>, que se "
+"utilizan para procesar la salida de Boefjes. Pueden crear hallazgos y "
+"objetos relacionados. Los bits también se utilizan para crear hallazgos "
+"específicos de la organización, basados ​​en requisitos de políticas. </p>"
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid ""
 "For the onboarding we will enable the Boefjes shown below. Once enabled "
-"these Boefjes gather publicly available information on suitable objects with "
-"a clearance level of 1 or higher. Normalizers and Bits are enabled by "
+"these Boefjes gather publicly available information on suitable objects with"
+" a clearance level of 1 or higher. Normalizers and Bits are enabled by "
 "default."
 msgstr ""
+"Para la incorporación habilitaremos el Boefjes que se muestra a "
+"continuación. Una vez habilitados, estos Boefjes recopilan información "
+"disponible públicamente sobre objetos adecuados con un nivel de autorización"
+" de 1 o superior. Normalizers y Bits están habilitados de forma "
+"predeterminada."
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid "Enable and continue"
-msgstr ""
+msgstr "Habilitar y continuar"
 
 #: onboarding/templates/step_9_choose_report_type.html
 msgid "Generate a report"
-msgstr ""
+msgstr "Generar un informe"
 
 #: onboarding/templates/step_9_choose_report_type.html
 msgid ""
@@ -2481,79 +2743,86 @@ msgid ""
 "can generate different types of reports in OpenKAT. Each report may require "
 "one or more plugins that provide the input for the report."
 msgstr ""
+"Los informes se pueden utilizar para obtener más información sobre los "
+"activos de su organización. Puede generar diferentes tipos de informes en "
+"OpenKAT. Cada informe puede requerir uno o más complementos que proporcionen"
+" información para el informe."
 
 #: onboarding/templates/step_9_choose_report_type.html
 msgid ""
 "For the onboarding we will generate a DNS report for your added URL. In the "
 "previous step you enabled the required plugins for this report."
 msgstr ""
+"Para la incorporación, generaremos un informe DNS para su URL agregado. En "
+"el paso anterior, habilitó los complementos necesarios para este informe."
 
 #: onboarding/templates/step_9_choose_report_type.html
 msgid "Generate DNS Report"
-msgstr ""
+msgstr "Generar informe DNS"
 
 #: onboarding/view_helpers.py
 msgid "1: Welcome"
-msgstr ""
+msgstr "1: Bienvenido"
 
 #: onboarding/view_helpers.py
 msgid "2: Organization setup"
-msgstr ""
+msgstr "2: configuración de la organización"
 
 #: onboarding/view_helpers.py
 msgid "3: Add object"
-msgstr ""
+msgstr "3: Agregar objeto"
 
 #: onboarding/view_helpers.py
 msgid "4: Plugins"
-msgstr ""
+msgstr "4: complementos"
 
 #: onboarding/view_helpers.py
 msgid "5: Generating report"
-msgstr ""
+msgstr "5: Generando informe"
 
 #: onboarding/views.py
 #, python-brace-format
 msgid "{org_name} successfully created."
-msgstr ""
+msgstr "{org_name} creado exitosamente."
 
 #: onboarding/views.py
 #, python-brace-format
 msgid "{org_name} successfully updated."
-msgstr ""
+msgstr "{org_name} actualizado correctamente."
 
 #: onboarding/views.py
 msgid "Creating an object"
-msgstr ""
+msgstr "Creando un objeto"
 
 #: onboarding/views.py
 msgid "Fetch the parent DNS zone of a hostname"
-msgstr ""
+msgstr "Obtener la zona principal DNS de un nombre de host"
 
 #: onboarding/views.py
 msgid "Finds subdomains by brute force"
-msgstr ""
+msgstr "Encuentra subdominios por fuerza bruta"
 
 #: onboarding/views.py
 msgid "Please select a plugin to proceed."
-msgstr ""
+msgstr "Seleccione un complemento para continuar."
 
 #: onboarding/views.py
 msgid "Please select all required plugins to proceed."
-msgstr ""
+msgstr "Seleccione todos los complementos necesarios para continuar."
 
 #: onboarding/views.py reports/views/aggregate_report.py
 #: reports/views/generate_report.py
 msgid "An error occurred while enabling {}. The plugin is not available."
 msgstr ""
+"Se produjo un error al habilitar {}. El complemento no está disponible."
 
 #: onboarding/views.py
 msgid "Plugins successfully enabled."
-msgstr ""
+msgstr "Complementos habilitados correctamente."
 
 #: onboarding/views.py
 msgid "Web URL not found."
-msgstr ""
+msgstr "Web URL no encontrada."
 
 #: onboarding/views.py
 msgid ""
@@ -2561,111 +2830,115 @@ msgid ""
 "waiting for Boefjes to complete. In the meantime get familiar with OpenKAT "
 "and visit the Reports History tab later."
 msgstr ""
+"La generación de su informe está programada para aproximadamente 3 minutos, "
+"mientras estamos esperando que se complete Boefjes. Mientras tanto, "
+"familiarícese con OpenKAT y visite la pestaña Historial de informes más "
+"adelante."
 
 #: reports/forms.py tools/forms/ooi_form.py
 msgid "Filter by OOI types"
-msgstr ""
+msgstr "Filtrar por tipos de OOI"
 
 #: reports/forms.py
 msgid "Today"
-msgstr ""
+msgstr "Hoy"
 
 #: reports/forms.py
 msgid "Different date"
-msgstr ""
+msgstr "fecha diferente"
 
 #: reports/forms.py
 msgid "No, just once"
-msgstr ""
+msgstr "No, solo una vez"
 
 #: reports/forms.py
 msgid "Yes, repeat"
-msgstr ""
+msgstr "Si, repite"
 
 #: reports/forms.py
 msgid "Start date"
-msgstr ""
+msgstr "Fecha de inicio"
 
 #: reports/forms.py
 msgid "Start time (UTC)"
-msgstr ""
+msgstr "Hora de inicio (UTC)"
 
 #: reports/forms.py
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Recurrence"
-msgstr ""
+msgstr "Reaparición"
 
 #: reports/forms.py
 msgid "No recurrence, just once"
-msgstr ""
+msgstr "Sin recurrencia, solo una vez"
 
 #: reports/forms.py
 msgid "Daily"
-msgstr ""
+msgstr "A diario"
 
 #: reports/forms.py
 msgid "Weekly"
-msgstr ""
+msgstr "Semanalmente"
 
 #: reports/forms.py
 msgid "Monthly"
-msgstr ""
+msgstr "Mensual"
 
 #: reports/forms.py
 msgid "Yearly"
-msgstr ""
+msgstr "Anual"
 
 #: reports/forms.py
 msgid "day"
-msgstr ""
+msgstr "día"
 
 #: reports/forms.py
 msgid "week"
-msgstr ""
+msgstr "semana"
 
 #: reports/forms.py
 msgid "month"
-msgstr ""
+msgstr "mes"
 
 #: reports/forms.py
 msgid "year"
-msgstr ""
+msgstr "año"
 
 #: reports/forms.py
 msgid "Never"
-msgstr ""
+msgstr "Nunca"
 
 #: reports/forms.py
 msgid "On"
-msgstr ""
+msgstr "En"
 
 #: reports/forms.py
 msgid "After"
-msgstr ""
+msgstr "Después"
 
 #: reports/forms.py
 msgid "Report name format"
-msgstr ""
+msgstr "Formato del nombre del informe"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/report_types/multi_organization_report/appendix.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Appendix"
-msgstr ""
+msgstr "Apéndice"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Currently filtered on"
-msgstr ""
+msgstr "Actualmente filtrado en"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/partials/report_sidemenu.html
 #: reports/templates/summary/report_asset_overview.html
 msgid "Selected Report Types"
-msgstr ""
+msgstr "Tipos de informes seleccionados"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Selected report types"
-msgstr ""
+msgstr "Tipos de informes seleccionados"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/partials/plugin_overview_table.html
@@ -2675,65 +2948,65 @@ msgstr ""
 #: reports/templates/report_overview/subreports_table.html
 #: reports/templates/summary/report_asset_overview.html
 msgid "Report type"
-msgstr ""
+msgstr "Tipo de informe"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Service Versions and Health"
-msgstr ""
+msgstr "Versiones de servicio y estado"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Service, version and health"
-msgstr ""
+msgstr "Servicio, versión y salud."
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/summary/service_health.html rocky/templates/footer.html
 #: rocky/templates/health.html
 msgid "Service"
-msgstr ""
+msgstr "Servicio"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/summary/service_health.html rocky/templates/health.html
 msgid "Version"
-msgstr ""
+msgstr "Versión"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: rocky/templates/footer.html rocky/views/health.py
 msgid "Health"
-msgstr ""
+msgstr "Salud"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: rocky/templates/health.html
 msgid "Healthy"
-msgstr ""
+msgstr "Saludable"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Unhealthy"
-msgstr ""
+msgstr "Malsano"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Used Config objects"
-msgstr ""
+msgstr "Objetos de configuración usados"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Used config objects"
-msgstr ""
+msgstr "Objetos de configuración usados"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Primary Key"
-msgstr ""
+msgstr "Clave primaria"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Bit ID"
-msgstr ""
+msgstr "ID de bit"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Config"
-msgstr ""
+msgstr "configuración"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "No config objects found."
-msgstr ""
+msgstr "No se encontraron objetos de configuración."
 
 #: reports/report_types/aggregate_organisation_report/asset_overview.html
 #: reports/report_types/multi_organization_report/asset_overview.html
@@ -2741,20 +3014,23 @@ msgstr ""
 #: reports/templates/partials/report_sidemenu.html
 #: reports/templates/summary/report_asset_overview.html
 msgid "Asset overview"
-msgstr ""
+msgstr "Resumen de activos"
 
 #: reports/report_types/aggregate_organisation_report/asset_overview.html
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid ""
-"An overview of the manually released scanned assets. Assets in <strong>bold</"
-"strong> are taken as a starting point, assets that are not in bold were "
-"found by OpenKAT itself."
+"An overview of the manually released scanned assets. Assets in "
+"<strong>bold</strong> are taken as a starting point, assets that are not in "
+"bold were found by OpenKAT itself."
 msgstr ""
+"Una descripción general de los activos escaneados publicados manualmente. "
+"Los activos en <strong>bold</strong> se toman como punto de partida, los "
+"activos que no están en negrita fueron encontrados por el propio OpenKAT."
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 #: reports/report_types/aggregate_organisation_report/report.html
 msgid "Overview of the basic security status"
-msgstr ""
+msgstr "Descripción general del estado de seguridad básico"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 msgid ""
@@ -2762,39 +3038,42 @@ msgid ""
 "assets. Basic security in order. In principle, all values in this table "
 "should be checked off."
 msgstr ""
+"Esta tabla proporciona una descripción general del estado de seguridad "
+"básico de los activos conocidos. Seguridad básica en orden. En principio, se"
+" deben marcar todos los valores de esta tabla."
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 msgid "Basic security status"
-msgstr ""
+msgstr "Estado de seguridad básico"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 #: reports/report_types/ipv6_report/report.html
 #: reports/report_types/multi_organization_report/ipv6.html
 #: reports/report_types/systems_report/report.html
 msgid "System type"
-msgstr ""
+msgstr "Tipo de sistema"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Safe connections"
-msgstr ""
+msgstr "Conexiones seguras"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 msgid "System Specific"
-msgstr ""
+msgstr "Específico del sistema"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 msgid "RPKI"
-msgstr ""
+msgstr "RPKI"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/rpki_report/report.html
 #: reports/report_types/safe_connections_report/report.html
 msgid "server"
-msgstr ""
+msgstr "servidor"
 
 #: reports/report_types/aggregate_organisation_report/findings.html
 #: reports/report_types/aggregate_organisation_report/report.html
@@ -2802,53 +3081,58 @@ msgid ""
 "This chapter contains information about the findings that have been "
 "identified for this organization."
 msgstr ""
+"Este capítulo contiene información sobre los hallazgos que se han "
+"identificado para esta organización."
 
 #: reports/report_types/aggregate_organisation_report/recommendations.html
 #: reports/report_types/multi_organization_report/recommendations.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Recommendations"
-msgstr ""
+msgstr "Recomendaciones"
 
 #: reports/report_types/aggregate_organisation_report/recommendations.html
 #, python-format
 msgid "There is <i>%(total_findings)s</i> vulnerability"
 msgid_plural "There are <i>%(total_findings)s</i> vulnerabilities"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Hay vulnerabilidades <i>%(total_findings)s</i>"
+msgstr[1] "Hay vulnerabilidades <i>%(total_findings)s</i>"
 
 #: reports/report_types/aggregate_organisation_report/recommendations.html
 #, python-format
 msgid "found on <i>%(total_systems)s</i> system."
 msgid_plural "found on <i>%(total_systems)s</i> systems."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "se encuentra en los sistemas <i>%(total_systems)s</i>."
+msgstr[1] "se encuentra en los sistemas <i>%(total_systems)s</i>."
 
 #: reports/report_types/aggregate_organisation_report/recommendations.html
 #: reports/report_types/multi_organization_report/recommendations.html
 msgid "There are no recommendations."
-msgstr ""
+msgstr "No hay recomendaciones."
 
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Basic security"
-msgstr ""
+msgstr "Seguridad básica"
 
 #: reports/report_types/aggregate_organisation_report/report.html
 msgid ""
 "In this chapter, first a table of compliance checks is displayed, followed "
 "by a detailed examination of compliance issues for each component."
 msgstr ""
+"En este capítulo, primero se muestra una tabla de verificaciones de "
+"cumplimiento, seguida de un examen detallado de los problemas de "
+"cumplimiento para cada componente."
 
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "System specific"
-msgstr ""
+msgstr "Específico del sistema"
 
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Resource Public Key Infrastructure"
-msgstr ""
+msgstr "Infraestructura de clave pública de recursos"
 
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/report_types/aggregate_organisation_report/vulnerabilities.html
@@ -2856,16 +3140,16 @@ msgstr ""
 #: reports/report_types/vulnerability_report/report.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Vulnerabilities"
-msgstr ""
+msgstr "Vulnerabilidades"
 
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/report_types/aggregate_organisation_report/vulnerabilities.html
 msgid "Vulnerabilities found are grouped per system."
-msgstr ""
+msgstr "Las vulnerabilidades encontradas se agrupan por sistema."
 
 #: reports/report_types/aggregate_organisation_report/report.py
 msgid "Aggregate Organisation Report"
-msgstr ""
+msgstr "Informe de organización agregado"
 
 #: reports/report_types/aggregate_organisation_report/rpki.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
@@ -2876,6 +3160,13 @@ msgid ""
 "misconfigurations and malicious route intercepts through verified route "
 "announcements, ensuring reliable server access and secure internet traffic."
 msgstr ""
+"Esta sección contiene información de seguridad básica sobre la "
+"infraestructura de clave pública de recursos. Si su servidor web emplea RPKI"
+" para sus direcciones IP y servidores de nombres asociados, mejora la "
+"protección de los visitantes contra configuraciones erróneas e "
+"intercepciones de rutas maliciosas a través de anuncios de rutas "
+"verificadas, lo que garantiza un acceso confiable al servidor y un tráfico "
+"de Internet seguro."
 
 #: reports/report_types/aggregate_organisation_report/safe_connections.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
@@ -2886,41 +3177,48 @@ msgid ""
 "strong encryption which protects the data from interception during "
 "communiction."
 msgstr ""
+"En este capítulo comprobamos si las conexiones de todos los puertos IP del "
+"sistema son seguras. Las conexiones seguras son importantes para evitar "
+"accesos no autorizados y violaciones de datos. Los cifrados sólidos son "
+"cruciales porque garantizan un cifrado sólido que protege los datos contra "
+"la interceptación durante la comunicación."
 
 #: reports/report_types/aggregate_organisation_report/summary.html
 #: reports/report_types/multi_organization_report/summary.html
 #: rocky/views/ooi_tree.py
 msgid "Summary"
-msgstr ""
+msgstr "Resumen"
 
 #: reports/report_types/aggregate_organisation_report/summary.html
 msgid "Critical Vulnerabilities"
-msgstr ""
+msgstr "Vulnerabilidades críticas"
 
 #: reports/report_types/aggregate_organisation_report/summary.html
 msgid "IPs scanned"
-msgstr ""
+msgstr "IPs escaneado"
 
 #: reports/report_types/aggregate_organisation_report/summary.html
 msgid "Hostnames scanned"
-msgstr ""
+msgstr "Nombres de host escaneados"
 
 #: reports/report_types/aggregate_organisation_report/summary.html
 msgid "Terms in report"
-msgstr ""
+msgstr "Términos en el informe"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/rpki_report/report.html
 #: reports/report_types/safe_connections_report/report.html
 #, python-format
 msgid ""
-"This table shows which checks were performed. Following that, the compliance "
-"issues, if any, are shown for each %(type)s Server."
+"This table shows which checks were performed. Following that, the compliance"
+" issues, if any, are shown for each %(type)s Server."
 msgstr ""
+"Esta tabla muestra qué controles se realizaron. A continuación, se muestran "
+"los problemas de cumplimiento, si los hay, para cada servidor %(type)s."
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 msgid "Check overview"
-msgstr ""
+msgstr "Ver descripción general"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/mail_report/report.html
@@ -2930,7 +3228,7 @@ msgstr ""
 #: reports/report_types/safe_connections_report/report.html
 #: reports/report_types/web_system_report/report.html
 msgid "Check"
-msgstr ""
+msgstr "Controlar"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/mail_report/report.html
@@ -2939,18 +3237,18 @@ msgstr ""
 #: reports/report_types/safe_connections_report/report.html
 #: reports/report_types/web_system_report/report.html
 msgid "Compliance"
-msgstr ""
+msgstr "Cumplimiento"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/rpki_report/report.html
 msgid "IPs are compliant"
-msgstr ""
+msgstr "IPs cumplen con"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/safe_connections_report/report.html
 #: reports/report_types/vulnerability_report/report.html
 msgid "Host:"
-msgstr ""
+msgstr "Anfitrión:"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/mail_report/report.html
@@ -2959,7 +3257,7 @@ msgstr ""
 #: reports/report_types/safe_connections_report/report.html
 #: reports/report_types/web_system_report/report.html
 msgid "Compliance issue"
-msgstr ""
+msgstr "Problema de cumplimiento"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/mail_report/report.html
@@ -2973,7 +3271,7 @@ msgstr ""
 #: rocky/templates/partials/ooi_report_findings_block_table.html
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "Risk level"
-msgstr ""
+msgstr "Nivel de riesgo"
 
 #: reports/report_types/aggregate_organisation_report/system_specific_overview.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
@@ -2982,28 +3280,43 @@ msgid ""
 "security and compliance issues come into play for different systems. They "
 "are listed here under each other."
 msgstr ""
+"Aquí es donde se realizan comprobaciones específicas de los tipos de "
+"sistemas. Entran en juego diferentes problemas de seguridad y cumplimiento "
+"para diferentes sistemas. Se enumeran aquí uno debajo del otro."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Term Overview"
-msgstr ""
+msgstr "Descripción general del término"
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid "For definitions of terms used in this chapter, see the glossary below."
 msgstr ""
+"Para conocer las definiciones de los términos utilizados en este capítulo, "
+"consulte el glosario a continuación."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
 "Web servers and domains are examples of digital assets within this "
-"framework. Web servers are essential for hosting and serving websites or web "
-"applications, while domains represent the online addresses used to access "
-"these resources. Other examples of assets in the IT realm include databases, "
-"user accounts, software applications, and networking infrastructure. Asset "
+"framework. Web servers are essential for hosting and serving websites or web"
+" applications, while domains represent the online addresses used to access "
+"these resources. Other examples of assets in the IT realm include databases,"
+" user accounts, software applications, and networking infrastructure. Asset "
 "management is a critical aspect of cybersecurity, involving the "
 "identification, classification, and protection of these assets to safeguard "
 "against threats and ensure the overall security and functionality of an "
 "organization's IT environment."
 msgstr ""
+"Los servidores y dominios web son ejemplos de activos digitales dentro de "
+"este marco. Los servidores web son esenciales para alojar y servir sitios "
+"web o aplicaciones web, mientras que los dominios representan las "
+"direcciones en línea utilizadas para acceder a estos recursos. Otros "
+"ejemplos de activos en el ámbito de TI incluyen bases de datos, cuentas de "
+"usuario, aplicaciones de software e infraestructura de redes. La gestión de "
+"activos es un aspecto crítico de la ciberseguridad, que implica la "
+"identificación, clasificación y protección de estos activos para protegerlos"
+" contra amenazas y garantizar la seguridad y funcionalidad generales del "
+"entorno de TI de una organización."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
@@ -3011,13 +3324,20 @@ msgid ""
 "hostnames or the IP address has a declared scan level that is at least L1. "
 "Type systems are web servers, mail servers and name servers (DNS)."
 msgstr ""
+"Múltiples nombres de host que se resuelven en una dirección IP donde al "
+"menos uno de los nombres de host o la dirección IP tiene un nivel de escaneo"
+" declarado que es al menos L1. Los sistemas tipo son servidores web, "
+"servidores de correo y servidores de nombres (DNS)."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
 "A fundamental component of the client-server model. A web server uses "
-"protocols like HTTP or HTTPS to facilitate communication between clients and "
-"the server."
+"protocols like HTTP or HTTPS to facilitate communication between clients and"
+" the server."
 msgstr ""
+"Un componente fundamental del modelo cliente-servidor. Un servidor web "
+"utiliza protocolos como HTTP o HTTPS para facilitar la comunicación entre "
+"los clientes y el servidor."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
@@ -3031,16 +3351,34 @@ msgid ""
 "emails, handling tasks such as authentication, spam filtering, and message "
 "storage."
 msgstr ""
+"Un servidor de correo es una aplicación de software especializada o un "
+"dispositivo de hardware que facilita el envío, la recepción y el "
+"almacenamiento de correos electrónicos dentro de una red informática. Al "
+"operar con el Protocolo simple de transferencia de correo (SMTP) para "
+"mensajes salientes y el Protocolo de acceso a mensajes de Internet (IMAP) o "
+"el Protocolo de oficina postal (POP) para mensajes entrantes, un servidor de"
+" correo administra la comunicación por correo electrónico enrutando mensajes"
+" entre usuarios y almacenándolos hasta que se recuperan. El servidor "
+"garantiza la transferencia eficiente y segura de correos electrónicos, "
+"manejando tareas como autenticación, filtrado de spam y almacenamiento de "
+"mensajes."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
-"A nameserver, or Domain Name System (DNS) server, is a critical component of "
-"the internet infrastructure responsible for translating human-readable "
-"domain names into IP addresses, enabling the seamless navigation of the web. "
-"When a user enters a domain name in a web browser, the nameserver is queried "
-"to obtain the corresponding IP address of the server hosting the associated "
-"website or service."
+"A nameserver, or Domain Name System (DNS) server, is a critical component of"
+" the internet infrastructure responsible for translating human-readable "
+"domain names into IP addresses, enabling the seamless navigation of the web."
+" When a user enters a domain name in a web browser, the nameserver is "
+"queried to obtain the corresponding IP address of the server hosting the "
+"associated website or service."
 msgstr ""
+"Un servidor de nombres, o servidor del Sistema de nombres de dominio (DNS), "
+"es un componente crítico de la infraestructura de Internet responsable de "
+"traducir nombres de dominio legibles por humanos en direcciones IP, lo que "
+"permite una navegación fluida por la web. Cuando un usuario ingresa un "
+"nombre de dominio en un navegador web, se consulta el servidor de nombres "
+"para obtener la dirección IP correspondiente del servidor que aloja el sitio"
+" web o servicio asociado."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
@@ -3055,15 +3393,26 @@ msgid ""
 "medical images, like X-rays, CT scans, and MRIs, utilizing a standardized "
 "format."
 msgstr ""
+"Un servidor DICOM, que significa Digital Imaging and Communications in "
+"Medicine, es un servidor especializado diseñado para el almacenamiento, "
+"recuperación e intercambio de imágenes médicas e información relacionada en "
+"la industria de la salud. DICOM es un estándar ampliamente adoptado que "
+"garantiza la interoperabilidad y coherencia en la comunicación de imágenes "
+"médicas y datos asociados entre diferentes dispositivos y sistemas, como "
+"equipos de imágenes médicas, sistemas de comunicación y archivo de imágenes "
+"(PACS) y sistemas de información radiológica (RIS). Los servidores DICOM "
+"almacenan y administran imágenes médicas específicas del paciente, como "
+"radiografías, tomografías computarizadas y resonancias magnéticas, "
+"utilizando un formato estandarizado."
 
 #: reports/report_types/aggregate_organisation_report/vulnerabilities.html
 #: reports/report_types/multi_organization_report/vulnerabilities.html
 msgid "No CVEs have been found."
-msgstr ""
+msgstr "No se han encontrado CVE."
 
 #: reports/report_types/dns_report/report.html
 msgid "Records found"
-msgstr ""
+msgstr "Registros encontrados"
 
 #: reports/report_types/dns_report/report.html
 msgid ""
@@ -3071,42 +3420,51 @@ msgid ""
 "DNSZone. Additionally the security measures table shows whether or not DNS "
 "relating security measures are enabled."
 msgstr ""
+"El informe DNS ofrece una descripción general de los registros DNS que se "
+"encontraron para DNSZone. Además, la tabla de medidas de seguridad muestra "
+"si las medidas de seguridad relacionadas con DNS están habilitadas o no."
 
 #: reports/report_types/dns_report/report.html
 msgid ""
 "<strong>Disclaimer:</strong> Not all DNSRecords are parsed in OpenKAT. DNS "
 "record types that are parsed and could be displayed in the table are:"
 msgstr ""
+"<strong>Descargo de responsabilidad:</strong> No todos los registros DNS se "
+"analizan en OpenKAT. Los tipos de registros DNS que se analizan y podrían "
+"mostrarse en la tabla son:"
 
 #: reports/report_types/dns_report/report.html
 msgid "All existing DNS record types can be found here:"
-msgstr ""
+msgstr "Todos los tipos de registros DNS existentes se pueden encontrar aquí:"
 
 #: reports/report_types/dns_report/report.html
 msgid "Record"
-msgstr ""
+msgstr "Registro"
 
 #: reports/report_types/dns_report/report.html
 msgid "TTL"
-msgstr ""
+msgstr "TTL"
 
 #: reports/report_types/dns_report/report.html
 msgid "Data"
-msgstr ""
+msgstr "Datos"
 
 #: reports/report_types/dns_report/report.html
 msgid "No records have been found."
-msgstr ""
+msgstr "No se han encontrado registros."
 
 #: reports/report_types/dns_report/report.html
 msgid "Security measures"
-msgstr ""
+msgstr "Medidas de seguridad"
 
 #: reports/report_types/dns_report/report.html
 msgid ""
-"The security measures table below shows which DNS relating security measures "
-"are enabled based on the contents of the DNS records."
+"The security measures table below shows which DNS relating security measures"
+" are enabled based on the contents of the DNS records."
 msgstr ""
+"La siguiente tabla de medidas de seguridad muestra qué medidas de seguridad "
+"relacionadas con DNS están habilitadas según el contenido de los registros "
+"DNS."
 
 #: reports/report_types/dns_report/report.html
 #: reports/templates/partials/report_ooi_list.html
@@ -3119,48 +3477,52 @@ msgstr ""
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 #: rocky/views/mixins.py
 msgid "Type"
-msgstr ""
+msgstr "Tipo"
 
 #: reports/report_types/dns_report/report.html
 msgid "Yes"
-msgstr ""
+msgstr "Sí"
 
 #: reports/report_types/dns_report/report.html
 msgid "No"
-msgstr ""
+msgstr "No"
 
 #: reports/report_types/dns_report/report.html
 #: reports/templates/partials/report_findings_table.html
 msgid "Other findings found"
-msgstr ""
+msgstr "Otros hallazgos encontrados"
 
 #: reports/report_types/dns_report/report.html
 msgid "Findings information"
-msgstr ""
+msgstr "Información de los hallazgos"
 
 #: reports/report_types/dns_report/report.py
 msgid "DNS Report"
-msgstr ""
+msgstr "Informe DNS"
 
 #: reports/report_types/dns_report/report.py
 msgid ""
 "DNS reports focus on domain name system configuration and potential "
 "weaknesses."
 msgstr ""
+"Los informes DNS se centran en la configuración del sistema de nombres de "
+"dominio y sus posibles debilidades."
 
 #: reports/report_types/findings_report/report.html
 msgid ""
 "The Findings Report contains information about the findings that have been "
 "identified for the selected asset and organization."
 msgstr ""
+"El Informe de hallazgos contiene información sobre los hallazgos que se han "
+"identificado para el activo y la organización seleccionados."
 
 #: reports/report_types/findings_report/report.py
 msgid "Findings Report"
-msgstr ""
+msgstr "Informe de hallazgos"
 
 #: reports/report_types/findings_report/report.py
 msgid "Shows all the finding types and their occurrences."
-msgstr ""
+msgstr "Muestra todos los tipos de hallazgos y sus ocurrencias."
 
 #: reports/report_types/ipv6_report/report.html
 msgid ""
@@ -3169,204 +3531,226 @@ msgid ""
 "over IPv6 or not. A green compliance check is shown if this is the case. A "
 "grey compliance cross is shown if no IPv6 address was detected."
 msgstr ""
+"El informe IPv6 proporciona una descripción general del estado actual de "
+"IPv6 del sistema identificado. La siguiente tabla muestra si se puede "
+"acceder al dominio a través de IPv6 o no. Si este es el caso, se muestra una"
+" verificación de cumplimiento verde. Se muestra una cruz de cumplimiento "
+"gris si no se detectó ninguna dirección IPv6."
 
 #: reports/report_types/ipv6_report/report.html
 msgid "IPv6 overview"
-msgstr ""
+msgstr "Descripción general de IPv6"
 
 #: reports/report_types/ipv6_report/report.html
 #: reports/report_types/systems_report/report.html
 msgid "Domain"
-msgstr ""
+msgstr "Dominio"
 
 #: reports/report_types/ipv6_report/report.py
 msgid "IPv6 Report"
-msgstr ""
+msgstr "Informe IPv6"
 
 #: reports/report_types/ipv6_report/report.py
 msgid "Check whether hostnames point to IPv6 addresses."
-msgstr ""
+msgstr "Compruebe si los nombres de host apuntan a direcciones IPv6."
 
 #: reports/report_types/mail_report/report.html
 msgid ""
 "The Mail Report provides an overview of the compliance checks associated "
 "with email servers. The current compliance checks the presence of SPF, DKIM "
 "and DMARC records. The table below shows for each of these checks how many "
-"of the identified mail servers are compliant, and if applicable a compliance "
-"issue description and risk level. The risk level may be different for your "
+"of the identified mail servers are compliant, and if applicable a compliance"
+" issue description and risk level. The risk level may be different for your "
 "specific environment."
 msgstr ""
+"El Informe de correo proporciona una descripción general de las "
+"comprobaciones de cumplimiento asociadas con los servidores de correo "
+"electrónico. El cumplimiento actual verifica la presencia de los registros "
+"SPF, DKIM y DMARC. La siguiente tabla muestra para cada una de estas "
+"comprobaciones cuántos de los servidores de correo identificados cumplen y, "
+"si corresponde, una descripción del problema de cumplimiento y el nivel de "
+"riesgo. El nivel de riesgo puede ser diferente para su entorno específico."
 
 #: reports/report_types/mail_report/report.html
 msgid "Mailserver compliance"
-msgstr ""
+msgstr "Cumplimiento del servidor de correo"
 
 #: reports/report_types/mail_report/report.html
 msgid "mailservers compliant"
-msgstr ""
+msgstr "compatible con servidores de correo"
 
 #: reports/report_types/mail_report/report.html
 msgid "No mailservers have been found on this system."
-msgstr ""
+msgstr "No se han encontrado servidores de correo en este sistema."
 
 #: reports/report_types/mail_report/report.py
 msgid "Mail Report"
-msgstr ""
+msgstr "Informe por correo"
 
 #: reports/report_types/mail_report/report.py
 msgid ""
 "System specific Mail Report that focusses on IP addresses and hostnames."
 msgstr ""
+"Informe de correo específico del sistema que se centra en direcciones y "
+"nombres de host IP."
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Overview of included assets"
-msgstr ""
+msgstr "Descripción general de los activos incluidos"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Asset"
-msgstr ""
+msgstr "Activo"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
 msgid "Amount"
-msgstr ""
+msgstr "Cantidad"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "IP addresses"
-msgstr ""
+msgstr "Direcciones IP"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Domain names"
-msgstr ""
+msgstr "Nombres de dominio"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Assets with most critical vulnerabilities"
-msgstr ""
+msgstr "Activos con vulnerabilidades más críticas"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Vulnerability"
-msgstr ""
+msgstr "Vulnerabilidad"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Organisation"
-msgstr ""
+msgstr "Organización"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "No vulnerabilities found."
-msgstr ""
+msgstr "No se encontraron vulnerabilidades."
 
 #: reports/report_types/multi_organization_report/basic_security_details.html
 msgid "Overview of safe connections"
-msgstr ""
+msgstr "Resumen de conexiones seguras"
 
 #: reports/report_types/multi_organization_report/basic_security_details.html
 #: reports/report_types/safe_connections_report/report.html
 msgid "Only Safe Ciphers"
-msgstr ""
+msgstr "Sólo cifrados seguros"
 
 #: reports/report_types/multi_organization_report/basic_security_details.html
 #: reports/report_types/safe_connections_report/report.html
 msgid "services are compliant"
-msgstr ""
+msgstr "los servicios son compatibles"
 
 #: reports/report_types/multi_organization_report/basic_security_details.html
 msgid "System specific checks"
-msgstr ""
+msgstr "Comprobaciones específicas del sistema"
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid "IPv6"
-msgstr ""
+msgstr "IPv6"
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid ""
-"IPv6 includes improvements in security features compared to IPv4. While IPv4 "
-"can implement security measures, IPv6 was designed with security in mind, "
+"IPv6 includes improvements in security features compared to IPv4. While IPv4"
+" can implement security measures, IPv6 was designed with security in mind, "
 "and its adoption can contribute to a more secure internet."
 msgstr ""
+"IPv6 incluye mejoras en las funciones de seguridad en comparación con IPv4. "
+"Si bien IPv4 puede implementar medidas de seguridad, IPv6 se diseñó teniendo"
+" en cuenta la seguridad y su adopción puede contribuir a una Internet más "
+"segura."
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid "In total "
-msgstr ""
+msgstr "En total"
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid " out of "
-msgstr ""
+msgstr "fuera de"
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid " systems have an IPv6 connection."
-msgstr ""
+msgstr "Los sistemas tienen una conexión IPv6."
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid "Overview of IP version compliance"
-msgstr ""
+msgstr "Descripción general del cumplimiento de la versión IP"
 
 #: reports/report_types/multi_organization_report/open_ports.html
 msgid ""
 "See an overview of open ports found over all systems and the services these "
 "systems provide."
 msgstr ""
+"Vea una descripción general de los puertos abiertos que se encuentran en "
+"todos los sistemas y los servicios que estos sistemas brindan."
 
 #: reports/report_types/multi_organization_report/open_ports.html
 msgid "Overview of detected open ports"
-msgstr ""
+msgstr "Descripción general de los puertos abiertos detectados"
 
 #: reports/report_types/multi_organization_report/open_ports.html
 #: reports/report_types/open_ports_report/report.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Open ports"
-msgstr ""
+msgstr "Puertos abiertos"
 
 #: reports/report_types/multi_organization_report/open_ports.html
 msgid "Occurrences (IP addresses)"
-msgstr ""
+msgstr "Ocurrencias (direcciones IP)"
 
 #: reports/report_types/multi_organization_report/open_ports.html
 #: reports/templates/summary/service_health.html
 msgid "Services"
-msgstr ""
+msgstr "Servicios"
 
 #: reports/report_types/multi_organization_report/open_ports.html
 msgid "No open ports found."
-msgstr ""
+msgstr "No se encontraron puertos abiertos."
 
 #: reports/report_types/multi_organization_report/recommendations.html
 msgid "Overview of recommendations"
-msgstr ""
+msgstr "Resumen de recomendaciones"
 
 #: reports/report_types/multi_organization_report/recommendations.html
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "Occurrence"
-msgstr ""
+msgstr "Aparición"
 
 #: reports/report_types/multi_organization_report/report.html
 msgid "No findings have been identified yet."
-msgstr ""
+msgstr "Aún no se han identificado hallazgos."
 
 #: reports/report_types/multi_organization_report/report.py
 msgid "Multi Organization Report"
-msgstr ""
+msgstr "Informe de varias organizaciones"
 
 #: reports/report_types/multi_organization_report/summary.html
 msgid "Best scoring security check"
-msgstr ""
+msgstr "Control de seguridad con mejor puntuación"
 
 #: reports/report_types/multi_organization_report/summary.html
 msgid "Worst scoring security check"
-msgstr ""
+msgstr "Control de seguridad con peor puntuación"
 
 #: reports/report_types/multi_organization_report/vulnerabilities.html
 msgid ""
 "Vulnerabilities found are grouped per system. Here, we only consider CVE "
 "vulnerabilities."
 msgstr ""
+"Las vulnerabilidades encontradas se agrupan por sistema. Aquí, sólo "
+"consideramos las vulnerabilidades CVE."
 
 #: reports/report_types/multi_organization_report/vulnerabilities.html
 msgid "Vulnerabilities grouped per system"
-msgstr ""
+msgstr "Vulnerabilidades agrupadas por sistema"
 
 #: reports/report_types/multi_organization_report/vulnerabilities.html
 msgid "total"
-msgstr ""
+msgstr "total"
 
 #: reports/report_types/name_server_report/report.html
 msgid ""
@@ -3379,73 +3763,92 @@ msgid ""
 "identified are shown too. The risk level may be different for your specific "
 "environment."
 msgstr ""
+"El Informe del servidor de nombres proporciona una descripción general de "
+"las comprobaciones de cumplimiento que se realizaron en los servidores de "
+"nombres de dominio identificados (DNS). Las verificaciones de cumplimiento "
+"verifican la presencia y validez de DNSSEC y si no se identificaron puertos "
+"innecesarios abiertos. La siguiente tabla ofrece una descripción general de "
+"las comprobaciones disponibles, incluido si el sistema pasó las "
+"comprobaciones realizadas. También se muestran el nivel de riesgo y el "
+"razonamiento de por qué se identificó un problema. El nivel de riesgo puede "
+"ser diferente para su entorno específico."
 
 #: reports/report_types/name_server_report/report.html
 msgid "Name server compliance"
-msgstr ""
+msgstr "Cumplimiento del servidor de nombres"
 
 #: reports/report_types/name_server_report/report.html
 msgid "DNSSEC Present"
-msgstr ""
+msgstr "DNSSEC Presente"
 
 #: reports/report_types/name_server_report/report.html
 msgid "name servers compliant"
-msgstr ""
+msgstr "servidores de nombres compatibles"
 
 #: reports/report_types/name_server_report/report.html
 msgid "Valid DNSSEC"
-msgstr ""
+msgstr "Válido DNSSEC"
 
 #: reports/report_types/name_server_report/report.html
 #: reports/report_types/web_system_report/report.html
 msgid "No unnecessary ports open"
-msgstr ""
+msgstr "No se abren puertos innecesarios"
 
 #: reports/report_types/name_server_report/report.html
 msgid "No nameservers have been found on this system."
-msgstr ""
+msgstr "No se han encontrado servidores de nombres en este sistema."
 
 #: reports/report_types/name_server_report/report.py
 msgid "Name Server Report"
-msgstr ""
+msgstr "Informe del servidor de nombres"
 
 #: reports/report_types/name_server_report/report.py
 msgid "Name Server Report checks name servers on basic security standards."
 msgstr ""
+"Name Server Report comprueba los servidores de nombres según los estándares "
+"de seguridad básicos."
 
 #: reports/report_types/open_ports_report/report.html
 msgid ""
-"The Open Ports Report provides an overview of the open ports identified on a "
-"system. The ports that are marked as <b>bold</b> were identified by direct "
-"scans performed by OpenKAT (such as nmap). Ports that are not marked in bold "
-"were identified through external services and/or scans (such as Shodan). "
+"The Open Ports Report provides an overview of the open ports identified on a"
+" system. The ports that are marked as <b>bold</b> were identified by direct "
+"scans performed by OpenKAT (such as nmap). Ports that are not marked in bold"
+" were identified through external services and/or scans (such as Shodan). "
 "Scans with the same hostnames, ports and IPs are merged."
 msgstr ""
+"El Informe de puertos abiertos proporciona una descripción general de los "
+"puertos abiertos identificados en un sistema. Los puertos marcados como "
+"<b>bold</b> se identificaron mediante escaneos directos realizados por "
+"OpenKAT (como nmap). Los puertos que no están marcados en negrita se "
+"identificaron mediante servicios y/o escaneos externos (como Shodan). Se "
+"fusionan los escaneos con los mismos nombres de host, puertos y IPs."
 
 #: reports/report_types/open_ports_report/report.html
 msgid "Overview of open ports found for the scanned assets"
 msgstr ""
+"Descripción general de los puertos abiertos encontrados para los activos "
+"escaneados"
 
 #: reports/report_types/open_ports_report/report.html
 #: reports/report_types/systems_report/report.html
 msgid "IP address"
-msgstr ""
+msgstr "Dirección IP"
 
 #: reports/report_types/open_ports_report/report.html
 msgid "Hostnames"
-msgstr ""
+msgstr "Nombres de host"
 
 #: reports/report_types/open_ports_report/report.html
 msgid "Direct scan"
-msgstr ""
+msgstr "Escaneo directo"
 
 #: reports/report_types/open_ports_report/report.py
 msgid "Open Ports Report"
-msgstr ""
+msgstr "Informe de puertos abiertos"
 
 #: reports/report_types/open_ports_report/report.py
 msgid "Find open ports of IP addresses"
-msgstr ""
+msgstr "Encuentre puertos abiertos de direcciones IP"
 
 #: reports/report_types/rpki_report/report.html
 msgid ""
@@ -3455,167 +3858,204 @@ msgid ""
 "misconfigurations and malicious route intercepts through verified route "
 "announcements, ensuring reliable server access and secure internet traffic."
 msgstr ""
+"Esta sección contiene información de seguridad básica sobre la "
+"infraestructura de clave pública de recursos (RPKI). Si su servidor web "
+"emplea RPKI para sus direcciones IP y servidores de nombres asociados, "
+"mejora la protección de los visitantes contra configuraciones erróneas e "
+"intercepciones de rutas maliciosas a través de anuncios de rutas "
+"verificadas, lo que garantiza un acceso confiable al servidor y un tráfico "
+"de Internet seguro."
 
 #: reports/report_types/rpki_report/report.html
 msgid ""
 "The RPKI Report shows if an RPKI route announcement was available for the "
 "system and if this announcement is not expired."
 msgstr ""
+"El Informe RPKI muestra si un anuncio de ruta RPKI estaba disponible para el"
+" sistema y si este anuncio no ha caducado."
 
 #: reports/report_types/rpki_report/report.html
 msgid "RPKI compliance"
-msgstr ""
+msgstr "Cumplimiento de RPKI"
 
 #: reports/report_types/rpki_report/report.html
 msgid "RPKI Available"
-msgstr ""
+msgstr "RPKI Disponible"
 
 #: reports/report_types/rpki_report/report.html
 msgid "RPKI valid"
-msgstr ""
+msgstr "RPKI válido"
 
 #: reports/report_types/rpki_report/report.html
 msgid "RPKI record is not valid."
-msgstr ""
+msgstr "El registro RPKI no es válido."
 
 #: reports/report_types/rpki_report/report.html
 msgid "RPKI record does not exist."
-msgstr ""
+msgstr "El registro RPKI no existe."
 
 #: reports/report_types/rpki_report/report.html
 #: reports/report_types/safe_connections_report/report.html
 msgid "No IPs have been found on this system."
-msgstr ""
+msgstr "No se ha encontrado ningún IPs en este sistema."
 
 #: reports/report_types/rpki_report/report.py
 msgid "RPKI Report"
-msgstr ""
+msgstr "Informe RPKI"
 
 #: reports/report_types/rpki_report/report.py
 msgid ""
-"Shows whether the IP is covered by a valid RPKI ROA. For a hostname it shows "
-"the IP addresses and whether they are covered by a valid RPKI ROA."
+"Shows whether the IP is covered by a valid RPKI ROA. For a hostname it shows"
+" the IP addresses and whether they are covered by a valid RPKI ROA."
 msgstr ""
+"Muestra si el IP está cubierto por un RPKI ROA válido. Para un nombre de "
+"host, muestra las direcciones IP y si están cubiertas por un RPKI ROA "
+"válido."
 
 #: reports/report_types/safe_connections_report/report.html
 msgid ""
 "The Safe Connections report provides an overview of the performed checks "
 "with regard to encrypted communication channels such as HTTPS. The table "
-"below gives an overview of the available checks including whether the system "
-"passed the performed checks. The risk level and reasoning as to why an issue "
-"was identified are shown too. The risk level may be different for your "
-"specific environment."
+"below gives an overview of the available checks including whether the system"
+" passed the performed checks. The risk level and reasoning as to why an "
+"issue was identified are shown too. The risk level may be different for your"
+" specific environment."
 msgstr ""
+"El informe Conexiones seguras proporciona una descripción general de las "
+"comprobaciones realizadas con respecto a canales de comunicación cifrados "
+"como HTTPS. La siguiente tabla ofrece una descripción general de las "
+"comprobaciones disponibles, incluido si el sistema pasó las comprobaciones "
+"realizadas. También se muestran el nivel de riesgo y el razonamiento de por "
+"qué se identificó un problema. El nivel de riesgo puede ser diferente para "
+"su entorno específico."
 
 #: reports/report_types/safe_connections_report/report.html
 msgid "Safe connections compliance"
-msgstr ""
+msgstr "Cumplimiento de conexiones seguras"
 
 #: reports/report_types/safe_connections_report/report.py
 msgid "Safe Connections Report"
-msgstr ""
+msgstr "Informe de conexiones seguras"
 
 #: reports/report_types/safe_connections_report/report.py
 msgid "Shows whether the IPService contains safe ciphers."
-msgstr ""
+msgstr "Muestra si el IPService contiene cifrados seguros."
 
 #: reports/report_types/systems_report/report.html
 msgid ""
-"The System Report provides an overview of the system types (types of similar "
-"services) that were identified for each system. The following system types "
+"The System Report provides an overview of the system types (types of similar"
+" services) that were identified for each system. The following system types "
 "can be identified: DNS servers, Web servers, Mail servers and those "
 "classified as 'Other' servers. Each hostname and/or IP address is given one "
 "or more system types depending on the identified ports and services. The "
 "table below gives an overview of these results."
 msgstr ""
+"El Informe del sistema proporciona una descripción general de los tipos de "
+"sistemas (tipos de servicios similares) que se identificaron para cada "
+"sistema. Se pueden identificar los siguientes tipos de sistemas: servidores "
+"DNS, servidores Web, servidores de Correo y los clasificados como 'Otros' "
+"servidores. A cada nombre de host y/o dirección IP se le asigna uno o más "
+"tipos de sistema según los puertos y servicios identificados. La siguiente "
+"tabla ofrece una descripción general de estos resultados."
 
 #: reports/report_types/systems_report/report.html
 msgid "Selected assets"
-msgstr ""
+msgstr "Activos seleccionados"
 
 #: reports/report_types/systems_report/report.html
 msgid "No system types have been identified on this system."
-msgstr ""
+msgstr "No se han identificado tipos de sistemas en este sistema."
 
 #: reports/report_types/systems_report/report.py
 msgid "System Report"
-msgstr ""
+msgstr "Informe del sistema"
 
 #: reports/report_types/systems_report/report.py
 msgid "Combine IP addresses, hostnames and services into systems."
-msgstr ""
+msgstr "Combine direcciones, nombres de host y servicios IP en sistemas."
 
 #: reports/report_types/tls_report/report.html
 msgid ""
 "The TLS Report shows which TLS protocols and ciphers were identified on the "
 "host for the provided port."
 msgstr ""
+"El informe TLS muestra qué protocolos y cifrados TLS se identificaron en el "
+"host para el puerto proporcionado."
 
 #: reports/report_types/tls_report/report.html
 msgid ""
 "The table below provides an overview of the identified TLS protocols and "
 "ciphers, including a status suggestion."
 msgstr ""
+"La siguiente tabla proporciona una descripción general de los protocolos y "
+"cifrados TLS identificados, incluida una sugerencia de estado."
 
 #: reports/report_types/tls_report/report.html
 msgid "Ciphers"
-msgstr ""
+msgstr "Cifrados"
 
 #: reports/report_types/tls_report/report.html
 msgid "Protocol"
-msgstr ""
+msgstr "Protocolo"
 
 #: reports/report_types/tls_report/report.html
 msgid "Encryption Algorithm"
-msgstr ""
+msgstr "Algoritmo de cifrado"
 
 #: reports/report_types/tls_report/report.html
 msgid "Bits"
-msgstr ""
+msgstr "bits"
 
 #: reports/report_types/tls_report/report.html
 msgid "Key Size"
-msgstr ""
+msgstr "Tamaño de clave"
 
 #: reports/report_types/tls_report/report.html
 #: rocky/templates/organizations/organization_list.html
 #: rocky/templates/organizations/organization_settings.html
 msgid "Code"
-msgstr ""
+msgstr "Código"
 
 #: reports/report_types/tls_report/report.html
 msgid "Phase out"
-msgstr ""
+msgstr "Reducir progresivamente"
 
 #: reports/report_types/tls_report/report.html
 msgid "Good"
-msgstr ""
+msgstr "Bien"
 
 #: reports/report_types/tls_report/report.html
 msgid ""
 "No ciphers were found for this combination of IP address, port and service."
 msgstr ""
+"No se encontraron cifrados para esta combinación de dirección, puerto y "
+"servicio IP."
 
 #: reports/report_types/tls_report/report.html
 msgid ""
-"The list below gives an overview of the findings based on the identified TLS "
-"protocols and ciphers. This includes the reasoning why the cipher or "
+"The list below gives an overview of the findings based on the identified TLS"
+" protocols and ciphers. This includes the reasoning why the cipher or "
 "protocol is marked as a finding."
 msgstr ""
+"La siguiente lista ofrece una descripción general de los hallazgos basados "
+"​​en los protocolos y cifrados TLS identificados. Esto incluye el "
+"razonamiento por el cual el cifrado o protocolo se marca como un hallazgo."
 
 #: reports/report_types/tls_report/report.py
 msgid "TLS Report"
-msgstr ""
+msgstr "Informe TLS"
 
 #: reports/report_types/tls_report/report.py
 msgid ""
 "TLS Report assesses the security of data encryption and transmission "
 "protocols."
 msgstr ""
+"El informe TLS evalúa la seguridad del cifrado de datos y los protocolos de "
+"transmisión."
 
 #: reports/report_types/vulnerability_report/report.html
 msgid "No vulnerabilities have been found on this system."
-msgstr ""
+msgstr "No se han encontrado vulnerabilidades en este sistema."
 
 #: reports/report_types/vulnerability_report/report.html
 msgid ""
@@ -3624,302 +4064,345 @@ msgid ""
 "the table shows the CVE scoring, the number of occurrences, and the CVE "
 "details."
 msgstr ""
+"El Informe de vulnerabilidad proporciona una descripción general de todas "
+"las vulnerabilidades CVE identificadas en los sistemas seleccionados. Para "
+"cada CVE, la tabla muestra la puntuación de CVE, el número de ocurrencias y "
+"los detalles de CVE."
 
 #: reports/report_types/vulnerability_report/report.html
 msgid "vulnerabilities on this system"
-msgstr ""
+msgstr "vulnerabilidades en este sistema"
 
 #: reports/report_types/vulnerability_report/report.html
 msgid "Advice"
-msgstr ""
+msgstr "Consejo"
 
 #: reports/report_types/vulnerability_report/report.py
 msgid "Vulnerability Report"
-msgstr ""
+msgstr "Informe de vulnerabilidad"
 
 #: reports/report_types/vulnerability_report/report.py
 msgid "Vulnerabilities found are grouped for each system."
-msgstr ""
+msgstr "Las vulnerabilidades encontradas se agrupan para cada sistema."
 
 #: reports/report_types/vulnerability_report/report.py
 msgid "First seen"
-msgstr ""
+msgstr "visto por primera vez"
 
 #: reports/report_types/vulnerability_report/report.py
 msgid "Last seen"
-msgstr ""
+msgstr "visto por última vez"
 
 #: reports/report_types/vulnerability_report/report.py
 msgid "Evidence"
-msgstr ""
+msgstr "Evidencia"
 
 #: reports/report_types/web_system_report/report.html
 msgid ""
-"The Web System Report provides an overview of various web server checks that "
-"were performed against the scanned system(s). For each performed check the "
+"The Web System Report provides an overview of various web server checks that"
+" were performed against the scanned system(s). For each performed check the "
 "table below shows whether or not the server is compliant with the checks. A "
 "description of why this compliant check failed is also shown, including an "
 "general risk level. The risk level may be different for your specific "
 "environment."
 msgstr ""
+"El Informe del sistema web proporciona una descripción general de varias "
+"comprobaciones del servidor web que se realizaron en los sistemas "
+"escaneados. Para cada verificación realizada, la siguiente tabla muestra si "
+"el servidor cumple o no con las comprobaciones. También se muestra una "
+"descripción de por qué falló esta verificación de cumplimiento, incluido un "
+"nivel de riesgo general. El nivel de riesgo puede ser diferente para su "
+"entorno específico."
 
 #: reports/report_types/web_system_report/report.html
 msgid "Web system compliance"
-msgstr ""
+msgstr "Cumplimiento del sistema web"
 
 #: reports/report_types/web_system_report/report.html
 msgid "CSP Present"
-msgstr ""
+msgstr "CSP Presente"
 
 #: reports/report_types/web_system_report/report.html
 msgid "webservers compliant"
-msgstr ""
+msgstr "compatible con servidores web"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Secure CSP Header"
-msgstr ""
+msgstr "Encabezado seguro CSP"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Redirects HTTP to HTTPS"
-msgstr ""
+msgstr "Redirecciona HTTP a HTTPS"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Offers HTTPS"
-msgstr ""
+msgstr "Ofertas HTTPS"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Has a Security.txt"
-msgstr ""
+msgstr "Tiene un archivo Security.txt"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Has a certificate"
-msgstr ""
+msgstr "Tiene un certificado"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Certificate is valid"
-msgstr ""
+msgstr "El certificado es válido"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Certificate is not expiring soon"
-msgstr ""
+msgstr "El certificado no caduca pronto"
 
 #: reports/report_types/web_system_report/report.html
 msgid "No webservers have been found on this system."
-msgstr ""
+msgstr "No se han encontrado servidores web en este sistema."
 
 #: reports/report_types/web_system_report/report.py
 msgid "Web System Report"
-msgstr ""
+msgstr "Informe del sistema web"
 
 #: reports/report_types/web_system_report/report.py
 msgid "Web System Reports check web systems on basic security standards."
 msgstr ""
+"Los informes del sistema web verifican los sistemas web según los estándares"
+" de seguridad básicos."
 
 #: reports/templates/partials/export_report_settings.html
 msgid "Report schedule"
-msgstr ""
+msgstr "Calendario de informes"
 
 #: reports/templates/partials/export_report_settings.html
 msgid ""
 "When scheduling your report, you have two options. You can either choose to "
 "generate it just once now, or set it to run automatically at regular "
-"intervals, like daily, weekly, or monthly. If you need the report just for a "
-"single occasion, select the one-time option."
+"intervals, like daily, weekly, or monthly. If you need the report just for a"
+" single occasion, select the one-time option."
 msgstr ""
+"Al programar su informe, tiene dos opciones. Puede optar por generarlo solo "
+"una vez ahora o configurarlo para que se ejecute automáticamente en "
+"intervalos regulares, como diario, semanal o mensual. Si necesita el informe"
+" solo para una única ocasión, seleccione la opción de una sola vez."
 
 #: reports/templates/partials/export_report_settings.html
 #: reports/templates/report_overview/report_history_table.html
 msgid "Report name"
-msgstr ""
+msgstr "Nombre del informe"
 
 #: reports/templates/partials/export_report_settings.html
 #, python-format, python-brace-format
 msgid ""
 "When generating reports, it is possible to give the report a name. The name "
-"can be static or dynamic. The default format for a report is '${report_type} "
-"for ${oois_count} objects'. These placeholders automatically adapt based on "
-"the report details. This format could for example return 'Aggregate Report "
+"can be static or dynamic. The default format for a report is '${report_type}"
+" for ${oois_count} objects'. These placeholders automatically adapt based on"
+" the report details. This format could for example return 'Aggregate Report "
 "for 15 objects'. Another placeholder that can be used is '${ooi}', which "
-"will show the name of the object when there is only one object. You can also "
-"customize the name by adding prefixes, suffixes, or other formats like '%%W' "
-"for the week number, using options from <a href=\"https://strftime.org/\" "
-"target=\"_blank\" rel=\"noopener\">Python strftime code</a>."
+"will show the name of the object when there is only one object. You can also"
+" customize the name by adding prefixes, suffixes, or other formats like "
+"'%%W' for the week number, using options from <a "
+"href=\"https://strftime.org/\" target=\"_blank\" rel=\"noopener\">Python "
+"strftime code</a>."
 msgstr ""
+"Al generar informes, es posible darle un nombre al informe. El nombre puede "
+"ser estático o dinámico. El formato predeterminado para un informe es "
+"'${report_type} para objetos ${oois_count}'. Estos marcadores de posición se"
+" adaptan automáticamente según los detalles del informe. Este formato "
+"podría, por ejemplo, devolver 'Informe agregado para 15 objetos'. Otro "
+"marcador de posición que se puede utilizar es '${ooi}', que mostrará el "
+"nombre del objeto cuando solo haya un objeto. También puede personalizar el "
+"nombre agregando prefijos, sufijos u otros formatos como '%%W' para el "
+"número de semana, usando opciones de <a href=\"https://strftime.org/\" "
+"target=\"_blank\" rel=\"noopener\">Python strftime code</a>."
 
 #: reports/templates/partials/export_report_settings.html
 #: reports/templates/partials/generate_report_header.html
 #: reports/templates/partials/new_report_action_button.html
 #: reports/views/generate_report.py
 msgid "Generate report"
-msgstr ""
+msgstr "Generar informe"
 
 #: reports/templates/partials/generate_report_header.html
 msgid "To generate an aggregate report, complete the following steps."
-msgstr ""
+msgstr "Para generar un informe agregado, complete los siguientes pasos."
 
 #: reports/templates/partials/generate_report_header.html
 msgid "To generate a multi report, complete the following steps."
-msgstr ""
+msgstr "Para generar un informe múltiple, complete los siguientes pasos."
 
 #: reports/templates/partials/generate_report_header.html
 msgid "To generate separate report(s), complete the following steps."
-msgstr ""
+msgstr "Para generar informes separados, complete los siguientes pasos."
 
 #: reports/templates/partials/generate_report_sidemenu.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Table of contents"
-msgstr ""
+msgstr "Tabla de contenido"
 
 #: reports/templates/partials/new_report_action_button.html
 msgid "Actions for creating a new report"
-msgstr ""
+msgstr "Acciones para crear un nuevo informe"
 
 #: reports/templates/partials/new_report_action_button.html
 msgid "Separate report(s)"
-msgstr ""
+msgstr "Informe(s) separado(s)"
 
 #: reports/templates/partials/new_report_action_button.html
 #: reports/views/aggregate_report.py
 msgid "Aggregate report"
-msgstr ""
+msgstr "Informe agregado"
 
 #: reports/templates/partials/new_report_action_button.html
 #: reports/views/multi_report.py
 msgid "Multi report"
-msgstr ""
+msgstr "Informe múltiple"
 
 #: reports/templates/partials/plugin_overview_table.html
 #: reports/templates/partials/report_sidemenu.html
 #: rocky/templates/oois/ooi_page_tabs.html
 msgid "Overview"
-msgstr ""
+msgstr "Descripción general"
 
 #: reports/templates/partials/plugin_overview_table.html
 msgid "Plugin overview table"
-msgstr ""
+msgstr "Tabla de descripción general de complementos"
 
 #: reports/templates/partials/plugin_overview_table.html
 #: reports/templates/partials/report_setup_scan.html
 msgid "Required plugins"
-msgstr ""
+msgstr "Complementos necesarios"
 
 #: reports/templates/partials/plugin_overview_table.html
 #: reports/templates/partials/report_setup_scan.html
 msgid "Suggested plugins"
-msgstr ""
+msgstr "Complementos sugeridos"
 
 #: reports/templates/partials/plugin_overview_table.html
 msgid "Action required"
-msgstr ""
+msgstr "Acción requerida"
 
 #: reports/templates/partials/plugin_overview_table.html
 msgid "Ready"
-msgstr ""
+msgstr "Listo"
 
 #: reports/templates/partials/report_findings_table.html
 msgid ""
 "This table provides an overview of the identified findings on the scanned "
 "systems. For each finding type it shows the risk level, the number of "
 "occurrences and the first known occurrence of the finding. The risk level "
-"may be different for your specific environment. The details can be seen when "
-"expanding a row. A description, the source, impact and recommendation of the "
-"finding can be found here. It also shows in which findings the finding type "
-"occurred."
+"may be different for your specific environment. The details can be seen when"
+" expanding a row. A description, the source, impact and recommendation of "
+"the finding can be found here. It also shows in which findings the finding "
+"type occurred."
 msgstr ""
+"Esta tabla proporciona una descripción general de los hallazgos "
+"identificados en los sistemas escaneados. Para cada tipo de hallazgo muestra"
+" el nivel de riesgo, el número de ocurrencias y la primera ocurrencia "
+"conocida del hallazgo. El nivel de riesgo puede ser diferente para su "
+"entorno específico. Los detalles se pueden ver al expandir una fila. Puede "
+"encontrar una descripción, la fuente, el impacto y la recomendación del "
+"hallazgo aquí. También muestra en qué hallazgos se produjo el tipo de "
+"hallazgo."
 
 #: reports/templates/partials/report_findings_table.html
 msgid "First known occurrence"
-msgstr ""
+msgstr "Primera ocurrencia conocida"
 
 #: reports/templates/partials/report_findings_table.html
 msgid "Open in report"
-msgstr ""
+msgstr "Abrir en informe"
 
 #: reports/templates/partials/report_findings_table.html
 msgid ""
 "No critical and high findings have been identified for this organization."
 msgstr ""
+"No se han identificado hallazgos críticos y altos para esta organización."
 
 #: reports/templates/partials/report_findings_table.html
 msgid "No findings have been identified for this organization."
-msgstr ""
+msgstr "No se han identificado hallazgos para esta organización."
 
 #: reports/templates/partials/report_header.html
 msgid "Download as PDF"
-msgstr ""
+msgstr "Descargar como PDF"
 
 #: reports/templates/partials/report_header.html
 #: rocky/templates/partials/ooi_list_toolbar.html
 msgid "Download as JSON"
-msgstr ""
+msgstr "Descargar como JSON"
 
 #: reports/templates/partials/report_header.html
 msgid "Open asset reports"
-msgstr ""
+msgstr "Abrir informes de activos"
 
 #: reports/templates/partials/report_header.html
 msgid "This is the OpenKAT report for organization"
-msgstr ""
+msgstr "Este es el informe OpenKAT para organización"
 
 #: reports/templates/partials/report_header.html
 msgid ""
 "All selected report types for the selected objects are displayed one below "
 "the other."
 msgstr ""
+"Todos los tipos de informes seleccionados para los objetos seleccionados se "
+"muestran uno debajo del otro."
 
 #: reports/templates/partials/report_header.html
 msgid "Created with data from:"
-msgstr ""
+msgstr "Creado con datos de:"
 
 #: reports/templates/partials/report_header.html
 msgid "Created on:"
-msgstr ""
+msgstr "Creado el:"
 
 #: reports/templates/partials/report_header.html
 msgid "Created from recipe:"
-msgstr ""
+msgstr "Creado a partir de receta:"
 
 #: reports/templates/partials/report_header.html
 msgid "Recipe created by:"
-msgstr ""
+msgstr "Receta creada por:"
 
 #: reports/templates/partials/report_header.html
 #, python-format
 msgid "This sector contains %(length)s scanned organizations."
-msgstr ""
+msgstr "Este sector contiene organizaciones escaneadas %(length)s."
 
 #: reports/templates/partials/report_header.html
 msgid "Of these organizations"
-msgstr ""
+msgstr "De estas organizaciones"
 
 #: reports/templates/partials/report_header.html
 msgid "organizations have tag"
-msgstr ""
+msgstr "las organizaciones tienen etiqueta"
 
 #: reports/templates/partials/report_header.html
 msgid "The basic security scores are around "
-msgstr ""
+msgstr "Los puntajes de seguridad básicos están alrededor"
 
 #: reports/templates/partials/report_header.html
 #, python-format
 msgid "A total of %(total)s critical vulnerabilities have been identified."
-msgstr ""
+msgstr "Se han identificado un total de vulnerabilidades críticas %(total)s."
 
 #: reports/templates/partials/report_introduction.html
 msgid "Introduction"
-msgstr ""
+msgstr "Introducción"
 
 #: reports/templates/partials/report_introduction.html
 msgid ""
 "This report gives an overview of the current state of security for your "
-"organisation for the selected date. The summary section provides an overview "
-"of the selected systems (objects), plugins and reports. This is followed "
+"organisation for the selected date. The summary section provides an overview"
+" of the selected systems (objects), plugins and reports. This is followed "
 "with the findings for each report."
 msgstr ""
+"Este informe ofrece una descripción general del estado actual de seguridad "
+"de su organización para la fecha seleccionada. La sección de resumen "
+"proporciona una descripción general de los sistemas (objetos), complementos "
+"e informes seleccionados. A esto le siguen las conclusiones de cada informe."
 
 #: reports/templates/partials/report_names_form.html
 msgid "Report names:"
-msgstr ""
+msgstr "Nombres de informes:"
 
 #: reports/templates/partials/report_names_form.html
 #: rocky/templates/forms/widgets/checkbox_group_table.html
@@ -3930,40 +4413,40 @@ msgstr ""
 #: rocky/templates/partials/form/field_input_multiselect.html
 #: rocky/templates/partials/form/field_input_radio.html
 msgid "Required"
-msgstr ""
+msgstr "Requerido"
 
 #: reports/templates/partials/report_names_form.html
 msgid "Add reference date"
-msgstr ""
+msgstr "Añadir fecha de referencia"
 
 #: reports/templates/partials/report_names_form.html
 #: reports/templates/report_overview/modal_partials/rename_modal.html
 msgid "Reset"
-msgstr ""
+msgstr "Reiniciar"
 
 #: reports/templates/partials/report_names_form.html
 msgid "No reference date"
-msgstr ""
+msgstr "Sin fecha de referencia"
 
 #: reports/templates/partials/report_names_form.html
 msgid "Day"
-msgstr ""
+msgstr "Día"
 
 #: reports/templates/partials/report_names_form.html
 msgid "Week"
-msgstr ""
+msgstr "Semana"
 
 #: reports/templates/partials/report_names_form.html
 msgid "Month"
-msgstr ""
+msgstr "Mes"
 
 #: reports/templates/partials/report_names_form.html
 msgid "Year"
-msgstr ""
+msgstr "Año"
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "Object selection"
-msgstr ""
+msgstr "Selección de objetos"
 
 #: reports/templates/partials/report_ooi_list.html
 msgid ""
@@ -3971,52 +4454,67 @@ msgid ""
 "continue with a live set or you can select the objects manually from the "
 "table below."
 msgstr ""
+"Seleccione qué objetos desea incluir en su informe. Puede continuar con un "
+"set en vivo o seleccionar los objetos manualmente de la siguiente tabla."
 
 #: reports/templates/partials/report_ooi_list.html
 msgid ""
-"A live set is a set of objects based on the applied filters. Any object that "
-"matches this applied filter (now or in the future) will be used as input for "
-"the scheduled report. If your live set filter (e.g. 'hostnames' with 'L2 "
-"clearance' that are 'declared') shows 2 hostnames that match the filter "
+"A live set is a set of objects based on the applied filters. Any object that"
+" matches this applied filter (now or in the future) will be used as input "
+"for the scheduled report. If your live set filter (e.g. 'hostnames' with 'L2"
+" clearance' that are 'declared') shows 2 hostnames that match the filter "
 "today, the scheduled report will run for those 2 hostnames. If you add 3 "
-"more hostnames tomorrow (with the same filter criteria), your next scheduled "
-"report will contain 5 hostnames. Your live set will update as you go."
+"more hostnames tomorrow (with the same filter criteria), your next scheduled"
+" report will contain 5 hostnames. Your live set will update as you go."
 msgstr ""
+"Un live set es un conjunto de objetos basados ​​en los filtros aplicados. "
+"Cualquier objeto que coincida con este filtro aplicado (ahora o en el "
+"futuro) se utilizará como entrada para el informe programado. Si su filtro "
+"de conjunto en vivo (por ejemplo, 'nombres de host' con 'autorización L2' "
+"que están 'declarados') muestra 2 nombres de host que coinciden con el "
+"filtro hoy, el informe programado se ejecutará para esos 2 nombres de host. "
+"Si agrega 3 nombres de host más mañana (con los mismos criterios de filtro),"
+" su próximo informe programado contendrá 5 nombres de host. Tu set en vivo "
+"se actualizará a medida que avanzas."
 
 #: reports/templates/partials/report_ooi_list.html
 msgid ""
 "Based on the current dataset, your selected filters result in the following "
 "objects."
 msgstr ""
+"Según el conjunto de datos actual, los filtros seleccionados dan como "
+"resultado los siguientes objetos."
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "objects selected"
-msgstr ""
+msgstr "objetos seleccionados"
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "Deselect all objects"
-msgstr ""
+msgstr "Deseleccionar todos los objetos"
 
 #: reports/templates/partials/report_ooi_list.html
 #: rocky/templates/oois/ooi_list.html
 #, python-format
 msgid "Showing %(length)s of %(total)s objects"
-msgstr ""
+msgstr "Mostrando %(length)s de objetos %(total)s"
 
 #: reports/templates/partials/report_ooi_list.html
 #, python-format
 msgid "Select all %(total_oois)s object"
 msgid_plural "Select all %(total_oois)s objects"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Seleccionar todos los objetos %(total_oois)s"
+msgstr[1] "Seleccionar todos los objetos %(total_oois)s"
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "Object name"
-msgstr ""
+msgstr "Nombre del objeto"
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "Report(s) may be empty due to no objects in the selected filters."
 msgstr ""
+"Los informes pueden estar vacíos debido a que no hay objetos en los filtros "
+"seleccionados."
 
 #: reports/templates/partials/report_ooi_list.html
 msgid ""
@@ -4024,53 +4522,64 @@ msgid ""
 "Future reports may contain data. It is still possible to generate the "
 "(potentially empty) report."
 msgstr ""
+"Los informes que coincidan con los filtros seleccionados estarán vacíos en "
+"este momento. Los informes futuros pueden contener datos. Todavía es posible"
+" generar el informe (potencialmente vacío)."
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "Continue with live set"
-msgstr ""
+msgstr "Continuar con el set en vivo"
 
 #: reports/templates/partials/report_ooi_list.html
 #: reports/templates/partials/report_types_selection.html
 msgid "Continue with selection"
-msgstr ""
+msgstr "Continuar con la selección"
 
 #: reports/templates/partials/report_setup_scan.html
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 #: reports/views/multi_report.py
 msgid "Configuration"
-msgstr ""
+msgstr "Configuración"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Set up the required plugins for this report."
-msgstr ""
+msgstr "Configure los complementos necesarios para este informe."
 
 #: reports/templates/partials/report_setup_scan.html
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugins"
-msgstr ""
+msgstr "Complementos"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid ""
 "KAT will be able to generate a full report when all the required and "
 "suggested boefjes are enabled."
 msgstr ""
+"KAT podrá generar un informe completo cuando todos los boefjes requeridos y "
+"sugeridos estén habilitados."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid ""
 "If you choose not to enable a plugin, the data that plugin would collect or "
-"produce will be left out of the report which will then be generated based on "
-"the available data collected by the enabled plugins."
+"produce will be left out of the report which will then be generated based on"
+" the available data collected by the enabled plugins."
 msgstr ""
+"Si elige no habilitar un complemento, los datos que ese complemento "
+"recopilaría o produciría se excluirán del informe que luego se generará en "
+"función de los datos disponibles recopilados por los complementos "
+"habilitados."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid ""
 "Some plugins are mandatory as they are crucial for a report type. Reports "
 "that don't have their requirements met will be skipped."
 msgstr ""
+"Algunos complementos son obligatorios ya que son cruciales para un tipo de "
+"informe. Se omitirán los informes que no cumplan con sus requisitos."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Warning! Before you proceed read the following points:"
-msgstr ""
+msgstr "¡Advertencia! Antes de continuar lea los siguientes puntos:"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid ""
@@ -4078,57 +4587,66 @@ msgid ""
 "enabled plugins and set clearance levels. This means that scans will run "
 "automatically. Be patient; plugins may take some time before they have "
 "collected all their data. Enabling them just before report generation will "
-"likely result in inaccurate reports, as plugins have not finished collecting "
-"data."
+"likely result in inaccurate reports, as plugins have not finished collecting"
+" data."
 msgstr ""
+"OpenKAT está diseñado para escanear todos los objetos conocidos de forma "
+"regular utilizando los complementos habilitados y estableciendo niveles de "
+"autorización. Esto significa que los análisis se ejecutarán automáticamente."
+" Ser paciente; Los complementos pueden tardar algún tiempo en recopilar "
+"todos sus datos. Habilitarlos justo antes de la generación del informe "
+"probablemente generará informes inexactos, ya que los complementos no han "
+"terminado de recopilar datos."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Good job! All required plugins are enabled."
-msgstr ""
+msgstr "¡Buen trabajo! Todos los complementos necesarios están habilitados."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "This report type requires the following plugins to be enabled:"
 msgstr ""
+"Este tipo de informe requiere que estén habilitados los siguientes "
+"complementos:"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Toggle all required plugins"
-msgstr ""
+msgstr "Alternar todos los complementos necesarios"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Show enabled plugins"
-msgstr ""
+msgstr "Mostrar complementos habilitados"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "There are no required plugins."
-msgstr ""
+msgstr "No hay complementos necesarios."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Good job! All suggested plugins are enabled."
-msgstr ""
+msgstr "¡Buen trabajo! Todos los complementos sugeridos están habilitados."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "The following plugins are optional to generate the report:"
-msgstr ""
+msgstr "Los siguientes complementos son opcionales para generar el informe:"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Toggle all optional plugins"
-msgstr ""
+msgstr "Alternar todos los complementos opcionales"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Hide suggested plugins"
-msgstr ""
+msgstr "Ocultar complementos sugeridos"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Show more suggested plugins"
-msgstr ""
+msgstr "Mostrar más complementos sugeridos"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "There are no optional plugins."
-msgstr ""
+msgstr "No hay complementos opcionales."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Enable selected plugins and continue"
-msgstr ""
+msgstr "Habilite los complementos seleccionados y continúe"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid ""
@@ -4137,72 +4655,82 @@ msgid ""
 "            severity that have been identified for this organization.\n"
 "        "
 msgstr ""
+"\n"
+"Este resumen muestra el número total de hallazgos por\n"
+"            gravedad que se han identificado para esta organización."
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Total per severity overview"
-msgstr ""
+msgstr "Resumen total por gravedad"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Critical"
-msgstr ""
+msgstr "Crítico"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "High"
-msgstr ""
+msgstr "Alto"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Medium"
-msgstr ""
+msgstr "Medio"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Low"
-msgstr ""
+msgstr "Bajo"
 
 #: reports/templates/partials/report_severity_totals_table.html
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Pending"
-msgstr ""
+msgstr "Pendiente"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Unknown"
-msgstr ""
+msgstr "Desconocido"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Total"
-msgstr ""
+msgstr "Total"
 
 #: reports/templates/partials/report_sidemenu.html
 msgid "Selected Objects"
-msgstr ""
+msgstr "Objetos seleccionados"
 
 #: reports/templates/partials/report_sidemenu.html
 msgid "Selected Plugins"
-msgstr ""
+msgstr "Complementos seleccionados"
 
 #: reports/templates/partials/report_sidemenu.html
 msgid "Used Config Objects"
-msgstr ""
+msgstr "Objetos de configuración usados"
 
 #: reports/templates/partials/report_types_selection.html
 msgid "Choose report types"
-msgstr ""
+msgstr "Elija tipos de informes"
 
 #: reports/templates/partials/report_types_selection.html
 msgid ""
-"Various types of reports, such as DNS reports and TLS reports, are essential "
-"for identifying vulnerabilities in different aspects of a system's security. "
-"DNS reports focus on domain name system configuration and potential "
-"weaknesses, while TLS reports assess the security of data encryption and "
-"transmission protocols, helping organizations pinpoint areas where security "
-"improvements are needed."
+"Various types of reports, such as DNS reports and TLS reports, are essential"
+" for identifying vulnerabilities in different aspects of a system's "
+"security. DNS reports focus on domain name system configuration and "
+"potential weaknesses, while TLS reports assess the security of data "
+"encryption and transmission protocols, helping organizations pinpoint areas "
+"where security improvements are needed."
 msgstr ""
+"Varios tipos de informes, como los informes DNS y TLS, son esenciales para "
+"identificar vulnerabilidades en diferentes aspectos de la seguridad de un "
+"sistema. Los informes DNS se centran en la configuración del sistema de "
+"nombres de dominio y las posibles debilidades, mientras que los informes TLS"
+" evalúan la seguridad del cifrado de datos y los protocolos de transmisión, "
+"ayudando a las organizaciones a identificar áreas donde se necesitan mejoras"
+" de seguridad."
 
 #: reports/templates/partials/report_types_selection.html
 #, python-format
 msgid "Selected object (%(total_oois)s)"
 msgid_plural "Selected objects (%(total_oois)s)"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Objetos seleccionados (%(total_oois)s)"
+msgstr[1] "Objetos seleccionados (%(total_oois)s)"
 
 #: reports/templates/partials/report_types_selection.html
 #, python-format
@@ -4210,43 +4738,46 @@ msgid ""
 "You have selected a live set in the previous step. Based on the current "
 "dataset, this live set results in %(total_oois)s objects."
 msgstr ""
+"Ha seleccionado un set en vivo en el paso anterior. Según el conjunto de "
+"datos actual, este conjunto en vivo da como resultado objetos "
+"%(total_oois)s."
 
 #: reports/templates/partials/report_types_selection.html
 msgid "Applied filters:"
-msgstr ""
+msgstr "Filtros aplicados:"
 
 #: reports/templates/partials/report_types_selection.html
 #, python-format
 msgid "You have selected %(total_oois)s object in the previous step."
 msgid_plural "You have selected %(total_oois)s objects in the previous step."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Ha seleccionado objetos %(total_oois)s en el paso anterior."
+msgstr[1] "Ha seleccionado objetos %(total_oois)s en el paso anterior."
 
 #: reports/templates/partials/report_types_selection.html
 msgid "Change selection"
-msgstr ""
+msgstr "Cambiar selección"
 
 #: reports/templates/partials/report_types_selection.html
 msgid "Available report types"
-msgstr ""
+msgstr "Tipos de informes disponibles"
 
 #: reports/templates/partials/report_types_selection.html
 msgid "All report types that are available for your selection."
-msgstr ""
+msgstr "Todos los tipos de informes que están disponibles para su selección."
 
 #: reports/templates/partials/report_types_selection.html
 msgid "Toggle all report types"
-msgstr ""
+msgstr "Alternar todos los tipos de informes"
 
 #: reports/templates/partials/return_button.html
 #, python-format
 msgid "%(btn_text)s"
-msgstr ""
+msgstr "%(btn_text)s"
 
 #: reports/templates/report_overview/modal_partials/delete_modal.html
 #: reports/templates/report_overview/modal_partials/share_modal.html
 msgid "Delete the following report(s):"
-msgstr ""
+msgstr "Elimine los siguientes informes:"
 
 #: reports/templates/report_overview/modal_partials/delete_modal.html
 #: reports/templates/report_overview/modal_partials/share_modal.html
@@ -4255,6 +4786,10 @@ msgid ""
 "report can still be accessed on timestamps before the deletion. Only the "
 "report is removed from the view, not the data it is based on."
 msgstr ""
+"Los informes eliminados se eliminan de la vista desde el momento de la "
+"eliminación. Aún se puede acceder al informe en las marcas de tiempo "
+"anteriores a la eliminación. Sólo se elimina de la vista el informe, no los "
+"datos en los que se basa."
 
 #: reports/templates/report_overview/modal_partials/delete_modal.html
 #: reports/templates/report_overview/modal_partials/share_modal.html
@@ -4263,6 +4798,9 @@ msgid ""
 "is part of a combined report, it will remain available in the combined "
 "report."
 msgstr ""
+"Aún es posible generar un nuevo informe para la misma fecha. Si el informe "
+"forma parte de un informe combinado, permanecerá disponible en el informe "
+"combinado."
 
 #: reports/templates/report_overview/modal_partials/delete_modal.html
 #: reports/templates/report_overview/modal_partials/rerun_modal.html
@@ -4270,81 +4808,89 @@ msgstr ""
 #: reports/templates/report_overview/scheduled_reports_table.html
 #: reports/templates/report_overview/subreports_table.html
 msgid "Reference date"
-msgstr ""
+msgstr "Fecha de referencia"
 
 #: reports/templates/report_overview/modal_partials/enable_disable_schedule_modal.html
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Disable schedule"
-msgstr ""
+msgstr "Desactivar horario"
 
 #: reports/templates/report_overview/modal_partials/enable_disable_schedule_modal.html
 #, python-format
 msgid ""
-"Are you sure you want to disable the schedule for <strong>%(report_name)s</"
-"strong>? The recipe will still exist and the schedule can be enabled later "
-"on."
+"Are you sure you want to disable the schedule for "
+"<strong>%(report_name)s</strong>? The recipe will still exist and the "
+"schedule can be enabled later on."
 msgstr ""
+"¿Está seguro de que desea desactivar la programación para "
+"<strong>%(report_name)s</strong>? La receta seguirá existiendo y la "
+"programación podrá habilitarse más adelante."
 
 #: reports/templates/report_overview/modal_partials/rename_modal.html
 msgid "Rename the following report(s):"
-msgstr ""
+msgstr "Cambie el nombre de los siguientes informes:"
 
 #: reports/templates/report_overview/modal_partials/rename_modal.html
 #: reports/templates/report_overview/report_history_table.html
 msgid "Rename"
-msgstr ""
+msgstr "Rebautizar"
 
 #: reports/templates/report_overview/modal_partials/rerun_modal.html
 msgid "Rerun the following report(s):"
-msgstr ""
+msgstr "Vuelva a ejecutar los siguientes informes:"
 
 #: reports/templates/report_overview/modal_partials/rerun_modal.html
 msgid ""
 "By submitting you're generating the selected reports again, using the "
 "current data."
 msgstr ""
+"Al enviarlo, estará generando los informes seleccionados nuevamente, "
+"utilizando los datos actuales."
 
 #: reports/templates/report_overview/modal_partials/rerun_modal.html
 #: reports/templates/report_overview/report_history_table.html
 msgid "Rerun"
-msgstr ""
+msgstr "Repetición"
 
 #: reports/templates/report_overview/report_history.html
 msgid "Reports history"
-msgstr ""
+msgstr "Historial de informes"
 
 #: reports/templates/report_overview/report_history.html
 msgid ""
 "On this page you can see all the reports that have been generated in the "
 "past. To create a new report, click the 'Generate Report' button."
 msgstr ""
+"En esta página puede ver todos los informes que se han generado en el "
+"pasado. Para crear un nuevo informe, haga clic en el botón 'Generar "
+"informe'."
 
 #: reports/templates/report_overview/report_history_table.html
 #: reports/templates/report_overview/subreports.html
 #, python-format
 msgid "Showing %(length)s of %(total)s reports"
-msgstr ""
+msgstr "Mostrando informes %(length)s de %(total)s"
 
 #: reports/templates/report_overview/report_history_table.html
 #: rocky/templates/tasks/reports.html
 msgid "Reports:"
-msgstr ""
+msgstr "Informes:"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "Shows parent report details"
-msgstr ""
+msgstr "Muestra detalles del informe principal"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "Close asset report object details"
-msgstr ""
+msgstr "Cerrar detalles del objeto del informe de activos"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "Open asset report object details"
-msgstr ""
+msgstr "Abrir detalles del objeto del informe de activos"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "Asset reports details"
-msgstr ""
+msgstr "Detalles de los informes de activos"
 
 #: reports/templates/report_overview/report_history_table.html
 #, python-format
@@ -4355,129 +4901,138 @@ msgid_plural ""
 "This report consists of %(counter)s asset reports with the following report "
 "types and objects:"
 msgstr[0] ""
+"Este informe consta de informes de activos %(counter)s con los siguientes "
+"tipos de informes y objetos:"
 msgstr[1] ""
+"Este informe consta de informes de activos %(counter)s con los siguientes "
+"tipos de informes y objetos:"
 
 #: reports/templates/report_overview/report_history_table.html
 #: reports/templates/report_overview/subreports_header.html
 #: reports/templates/report_overview/subreports_table.html
 #: reports/views/report_overview.py
 msgid "Asset reports"
-msgstr ""
+msgstr "Informes de activos"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "Shows asset report details"
-msgstr ""
+msgstr "Muestra detalles del informe de activos"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "View all asset reports"
-msgstr ""
+msgstr "Ver todos los informes de activos"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "No reports have been generated yet."
-msgstr ""
+msgstr "Aún no se han generado informes."
 
 #: reports/templates/report_overview/report_overview_header.html
 #: reports/views/base.py rocky/templates/header.html
 #: rocky/templates/tasks/partials/tab_navigation.html
 #: rocky/templates/tasks/reports.html rocky/views/tasks.py
 msgid "Reports"
-msgstr ""
+msgstr "Informes"
 
 #: reports/templates/report_overview/report_overview_header.html
 msgid "An overview of reports that are scheduled or have been generated."
 msgstr ""
+"Una descripción general de los informes que están programados o que se han "
+"generado."
 
 #: reports/templates/report_overview/report_overview_navigation.html
 msgid "Scheduled"
-msgstr ""
+msgstr "Programado"
 
 #: reports/templates/report_overview/report_overview_navigation.html
 msgid "History"
-msgstr ""
+msgstr "Historia"
 
 #: reports/templates/report_overview/scheduled_reports.html
 msgid "Scheduled reports"
-msgstr ""
+msgstr "Informes programados"
 
 #: reports/templates/report_overview/scheduled_reports.html
 msgid ""
-"On this page you can see all the reports that are or have been scheduled. To "
-"schedule a report, select a start date and recurrence while generating a "
+"On this page you can see all the reports that are or have been scheduled. To"
+" schedule a report, select a start date and recurrence while generating a "
 "report."
 msgstr ""
+"En esta página podrás ver todos los informes que están o han estado "
+"programados. Para programar un informe, seleccione una fecha de inicio y una"
+" recurrencia mientras genera un informe."
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 #, python-format
 msgid "Showing %(length)s of %(total)s schedules"
-msgstr ""
+msgstr "Mostrando horarios %(length)s de %(total)s"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Scheduled reports:"
-msgstr ""
+msgstr "Informes programados:"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Scheduled for"
-msgstr ""
+msgstr "Programado para"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Schedule status"
-msgstr ""
+msgstr "Estado del horario"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Once"
-msgstr ""
+msgstr "Una vez"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Recent reports"
-msgstr ""
+msgstr "Informes recientes"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Scheduled Reports:"
-msgstr ""
+msgstr "Informes programados:"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Show report details"
-msgstr ""
+msgstr "Mostrar detalles del informe"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "objects"
-msgstr ""
+msgstr "objetos"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Enable schedule"
-msgstr ""
+msgstr "Habilitar horario"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "No scheduled reports have been generated yet."
-msgstr ""
+msgstr "Aún no se han generado informes programados."
 
 #: reports/templates/report_overview/subreports_header.html
 msgid "Back to Reports History"
-msgstr ""
+msgstr "Volver al historial de informes"
 
 #: reports/templates/report_overview/subreports_header.html
 msgid "An overview of all underlying reports of"
-msgstr ""
+msgstr "Una visión general de todos los informes subyacentes de"
 
 #: reports/templates/report_overview/subreports_header.html
 #: reports/templates/report_overview/subreports_table.html
 msgid "Shows report details"
-msgstr ""
+msgstr "Muestra detalles del informe"
 
 #: reports/templates/report_overview/subreports_table.html
 #: rocky/templates/tasks/boefjes.html
 #: rocky/templates/tasks/plugin_detail_task_list.html
 msgid "Input Object"
-msgstr ""
+msgstr "Objeto de entrada"
 
 #: reports/templates/report_schedules/delete_recipe_modal.html
 msgid "Delete report recipe"
-msgstr ""
+msgstr "Eliminar receta de informe"
 
 #: reports/templates/report_schedules/delete_recipe_modal.html
 #, python-format
 msgid "Are you sure you want to delete report recipe \"%(name)s\"?"
-msgstr ""
+msgstr "¿Está seguro de que desea eliminar la receta del informe \"%(name)s\"?"
 
 #: reports/templates/report_schedules/delete_recipe_modal.html
 msgid ""
@@ -4485,164 +5040,190 @@ msgid ""
 "not be possible anymore to see or enable the schedule. You will find "
 "previously generated reports in the report history tab."
 msgstr ""
+"Eliminar esta receta de informe significa que se eliminará permanentemente. "
+"Ya no será posible ver ni habilitar el horario. Encontrará informes "
+"generados previamente en la pestaña Historial de informes."
 
 #: reports/templates/summary/report_asset_overview.html
 msgid ""
-"The objects listed in the table below were used to generate this report. For "
-"each object in the table it additionally shows the clearance level and "
+"The objects listed in the table below were used to generate this report. For"
+" each object in the table it additionally shows the clearance level and "
 "whether or not the object was added by a user ('Declared') or indirectly "
 "identified through another service or system ('Inherited')."
 msgstr ""
+"Los objetos enumerados en la siguiente tabla se utilizaron para generar este"
+" informe. Para cada objeto en la tabla, muestra adicionalmente el nivel de "
+"autorización y si el objeto fue agregado por un usuario (\"Declarado\") o "
+"identificado indirectamente a través de otro servicio o sistema "
+"(\"Heredado\")."
 
 #: reports/templates/summary/report_asset_overview.html
 msgid "No objects found."
-msgstr ""
+msgstr "No se encontraron objetos."
 
 #: reports/templates/summary/report_asset_overview.html
 msgid ""
 "The table below shows which reports were chosen to generate this report, "
 "including a report description."
 msgstr ""
+"La siguiente tabla muestra qué informes se eligieron para generar este "
+"informe, incluida una descripción del informe."
 
 #: reports/templates/summary/report_asset_overview.html
 msgid "No report types found."
-msgstr ""
+msgstr "No se encontraron tipos de informes."
 
 #: reports/templates/summary/selected_plugins.html
 msgid ""
 "The table below shows all required or optional plugins for the selected "
 "reports."
 msgstr ""
+"La siguiente tabla muestra todos los complementos necesarios u opcionales "
+"para los informes seleccionados."
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Required and optional plugins"
-msgstr ""
+msgstr "Complementos necesarios y opcionales"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugin enabled"
-msgstr ""
+msgstr "Complemento habilitado"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugin options"
-msgstr ""
+msgstr "Opciones de complemento"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugin scan level"
-msgstr ""
+msgstr "Nivel de escaneo de complementos"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Enabled."
-msgstr ""
+msgstr "Activado."
 
 #: reports/templates/summary/selected_plugins.html
 msgid "required"
-msgstr ""
+msgstr "requerido"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "optional"
-msgstr ""
+msgstr "opcional"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugin extra info"
-msgstr ""
+msgstr "Información adicional del complemento"
 
 #: reports/templates/summary/selected_plugins.html
 msgid ""
 "There are no required or optional plugins needed for the selected report "
 "types."
 msgstr ""
+"No se necesitan complementos obligatorios ni opcionales para los tipos de "
+"informes seleccionados."
 
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 #: reports/views/multi_report.py
 msgid "Select objects"
-msgstr ""
+msgstr "Seleccionar objetos"
 
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 #: reports/views/multi_report.py
 msgid "Select report types"
-msgstr ""
+msgstr "Seleccionar tipos de informes"
 
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 #: reports/views/multi_report.py
 msgid "Export setup"
-msgstr ""
+msgstr "Configuración de exportación"
 
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 msgid "Save report"
-msgstr ""
+msgstr "Guardar informe"
 
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 msgid "You do not have the required permissions to enable plugins."
-msgstr ""
+msgstr "No tienes los permisos necesarios para habilitar complementos."
 
 #: reports/views/base.py
 msgid "Select at least one OOI to proceed."
-msgstr ""
+msgstr "Seleccione al menos un OOI para continuar."
 
 #: reports/views/base.py
 msgid "Select at least one report type to proceed."
-msgstr ""
+msgstr "Seleccione al menos un tipo de informe para continuar."
 
 #: reports/views/mixins.py
 msgid ""
 "No data could be found for %(report_types). Object(s) did not exist on "
 "%(date)s."
 msgstr ""
+"No se pudieron encontrar datos para %(report_types). Los objetos no existían"
+" en %(date)s."
 
 #: reports/views/multi_report.py
 msgid "View report"
-msgstr ""
+msgstr "Ver informe"
 
 #: reports/views/report_overview.py
 msgid "Not enough permissions"
-msgstr ""
+msgstr "No hay suficientes permisos"
 
 #: reports/views/report_overview.py
 msgid "Recipe '{}' deleted successfully"
-msgstr ""
+msgstr "La receta '{}' se eliminó correctamente"
 
 #: reports/views/report_overview.py
 msgid "Recipe not found."
-msgstr ""
+msgstr "Receta no encontrada."
 
 #: reports/views/report_overview.py
 msgid "No schedule or recipe selected"
-msgstr ""
+msgstr "No se seleccionó ningún horario o receta"
 
 #: reports/views/report_overview.py
 msgid ""
 "Schedule disabled successfully. '{}' will not be generated automatically "
 "until the schedule is enabled again."
 msgstr ""
+"Programación deshabilitada exitosamente. '{}' no se generará automáticamente"
+" hasta que la programación se habilite nuevamente."
 
 #: reports/views/report_overview.py
 msgid ""
 "Schedule enabled successfully. '{}' will be generated according to schedule."
 msgstr ""
+"Programación habilitada exitosamente. '{}' se generará según lo programado."
 
 #: reports/views/report_overview.py
 msgid "An unexpected error occurred, please check logs for more info."
 msgstr ""
+"Se produjo un error inesperado. Consulte los registros para obtener más "
+"información."
 
 #: reports/views/report_overview.py
 msgid "Other OOI type selected than Report"
-msgstr ""
+msgstr "Otro tipo de OOI seleccionado además de Informe"
 
 #: reports/views/report_overview.py
 msgid "Deletion successful."
-msgstr ""
+msgstr "Eliminación exitosa."
 
 #: reports/views/report_overview.py
 msgid ""
 "Multi organization reports cannot be rescheduled. It consists of imported "
 "data from different organizations and is not based on newly generated data."
 msgstr ""
+"Los informes de varias organizaciones no se pueden reprogramar. Consiste en "
+"datos importados de diferentes organizaciones y no se basa en datos recién "
+"generados."
 
 #: reports/views/report_overview.py
 msgid ""
 "Rerun successful. It may take a moment before the new report has been "
 "generated."
 msgstr ""
+"Vuelva a ejecutar con éxito. Es posible que pase un momento antes de que se "
+"genere el nuevo informe."
 
 #: reports/views/report_overview.py
 #, python-format
@@ -4650,379 +5231,389 @@ msgid ""
 "Couldn't rerun %s, since the recipe for this report has been disabled or "
 "deleted."
 msgstr ""
+"No se pudo volver a ejecutar %s porque la receta para este informe se "
+"deshabilitó o eliminó."
 
 #: reports/views/report_overview.py
 msgid "Renaming failed. Empty report name found."
-msgstr ""
+msgstr "Error al cambiar el nombre. Se encontró un nombre de informe vacío."
 
 #: reports/views/report_overview.py
 msgid "Report names and reports does not match."
-msgstr ""
+msgstr "Los nombres de los informes y los informes no coinciden."
 
 #: reports/views/report_overview.py
 msgid "Reports successfully renamed."
-msgstr ""
+msgstr "Informes renombrados exitosamente."
 
 #: reports/views/report_overview.py
 msgid "Report {} could not be renamed."
-msgstr ""
+msgstr "No se pudo cambiar el nombre del informe {}."
 
 #: reports/views/view_helpers.py
 msgid "1: Select objects"
-msgstr ""
+msgstr "1: Seleccionar objetos"
 
 #: reports/views/view_helpers.py
 msgid "2: Choose report types"
-msgstr ""
+msgstr "2: Elija tipos de informes"
 
 #: reports/views/view_helpers.py
 msgid "3: Configuration"
-msgstr ""
+msgstr "3: Configuración"
 
 #: reports/views/view_helpers.py
 msgid "4: Export setup"
-msgstr ""
+msgstr "4: configuración de exportación"
 
 #: reports/views/view_helpers.py
 msgid "3: Export setup"
-msgstr ""
+msgstr "3: configuración de exportación"
 
 #: tools/forms/base.py
 msgid "Date"
-msgstr ""
-
-#: tools/forms/base.py tools/forms/scheduler.py
-msgid "The selected date is in the future. Please select a different date."
-msgstr ""
+msgstr "Fecha"
 
 #: tools/forms/boefje.py
 msgid "For example: -sTU --top-ports 1000"
-msgstr ""
+msgstr "Por ejemplo: -sTU --top-ports 1000"
 
 #: tools/forms/boefje.py
 msgid "JSON Schema"
-msgstr ""
+msgstr "Esquema JSON"
 
 #: tools/forms/boefje.py
 msgid "Input object type"
-msgstr ""
+msgstr "Tipo de objeto de entrada"
 
 #: tools/forms/boefje.py
 msgid "Output mime types"
-msgstr ""
+msgstr "Tipos de mime de salida"
 
 #: tools/forms/boefje.py
 msgid "Scan type"
-msgstr ""
+msgstr "Tipo de escaneo"
 
 #: tools/forms/boefje.py
 msgid "Interval amount"
-msgstr ""
+msgstr "Cantidad de intervalo"
 
 #: tools/forms/boefje.py
 msgid ""
 "Specify the scanning interval for this Boefje. The default is 24 hours. For "
 "example: 5 minutes will let the Boefje scan every 5 minutes."
 msgstr ""
+"Especifique el intervalo de escaneo para este Boefje. El valor "
+"predeterminado es 24 horas. Por ejemplo: 5 minutos permitirán que el Boefje "
+"escanee cada 5 minutos."
 
 #: tools/forms/boefje.py
 msgid "Interval frequency"
-msgstr ""
+msgstr "Frecuencia de intervalo"
 
 #: tools/forms/boefje.py
 msgid "Object creation/change"
-msgstr ""
+msgstr "Creación/cambio de objetos"
 
 #: tools/forms/boefje.py
 msgid ""
 "Choose weather the Boefje should run after creating and/or changing an "
 "object. "
 msgstr ""
+"Elija si el Boefje debe ejecutarse después de crear y/o cambiar un objeto."
 
 #: tools/forms/finding_type.py
 msgid "KAT-ID"
-msgstr ""
+msgstr "KAT-ID"
 
 #: tools/forms/finding_type.py
 msgid "Unique ID within OpenKAT, for this type"
-msgstr ""
+msgstr "ID único dentro de OpenKAT, para este tipo"
 
 #: tools/forms/finding_type.py
 msgid "Title"
-msgstr ""
+msgstr "Título"
 
 #: tools/forms/finding_type.py
 msgid "Give the finding type a fitting title"
-msgstr ""
+msgstr "Asigne un título adecuado al tipo de hallazgo"
 
 #: tools/forms/finding_type.py
 msgid "Describe the finding type"
-msgstr ""
+msgstr "Describir el tipo de hallazgo"
 
 #: tools/forms/finding_type.py
 msgid "Risk"
-msgstr ""
+msgstr "Riesgo"
 
 #: tools/forms/finding_type.py
 msgid "Solution"
-msgstr ""
+msgstr "Solución"
 
 #: tools/forms/finding_type.py
 msgid "How can this be solved?"
-msgstr ""
+msgstr "¿Cómo se puede solucionar esto?"
 
 #: tools/forms/finding_type.py
 msgid "Describe how this type of finding can be solved"
-msgstr ""
+msgstr "Describe cómo se puede resolver este tipo de hallazgo."
 
 #: tools/forms/finding_type.py
 msgid "References"
-msgstr ""
+msgstr "Referencias"
 
 #: tools/forms/finding_type.py
 msgid "Please give some references on the solution"
-msgstr ""
+msgstr "Por favor proporcione algunas referencias sobre la solución."
 
 #: tools/forms/finding_type.py
 msgid "Please give sources and references on the suggested solution"
-msgstr ""
+msgstr "Proporcione fuentes y referencias sobre la solución sugerida."
 
 #: tools/forms/finding_type.py
 msgid "Impact description"
-msgstr ""
+msgstr "Descripción del impacto"
 
 #: tools/forms/finding_type.py
 msgid "Describe the solutions impact"
-msgstr ""
+msgstr "Describir el impacto de las soluciones."
 
 #: tools/forms/finding_type.py
 msgid "Solution chance"
-msgstr ""
+msgstr "Posibilidad de solución"
 
 #: tools/forms/finding_type.py
 msgid "Solution impact"
-msgstr ""
+msgstr "Impacto de la solución"
 
 #: tools/forms/finding_type.py
 msgid "Solution effort"
-msgstr ""
+msgstr "Esfuerzo de solución"
 
 #: tools/forms/finding_type.py
 msgid "ID should start with "
-msgstr ""
+msgstr "La identificación debe comenzar con"
 
 #: tools/forms/finding_type.py
 msgid "Finding type already exists"
-msgstr ""
+msgstr "El tipo de hallazgo ya existe"
 
 #: tools/forms/finding_type.py
 msgid "Click to select one of the available options"
-msgstr ""
+msgstr "Haga clic para seleccionar una de las opciones disponibles"
 
 #: tools/forms/finding_type.py
 #: rocky/templates/partials/finding_occurrence_definition_list.html
 msgid "Proof"
-msgstr ""
+msgstr "Prueba"
 
 #: tools/forms/finding_type.py
 msgid "Provide evidence of your finding"
-msgstr ""
+msgstr "Proporcione evidencia de su hallazgo"
 
 #: tools/forms/finding_type.py
 msgid "Describe your finding"
-msgstr ""
+msgstr "Describe tu hallazgo"
 
 #: tools/forms/finding_type.py
 msgid "Reproduce finding"
-msgstr ""
+msgstr "Reproducir hallazgo"
 
 #: tools/forms/finding_type.py
 msgid "Please explain how to reproduce your finding"
-msgstr ""
+msgstr "Por favor explique cómo reproducir su hallazgo."
 
 #: tools/forms/finding_type.py tools/forms/upload_raw.py
 msgid "Date/Time (UTC)"
-msgstr ""
+msgstr "Fecha/Hora (UTC)"
 
 #: tools/forms/finding_type.py tools/forms/upload_raw.py
 msgid "Doc! I'm from the future, I'm here to take you back!"
-msgstr ""
+msgstr "¡Doc! ¡Soy del futuro, estoy aquí para llevarte de regreso!"
 
 #: tools/forms/finding_type.py
 msgid "OOI doesn't exist"
-msgstr ""
+msgstr "OOI no existe"
 
 #: tools/forms/findings.py
 msgid "Show non-muted findings"
-msgstr ""
+msgstr "Mostrar resultados no silenciados"
 
 #: tools/forms/findings.py
 msgid "Show muted findings"
-msgstr ""
+msgstr "Mostrar resultados silenciados"
 
 #: tools/forms/findings.py
 msgid "Show muted and non-muted findings"
-msgstr ""
+msgstr "Mostrar resultados silenciados y no silenciados"
 
 #: tools/forms/findings.py
 msgid "Filter by severity"
-msgstr ""
+msgstr "Filtrar por gravedad"
 
 #: tools/forms/findings.py
 msgid "Filter by muted findings"
-msgstr ""
+msgstr "Filtrar por resultados silenciados"
 
 #: tools/forms/findings.py tools/forms/ooi_form.py tools/forms/scheduler.py
 msgid "Search"
-msgstr ""
+msgstr "Buscar"
 
 #: tools/forms/findings.py
 msgid "Object ID contains (case sensitive)"
-msgstr ""
+msgstr "El ID del objeto contiene (distingue entre mayúsculas y minúsculas)"
 
 #: tools/forms/ooi.py
 msgid "Filter types"
-msgstr ""
+msgstr "Tipos de filtro"
 
 #: tools/forms/ooi.py
 msgid "Clearance Level"
-msgstr ""
+msgstr "Nivel de autorización"
 
 #: tools/forms/ooi.py
 msgid "Next scan"
-msgstr ""
+msgstr "Siguiente escaneo"
 
 #: tools/forms/ooi.py
 msgid "Show objects that don't meet the Boefjes scan level."
-msgstr ""
+msgstr "Muestra objetos que no cumplen con el nivel de escaneo Boefjes."
 
 #: tools/forms/ooi.py
 msgid "Show Boefjes that exceed the objects clearance level."
-msgstr ""
+msgstr "Mostrar Boefjes que exceden el nivel de separación de objetos."
 
 #: tools/forms/ooi.py
 msgid ""
-"All the boefjes with a scan level below or equal to the clearance level will "
-"be allowed to scan this object."
+"All the boefjes with a scan level below or equal to the clearance level will"
+" be allowed to scan this object."
 msgstr ""
+"Todos los boefjes con un nivel de escaneo inferior o igual al nivel de "
+"autorización podrán escanear este objeto."
 
 #: tools/forms/ooi.py
 msgid "Expires by (UTC)"
-msgstr ""
+msgstr "Expira por (UTC)"
 
 #: tools/forms/ooi_form.py
 msgid "option"
-msgstr ""
+msgstr "opción"
 
 #: tools/forms/ooi_form.py
 #, python-brace-format
 msgid "Optionally choose a {option_label}"
-msgstr ""
+msgstr "Opcionalmente elija un {option_label}"
 
 #: tools/forms/ooi_form.py
 #, python-brace-format
 msgid "Please choose a {option_label}"
-msgstr ""
+msgstr "Por favor elija un {option_label}"
 
 #: tools/forms/ooi_form.py
 msgid "Filter by clearance level"
-msgstr ""
+msgstr "Filtrar por nivel de autorización"
 
 #: tools/forms/ooi_form.py
 msgid "Filter by clearance type"
-msgstr ""
+msgstr "Filtrar por tipo de liquidación"
 
 #: tools/forms/scheduler.py
 msgid "From"
-msgstr ""
+msgstr "De"
 
 #: tools/forms/scheduler.py
 msgid "To"
-msgstr ""
+msgstr "A"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Cancelled"
-msgstr ""
+msgstr "Cancelado"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Completed"
-msgstr ""
+msgstr "Terminado"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Dispatched"
-msgstr ""
+msgstr "Enviado"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Failed"
-msgstr ""
+msgstr "Fallido"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Queued"
-msgstr ""
+msgstr "En cola"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Running"
-msgstr ""
+msgstr "Correr"
 
 #: tools/forms/scheduler.py
 msgid "Search by object name"
+msgstr "Buscar por nombre de objeto"
+
+#: tools/forms/scheduler.py
+msgid "The selected date is in the future. Please select a different date."
 msgstr ""
+"La fecha seleccionada es en el futuro. Por favor seleccione una fecha "
+"diferente."
 
 #: tools/forms/settings.py
 msgid "--- Show all ----"
-msgstr ""
+msgstr "--- Mostrar todo ----"
 
 #: tools/forms/settings.py
 msgid "recommendation"
-msgstr ""
+msgstr "recomendación"
 
 #: tools/forms/settings.py
 msgid "low"
-msgstr ""
+msgstr "bajo"
 
 #: tools/forms/settings.py
 msgid "medium"
-msgstr ""
+msgstr "medio"
 
 #: tools/forms/settings.py
 msgid "high"
-msgstr ""
+msgstr "alto"
 
 #: tools/forms/settings.py
 msgid "very high"
-msgstr ""
+msgstr "muy alto"
 
 #: tools/forms/settings.py
 msgid "critical"
-msgstr ""
+msgstr "crítico"
 
 #: tools/forms/settings.py
 msgid "quickfix"
-msgstr ""
+msgstr "solución rápida"
 
 #: tools/forms/settings.py
 msgid "Declared"
-msgstr ""
+msgstr "Declarado"
 
 #: tools/forms/settings.py
 msgid "Inherited"
-msgstr ""
+msgstr "Heredado"
 
 #: tools/forms/settings.py
 msgid "Empty"
-msgstr ""
+msgstr "Vacío"
 
 #: tools/forms/settings.py
 msgid "Add one finding type ID per line."
-msgstr ""
+msgstr "Agregue un ID de tipo de hallazgo por línea."
 
 #: tools/forms/settings.py
 msgid "Add the date and time of your finding (UTC)"
-msgstr ""
+msgstr "Añade la fecha y hora de tu hallazgo (UTC)"
 
 #: tools/forms/settings.py
 msgid "Add the date and time of when the raw file was generated (UTC)"
-msgstr ""
+msgstr "Agregue la fecha y hora en que se generó el archivo sin formato (UTC)"
 
 #: tools/forms/settings.py
 msgid ""
@@ -5030,20 +5621,29 @@ msgid ""
 "to see the status of your network through time. Select a datetime to change "
 "the view to represent that moment in time."
 msgstr ""
+"OpenKAT almacena una indicación de tiempo con cada observación, por lo que "
+"es posible ver el estado de su red a través del tiempo. Seleccione una fecha"
+" y hora para cambiar la vista para representar ese momento en el tiempo."
 
 #: tools/forms/settings.py
 msgid ""
-"<p>The name of the Docker image. For example: <i>'ghcr.io/minvws/openkat/"
-"nmap'</i>. In OpenKAT, all Boefjes with the same container image will be "
-"seen as 'variants' and will be shown together on the Boefje detail page. </"
-"p> "
+"<p>The name of the Docker image. For example: "
+"<i>'ghcr.io/minvws/openkat/nmap'</i>. In OpenKAT, all Boefjes with the same "
+"container image will be seen as 'variants' and will be shown together on the"
+" Boefje detail page. </p> "
 msgstr ""
+"<p>El nombre de la imagen de Docker. Por ejemplo: "
+"<i>'ghcr.io/minvws/openkat/nmap'</i>. En OpenKAT, todos los Boefjes con la "
+"misma imagen de contenedor se verán como 'variantes' y se mostrarán juntos "
+"en la página de detalles de Boefje. </p>"
 
 #: tools/forms/settings.py
 msgid ""
 "A description of the Boefje explaining in short what it can do. This will "
 "both be displayed inside the KAT-alogus and on the Boefje details page."
 msgstr ""
+"Una descripción del Boefje explicando brevemente lo que puede hacer. Esto se"
+" mostrará dentro del análogo KAT y en la página de detalles de Boefje."
 
 #: tools/forms/settings.py
 msgid ""
@@ -5051,164 +5651,199 @@ msgid ""
 "objects, press and hold the 'ctrl'/'command' key and then click the items "
 "you want to select. "
 msgstr ""
+"Seleccione los tipos de objetos que consume su Boefje. Para seleccionar "
+"varios objetos, mantenga presionada la tecla 'ctrl'/'comando' y luego haga "
+"clic en los elementos que desea seleccionar."
 
 #: tools/forms/settings.py
 msgid ""
 "<p>If any other settings are needed for your Boefje, add these as a JSON "
 "Schema, otherwise, leave the field empty or 'null'.</p> <p> This JSON is "
-"used as the basis for a form for the user. When the user enables this Boefje "
-"they can get the option to give extra information. For example, it can "
+"used as the basis for a form for the user. When the user enables this Boefje"
+" they can get the option to give extra information. For example, it can "
 "contain an API key that the script requires.</p> <p>More information about "
-"what the schema.json file looks like can be found <a href='https://docs."
-"openkat.nl/developer_documentation/development_tutorial/creating_a_boefje."
-"html'> here</a>.</p> "
+"what the schema.json file looks like can be found <a "
+"href='https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html'>"
+" here</a>.</p> "
 msgstr ""
+"<p>Si se necesita alguna otra configuración para su Boefje, agréguela como "
+"un esquema JSON; de lo contrario, deje el campo vacío o \"nulo\".</p> <p> "
+"Este JSON se utiliza como base para un formulario para el usuario. Cuando el"
+" usuario habilita este Boefje, puede tener la opción de brindar información "
+"adicional. Por ejemplo, puede contener una clave API que requiere el "
+"script.</p> <p>Más información sobre cómo se ve el archivo esquema.json se "
+"puede encontrar <a "
+"href='https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html'>"
+" aquí</a>.</p>"
 
 #: tools/forms/settings.py
 msgid ""
 "<p>Add a set of mime types that are produced by this Boefje, separated by "
-"commas. For example: <i>'text/html'</i>, <i>'image/jpeg'</i> or <i>'boefje/"
-"{boefje-id}'</i></p> <p>These output mime types will be shown on the Boefje "
-"detail page as information for other users. </p> "
+"commas. For example: <i>'text/html'</i>, <i>'image/jpeg'</i> or "
+"<i>'boefje/{boefje-id}'</i></p> <p>These output mime types will be shown on "
+"the Boefje detail page as information for other users. </p> "
 msgstr ""
+"<p>Agregue un conjunto de tipos mime producidos por este Boefje, separados "
+"por comas. Por ejemplo: <i>'text/html'</i>, <i>'image/jpeg'</i> o "
+"<i>'boefje/{boefje-id}'</i></p> <p> Estos tipos de MIME de salida se "
+"mostrarán en la Página de detalles Boefje como información para otros "
+"usuarios. </p>"
 
 #: tools/forms/settings.py
 msgid ""
 "<p>Select a clearance level for your Boefje. For more information about the "
-"different clearance levels please check the <a href='https://docs.openkat.nl/"
-"manual/usermanual.html#scan-levels-clearance-indemnities'> documentation</a>."
-"</p> "
+"different clearance levels please check the <a "
+"href='https://docs.openkat.nl/manual/usermanual.html#scan-levels-clearance-"
+"indemnities'> documentation</a>.</p> "
 msgstr ""
+"<p>Seleccione un nivel de autorización para su Boefje. Para obtener más "
+"información sobre los diferentes niveles de autorización, consulte la "
+"documentación <a href='https://docs.openkat.nl/manual/usermanual.html#scan-"
+"levels-clearance-indemnities'></a>.</p>"
 
 #: tools/forms/settings.py
 msgid ""
-"Choose when this Boefje will scan objects. It can run on a given interval or "
-"it can run every time an object has been created or changed. "
+"Choose when this Boefje will scan objects. It can run on a given interval or"
+" it can run every time an object has been created or changed. "
 msgstr ""
+"Elija cuándo este Boefje escaneará objetos. Puede ejecutarse en un intervalo"
+" determinado o puede ejecutarse cada vez que se crea o modifica un objeto."
 
 #: tools/forms/settings.py
 msgid "Depth of the tree."
-msgstr ""
+msgstr "Profundidad del árbol."
 
 #: tools/forms/upload_csv.py
 msgid "Only CSV file supported"
-msgstr ""
+msgstr "Solo se admite el archivo CSV"
 
 #: tools/forms/upload_csv.py
 msgid "File could not be decoded"
-msgstr ""
+msgstr "El archivo no se pudo decodificar"
 
 #: tools/forms/upload_csv.py
 msgid "No file selected"
-msgstr ""
+msgstr "Ningún archivo seleccionado"
 
 #: tools/forms/upload_csv.py
 msgid "The uploaded file is empty."
-msgstr ""
+msgstr "El archivo cargado está vacío."
 
 #: tools/forms/upload_csv.py
 msgid "The number of columns do not meet the requirements."
-msgstr ""
+msgstr "El número de columnas no cumple con los requisitos."
 
 #: tools/forms/upload_csv.py
 msgid "OOI Type in CSV does not meet the criteria."
-msgstr ""
+msgstr "OOI El tipo CSV no cumple con los criterios."
 
 #: tools/forms/upload_csv.py
 msgid "An error has occurred during the parsing of the csv file:"
-msgstr ""
+msgstr "Se ha producido un error durante el análisis del archivo csv:"
 
 #: tools/forms/upload_csv.py
 msgid "Upload CSV file"
-msgstr ""
+msgstr "Sube el archivo CSV"
 
 #: tools/forms/upload_csv.py
 msgid "Only accepts CSV file."
-msgstr ""
+msgstr "Solo acepta archivos CSV."
 
 #: tools/forms/upload_oois.py rocky/templates/partials/explanations.html
 msgid "Object Type"
-msgstr ""
+msgstr "Tipo de objeto"
 
 #: tools/forms/upload_oois.py
 msgid "Choose a type of which objects are added."
-msgstr ""
+msgstr "Elija un tipo de qué objetos se agregan."
 
 #: tools/forms/upload_raw.py
 msgid "Mime types"
-msgstr ""
+msgstr "tipos de mimo"
 
 #: tools/forms/upload_raw.py
 msgid ""
-"<p>Add a set of mime types, separated by commas, for example:</"
-"p><p><i>\"text/html, image/jpeg\"</i> or <i>\"boefje/dns-records\"</i>.</"
-"p><p>Mime types are used to match the correct normalizer to a raw file. When "
-"the mime type \"boefje/dns-records\" is added, the normalizer expects the "
-"raw file to contain dns scan information.</p>"
+"<p>Add a set of mime types, separated by commas, for "
+"example:</p><p><i>\"text/html, image/jpeg\"</i> or <i>\"boefje/dns-"
+"records\"</i>.</p><p>Mime types are used to match the correct normalizer to "
+"a raw file. When the mime type \"boefje/dns-records\" is added, the "
+"normalizer expects the raw file to contain dns scan information.</p>"
 msgstr ""
+"<p>Agregue un conjunto de tipos MIME, separados por comas, por "
+"ejemplo:</p><p><i>\"text/html, image/jpeg\"</i> o <i>\"boefje/dns-"
+"records\"</i>.</p><p>Los tipos mime se utilizan para hacer coincidir el "
+"normalizador correcto con un archivo sin formato. Cuando se agrega el tipo "
+"mime \"boefje/dns-records\", el normalizador espera que el archivo sin "
+"formato contenga información de escaneo dns.</p>"
 
 #: tools/forms/upload_raw.py rocky/templates/partials/ooi_list_toolbar.html
 #: rocky/templates/upload_raw.html
 msgid "Upload raw file"
-msgstr ""
+msgstr "Subir archivo sin formato"
 
 #: tools/forms/upload_raw.py
 msgid "Input or Scan OOI"
-msgstr ""
+msgstr "Entrada o escaneo OOI"
 
 #: tools/forms/upload_raw.py
 msgid "Click to select one of the available options, or type one yourself"
 msgstr ""
+"Haga clic para seleccionar una de las opciones disponibles o escriba una "
+"usted mismo"
 
 #: tools/forms/upload_raw.py
 msgid "OOI doesn't exist, try another valid time"
-msgstr ""
+msgstr "OOI no existe, prueba con otro horario válido"
 
 #: tools/models.py
 msgid ""
-"A short code containing only lower-case unicode letters, numbers, hyphens or "
-"underscores that will be used in URLs and paths."
+"A short code containing only lower-case unicode letters, numbers, hyphens or"
+" underscores that will be used in URLs and paths."
 msgstr ""
+"Un código corto que contiene solo letras Unicode minúsculas, números, "
+"guiones o guiones bajos que se utilizarán en URLs y las rutas."
 
 #: tools/models.py
 msgid ""
 "This organization code is reserved by OpenKAT and cannot be used. Choose "
 "another organization code."
 msgstr ""
+"Este código de organización está reservado por OpenKAT y no se puede "
+"utilizar. Elija otro código de organización."
 
 #: tools/models.py
 msgid "new"
-msgstr ""
+msgstr "nuevo"
 
 #: tools/templatetags/ooi_extra.py
 msgid "Unknown user"
-msgstr ""
+msgstr "Usuario desconocido"
 
 #: tools/view_helpers.py rocky/templates/header.html
 #: rocky/templates/organizations/organization_member_list.html
 #: rocky/views/organization_member_edit.py
 msgid "Members"
-msgstr ""
+msgstr "Miembros"
 
 #: rocky/forms.py
 msgid "Current status"
-msgstr ""
+msgstr "Estado actual"
 
 #: rocky/forms.py rocky/templates/organizations/organization_member_list.html
 msgid "Active"
-msgstr ""
+msgstr "Activo"
 
 #: rocky/forms.py rocky/templates/organizations/organization_member_list.html
 msgid "New"
-msgstr ""
+msgstr "Nuevo"
 
 #: rocky/forms.py
 msgid "Account status"
-msgstr ""
+msgstr "Estado de la cuenta"
 
 #: rocky/forms.py
 msgid "Not blocked"
-msgstr ""
+msgstr "No bloqueado"
 
 #: rocky/messaging.py
 msgid ""
@@ -5216,242 +5851,256 @@ msgid ""
 "needs at least a clearance level of L{} in order to do a proper onboarding. "
 "Edit this member and change the clearance level if necessary."
 msgstr ""
+"Ha confiado en este miembro con un nivel de autorización de L{}. Este "
+"miembro necesita al menos un nivel de autorización de L{} para poder "
+"realizar una incorporación adecuada. Edite este miembro y cambie el nivel de"
+" autorización si es necesario."
 
 #: rocky/paginator.py
 msgid "That page number is not an integer"
-msgstr ""
+msgstr "Ese número de página no es un número entero."
 
 #: rocky/paginator.py
 msgid "That page number is less than 1"
-msgstr ""
+msgstr "Ese número de página es menor que 1."
 
 #: rocky/paginator.py
 msgid "That page contains no results"
-msgstr ""
+msgstr "Esa página no contiene resultados."
 
 #: rocky/scheduler.py
 msgid ""
 "The Scheduler has an unexpected error. Check the Scheduler logs for further "
 "details."
 msgstr ""
+"El Programador tiene un error inesperado. Consulte los registros del "
+"Programador para obtener más detalles."
 
 #: rocky/scheduler.py
 msgid "Could not connect to Scheduler. Service is possibly down."
 msgstr ""
+"No se pudo conectar al Programador. Posiblemente el servicio esté caído."
 
 #: rocky/scheduler.py
 msgid "Your request could not be validated."
-msgstr ""
+msgstr "Su solicitud no pudo ser validada."
 
 #: rocky/scheduler.py
 msgid "Task could not be found."
-msgstr ""
+msgstr "No se pudo encontrar la tarea."
 
 #: rocky/scheduler.py
 msgid ""
 "Scheduler is receiving too many requests. Increase SCHEDULER_PQ_MAXSIZE or "
 "wait for task to finish."
 msgstr ""
+"El programador recibe demasiadas solicitudes. Aumente SCHEDULER_PQ_MAXSIZE o"
+" espere a que finalice la tarea."
 
 #: rocky/scheduler.py
 msgid "Bad request. Your request could not be interpreted by the Scheduler."
 msgstr ""
+"Solicitud incorrecta. El Programador no pudo interpretar su solicitud."
 
 #: rocky/scheduler.py
 msgid "The Scheduler has received a conflict. Your task is already in queue."
-msgstr ""
+msgstr "El Programador ha recibido un conflicto. Tu tarea ya está en cola."
 
 #: rocky/scheduler.py
 msgid "A HTTPError occurred. See Scheduler logs for more info."
 msgstr ""
+"Se produjo un error HTTP. Consulte Registros del programador para obtener "
+"más información."
 
 #: rocky/scheduler.py
 msgid "Schedule list: "
-msgstr ""
+msgstr "Lista de horarios:"
 
 #: rocky/scheduler.py
 msgid "Task list: "
-msgstr ""
+msgstr "Lista de tareas:"
 
 #: rocky/settings.py
 msgid "Blue light"
-msgstr ""
+msgstr "luz azul"
 
 #: rocky/settings.py
 msgid "Blue medium"
-msgstr ""
+msgstr "Azul medio"
 
 #: rocky/settings.py
 msgid "Blue dark"
-msgstr ""
+msgstr "azul oscuro"
 
 #: rocky/settings.py
 msgid "Green light"
-msgstr ""
+msgstr "luz verde"
 
 #: rocky/settings.py
 msgid "Green medium"
-msgstr ""
+msgstr "Verde medio"
 
 #: rocky/settings.py
 msgid "Green dark"
-msgstr ""
+msgstr "verde oscuro"
 
 #: rocky/settings.py
 msgid "Yellow light"
-msgstr ""
+msgstr "luz amarilla"
 
 #: rocky/settings.py
 msgid "Yellow medium"
-msgstr ""
+msgstr "Amarillo medio"
 
 #: rocky/settings.py
 msgid "Yellow dark"
-msgstr ""
+msgstr "amarillo oscuro"
 
 #: rocky/settings.py
 msgid "Orange light"
-msgstr ""
+msgstr "luz naranja"
 
 #: rocky/settings.py
 msgid "Orange medium"
-msgstr ""
+msgstr "Naranja mediana"
 
 #: rocky/settings.py
 msgid "Orange dark"
-msgstr ""
+msgstr "naranja oscuro"
 
 #: rocky/settings.py
 msgid "Red light"
-msgstr ""
+msgstr "Luz roja"
 
 #: rocky/settings.py
 msgid "Red medium"
-msgstr ""
+msgstr "rojo medio"
 
 #: rocky/settings.py
 msgid "Red dark"
-msgstr ""
+msgstr "rojo oscuro"
 
 #: rocky/settings.py
 msgid "Violet light"
-msgstr ""
+msgstr "luz violeta"
 
 #: rocky/settings.py
 msgid "Violet medium"
-msgstr ""
+msgstr "violeta medio"
 
 #: rocky/settings.py
 msgid "Violet dark"
-msgstr ""
+msgstr "violeta oscuro"
 
 #: rocky/settings.py
 msgid "Plain"
-msgstr ""
+msgstr "Plano"
 
 #: rocky/settings.py
 msgid "Solid"
-msgstr ""
+msgstr "Sólido"
 
 #: rocky/settings.py
 msgid "Dashed"
-msgstr ""
+msgstr "discontinuo"
 
 #: rocky/settings.py
 msgid "Dotted"
-msgstr ""
+msgstr "Punteado"
 
 #: rocky/templates/403.html
 msgid "Error code 403: Unauthorized"
-msgstr ""
+msgstr "Código de error 403: no autorizado"
 
 #: rocky/templates/403.html
 msgid "Your account is not authorized to access this page or organization."
 msgstr ""
+"Su cuenta no está autorizada para acceder a esta página u organización."
 
 #: rocky/templates/403.html
 msgid "Please contact your system administrator."
-msgstr ""
+msgstr "Comuníquese con el administrador de su sistema."
 
 #: rocky/templates/403.html rocky/templates/404.html
 msgid "You may want to go back to the"
-msgstr ""
+msgstr "Es posible que desee volver a la"
 
 #: rocky/templates/403.html rocky/templates/404.html
 msgid "Crisis Room"
-msgstr ""
+msgstr "Sala de crisis"
 
 #: rocky/templates/404.html
 msgid "Error code 404: Page not found"
-msgstr ""
+msgstr "Código de error 404: página no encontrada"
 
 #: rocky/templates/404.html
 msgid ""
 "The page you wanted to see or the file you wanted to view was not found."
 msgstr ""
+"No se encontró la página que deseaba ver o el archivo que deseaba ver."
 
 #: rocky/templates/admin/base.html
 msgid "Skip to main content"
-msgstr ""
+msgstr "Saltar al contenido principal"
 
 #: rocky/templates/admin/base.html
 msgid "Welcome,"
-msgstr ""
+msgstr "Bienvenido,"
 
 #: rocky/templates/admin/base.html
 msgid "View site"
-msgstr ""
+msgstr "Ver sitio"
 
 #: rocky/templates/admin/base.html
 msgid "Documentation"
-msgstr ""
+msgstr "Documentación"
 
 #: rocky/templates/admin/base.html
 msgid "Change password"
-msgstr ""
+msgstr "Cambiar la contraseña"
 
 #: rocky/templates/admin/base.html
 msgid "Log out"
-msgstr ""
+msgstr "Finalizar la sesión"
 
 #: rocky/templates/admin/base.html rocky/templates/header.html
 msgid "Breadcrumbs"
-msgstr ""
+msgstr "Pan rallado"
 
 #: rocky/templates/admin/base.html rocky/templates/admin/change_form.html
 #: rocky/templates/admin/change_list.html
 #: rocky/templates/admin/delete_confirmation.html
 #: rocky/templates/admin/delete_selected_confirmation.html
 msgid "Home"
-msgstr ""
+msgstr "Hogar"
 
 #: rocky/templates/admin/change_form.html
 #, python-format
 msgid "Add %(name)s"
-msgstr ""
+msgstr "Añadir %(name)s"
 
 #: rocky/templates/admin/change_form.html
 #: rocky/templates/admin/change_list.html
 msgid "Please correct the error below."
 msgid_plural "Please correct the errors below."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Corrija los errores a continuación."
+msgstr[1] "Corrija los errores a continuación."
 
 #: rocky/templates/admin/change_list.html
 msgid "Filter"
-msgstr ""
+msgstr "Filtrar"
 
 #: rocky/templates/admin/change_list.html
 msgid "Hide counts"
-msgstr ""
+msgstr "Ocultar recuentos"
 
 #: rocky/templates/admin/change_list.html
 msgid "Show counts"
-msgstr ""
+msgstr "Mostrar recuentos"
 
 #: rocky/templates/admin/change_list.html
 msgid "Clear all filters"
-msgstr ""
+msgstr "Limpiar todos los filtros"
 
 #: rocky/templates/admin/delete_confirmation.html
 #, python-format
@@ -5460,13 +6109,18 @@ msgid ""
 "related objects, but your account doesn't have permission to delete the "
 "following types of objects"
 msgstr ""
+"Eliminar el %(object_name)s '%(escaped_object)s' daría como resultado la "
+"eliminación de objetos relacionados, pero su cuenta no tiene permiso para "
+"eliminar los siguientes tipos de objetos"
 
 #: rocky/templates/admin/delete_confirmation.html
 #, python-format
 msgid ""
-"Deleting the %(object_name)s '%(escaped_object)s' would require deleting the "
-"following protected related objects"
+"Deleting the %(object_name)s '%(escaped_object)s' would require deleting the"
+" following protected related objects"
 msgstr ""
+"Para eliminar el %(object_name)s '%(escaped_object)s' sería necesario "
+"eliminar los siguientes objetos relacionados protegidos"
 
 #: rocky/templates/admin/delete_confirmation.html
 #, python-format
@@ -5474,20 +6128,23 @@ msgid ""
 "Are you sure you want to delete the %(object_name)s \"%(escaped_object)s\"? "
 "All of the following related items will be deleted"
 msgstr ""
+"¿Está seguro de que desea eliminar el %(object_name)s "
+"\"%(escaped_object)s\"? Se eliminarán todos los siguientes elementos "
+"relacionados"
 
 #: rocky/templates/admin/delete_confirmation.html
 #: rocky/templates/admin/delete_selected_confirmation.html
 msgid "Yes, I’m sure"
-msgstr ""
+msgstr "Si, estoy seguro"
 
 #: rocky/templates/admin/delete_confirmation.html
 #: rocky/templates/admin/delete_selected_confirmation.html
 msgid "No, take me back"
-msgstr ""
+msgstr "No, llévame de vuelta"
 
 #: rocky/templates/admin/delete_selected_confirmation.html
 msgid "Delete multiple objects"
-msgstr ""
+msgstr "Eliminar múltiples objetos"
 
 #: rocky/templates/admin/delete_selected_confirmation.html
 #, python-format
@@ -5496,6 +6153,9 @@ msgid ""
 "objects, but your account doesn't have permission to delete the following "
 "types of objects"
 msgstr ""
+"Eliminar el %(objects_name)s seleccionado daría como resultado la "
+"eliminación de objetos relacionados, pero su cuenta no tiene permiso para "
+"eliminar los siguientes tipos de objetos"
 
 #: rocky/templates/admin/delete_selected_confirmation.html
 #, python-format
@@ -5503,6 +6163,8 @@ msgid ""
 "Deleting the selected %(objects_name)s would require deleting the following "
 "protected related objects"
 msgstr ""
+"Eliminar el %(objects_name)s seleccionado requeriría eliminar los siguientes"
+" objetos relacionados protegidos"
 
 #: rocky/templates/admin/delete_selected_confirmation.html
 #, python-format
@@ -5510,64 +6172,69 @@ msgid ""
 "Are you sure you want to delete the selected %(objects_name)s? All of the "
 "following objects and their related items will be deleted"
 msgstr ""
+"¿Está seguro de que desea eliminar el %(objects_name)s seleccionado? Se "
+"eliminarán todos los siguientes objetos y sus elementos relacionados."
 
 #: rocky/templates/admin/popup_response.html
 msgid "Popup closing…"
-msgstr ""
+msgstr "Cierre de ventana emergente…"
 
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
-#: rocky/templates/header.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
 msgid "Close menu"
-msgstr ""
+msgstr "Cerrar menú"
 
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
-#: rocky/templates/header.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
 msgid "Main navigation"
-msgstr ""
+msgstr "Navegación principal"
 
 #: rocky/templates/dashboard_client.html
 msgid "Indemnifications"
-msgstr ""
+msgstr "Indemnizaciones"
 
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html
 #: rocky/templates/partials/secondary-menu.html
 msgid "Logout"
-msgstr ""
+msgstr "Cerrar sesión"
 
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html
 msgid "Welcome"
-msgstr ""
+msgstr "Bienvenido"
 
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html
 msgid "User overview"
-msgstr ""
+msgstr "Descripción general del usuario"
 
 #: rocky/templates/dashboard_redteam.html
 #: rocky/templates/partials/notifications_block.html
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "warning"
-msgstr ""
+msgstr "advertencia"
 
 #: rocky/templates/dashboard_redteam.html
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 #: rocky/templates/partials/notifications_block.html
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "Warning:"
-msgstr ""
+msgstr "Advertencia:"
 
 #: rocky/templates/dashboard_redteam.html
 msgid "Organization code missing"
-msgstr ""
+msgstr "Falta el código de organización"
 
 #: rocky/templates/finding_type_add.html
 #: rocky/templates/partials/findings_list_toolbar.html
 #: rocky/views/finding_type_add.py
 msgid "Add finding type"
-msgstr ""
+msgstr "Agregar tipo de hallazgo"
 
 #: rocky/templates/finding_type_add.html
 msgid "Finding Type"
-msgstr ""
+msgstr "Tipo de hallazgo"
 
 #: rocky/templates/findings/finding_add.html
 #: rocky/templates/oois/ooi_detail_findings_list.html
@@ -5575,11 +6242,11 @@ msgstr ""
 #: rocky/templates/partials/findings_list_toolbar.html
 #: rocky/views/finding_add.py
 msgid "Add finding"
-msgstr ""
+msgstr "Agregar hallazgo"
 
 #: rocky/templates/findings/finding_list.html
-msgid "Findings @ "
-msgstr ""
+msgid "Findings "
+msgstr "Recomendaciones"
 
 #: rocky/templates/findings/finding_list.html
 #, python-format
@@ -5588,107 +6255,116 @@ msgid ""
 "<strong>%(organization_name)s</strong>. Each finding relates to an object. "
 "Click a finding for additional information."
 msgstr ""
+"Una descripción general de todos los hallazgos OpenKAT encontrados para la "
+"organización <strong>%(organization_name)s</strong>. Cada hallazgo se "
+"relaciona con un objeto. Haga clic en un hallazgo para obtener información "
+"adicional."
 
 #: rocky/templates/findings/finding_list.html
 #, python-format
 msgid "Showing %(length)s of %(total)s findings"
-msgstr ""
+msgstr "Mostrando %(length)s de los hallazgos de %(total)s"
 
 #: rocky/templates/findings/finding_list.html
 #: rocky/templates/partials/mute_findings_modal.html
 msgid "Mute findings"
-msgstr ""
+msgstr "Silenciar hallazgos"
 
 #: rocky/templates/findings/finding_list.html
 msgid "Unmute findings"
-msgstr ""
+msgstr "Dejar de silenciar los resultados"
 
 #: rocky/templates/findings/findings_filter.html
 #: rocky/templates/partials/elements/ooi_list_settings_form.html
 #: rocky/templates/tasks/partials/task_filter.html
 msgid "Set filters"
-msgstr ""
+msgstr "Establecer filtros"
 
 #: rocky/templates/findings/findings_filter.html
 #: rocky/templates/partials/elements/ooi_list_settings_form.html
 #: rocky/templates/tasks/partials/task_filter.html
 msgid "Clear filters"
-msgstr ""
+msgstr "Limpiar filtros"
 
 #: rocky/templates/footer.html rocky/views/privacy_statement.py
 msgid "Privacy Statement"
-msgstr ""
+msgstr "Declaración de privacidad"
 
 #: rocky/templates/forms/json_schema_form.html
 msgid "Fill out this form to answer the Question (again):"
-msgstr ""
+msgstr "Complete este formulario para responder la Pregunta (nuevamente):"
 
 #: rocky/templates/graph-d3.html
 msgid ""
 "Click a circle to collapse / expand the tree, click the text to view the "
 "tree from that OOI and hover over the text to see details."
 msgstr ""
+"Haga clic en un círculo para contraer/expandir el árbol, haga clic en el "
+"texto para ver el árbol desde ese OOI y coloque el cursor sobre el texto "
+"para ver los detalles."
 
 #: rocky/templates/graph-d3.html
 msgid "Tree graph"
-msgstr ""
+msgstr "Gráfico de árbol"
 
 #: rocky/templates/header.html
 msgid "Menu"
-msgstr ""
+msgstr "Menú"
 
 #: rocky/templates/header.html
 msgid "OpenKAT logo, go to the homepage of OpenKAT"
-msgstr ""
+msgstr "Logotipo de OpenKAT, ir a la página de inicio de OpenKAT"
 
 #: rocky/templates/header.html rocky/templates/tasks/ooi_detail_task_list.html
 #: rocky/templates/tasks/partials/tasks_overview_header.html
 #: rocky/templates/tasks/plugin_detail_task_list.html
 #: rocky/views/task_detail.py rocky/views/tasks.py
 msgid "Tasks"
-msgstr ""
+msgstr "Tareas"
 
 #: rocky/templates/health.html
 msgid "Health Checks"
-msgstr ""
+msgstr "Controles de salud"
 
 #: rocky/templates/health.html
 msgid "Health checks"
-msgstr ""
+msgstr "Controles de salud"
 
 #: rocky/templates/health.html
 msgid "Additional"
-msgstr ""
+msgstr "Adicional"
 
 #: rocky/templates/indemnification_present.html
 msgid "Indemnification"
-msgstr ""
+msgstr "Indemnización"
 
 #: rocky/templates/indemnification_present.html
 msgid ""
 "Indemnification on the organization present. You may now add objects and "
 "start scans."
 msgstr ""
+"Indemnización a la organización presente. Ahora puede agregar objetos e "
+"iniciar escaneos."
 
 #: rocky/templates/indemnification_present.html
 msgid "Go to Objects"
-msgstr ""
+msgstr "Ir a objetos"
 
 #: rocky/templates/indemnification_present.html
 msgid "Go to"
-msgstr ""
+msgstr "Ir a"
 
 #: rocky/templates/landing_page.html
 msgid "Welcome to OpenKAT"
-msgstr ""
+msgstr "Bienvenido a OpenKAT"
 
 #: rocky/templates/landing_page.html
 msgid "Kwetsbaarheden Analyse Tool"
-msgstr ""
+msgstr "Herramienta de análisis de Kwetsbaarheden"
 
 #: rocky/templates/landing_page.html
 msgid "What is OpenKAT?"
-msgstr ""
+msgstr "¿Qué es OpenKAT?"
 
 #: rocky/templates/landing_page.html
 msgid ""
@@ -5696,261 +6372,300 @@ msgid ""
 "by the Ministry of Health, Welfare and Sport to make your and our world "
 "safer."
 msgstr ""
+"OpenKAT es una herramienta de análisis de vulnerabilidad. Un proyecto de "
+"código abierto desarrollado por el Ministerio de Salud, Bienestar y Deportes"
+" para hacer que su mundo y el nuestro sean más seguros."
 
 #: rocky/templates/landing_page.html
 msgid "OpenKAT sees"
-msgstr ""
+msgstr "OpenKAT ve"
 
 #: rocky/templates/landing_page.html
 msgid ""
 "Dozens of tools are integrated in OpenKAT to view the world (digital and "
 "analog)."
 msgstr ""
+"Docenas de herramientas están integradas en OpenKAT para ver el mundo "
+"(digital y analógico)."
 
 #: rocky/templates/landing_page.html
 msgid "Our motto is therefore: I see, I see, what you do not see."
-msgstr ""
+msgstr "Nuestro lema es, por tanto: Veo, veo lo que tú no ves."
 
 #: rocky/templates/landing_page.html
 msgid "OpenKAT knows"
-msgstr ""
+msgstr "OpenKAT sabe"
 
 #: rocky/templates/landing_page.html
 msgid ""
 "OpenKAT does not forget (just like that), and can be queried without "
 "scanning again. Also about a historical situation."
 msgstr ""
+"OpenKAT no se olvida (así como así) y se puede consultar sin volver a "
+"escanear. También sobre una situación histórica."
 
 #: rocky/templates/landing_page.html
 msgid "OpenKAT is secure"
-msgstr ""
+msgstr "OpenKAT es seguro"
 
 #: rocky/templates/landing_page.html
 msgid ""
 "Forensically secured storage of evidence is one of the basic ingredients of "
 "OpenKAT."
 msgstr ""
+"El almacenamiento de pruebas con seguridad forense es uno de los "
+"ingredientes básicos de OpenKAT."
 
 #: rocky/templates/landing_page.html
 msgid "OpenKAT is sweet"
-msgstr ""
+msgstr "OpenKAT es dulce"
 
 #: rocky/templates/landing_page.html
 msgid ""
-"OpenKAT thinks about privacy, and stores what is necessary, within the rules "
-"of your organization and the law."
+"OpenKAT thinks about privacy, and stores what is necessary, within the rules"
+" of your organization and the law."
 msgstr ""
+"OpenKAT piensa en la privacidad, y almacena lo necesario, dentro de las "
+"reglas de tu organización y la ley."
 
 #: rocky/templates/landing_page.html
 msgid "A wide playing field"
-msgstr ""
+msgstr "Un amplio campo de juego"
 
 #: rocky/templates/landing_page.html
 msgid ""
-"OpenKAT makes a copy of the actual reality by means of the integrated tools. "
-"Within this copy you can search for answers to countless security and policy "
-"questions. Expected and unexpected changes in the world are made visible, "
-"and where necessary reported or made known directly to the right people."
+"OpenKAT makes a copy of the actual reality by means of the integrated tools."
+" Within this copy you can search for answers to countless security and "
+"policy questions. Expected and unexpected changes in the world are made "
+"visible, and where necessary reported or made known directly to the right "
+"people."
 msgstr ""
+"OpenKAT realiza una copia de la realidad real mediante las herramientas "
+"integradas. En esta copia puede buscar respuestas a innumerables preguntas "
+"sobre políticas y seguridad. Los cambios esperados e inesperados en el mundo"
+" se hacen visibles y, cuando es necesario, se informan o se dan a conocer "
+"directamente a las personas adecuadas."
 
 #: rocky/templates/legal/privacy_statement.html
 msgid "OpenKAT Privacy Statement"
-msgstr ""
+msgstr "Declaración de privacidad OpenKAT"
 
 #: rocky/templates/legal/privacy_statement.html
 msgid ""
 "OpenKAT is dedicated to protecting the confidentiality and privacy of "
-"information entrusted to it. As part of this fundamental obligation, OpenKAT "
-"is committed to the appropriate protection and use of personal information "
+"information entrusted to it. As part of this fundamental obligation, OpenKAT"
+" is committed to the appropriate protection and use of personal information "
 "(sometimes referred to as \"personal data\", \"personally identifiable "
 "information\" or \"PII\") that has been collected online."
 msgstr ""
+"OpenKAT se dedica a proteger la confidencialidad y privacidad de la "
+"información que se le confía. Como parte de esta obligación fundamental, "
+"OpenKAT se compromete a la protección y el uso adecuados de la información "
+"personal (a veces denominada \"datos personales\", \"información de "
+"identificación personal\" o \"PII\") que se ha recopilado en línea."
 
 #: rocky/templates/oois/error.html
 msgid "Object List"
-msgstr ""
+msgstr "Lista de objetos"
 
 #: rocky/templates/oois/error.html
 msgid "An error occurred. Please contact a system administrator."
-msgstr ""
+msgstr "Se produjo un error. Comuníquese con un administrador del sistema."
 
 #: rocky/templates/oois/ooi_add.html
 #, python-format
 msgid "Add a %(display_type)s"
-msgstr ""
+msgstr "Agregar un %(display_type)s"
 
 #: rocky/templates/oois/ooi_add.html
 msgid ""
 "Here you can add the asset of the client. Findings can be added to these in "
 "the findings page."
 msgstr ""
+"Aquí puede agregar el activo del cliente. Los hallazgos se pueden agregar a "
+"estos en la página de hallazgos."
 
 #: rocky/templates/oois/ooi_add.html
 #, python-format
 msgid "Add %(display_type)s"
-msgstr ""
+msgstr "Añadir %(display_type)s"
 
 #: rocky/templates/oois/ooi_add_type_select.html
 #: rocky/templates/oois/ooi_detail_add_related_object.html
 #: rocky/templates/partials/elements/ooi_add_type_select_form.html
 #: rocky/templates/partials/ooi_list_toolbar.html rocky/views/ooi_add.py
 msgid "Add object"
-msgstr ""
+msgstr "Agregar objeto"
 
 #: rocky/templates/oois/ooi_add_type_select.html
 msgid "Select the type of object you want to create."
-msgstr ""
+msgstr "Seleccione el tipo de objeto que desea crear."
 
 #: rocky/templates/oois/ooi_delete.html
 #, python-format
 msgid "Delete %(primary_key)s"
-msgstr ""
+msgstr "Eliminar %(primary_key)s"
 
 #: rocky/templates/oois/ooi_delete.html
 msgid "Are you sure?"
-msgstr ""
+msgstr "¿Está seguro?"
 
 #: rocky/templates/oois/ooi_delete.html
 #, python-format
 msgid "Here you can delete the %(display_type)s."
-msgstr ""
+msgstr "Aquí puede eliminar el %(display_type)s."
 
 #: rocky/templates/oois/ooi_delete.html
 msgid "To be deleted object(s)"
-msgstr ""
+msgstr "Objeto(s) a eliminar"
 
 #: rocky/templates/oois/ooi_delete.html
 #: rocky/templates/partials/elements/ooi_tree_condensed_table.html
 msgid "Key"
-msgstr ""
+msgstr "Llave"
 
 #: rocky/templates/oois/ooi_delete.html
 #: rocky/templates/partials/ooi_detail_toolbar.html
 #, python-format
 msgid "Delete %(display_type)s"
-msgstr ""
+msgstr "Eliminar %(display_type)s"
 
 #: rocky/templates/oois/ooi_delete.html
 msgid "Deletion not possible for types: KATFindingType and CVEFindingType"
-msgstr ""
+msgstr "No es posible eliminar los tipos: KATFindingType y CVEFindingType"
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "using boefjes"
-msgstr ""
+msgstr "usando boefjes"
 
 #: rocky/templates/oois/ooi_detail.html
 #: rocky/templates/organizations/organization_settings.html
 msgid "indemnification warning"
-msgstr ""
+msgstr "advertencia de indemnización"
 
 #: rocky/templates/oois/ooi_detail.html
 #, python-format
 msgid ""
-"<strong>Warning:</strong> There is no indemnification for this organization. "
-"Go to the <a href=\"%(organization_settings)s\">organization settings page</"
-"a> to add one."
+"<strong>Warning:</strong> There is no indemnification for this organization."
+" Go to the <a href=\"%(organization_settings)s\">organization settings "
+"page</a> to add one."
 msgstr ""
+"<strong>Advertencia:</strong> No existe ninguna indemnización para esta "
+"organización. Vaya a la página de configuración de la organización <a "
+"href=\"%(organization_settings)s\"></a> para agregar uno."
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "Permission warning"
-msgstr ""
+msgstr "Advertencia de permiso"
 
 #: rocky/templates/oois/ooi_detail.html
 msgid ""
 "<strong>Warning:</strong> You don't have the proper permission at the "
 "organizational level to scan objects. Contact your administrator."
 msgstr ""
+"<strong>Advertencia:</strong> No tiene el permiso adecuado a nivel "
+"organizacional para escanear objetos. Póngase en contacto con su "
+"administrador."
 
 #: rocky/templates/oois/ooi_detail.html
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Scan warning"
-msgstr ""
+msgstr "Advertencia de escaneo"
 
 #: rocky/templates/oois/ooi_detail.html
 #, python-format
 msgid ""
-"<strong>Warning:</strong> You are not allowed to scan this OOI. Your maximum "
-"clearance level is %(member_clearance_level)s and this OOI has level "
+"<strong>Warning:</strong> You are not allowed to scan this OOI. Your maximum"
+" clearance level is %(member_clearance_level)s and this OOI has level "
 "%(boefje_scan_level)s. Go to your <a href=\"%(account_details)s\">account "
 "details</a> to manage your clearance level."
 msgstr ""
+"<strong>Advertencia:</strong> No tiene permiso para escanear este OOI. Su "
+"nivel máximo de autorización es %(member_clearance_level)s y este OOI tiene "
+"el nivel %(boefje_scan_level)s. Vaya a los detalles de su cuenta <a "
+"href=\"%(account_details)s\"></a> para administrar su nivel de autorización."
 
 #: rocky/templates/oois/ooi_detail.html rocky/templates/scan.html
 msgid "Boefjes overview"
-msgstr ""
+msgstr "Descripción general de Boefjes"
 
 #: rocky/templates/oois/ooi_detail.html
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 #: rocky/templates/scan.html rocky/templates/tasks/boefjes.html
 #: rocky/templates/tasks/normalizers.html
 msgid "Boefje"
-msgstr ""
+msgstr "Boefje"
 
 #: rocky/templates/oois/ooi_detail.html rocky/templates/scan.html
 msgid "Scan profile"
-msgstr ""
+msgstr "Perfil de escaneo"
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "Unable to start scan. See the warning for more details."
 msgstr ""
+"No se puede iniciar el escaneo. Consulte la advertencia para obtener más "
+"detalles."
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "Start scan"
-msgstr ""
+msgstr "Iniciar escaneo"
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "There are no boefjes enabled to scan an OOI of type"
-msgstr ""
+msgstr "No hay boefjes habilitados para escanear un tipo OOI"
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "See"
-msgstr ""
+msgstr "Ver"
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "to find and enable boefjes that can scan within the current level."
 msgstr ""
+"para encontrar y habilitar boefjes que puedan escanear dentro del nivel "
+"actual."
 
 #: rocky/templates/oois/ooi_detail_add_related_object.html
 #: rocky/templates/partials/ooi_detail_related_object.html
 msgid "Add related object"
-msgstr ""
+msgstr "Agregar objeto relacionado"
 
 #: rocky/templates/oois/ooi_detail_add_related_object.html
 #: rocky/templates/oois/ooi_detail_object.html
 msgid "Object details"
-msgstr ""
+msgstr "Detalles del objeto"
 
 #: rocky/templates/oois/ooi_detail_add_related_object.html
 #: rocky/templates/partials/elements/ooi_add_type_select_form.html
 msgid "Object type"
-msgstr ""
+msgstr "tipo de objeto"
 
 #: rocky/templates/oois/ooi_detail_add_related_object.html
 #: rocky/templates/partials/elements/ooi_add_type_select_form.html
 msgid "Choose an object type to add"
-msgstr ""
+msgstr "Elija un tipo de objeto para agregar"
 
 #: rocky/templates/oois/ooi_detail_add_related_object.html
 #: rocky/templates/partials/elements/ooi_add_type_select_form.html
 msgid "Select an object type to add."
-msgstr ""
+msgstr "Seleccione un tipo de objeto para agregar."
 
 #: rocky/templates/oois/ooi_detail_findings_list.html
 msgid "Overview of findings for"
-msgstr ""
+msgstr "Resumen de los hallazgos de"
 
 #: rocky/templates/oois/ooi_detail_findings_list.html
 msgid "Score"
-msgstr ""
+msgstr "Puntaje"
 
 #: rocky/templates/oois/ooi_detail_findings_list.html
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "Finding details"
-msgstr ""
+msgstr "Encontrar detalles"
 
 #: rocky/templates/oois/ooi_detail_findings_overview.html
 msgid "Overview of the number of findings and their severity found on"
 msgstr ""
+"Descripción general del número de hallazgos y su gravedad encontrados en"
 
 #: rocky/templates/oois/ooi_detail_findings_overview.html
 msgid ""
@@ -5958,206 +6673,224 @@ msgid ""
 "table shows the number of unique findings found as well as the number of "
 "occurrences."
 msgstr ""
+"Los hallazgos pueden ocurrir varias veces. Para brindar una mejor "
+"comprensión, la siguiente tabla muestra la cantidad de hallazgos únicos "
+"encontrados, así como la cantidad de ocurrencias."
 
 #: rocky/templates/oois/ooi_detail_findings_overview.html
 msgid "See finding details"
-msgstr ""
+msgstr "Ver detalles del hallazgo"
 
 #: rocky/templates/oois/ooi_detail_findings_overview.html
 msgid "Total findings"
-msgstr ""
+msgstr "Hallazgos totales"
 
 #: rocky/templates/oois/ooi_detail_object.html
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Inactive"
-msgstr ""
+msgstr "Inactivo"
 
 #: rocky/templates/oois/ooi_detail_origins_declarations.html
 msgid "Declarations"
-msgstr ""
+msgstr "Declaraciones"
 
 #: rocky/templates/oois/ooi_detail_origins_inference.html
 msgid "Inferred by"
-msgstr ""
+msgstr "Inferido por"
 
 #: rocky/templates/oois/ooi_detail_origins_inference.html
 msgid "Bit"
-msgstr ""
+msgstr "Poco"
 
 #: rocky/templates/oois/ooi_detail_origins_inference.html
 msgid "Parameters"
-msgstr ""
+msgstr "Parámetros"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "Last observed by"
-msgstr ""
+msgstr "Observado por última vez por"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "Task ID"
-msgstr ""
+msgstr "ID de tarea"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "When"
-msgstr ""
+msgstr "Cuando"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 #: rocky/templates/tasks/normalizers.html
 msgid "Normalizer"
-msgstr ""
+msgstr "Normalizer"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "This scan was manually created."
-msgstr ""
+msgstr "Este escaneo se creó manualmente."
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "The boefje has since been deleted or disabled."
-msgstr ""
+msgstr "Desde entonces, el boefje ha sido eliminado o desactivado."
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "No Raw file could be found, this might point to an error in OpenKAT"
 msgstr ""
+"No se pudo encontrar ningún archivo sin formato, esto podría indicar un "
+"error en OpenKAT"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Warning"
-msgstr ""
+msgstr "Advertencia"
 
 #: rocky/templates/oois/ooi_edit.html
 #, python-format
 msgid "Edit %(type)s: %(ooi_human_readable)s"
-msgstr ""
+msgstr "Editar %(type)s: %(ooi_human_readable)s"
 
 #: rocky/templates/oois/ooi_edit.html
 msgid "Primary key fields cannot be edited."
-msgstr ""
+msgstr "Los campos de clave principal no se pueden editar."
 
 #: rocky/templates/oois/ooi_edit.html
 #, python-format
 msgid "Save %(display_type)s"
-msgstr ""
+msgstr "Guardar %(display_type)s"
 
 #: rocky/templates/oois/ooi_findings.html
 msgid "Currently no findings have been identified for OOI"
-msgstr ""
+msgstr "Actualmente no se han identificado resultados para OOI"
 
 #: rocky/templates/oois/ooi_list.html
 #, python-format
 msgid ""
-"An overview of objects found for organization <strong>%(organization_name)s</"
-"strong>. Objects can be added manually or by running Boefjes. Click an "
-"object for additional information."
+"An overview of objects found for organization "
+"<strong>%(organization_name)s</strong>. Objects can be added manually or by "
+"running Boefjes. Click an object for additional information."
 msgstr ""
+"Una descripción general de los objetos encontrados para la organización "
+"<strong>%(organization_name)s</strong>. Los objetos se pueden agregar "
+"manualmente o ejecutando Boefjes. Haga clic en un objeto para obtener "
+"información adicional."
 
 #: rocky/templates/oois/ooi_list.html
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Edit clearance level"
-msgstr ""
+msgstr "Editar nivel de autorización"
 
 #: rocky/templates/oois/ooi_mute_finding.html
 msgid "Mute finding:"
-msgstr ""
+msgstr "Búsqueda silenciosa:"
 
 #: rocky/templates/oois/ooi_mute_finding.html
 msgid "Give a reason below why you want to mute this finding."
 msgstr ""
+"Indique a continuación el motivo por el que desea silenciar este hallazgo."
 
 #: rocky/templates/oois/ooi_mute_finding.html
 #: rocky/templates/partials/mute_findings_modal.html
 #: rocky/templates/partials/ooi_detail_toolbar.html
 msgid "Mute finding"
-msgstr ""
+msgstr "Búsqueda silenciosa"
 
 #: rocky/templates/oois/ooi_mute_finding.html
 msgid "Mute"
-msgstr ""
+msgstr "Silenciar"
 
 #: rocky/templates/oois/ooi_page_tabs.html
 msgid "List of views for OOI"
-msgstr ""
+msgstr "Lista de vistas para OOI"
 
 #: rocky/templates/oois/ooi_past_due_warning.html
 msgid "This object is past due"
-msgstr ""
+msgstr "Este objeto está vencido"
 
 #: rocky/templates/oois/ooi_past_due_warning.html
 msgid "This object is past due and has been deleted"
-msgstr ""
+msgstr "Este objeto está vencido y ha sido eliminado."
 
 #: rocky/templates/oois/ooi_past_due_warning.html
 msgid ""
 "This object is past due. You are viewing the object state in a past state."
 msgstr ""
+"Este objeto está vencido. Estás viendo el estado del objeto en un estado "
+"pasado."
 
 #: rocky/templates/oois/ooi_past_due_warning.html
 msgid ""
 "You will not be able to add Findings or other OOI's to past due objects."
-msgstr ""
+msgstr "No podrá agregar Hallazgos u otros OOI a objetos vencidos."
 
 #: rocky/templates/oois/ooi_past_due_warning.html
 #: rocky/templates/partials/hyperlink_ooi_id.html
 #, python-format
 msgid "Show details for %(name)s"
-msgstr ""
+msgstr "Mostrar detalles de %(name)s"
 
 #: rocky/templates/oois/ooi_past_due_warning.html
 msgid "View the current state"
-msgstr ""
+msgstr "Ver el estado actual"
 
 #: rocky/templates/oois/ooi_past_due_warning.html
 msgid ""
 "You will not be able to add Findings or other OOI's, this object has been "
 "deleted and is no longer available."
 msgstr ""
+"No podrá agregar Hallazgos u otros OOI, este objeto ha sido eliminado y ya "
+"no está disponible."
 
 #: rocky/templates/oois/ooi_summary.html
 msgid "Summary for"
-msgstr ""
+msgstr "Resumen para"
 
 #: rocky/templates/oois/ooi_summary.html
 msgid "Below you can see findings that were found for"
-msgstr ""
+msgstr "A continuación puede ver los hallazgos que se encontraron para"
 
 #: rocky/templates/oois/ooi_summary.html
 msgid "and direct  children of this"
-msgstr ""
+msgstr "y los hijos directos de este"
 
 #: rocky/templates/oois/ooi_summary.html
 msgid "This"
-msgstr ""
+msgstr "Este"
 
 #: rocky/templates/oois/ooi_summary.html
 msgid "tree view"
-msgstr ""
+msgstr "vista de arbol"
 
 #: rocky/templates/oois/ooi_summary.html
 msgid "of the"
-msgstr ""
+msgstr "del"
 
 #: rocky/templates/oois/ooi_summary.html
 msgid "shows the same objects."
-msgstr ""
+msgstr "muestra los mismos objetos."
 
 #: rocky/templates/organizations/organization_add.html
 msgid ""
-"Please enter the following organization details. These details can be edited "
-"within the organization page within OpenKAT when necessary."
+"Please enter the following organization details. These details can be edited"
+" within the organization page within OpenKAT when necessary."
 msgstr ""
+"Por favor ingrese los siguientes detalles de la organización. Estos detalles"
+" se pueden editar dentro de la página de la organización dentro de OpenKAT "
+"cuando sea necesario."
 
 #: rocky/templates/organizations/organization_edit.html
 msgid "Edit organization"
-msgstr ""
+msgstr "Editar organización"
 
 #: rocky/templates/organizations/organization_edit.html
 msgid "Save organization"
-msgstr ""
+msgstr "Guardar organización"
 
 #: rocky/templates/organizations/organization_list.html
 msgid "An overview of all organizations you are a member of."
 msgstr ""
+"Una descripción general de todas las organizaciones de las que es miembro."
 
 #: rocky/templates/organizations/organization_list.html
 msgid "Add new organization"
-msgstr ""
+msgstr "Agregar nueva organización"
 
 #: rocky/templates/organizations/organization_list.html
 #, python-format
@@ -6166,72 +6899,81 @@ msgid ""
 "                            Showing %(total)s organizations\n"
 "                        "
 msgstr ""
+"\n"
+"Mostrando organizaciones %(total)s"
 
 #: rocky/templates/organizations/organization_list.html
 msgid "Organization overview:"
-msgstr ""
+msgstr "Descripción general de la organización:"
 
 #: rocky/templates/organizations/organization_list.html
 #: rocky/templates/organizations/organization_settings.html
 msgid "Tags"
-msgstr ""
+msgstr "Etiquetas"
 
 #: rocky/templates/organizations/organization_list.html
 msgid "There were no organizations found for your user account"
-msgstr ""
+msgstr "No se encontraron organizaciones para su cuenta de usuario"
 
 #: rocky/templates/organizations/organization_list.html
 msgid "Actions to perform for all of your organizations."
-msgstr ""
+msgstr "Acciones a realizar para todas sus organizaciones."
 
 #: rocky/templates/organizations/organization_list.html
 #: rocky/templates/organizations/organization_settings.html
 msgid "Rerun all bits"
-msgstr ""
+msgstr "Vuelva a ejecutar todos los bits"
 
 #: rocky/templates/organizations/organization_member_add.html
 msgid "Change account type"
-msgstr ""
+msgstr "Cambiar tipo de cuenta"
 
 #: rocky/templates/organizations/organization_member_add_header.html
 #: rocky/views/organization_member_add.py
 msgid "Add member"
-msgstr ""
+msgstr "Agregar miembro"
 
 #: rocky/templates/organizations/organization_member_add_header.html
 #, python-format
 msgid ""
-"Creating a new member of organization <strong>%(organization)s</strong>. For "
-"detailed information about the different account types, check the <a "
+"Creating a new member of organization <strong>%(organization)s</strong>. For"
+" detailed information about the different account types, check the <a "
 "href=\"https://docs.openkat.nl/basics/users-and-organisations.html#users\" "
 "target=\"_blank\" rel=\"noopener\">documentation</a>."
 msgstr ""
+"Creando un nuevo miembro de la organización "
+"<strong>%(organization)s</strong>. Para obtener información detallada sobre "
+"los diferentes tipos de cuentas, consulte la documentación <a "
+"href=\"https://docs.openkat.nl/basics/users-and-organisations.html#users\" "
+"target=\"_blank\" rel=\"noopener\"></a>."
 
 #: rocky/templates/organizations/organization_member_edit.html
 #: rocky/views/organization_member_edit.py
 msgid "Edit member"
-msgstr ""
+msgstr "Editar miembro"
 
 #: rocky/templates/organizations/organization_member_edit.html
 msgid "Save member"
-msgstr ""
+msgstr "Guardar miembro"
 
 #: rocky/templates/organizations/organization_member_list.html
 #, python-format
 msgid "An overview of members of <strong>%(organization_name)s</strong>."
 msgstr ""
+"Una descripción general de los miembros de "
+"<strong>%(organization_name)s</strong>."
 
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Add member(s)"
-msgstr ""
+msgstr "Agregar miembro(s)"
 
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Manually"
-msgstr ""
+msgstr "A mano"
 
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Upload a CSV"
-msgstr ""
+msgstr "Sube un CSV"
 
 #: rocky/templates/organizations/organization_member_list.html
 #, python-format
@@ -6240,27 +6982,29 @@ msgid ""
 "                        Showing %(total)s members\n"
 "                    "
 msgstr ""
+"\n"
+"Mostrando miembros de %(total)s"
 
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Member overview:"
-msgstr ""
+msgstr "Resumen de miembros:"
 
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Role"
-msgstr ""
+msgstr "Role"
 
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Assigned clearance level"
-msgstr ""
+msgstr "Nivel de autorización asignado"
 
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Super user"
-msgstr ""
+msgstr "superusuario"
 
 #: rocky/templates/organizations/organization_member_upload.html
 #: rocky/views/organization_member_add.py
 msgid "Add members"
-msgstr ""
+msgstr "Agregar miembros"
 
 #: rocky/templates/organizations/organization_member_upload.html
 #, python-format
@@ -6268,14 +7012,19 @@ msgid ""
 "To upload multiple members at once, you can upload a CSV file or you can <a "
 "href=\"%(download_url)s\">download the template</a>."
 msgstr ""
+"Para cargar varios miembros a la vez, puede cargar un archivo CSV o puede "
+"descargar <a href=\"%(download_url)s\"> la plantilla </a>."
 
 #: rocky/templates/organizations/organization_member_upload.html
-msgid "To create a custom CSV file, make sure it meets the following criteria:"
+msgid ""
+"To create a custom CSV file, make sure it meets the following criteria:"
 msgstr ""
+"Para crear un archivo CSV personalizado, asegúrese de que cumpla con los "
+"siguientes criterios:"
 
 #: rocky/templates/organizations/organization_member_upload.html
 msgid "Upload"
-msgstr ""
+msgstr "Subir"
 
 #: rocky/templates/organizations/organization_settings.html
 #, python-format
@@ -6283,177 +7032,201 @@ msgid ""
 "An overview of general information and settings for "
 "<strong>%(organization_name)s</strong>."
 msgstr ""
+"Una descripción general de la información general y la configuración de "
+"<strong>%(organization_name)s</strong>."
 
 #: rocky/templates/organizations/organization_settings.html
 msgid ""
 "<strong>Warning:</strong> Indemnification is not set for this organization."
 msgstr ""
+"<strong>Advertencia:</strong> La indemnización no está establecida para esta"
+" organización."
 
 #: rocky/templates/organizations/organization_settings.html
 #: rocky/views/indemnification_add.py
 msgid "Add indemnification"
-msgstr ""
+msgstr "Añadir indemnización"
 
 #: rocky/templates/partials/current_config.html
 msgid "Current configuration"
-msgstr ""
+msgstr "Configuración actual"
 
 #: rocky/templates/partials/delete_ooi_modal.html
 msgid "Delete objects"
-msgstr ""
+msgstr "Eliminar objetos"
 
 #: rocky/templates/partials/delete_ooi_modal.html
 msgid ""
-"Are you sure you want to delete all the selected objects? The history of the "
-"deleted objects will still be available."
+"Are you sure you want to delete all the selected objects? The history of the"
+" deleted objects will still be available."
 msgstr ""
+"¿Está seguro de que desea eliminar todos los objetos seleccionados? El "
+"historial de los objetos eliminados seguirá estando disponible."
 
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 msgid "Edit clearance level settings"
-msgstr ""
+msgstr "Editar la configuración del nivel de autorización"
 
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 msgid "You are editing clearance level of all the selected objects."
 msgstr ""
+"Estás editando el nivel de autorización de todos los objetos seleccionados."
 
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 msgid "Switching between declare and inherit"
-msgstr ""
+msgstr "Cambiar entre declarar y heredar"
 
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 msgid ""
 "Clearance levels can be automatically inherited or you can manually declare "
-"the clearance level for an object. Switching to inherit clearance level will "
-"also recalculate the clearance levels of objects that inherit from these "
+"the clearance level for an object. Switching to inherit clearance level will"
+" also recalculate the clearance levels of objects that inherit from these "
 "clearance levels."
 msgstr ""
+"Los niveles de autorización se pueden heredar automáticamente o puede "
+"declarar manualmente el nivel de autorización para un objeto. Al cambiar a "
+"heredar el nivel de autorización también se recalcularán los niveles de "
+"autorización de los objetos que heredan de estos niveles de autorización."
 
 #: rocky/templates/partials/elements/ooi_detail_settings.html
 msgid "Observed at"
-msgstr ""
+msgstr "Observado en"
 
 #: rocky/templates/partials/elements/ooi_detail_settings.html
 #: rocky/templates/partials/elements/ooi_report_settings.html
 msgid "Show settings"
-msgstr ""
+msgstr "Mostrar configuración"
 
 #: rocky/templates/partials/elements/ooi_detail_settings.html
 #: rocky/templates/partials/elements/ooi_report_settings.html
 msgid "Hide settings"
-msgstr ""
+msgstr "Ocultar configuración"
 
 #: rocky/templates/partials/elements/ooi_list_settings_form.html
 msgid "Toggle all OOI types"
-msgstr ""
+msgstr "Alternar todos los tipos de OOI"
 
 #: rocky/templates/partials/elements/ooi_tree_condensed_table.html
 msgid "Children"
-msgstr ""
+msgstr "Niños"
 
 #: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
 #, python-format
 msgid "Show details for %(object_id)s, with %(child_count)s children."
-msgstr ""
+msgstr "Mostrar detalles de %(object_id)s, con hijos %(child_count)s."
 
 #: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
 #, python-format
 msgid ""
 "Show tree for %(object_id)s with only children of type %(object_ooi_type)s"
 msgstr ""
+"Mostrar árbol para %(object_id)s con solo hijos de tipo %(object_ooi_type)s"
 
 #: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
 #, python-format
 msgid "Unfold %(object_id)s with %(child_count)s children"
-msgstr ""
+msgstr "Despliegue %(object_id)s con niños %(child_count)s"
 
 #: rocky/templates/partials/elements/ooi_tree_table.html
 msgid "go to:"
-msgstr ""
+msgstr "ir a:"
 
 #: rocky/templates/partials/elements/ooi_tree_table.html
 msgid "Go to detailpage"
-msgstr ""
+msgstr "Ir a la página de detalles"
 
 #: rocky/templates/partials/elements/ooi_tree_table.html
 msgid "detail"
-msgstr ""
+msgstr "detalle"
 
 #: rocky/templates/partials/elements/ooi_tree_table.html
 msgid "Go to tree view"
-msgstr ""
+msgstr "Ir a la vista de árbol"
 
 #: rocky/templates/partials/elements/ooi_tree_table.html
 msgid "tree"
-msgstr ""
+msgstr "árbol"
 
 #: rocky/templates/partials/elements/ooi_tree_table.html
 msgid "Go to graph view"
-msgstr ""
+msgstr "Ir a la vista de gráfico"
 
 #: rocky/templates/partials/elements/ooi_tree_table.html
 msgid "graph"
-msgstr ""
+msgstr "gráfico"
 
 #: rocky/templates/partials/explanations.html
 msgid "Clearance level inheritance"
-msgstr ""
+msgstr "Herencia del nivel de autorización"
 
 #: rocky/templates/partials/explanations.html
 msgid "OOI"
-msgstr ""
+msgstr "OOI"
+
+#: rocky/templates/partials/explanations.html
+msgid "This OOI"
+msgstr "Este OOI"
 
 #: rocky/templates/partials/explanations.html
 msgid "Origin"
-msgstr ""
+msgstr "Origen"
+
+#: rocky/templates/partials/explanations.html
+msgid "declared"
+msgstr "declarado"
+
+#: rocky/templates/partials/explanations.html
+msgid "inherited from ↓"
+msgstr "heredado de ↓"
 
 #: rocky/templates/partials/explanations.html
 msgid "Show clearance level inheritance"
-msgstr ""
+msgstr "Mostrar herencia de nivel de autorización"
 
 #: rocky/templates/partials/finding_occurrence_definition_list.html
 msgid "Reproduction"
-msgstr ""
+msgstr "Reproducción"
 
 #: rocky/templates/partials/form/checkbox_group_table_form.html
 msgid "Please enable plugin to start scanning."
-msgstr ""
+msgstr "Habilite el complemento para comenzar a escanear."
 
 #: rocky/templates/partials/form/field_input.html
 msgid "Not set"
-msgstr ""
+msgstr "No establecido"
 
 #: rocky/templates/partials/form/field_input.html
 msgid "Forgot email"
-msgstr ""
+msgstr "Olvidé el correo electrónico"
 
 #: rocky/templates/partials/form/field_input.html
 msgid "Forgot password"
-msgstr ""
+msgstr "Has olvidado tu contraseña"
 
 #: rocky/templates/partials/form/field_input_errors.html
 #: rocky/templates/partials/notifications_block.html
 msgid "error"
-msgstr ""
+msgstr "error"
 
 #: rocky/templates/partials/form/field_input_errors.html
 #: rocky/templates/partials/form/form_errors.html
 #: rocky/templates/partials/notifications_block.html
 msgid "Error:"
-msgstr ""
+msgstr "Error:"
 
 #: rocky/templates/partials/form/field_input_help_text.html
 msgid "Open explanation"
-msgstr ""
+msgstr "Explicación abierta"
 
 #: rocky/templates/partials/form/field_input_help_text.html
 msgid "Close explanation"
-msgstr ""
+msgstr "Cerrar explicación"
 
 #: rocky/templates/partials/form/field_input_help_text.html
 #: rocky/templates/partials/notifications_block.html
 #: rocky/templates/two_factor/core/login.html
 msgid "Explanation:"
-msgstr ""
+msgstr "Explicación:"
 
 #: rocky/templates/partials/form/indemnification_add_form.html
 msgid ""
@@ -6462,218 +7235,231 @@ msgid ""
 "negative impact on (your) assets. Therefore it is important to know and be "
 "aware of the impact of security scans."
 msgstr ""
+"Por lo general, solo se permite realizar análisis de seguridad de activos si"
+" tiene permiso para escanear esos activos. Ciertos análisis también pueden "
+"tener un impacto negativo en (sus) activos. Por lo tanto, es importante "
+"conocer y ser consciente del impacto de los análisis de seguridad."
 
 #: rocky/templates/partials/form/indemnification_add_form.html
 msgid ""
-"An organization indemnification is required before you can use OpenKAT. With "
-"the indemnification you declare that you, as a person, can be held "
+"An organization indemnification is required before you can use OpenKAT. With"
+" the indemnification you declare that you, as a person, can be held "
 "accountable."
 msgstr ""
+"Se requiere una indemnización de la organización antes de poder utilizar "
+"OpenKAT. Con la indemnización usted declara que usted, como persona, puede "
+"ser considerado responsable."
 
 #: rocky/templates/partials/form/indemnification_add_form.html
 msgid "Set an indemnification"
-msgstr ""
+msgstr "Establecer una indemnización"
 
 #: rocky/templates/partials/hyperlink_ooi_type.html
 #, python-format
 msgid "Only show objects of type %(type)s"
-msgstr ""
+msgstr "Mostrar solo objetos de tipo %(type)s"
 
 #: rocky/templates/partials/list_filters.html
 msgid "Hide filter options"
-msgstr ""
+msgstr "Ocultar opciones de filtro"
 
 #: rocky/templates/partials/list_filters.html
 msgid "Show filter options"
-msgstr ""
+msgstr "Mostrar opciones de filtro"
 
 #: rocky/templates/partials/list_paginator.html
 msgid "List pagination"
-msgstr ""
+msgstr "Paginación de lista"
 
 #: rocky/templates/partials/list_paginator.html
 msgid "Previous Page"
-msgstr ""
+msgstr "Página anterior"
 
 #: rocky/templates/partials/list_paginator.html
 msgid "Previous"
-msgstr ""
+msgstr "Anterior"
 
 #: rocky/templates/partials/list_paginator.html
 msgid "Five Pages Back"
-msgstr ""
+msgstr "Cinco páginas atrás"
 
 #: rocky/templates/partials/list_paginator.html
 #: rocky/templates/partials/pagination.html
 msgid "Page"
-msgstr ""
+msgstr "Página"
+
+#: rocky/templates/partials/list_paginator.html
+msgid "Current"
+msgstr "Actual"
 
 #: rocky/templates/partials/list_paginator.html
 msgid "Five Pages Forward"
-msgstr ""
+msgstr "Cinco páginas adelante"
 
 #: rocky/templates/partials/list_paginator.html
 msgid "Next Page"
-msgstr ""
+msgstr "Página siguiente"
 
 #: rocky/templates/partials/list_paginator.html
 msgid "Next"
-msgstr ""
+msgstr "Próximo"
 
 #: rocky/templates/partials/mute_findings_modal.html
 msgid "You are muting the selected findings."
-msgstr ""
+msgstr "Está silenciando los resultados seleccionados."
 
 #: rocky/templates/partials/mute_findings_modal.html
 msgid "Reason:"
-msgstr ""
+msgstr "Razón:"
 
 #: rocky/templates/partials/mute_findings_modal.html
 msgid "Expires by (UTC):"
-msgstr ""
+msgstr "Vence en (UTC):"
 
 #: rocky/templates/partials/notifications_block.html
 msgid "Confirmation:"
-msgstr ""
+msgstr "Confirmación:"
 
 #: rocky/templates/partials/ooi_detail_related_object.html
 msgid "No related object known for"
-msgstr ""
+msgstr "No se conoce ningún objeto relacionado"
 
 #: rocky/templates/partials/ooi_detail_toolbar.html
 msgid "Generate Report"
-msgstr ""
+msgstr "Generar informe"
 
 #: rocky/templates/partials/ooi_detail_toolbar.html
 #, python-format
 msgid "Edit %(display_type)s"
-msgstr ""
+msgstr "Editar %(display_type)s"
 
 #: rocky/templates/partials/ooi_head.html
-#, python-format
-msgid ""
-"An overview of \"%(ooi)s\", object type \"%(type)s\". This shows general "
-"information and its related objects. It also gives the possibility to add "
-"additional related objects, or to scan for them."
-msgstr ""
+msgid "Data from:"
+msgstr "Datos de:"
+
+#: rocky/templates/partials/ooi_head.html
+msgid "(Now)"
+msgstr "(Ahora)"
 
 #: rocky/templates/partials/ooi_list_toolbar.html
 msgid "Scan for objects"
-msgstr ""
+msgstr "Escanear en busca de objetos"
 
 #: rocky/templates/partials/ooi_list_toolbar.html
 #: rocky/templates/upload_csv.html rocky/views/upload_csv.py
 msgid "Upload CSV"
-msgstr ""
+msgstr "Subir CSV"
 
 #: rocky/templates/partials/ooi_list_toolbar.html
 msgid "Export"
-msgstr ""
+msgstr "Exportar"
 
 #: rocky/templates/partials/ooi_list_toolbar.html
 msgid "Download as CSV"
-msgstr ""
+msgstr "Descargar como CSV"
 
 #: rocky/templates/partials/ooi_report_findings_block.html
 #, python-format
 msgid "%(total)s findings on %(name)s"
-msgstr ""
+msgstr "Hallazgos de %(total)s en %(name)s"
 
 #: rocky/templates/partials/ooi_report_findings_block_table.html
 #, python-format
 msgid "Findings for %(type)s %(name)s on %(observed_at)s:"
-msgstr ""
+msgstr "Hallazgos para %(type)s %(name)s en %(observed_at)s:"
 
 #: rocky/templates/partials/ooi_report_findings_block_table.html
 msgid "Open finding details"
-msgstr ""
+msgstr "Abrir detalles del hallazgo"
 
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 #, python-format
 msgid "Details of %(object_id)s"
-msgstr ""
+msgstr "Detalles de %(object_id)s"
 
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid ""
 "The severity of this findingtype has not (yet) been determined by the data "
 "source. This situation requires manual investigation of the severity."
 msgstr ""
+"La fuente de datos no ha determinado (aún) la gravedad de este tipo de "
+"hallazgo. Esta situación requiere una investigación manual de la gravedad."
 
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "Total occurrences"
-msgstr ""
+msgstr "Total de ocurrencias"
 
 #: rocky/templates/partials/ooi_tree_toolbar_bottom.html
 msgid "Tree - dense view"
-msgstr ""
+msgstr "Árbol - vista densa"
 
 #: rocky/templates/partials/ooi_tree_toolbar_bottom.html
 msgid "Tree - table view"
-msgstr ""
+msgstr "Árbol - vista de tabla"
 
 #: rocky/templates/partials/organization_member_list_filters.html
 msgid "Update List"
-msgstr ""
+msgstr "Lista de actualización"
 
 #: rocky/templates/partials/organization_properties_table.html
 msgid "Organization name"
-msgstr ""
+msgstr "Nombre de la organización"
 
 #: rocky/templates/partials/organization_properties_table.html
 msgid "Organization code"
-msgstr ""
+msgstr "Código de organización"
 
 #: rocky/templates/partials/organizations_menu_dropdown.html
 msgid "Select organization"
-msgstr ""
+msgstr "Seleccionar organización"
 
 #: rocky/templates/partials/organizations_menu_dropdown.html
 msgid "All organizations"
-msgstr ""
+msgstr "Todas las organizaciones"
 
 #: rocky/templates/partials/page-meta.html
 msgid "Logged in as:"
-msgstr ""
+msgstr "Iniciado sesión como:"
 
 #: rocky/templates/partials/pagination.html
 msgid "of"
-msgstr ""
+msgstr "de"
 
 #: rocky/templates/partials/pagination.html
 msgid "first"
-msgstr ""
+msgstr "primero"
 
 #: rocky/templates/partials/pagination.html
 msgid "previous"
-msgstr ""
+msgstr "anterior"
 
 #: rocky/templates/partials/pagination.html
 msgid "next"
-msgstr ""
+msgstr "próximo"
 
 #: rocky/templates/partials/pagination.html
 msgid "last"
-msgstr ""
+msgstr "último"
 
 #: rocky/templates/partials/secondary-menu.html
 msgid "User navigation"
-msgstr ""
+msgstr "Navegación del usuario"
 
 #: rocky/templates/partials/secondary-menu.html
 msgid "Close user navigation"
-msgstr ""
+msgstr "Cerrar la navegación del usuario"
 
 #: rocky/templates/partials/secondary-menu.html
 msgid "My organizations"
-msgstr ""
+msgstr "Mis organizaciones"
 
 #: rocky/templates/partials/secondary-menu.html
 msgid "Profile"
-msgstr ""
+msgstr "Perfil"
 
 #: rocky/templates/partials/skip-to-content.html
 msgid "Go to content"
-msgstr ""
+msgstr "Ir al contenido"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid ""
@@ -6682,50 +7468,59 @@ msgid ""
 "This means that the clearance level might stay the same, increase or "
 "decrease, depending on other declared clearance levels."
 msgstr ""
+"El nivel de autorización determina el nivel de escaneos de Boefje permitidos"
+" en este objeto. Un objeto hereda su nivel de autorización de los objetos "
+"vecinos. Esto significa que el nivel de autorización puede permanecer igual,"
+" aumentar o disminuir, dependiendo de otros niveles de autorización "
+"declarados."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Empty clearance level explanation"
-msgstr ""
+msgstr "Explicación del nivel de autorización vacío"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Empty:"
-msgstr ""
+msgstr "Vacío:"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid ""
 "This object has a clearance level of \"empty\". This means that this object "
 "has no clearance level."
 msgstr ""
+"Este objeto tiene un nivel de autorización \"vacío\". Esto significa que "
+"este objeto no tiene nivel de autorización."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Indemnification warning"
-msgstr ""
+msgstr "Advertencia de indemnización"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Indemnification is not set for this organization."
-msgstr ""
+msgstr "La indemnización no está prevista para esta organización."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Go to the"
-msgstr ""
+msgstr "Ir al"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "organization settings page"
-msgstr ""
+msgstr "página de configuración de la organización"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "to add one."
-msgstr ""
+msgstr "para agregar uno."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Set clearance level warning"
-msgstr ""
+msgstr "Establecer advertencia de nivel de autorización"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid ""
 "You don't have permissions to set the clearance level. Contact your "
 "administrator."
 msgstr ""
+"No tienes permisos para establecer el nivel de autorización. Póngase en "
+"contacto con su administrador."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 #, python-format
@@ -6734,115 +7529,128 @@ msgid ""
 "clearance level is %(member_clearance_level)s and this OOI has level "
 "%(boefje_scan_level)s."
 msgstr ""
+"No se le permite establecer el nivel de autorización de este OOI. Su nivel "
+"máximo de autorización es %(member_clearance_level)s y este OOI tiene el "
+"nivel %(boefje_scan_level)s."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Go to your"
-msgstr ""
+msgstr "Ve a tu"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "account details"
-msgstr ""
+msgstr "detalles de la cuenta"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "to manage your clearance level."
-msgstr ""
+msgstr "para gestionar su nivel de autorización."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Current clearance level"
-msgstr ""
+msgstr "Nivel de autorización actual"
 
 #: rocky/templates/tasks/boefje_task_detail.html
 msgid ""
 "An overview of the boefje task, the input OOI and the RAW data it generated."
 msgstr ""
+"Una descripción general de la tarea de boefje, la entrada OOI y los datos "
+"RAW que generó."
 
 #: rocky/templates/tasks/boefje_task_detail.html
 #: rocky/templates/tasks/partials/task_actions.html
 msgid "Download meta and raw data"
-msgstr ""
+msgstr "Descargar metadatos y datos sin procesar"
 
 #: rocky/templates/tasks/boefje_task_detail.html
 msgid "Download meta data"
-msgstr ""
+msgstr "Descargar metadatos"
 
 #: rocky/templates/tasks/boefje_task_detail.html
 msgid "Input object"
-msgstr ""
+msgstr "Objeto de entrada"
 
 #: rocky/templates/tasks/boefjes.html
 msgid "There are no tasks for boefjes."
-msgstr ""
+msgstr "No hay tareas para boefjes."
 
 #: rocky/templates/tasks/boefjes.html
 msgid "List of tasks for boefjes."
-msgstr ""
+msgstr "Lista de tareas para boefjes."
 
 #: rocky/templates/tasks/boefjes.html rocky/templates/tasks/reports.html
 msgid "Organization Code"
-msgstr ""
+msgstr "Código de organización"
 
 #: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
 #: rocky/templates/tasks/ooi_detail_task_list.html
 #: rocky/templates/tasks/plugin_detail_task_list.html
 msgid "Created date"
-msgstr ""
+msgstr "Fecha de creación"
 
 #: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
 #: rocky/templates/tasks/reports.html
 msgid "Modified date"
-msgstr ""
+msgstr "Fecha de modificación"
 
 #: rocky/templates/tasks/normalizers.html
 msgid "There are no tasks for normalizers."
-msgstr ""
+msgstr "No hay tareas para normalizadores."
 
 #: rocky/templates/tasks/normalizers.html
 msgid "List of tasks for normalizers."
-msgstr ""
+msgstr "Lista de tareas para normalizadores."
 
 #: rocky/templates/tasks/normalizers.html
 msgid "Boefje input OOI"
-msgstr ""
+msgstr "Entrada Boefje OOI"
 
 #: rocky/templates/tasks/normalizers.html
 msgid "Manually added"
-msgstr ""
+msgstr "Agregado manualmente"
 
 #: rocky/templates/tasks/ooi_detail_task_list.html
 msgid "There have been no tasks."
-msgstr ""
+msgstr "No ha habido tareas."
 
 #: rocky/templates/tasks/partials/stats.html
 msgid "Task statistics - Last 24 hours"
-msgstr ""
+msgstr "Estadísticas de tareas: últimas 24 horas"
 
 #: rocky/templates/tasks/partials/stats.html
 msgid "All times in UTC, blocks of 1 hour."
-msgstr ""
+msgstr "Todos los horarios en UTC, bloques de 1 hora."
 
 #: rocky/templates/tasks/partials/stats.html
 msgid "Timeslot"
-msgstr ""
+msgstr "Intervalo de tiempo"
 
 #: rocky/templates/tasks/partials/stats.html
 msgid "Could not load stats, Scheduler error."
-msgstr ""
+msgstr "No se pudieron cargar las estadísticas, error del programador."
 
 #: rocky/templates/tasks/partials/tab_navigation.html
 msgid "List of tasks"
-msgstr ""
+msgstr "Lista de tareas"
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Loading..."
+msgstr "Cargando..."
 
 #: rocky/templates/tasks/partials/task_actions.html
 msgid "Yielded objects"
-msgstr ""
+msgstr "Objetos cedidos"
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Yielded raw files"
+msgstr "Archivos sin procesar obtenidos"
 
 #: rocky/templates/tasks/partials/task_actions.html
 msgid "Reschedule"
-msgstr ""
+msgstr "Reprogramar"
 
 #: rocky/templates/tasks/partials/task_actions.html
 msgid "Download task data"
-msgstr ""
+msgstr "Descargar datos de la tarea"
 
 #: rocky/templates/tasks/partials/tasks_overview_header.html
 #, python-format
@@ -6853,39 +7661,44 @@ msgid ""
 "Report tasks. This task aggregates and presents findings from both Boefjes "
 "and Normalizers."
 msgstr ""
+"Una descripción general de las tareas para "
+"<strong>%(organization)s</strong>. Las tareas se dividen en Boefjes, "
+"Normalizers e Informes. Objetos de escaneo Boefjes y despacho Normalizers en"
+" el tipo MIME de salida. Además, hay tareas de informe. Esta tarea agrega y "
+"presenta los resultados de Boefjes y Normalizers."
 
 #: rocky/templates/tasks/plugin_detail_task_list.html
 msgid "There are no tasks for"
-msgstr ""
+msgstr "No hay tareas para"
 
 #: rocky/templates/tasks/plugin_detail_task_list.html
 msgid "List of tasks for"
-msgstr ""
+msgstr "Lista de tareas para"
 
 #: rocky/templates/tasks/reports.html
 msgid "There are no tasks for reports."
-msgstr ""
+msgstr "No hay tareas para informes."
 
 #: rocky/templates/tasks/reports.html
 msgid "List of tasks for reports."
-msgstr ""
+msgstr "Lista de tareas para informes."
 
 #: rocky/templates/tasks/reports.html
 msgid "Recipe ID"
-msgstr ""
+msgstr "ID de receta"
 
 #: rocky/templates/two_factor/_wizard_actions.html
 msgid "Log in"
-msgstr ""
+msgstr "Acceso"
 
 #: rocky/templates/two_factor/_wizard_actions.html
 msgid "Authenticate"
-msgstr ""
+msgstr "Autenticar"
 
 #: rocky/templates/two_factor/core/backup_tokens.html
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Backup Tokens"
-msgstr ""
+msgstr "Fichas de respaldo"
 
 #: rocky/templates/two_factor/core/backup_tokens.html
 msgid ""
@@ -6894,45 +7707,53 @@ msgid ""
 "you've used up all your backup tokens, you can generate a new set of backup "
 "tokens. Only the backup tokens shown below will be valid."
 msgstr ""
+"Los tokens de respaldo se pueden usar cuando sus números de teléfono "
+"principal y de respaldo no están disponibles. Los tokens de respaldo a "
+"continuación se pueden usar para la verificación de inicio de sesión. Si ha "
+"agotado todos sus tokens de respaldo, puede generar un nuevo conjunto de "
+"tokens de respaldo. Solo serán válidos los tokens de respaldo que se "
+"muestran a continuación."
 
 #: rocky/templates/two_factor/core/backup_tokens.html
 msgid "Print these tokens and keep them somewhere safe."
-msgstr ""
+msgstr "Imprime estas fichas y guárdalas en un lugar seguro."
 
 #: rocky/templates/two_factor/core/backup_tokens.html
 msgid "You don't have any backup codes yet."
-msgstr ""
+msgstr "Aún no tienes ningún código de respaldo."
 
 #: rocky/templates/two_factor/core/backup_tokens.html
 msgid "Generate Tokens"
-msgstr ""
+msgstr "Generar fichas"
 
 #: rocky/templates/two_factor/core/backup_tokens.html
 #: rocky/templates/two_factor/core/setup_complete.html
 msgid "Back to Account Security"
-msgstr ""
+msgstr "Volver a Seguridad de la cuenta"
 
 #: rocky/templates/two_factor/core/login.html
 msgid "You are logged in."
-msgstr ""
+msgstr "Has iniciado sesión."
 
 #: rocky/templates/two_factor/core/login.html
 msgid "Two factor authentication is enabled for your account."
-msgstr ""
+msgstr "La autenticación de dos factores está habilitada para su cuenta."
 
 #: rocky/templates/two_factor/core/login.html
 msgid ""
 "Two factor authentication is not enabled for your account. Enable it to "
 "continue."
 msgstr ""
+"La autenticación de dos factores no está habilitada para su cuenta. "
+"Habilítelo para continuar."
 
 #: rocky/templates/two_factor/core/login.html
 msgid "Setup two factor authentication"
-msgstr ""
+msgstr "Configurar la autenticación de dos factores"
 
 #: rocky/templates/two_factor/core/login.html
 msgid "Credentials"
-msgstr ""
+msgstr "Cartas credenciales"
 
 #: rocky/templates/two_factor/core/login.html
 msgid ""
@@ -6940,18 +7761,22 @@ msgid ""
 "been generated for you to print and keep safe. Please enter one of these "
 "backup tokens to login to your account."
 msgstr ""
+"Utilice este formulario para ingresar tokens de respaldo para iniciar "
+"sesión. Estos tokens se han generado para que usted los imprima y los "
+"mantenga seguros. Ingrese uno de estos tokens de respaldo para iniciar "
+"sesión en su cuenta."
 
 #: rocky/templates/two_factor/core/login.html
 msgid "As a last resort, you can use a backup token:"
-msgstr ""
+msgstr "Como último recurso, puedes utilizar un token de respaldo:"
 
 #: rocky/templates/two_factor/core/login.html
 msgid "Use Backup Token"
-msgstr ""
+msgstr "Usar token de respaldo"
 
 #: rocky/templates/two_factor/core/otp_required.html
 msgid "Permission Denied"
-msgstr ""
+msgstr "Permiso denegado"
 
 #: rocky/templates/two_factor/core/otp_required.html
 msgid ""
@@ -6959,242 +7784,297 @@ msgid ""
 "authentication for security reasons. You need to enable these security "
 "features in order to access this page."
 msgstr ""
+"La página que solicitó obliga a los usuarios a verificar mediante "
+"autenticación de dos factores por razones de seguridad. Debe habilitar estas"
+" funciones de seguridad para poder acceder a esta página."
 
 #: rocky/templates/two_factor/core/otp_required.html
 #: rocky/templates/two_factor/profile/profile.html
 msgid ""
-"Two-factor authentication is not enabled for your account. Enable two-factor "
-"authentication for enhanced account security."
+"Two-factor authentication is not enabled for your account. Enable two-factor"
+" authentication for enhanced account security."
 msgstr ""
+"La autenticación de dos factores no está habilitada para su cuenta. Habilite"
+" la autenticación de dos factores para mejorar la seguridad de la cuenta."
 
 #: rocky/templates/two_factor/core/otp_required.html
 #: rocky/templates/two_factor/core/setup.html
 #: rocky/templates/two_factor/core/setup_complete.html
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Enable Two-Factor Authentication"
-msgstr ""
+msgstr "Habilite la autenticación de dos factores"
 
 #: rocky/templates/two_factor/core/phone_register.html
 msgid "Add Backup Phone"
-msgstr ""
+msgstr "Agregar teléfono de respaldo"
 
 #: rocky/templates/two_factor/core/phone_register.html
 msgid ""
 "You'll be adding a backup phone number to your account. This number will be "
 "used if your primary method of registration is not available."
 msgstr ""
+"Agregarás un número de teléfono de respaldo a tu cuenta. Este número se "
+"utilizará si su método principal de registro no está disponible."
 
 #: rocky/templates/two_factor/core/phone_register.html
 msgid ""
 "We've sent a token to your phone number. Please enter the token you've "
 "received."
 msgstr ""
+"Le hemos enviado un token a su número de teléfono. Por favor ingresa el "
+"token que has recibido."
 
 #: rocky/templates/two_factor/core/setup.html
 msgid ""
 "To start using a token generator, please use your smartphone to scan the QR "
-"code below or use the setup key. For example, use GoogleAuthenticator. Then, "
-"enter the token generated by the app."
+"code below or use the setup key. For example, use GoogleAuthenticator. Then,"
+" enter the token generated by the app."
 msgstr ""
+"Para comenzar a usar un generador de tokens, use su teléfono inteligente "
+"para escanear el código QR a continuación o use la clave de configuración. "
+"Por ejemplo, utilice GoogleAuthenticator. Luego, ingresa el token generado "
+"por la aplicación."
 
 #: rocky/templates/two_factor/core/setup.html
 msgid "QR code"
-msgstr ""
+msgstr "código qr"
 
 #: rocky/templates/two_factor/core/setup.html
 msgid "Setup key"
-msgstr ""
+msgstr "Clave de configuración"
 
 #: rocky/templates/two_factor/core/setup.html
 msgid ""
-"The secret key is a 32 characters representation of the QR code. There are 2 "
-"options to setup the two factor authtentication. You can scan the QR code "
+"The secret key is a 32 characters representation of the QR code. There are 2"
+" options to setup the two factor authtentication. You can scan the QR code "
 "above or you can insert this key using the secret key option of the "
 "authenticator app."
 msgstr ""
+"La clave secreta es una representación de 32 caracteres del código QR. Hay 2"
+" opciones para configurar la autenticación de dos factores. Puede escanear "
+"el código QR de arriba o insertar esta clave usando la opción de clave "
+"secreta de la aplicación de autenticación."
 
 #: rocky/templates/two_factor/core/setup_complete.html
-msgid "Congratulations, you've successfully enabled two-factor authentication."
+msgid ""
+"Congratulations, you've successfully enabled two-factor authentication."
 msgstr ""
+"Felicitaciones, ha habilitado con éxito la autenticación de dos factores."
 
 #: rocky/templates/two_factor/core/setup_complete.html
 msgid "Start using OpenKAT"
-msgstr ""
+msgstr "Comience a usar OpenKAT"
 
 #: rocky/templates/two_factor/core/setup_complete.html
 msgid ""
 "However, it might happen that you don't have access to your primary token "
 "device. To enable account recovery, add a phone number."
 msgstr ""
+"Sin embargo, puede suceder que no tengas acceso a tu dispositivo token "
+"principal. Para habilitar la recuperación de cuenta, agregue un número de "
+"teléfono."
 
 #: rocky/templates/two_factor/core/setup_complete.html
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Add Phone Number"
-msgstr ""
+msgstr "Agregar número de teléfono"
 
 #: rocky/templates/two_factor/profile/disable.html
 msgid "Disable Two-factor Authentication"
-msgstr ""
+msgstr "Deshabilitar la autenticación de dos factores"
 
 #: rocky/templates/two_factor/profile/disable.html
 msgid ""
 "You are about to disable two-factor authentication. This weakens your "
 "account security, are you sure?"
 msgstr ""
+"Estás a punto de desactivar la autenticación de dos factores. Esto debilita "
+"la seguridad de tu cuenta, ¿estás seguro?"
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Account Security"
-msgstr ""
+msgstr "Seguridad de la cuenta"
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Tokens will be generated by your token generator."
-msgstr ""
+msgstr "Los tokens serán generados por su generador de tokens."
 
 #: rocky/templates/two_factor/profile/profile.html
 #, python-format
 msgid "Primary method: %(primary)s"
-msgstr ""
+msgstr "Método primario: %(primary)s"
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Tokens will be generated by your YubiKey."
-msgstr ""
+msgstr "Los tokens serán generados por tu YubiKey."
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Backup Phone Numbers"
-msgstr ""
+msgstr "Números de teléfono de respaldo"
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid ""
 "If your primary method is not available, we are able to send backup tokens "
 "to the phone numbers listed below."
 msgstr ""
+"Si su método principal no está disponible, podemos enviar tokens de respaldo"
+" a los números de teléfono que se enumeran a continuación."
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Unregister"
-msgstr ""
+msgstr "Darse de baja"
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid ""
 "If you don't have any device with you, you can access your account using "
 "backup tokens."
 msgstr ""
+"Si no tiene ningún dispositivo consigo, puede acceder a su cuenta utilizando"
+" tokens de respaldo."
 
 #: rocky/templates/two_factor/profile/profile.html
 #, python-format
 msgid "You have only one backup token remaining."
 msgid_plural "You have %(counter)s backup tokens remaining."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Te quedan tokens de respaldo %(counter)s."
+msgstr[1] "Te quedan tokens de respaldo %(counter)s."
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Show Codes"
-msgstr ""
+msgstr "Mostrar códigos"
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Disable Two-Factor Authentication"
-msgstr ""
+msgstr "Deshabilitar la autenticación de dos factores"
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid ""
-"However we strongly discourage you to do so, you can also disable two-factor "
-"authentication for your account."
+"However we strongly discourage you to do so, you can also disable two-factor"
+" authentication for your account."
 msgstr ""
+"Sin embargo, le desaconsejamos encarecidamente que lo haga; también puede "
+"desactivar la autenticación de dos factores para su cuenta."
 
 #: rocky/templates/two_factor/twilio/sms_message.html
 #, python-format
 msgid "Your OTP token is %(token)s"
-msgstr ""
+msgstr "Su token OTP es %(token)s"
 
 #: rocky/templates/upload_csv.html
 msgid "Automate the creation of multiple objects by uploading a CSV file."
-msgstr ""
+msgstr "Automatice la creación de múltiples objetos cargando un archivo CSV."
 
 #: rocky/templates/upload_csv.html
 msgid "These are the criteria for CSV upload:"
-msgstr ""
+msgstr "Estos son los criterios para la carga de CSV:"
 
 #: rocky/templates/upload_raw.html
 msgid "Automate the creation of multiple objects by uploading a raw file."
 msgstr ""
+"Automatice la creación de múltiples objetos cargando un archivo sin formato."
 
 #: rocky/templates/upload_raw.html
 msgid ""
-"An input OOI can be selected for the normalizer to attach newly yielded OOIs "
-"to. If no input OOI was used for the raw file, a placeholder ExternalScan "
+"An input OOI can be selected for the normalizer to attach newly yielded OOIs"
+" to. If no input OOI was used for the raw file, a placeholder ExternalScan "
 "OOI can be used. ExternalScan OOIs can be created from the objects page. "
 "When a new version of the raw file is generated, the same ExternalScan OOI "
 "should be chosen to ensure that old results are overwritten."
 msgstr ""
+"Se puede seleccionar una entrada OOI para que el normalizador conecte el "
+"OOIs recién cedido. Si no se utilizó ninguna entrada OOI para el archivo sin"
+" formato, se puede utilizar un marcador de posición ExternalScan OOI. "
+"ExternalScan OOIs se puede crear desde la página de objetos. Cuando se "
+"genera una nueva versión del archivo sin formato, se debe elegir el mismo "
+"ExternalScan OOI para garantizar que se sobrescriban los resultados "
+"antiguos."
 
 #: rocky/templates/upload_raw.html rocky/views/upload_raw.py
 msgid "Upload raw"
-msgstr ""
+msgstr "Subir sin formato"
 
 #: rocky/views/bytes_raw.py
 msgid "Getting raw data failed."
-msgstr ""
+msgstr "Error al obtener datos sin procesar."
 
 #: rocky/views/bytes_raw.py
 msgid "The task does not have any raw data."
-msgstr ""
+msgstr "La tarea no tiene datos sin procesar."
 
 #: rocky/views/finding_list.py rocky/views/ooi_list.py
 msgid "Unknown action."
-msgstr ""
+msgstr "Acción desconocida."
 
 #: rocky/views/health.py
 msgid "Beautified"
-msgstr ""
+msgstr "Embellecido"
 
 #: rocky/views/indemnification_add.py
 msgid "Indemnification successfully set."
-msgstr ""
+msgstr "Indemnización establecida exitosamente."
 
 #: rocky/views/mixins.py
 msgid "The selected date is in the future."
-msgstr ""
+msgstr "La fecha seleccionada es en el futuro."
 
 #: rocky/views/mixins.py
 msgid "Can not parse date, falling back to show current date."
 msgstr ""
+"No se puede analizar la fecha, retrocediendo para mostrar la fecha actual."
+
+#: rocky/views/mixins.py
+#, python-format
+msgid "Could not load origins for OOI: %s from octopoes"
+msgstr "No se pudieron cargar orígenes para OOI: %s de octopoes"
+
+#: rocky/views/mixins.py
+msgid "Could not load normalizer metas from bytes"
+msgstr "No se pudieron cargar metas del normalizador desde bytes"
+
+#: rocky/views/mixins.py
+#, python-format
+msgid "Could not load boefje %s from katalogus"
+msgstr "No se pudo cargar boefje %s desde el catálogo"
 
 #: rocky/views/mixins.py
 msgid "You do not have the permission to add items to a dashboard."
-msgstr ""
+msgstr "No tiene permiso para agregar elementos a un panel."
 
 #: rocky/views/mixins.py
 msgid "Dashboard item has been added."
-msgstr ""
+msgstr "Se ha agregado un elemento del panel de control."
 
 #: rocky/views/ooi_add.py
 #, python-format
 msgid "Add %(ooi_type)s"
-msgstr ""
+msgstr "Añadir %(ooi_type)s"
 
 #: rocky/views/ooi_detail.py
 msgid ""
 "Cannot set clearance level. It must be provided and must be a valid number."
 msgstr ""
+"No se puede establecer el nivel de autorización. Debe ser proporcionado y "
+"debe ser un número válido."
 
 #: rocky/views/ooi_detail.py
 msgid "Only Question OOIs can be answered."
-msgstr ""
+msgstr "Sólo se puede responder la pregunta OOIs."
 
 #: rocky/views/ooi_detail.py
 msgid "Question has been answered."
-msgstr ""
+msgstr "La pregunta ha sido respondida."
 
 #: rocky/views/ooi_detail_related_object.py
 msgid " (as "
-msgstr ""
+msgstr "(como"
 
 #: rocky/views/ooi_findings.py
 msgid "Object findings"
-msgstr ""
+msgstr "Hallazgos de objetos"
 
 #: rocky/views/ooi_list.py
 msgid "No OOIs selected."
-msgstr ""
+msgstr "No se seleccionó ningún OOIs."
 
 #: rocky/views/ooi_list.py
 #, python-format
@@ -7202,6 +8082,8 @@ msgid ""
 "Could not raise clearance levels to L%s. Indemnification not present at "
 "organization %s."
 msgstr ""
+"No se pudieron aumentar los niveles de autorización a L%s. Indemnización no "
+"presente en la organización %s."
 
 #: rocky/views/ooi_list.py
 #, python-format
@@ -7209,6 +8091,9 @@ msgid ""
 "Could not raise clearance level to L%s. You were trusted a clearance level "
 "of L%s. Contact your administrator to receive a higher clearance."
 msgstr ""
+"No se pudo aumentar el nivel de autorización a L%s. Se le confió un nivel de"
+" autorización de L%s. Comuníquese con su administrador para recibir una "
+"autorización mayor."
 
 #: rocky/views/ooi_list.py
 #, python-format
@@ -7216,42 +8101,49 @@ msgid ""
 "Could not raise clearance level to L%s. You acknowledged a clearance level "
 "of L%s. Please accept the clearance level below to proceed."
 msgstr ""
+"No se pudo aumentar el nivel de autorización a L%s. Usted reconoció un nivel"
+" de autorización de L%s. Acepte el nivel de autorización a continuación para"
+" continuar."
 
 #: rocky/views/ooi_list.py
 msgid "An error occurred while saving clearance levels."
-msgstr ""
+msgstr "Se produjo un error al guardar los niveles de autorización."
 
 #: rocky/views/ooi_list.py
 msgid "One of the OOI's doesn't exist"
-msgstr ""
+msgstr "Uno de los OOI no existe"
 
 #: rocky/views/ooi_list.py
 #, python-format
 msgid "Successfully set scan profile to %s for %d OOIs."
-msgstr ""
+msgstr "Configure correctamente el perfil de escaneo en %s para %d OOIs."
 
 #: rocky/views/ooi_list.py
 msgid "An error occurred while setting clearance levels to inherit."
 msgstr ""
+"Se produjo un error al configurar los niveles de autorización para heredar."
 
 #: rocky/views/ooi_list.py
 msgid ""
-"An error occurred while setting clearance levels to inherit: one of the OOIs "
-"doesn't exist."
+"An error occurred while setting clearance levels to inherit: one of the OOIs"
+" doesn't exist."
 msgstr ""
+"Se produjo un error al configurar los niveles de autorización para heredar: "
+"uno de los OOIs no existe."
 
 #: rocky/views/ooi_list.py
 #, python-format
 msgid "Successfully set %d OOI(s) clearance level to inherit."
 msgstr ""
+"Se estableció correctamente el nivel de autorización %d OOI(s) para heredar."
 
 #: rocky/views/ooi_list.py
 msgid "An error occurred while deleting oois."
-msgstr ""
+msgstr "Se produjo un error al eliminar oois."
 
 #: rocky/views/ooi_list.py
 msgid "An error occurred while deleting OOIs: one of the OOIs doesn't exist."
-msgstr ""
+msgstr "Se produjo un error al eliminar OOIs: uno de los OOIs no existe."
 
 #: rocky/views/ooi_list.py
 #, python-format
@@ -7259,115 +8151,118 @@ msgid ""
 "Successfully deleted %d ooi(s). Note: Bits can recreate objects "
 "automatically."
 msgstr ""
+"Ooi(s) %d eliminados correctamente. Nota: Los bits pueden recrear objetos "
+"automáticamente."
 
 #: rocky/views/ooi_mute.py
 msgid "Please select at least one finding."
-msgstr ""
+msgstr "Seleccione al menos un hallazgo."
 
 #: rocky/views/ooi_mute.py
 msgid "Finding(s) successfully unmuted."
-msgstr ""
+msgstr "Los hallazgos se activaron con éxito."
 
 #: rocky/views/ooi_mute.py
 msgid "Finding(s) successfully muted."
-msgstr ""
+msgstr "Hallazgos silenciados exitosamente."
 
 #: rocky/views/ooi_tree.py
 msgid "Tree Visualisation"
-msgstr ""
+msgstr "Visualización de árboles"
 
 #: rocky/views/ooi_tree.py
 msgid "Graph Visualisation"
-msgstr ""
+msgstr "Visualización de gráficos"
 
 #: rocky/views/ooi_view.py
 msgid "Observed_at: "
-msgstr ""
+msgstr "Observado_en:"
 
 #: rocky/views/ooi_view.py
 msgid "OOI types: "
-msgstr ""
+msgstr "Tipos OOI:"
 
 #: rocky/views/ooi_view.py
 msgid "Clearance level: "
-msgstr ""
+msgstr "Nivel de autorización:"
 
 #: rocky/views/ooi_view.py
 msgid "Clearance type: "
-msgstr ""
+msgstr "Tipo de liquidación:"
 
 #: rocky/views/ooi_view.py
 msgid "Searching for: "
-msgstr ""
+msgstr "Buscando:"
 
 #: rocky/views/organization_add.py
 msgid "Setup"
-msgstr ""
+msgstr "Configuración"
 
 #: rocky/views/organization_add.py
 msgid "Organization added successfully."
-msgstr ""
+msgstr "Organización agregada exitosamente."
 
 #: rocky/views/organization_add.py
 msgid "You are not allowed to add organizations."
-msgstr ""
+msgstr "No se le permite agregar organizaciones."
 
 #: rocky/views/organization_edit.py
 #, python-format
 msgid "Organization %s successfully updated."
-msgstr ""
+msgstr "Organización %s actualizada correctamente."
 
 #: rocky/views/organization_member_add.py
 msgid "Add column titles, followed by each object on a new line."
 msgstr ""
+"Agregue títulos de columna, seguidos de cada objeto en una nueva línea."
 
 #: rocky/views/organization_member_add.py
 msgid "The columns are: "
-msgstr ""
+msgstr "Las columnas son:"
 
 #: rocky/views/organization_member_add.py
 msgid "Clearance levels should be between -1 and 4."
-msgstr ""
+msgstr "Los niveles de autorización deben estar entre -1 y 4."
 
 #: rocky/views/organization_member_add.py
 msgid "Account type can be one of: "
-msgstr ""
+msgstr "El tipo de cuenta puede ser uno de:"
 
 #: rocky/views/organization_member_add.py
 msgid "Member added successfully."
-msgstr ""
+msgstr "Miembro agregado exitosamente."
 
 #: rocky/views/organization_member_add.py
 msgid "The csv file is missing required columns"
-msgstr ""
+msgstr "Al archivo csv le faltan las columnas obligatorias"
 
 #: rocky/views/organization_member_add.py
 #, python-brace-format
 msgid "Invalid account type: '{account_type}'"
-msgstr ""
+msgstr "Tipo de cuenta no válido: '{account_type}'"
 
 #: rocky/views/organization_member_add.py
 #, python-brace-format
 msgid "Invalid data for: '{email}'"
-msgstr ""
+msgstr "Datos no válidos para: '{email}'"
 
 #: rocky/views/organization_member_add.py
 #, python-brace-format
 msgid "Invalid email address: '{email}'"
-msgstr ""
+msgstr "Dirección de correo electrónico no válida: '{email}'"
 
 #: rocky/views/organization_member_add.py
 msgid "Successfully processed users from csv."
-msgstr ""
+msgstr "Usuarios procesados ​​exitosamente desde csv."
 
 #: rocky/views/organization_member_add.py
 msgid "Error parsing the csv file. Please verify its contents."
-msgstr ""
+msgstr "Error al analizar el archivo csv. Por favor verifique su contenido."
 
 #: rocky/views/organization_member_edit.py
 #, python-format
 msgid "Member %s successfully updated."
-msgstr ""
+msgstr "Miembro %s actualizado correctamente."
 
 #: rocky/views/organization_member_edit.py
 #, python-format
@@ -7377,44 +8272,55 @@ msgid ""
 "level L%s. For this reason the acknowledged clearance level has been set at "
 "the same level as trusted clearance level."
 msgstr ""
+"El nivel de autorización confiable actualizado de L%s es inferior al nivel "
+"de autorización reconocido del miembro de L%s. Este miembro solo tiene "
+"autorización para el nivel L%s. Por este motivo, el nivel de autorización "
+"reconocido se ha establecido al mismo nivel que el nivel de autorización "
+"confiable."
 
 #: rocky/views/organization_member_edit.py
 msgid ""
 "You have trusted this member with a higher trusted level than member "
 "acknowledged. Member must first accept this level to use it."
 msgstr ""
+"Ha confiado en este miembro con un nivel de confianza más alto que el "
+"reconocido por el miembro. El miembro primero debe aceptar este nivel para "
+"usarlo."
 
 #: rocky/views/organization_member_list.py
 #, python-format
 msgid "Blocked member %s successfully."
-msgstr ""
+msgstr "Miembro bloqueado %s exitosamente."
 
 #: rocky/views/organization_member_list.py
 #, python-format
 msgid "Unblocked member %s successfully."
-msgstr ""
+msgstr "Miembro desbloqueado %s exitosamente."
 
 #: rocky/views/organization_settings.py
 #, python-brace-format
 msgid "Recalculated {number_of_bits} bits. Duration: {duration}"
-msgstr ""
+msgstr "Bits {number_of_bits} recalculados. Duración: {duration}"
 
 #: rocky/views/page_actions.py
 msgid "Could not process your request, action required."
-msgstr ""
+msgstr "No se pudo procesar su solicitud, se requiere acción."
 
 #: rocky/views/scan_profile.py
 msgid ""
-"Cannot set clearance level. The clearance type must be inherited or declared."
+"Cannot set clearance level. The clearance type must be inherited or "
+"declared."
 msgstr ""
+"No se puede establecer el nivel de autorización. El tipo de liquidación debe"
+" ser heredado o declarado."
 
 #: rocky/views/scans.py
 msgid "Scans"
-msgstr ""
+msgstr "Escaneos"
 
 #: rocky/views/scheduler.py
 msgid "Your report has been scheduled."
-msgstr ""
+msgstr "Su informe ha sido programado."
 
 #: rocky/views/scheduler.py
 msgid ""
@@ -7422,63 +8328,80 @@ msgid ""
 "will be added to the object list when they are in. It may take some time, a "
 "refresh of the page may be needed to show the results."
 msgstr ""
+"Su tarea está programada y pronto se iniciará en segundo plano. Los "
+"resultados se agregarán a la lista de objetos cuando estén disponibles. "
+"Puede llevar algún tiempo y es posible que sea necesario actualizar la "
+"página para mostrar los resultados."
 
 #: rocky/views/tasks.py
 #, python-brace-format
 msgid "Fetching tasks failed: no connection with scheduler: {error}"
 msgstr ""
+"Error al recuperar tareas: no hay conexión con el programador: {error}"
 
 #: rocky/views/tasks.py
 msgid "All Tasks"
-msgstr ""
+msgstr "Todas las tareas"
 
 #: rocky/views/upload_csv.py
 msgid "Add column titles. Followed by each object on a new line."
 msgstr ""
+"Agregue títulos de columnas. Seguido de cada objeto en una nueva línea."
 
 #: rocky/views/upload_csv.py
 msgid ""
 "For URL object type, a column 'raw' with URL values is required, starting "
 "with http:// or https://, optionally a second column 'network' is supported "
 msgstr ""
+"Para el tipo de objeto URL, se requiere una columna 'sin formato' con "
+"valores URL, comenzando con http:// o https://,, opcionalmente se admite una"
+" segunda columna 'red'"
 
 #: rocky/views/upload_csv.py
 msgid ""
 "For Hostname object type, a column with 'name' values is required, "
 "optionally a second column 'network' is supported "
 msgstr ""
+"Para el tipo de objeto Nombre de host, se requiere una columna con valores "
+"de 'nombre'; opcionalmente, se admite una segunda columna 'red'"
 
 #: rocky/views/upload_csv.py
 msgid ""
 "For IPAddressV4 and IPAddressV6 object types, a column of 'address' is "
 "required, optionally a second column 'network' is supported "
 msgstr ""
+"Para los tipos de objetos IPAddressV4 e IPAddressV6, se requiere una columna"
+" de 'dirección'; opcionalmente, se admite una segunda columna 'red'"
 
 #: rocky/views/upload_csv.py
 msgid ""
 "Clearance levels can be controlled by a column 'clearance' taking numerical "
-"values 0, 1, 2, 3, and 4 for the corresponding clearance level (other values "
-"are ignored) "
+"values 0, 1, 2, 3, and 4 for the corresponding clearance level (other values"
+" are ignored) "
 msgstr ""
+"Los niveles de autorización se pueden controlar mediante una columna "
+"'autorización' que toma los valores numéricos 0, 1, 2, 3 y 4 para el nivel "
+"de autorización correspondiente (otros valores se ignoran)"
 
 #: rocky/views/upload_csv.py
 msgid "Object(s) could not be created for row number(s): "
-msgstr ""
+msgstr "No se pudieron crear objetos para los números de fila:"
 
 #: rocky/views/upload_csv.py
 msgid "Object(s) successfully added."
-msgstr ""
+msgstr "Objeto(s) agregado(s) exitosamente."
 
 #: rocky/views/upload_raw.py
 #, python-format
 msgid "Raw file could not be uploaded to Bytes: status code %d"
 msgstr ""
+"El archivo sin formato no se pudo cargar en Bytes: código de estado %d"
 
 #: rocky/views/upload_raw.py
 #, python-format
 msgid "Raw file could not be uploaded to Bytes: %s"
-msgstr ""
+msgstr "El archivo sin formato no se pudo cargar en Bytes: %s"
 
 #: rocky/views/upload_raw.py
 msgid "Raw file successfully added."
-msgstr ""
+msgstr "Archivo sin formato agregado exitosamente."


### PR DESCRIPTION
## Summary
- update the Spanish Django translation catalog from the current Weblate template
- fill previously untranslated strings using machine translation with protected placeholders and OpenKAT domain terms
- update translation metadata

## Validation
- msgfmt --statistics --check rocky/rocky/locale/es/LC_MESSAGES/django.po

Note: these translations were machine-assisted and should be reviewed by a Spanish speaker before release.