### PR TITLE
Update Papiamento translations

### DIFF
--- a/rocky/rocky/locale/pap/LC_MESSAGES/django.po
+++ b/rocky/rocky/locale/pap/LC_MESSAGES/django.po
@@ -1,13 +1,12 @@
-#: reports/forms.py
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: OpenKAT\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-20 07:38+0000\n"
-"PO-Revision-Date: 2025-08-22 09:39+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
-"Language-Team: Papiamento <https://hosted.weblate.org/projects/openkat/nl-"
-"kat-coordination/pap/>\n"
+"POT-Creation-Date: 2026-03-28 14:22+0000\n"
+"PO-Revision-Date: 2026-07-14 00:00+0000\n"
+"Last-Translator: Brenno de Winter <brenno@dewinter.com>\n"
+"Language-Team: Papiamento <https://hosted.weblate.org/projects/openkat/nl-kat-coordination/pap/>\n"
 "Language: pap\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -44,11 +43,11 @@ msgstr "Nòmber"
 
 #: account/forms/account_setup.py
 msgid "The name that will be used in order to communicate."
-msgstr ""
+msgstr "E nòmber ku lo wòrdu usá pa por komuniká."
 
 #: account/forms/account_setup.py
 msgid "Please provide username"
-msgstr ""
+msgstr "Por fabor duna nòmber di usuario"
 
 #: account/forms/account_setup.py
 #: rocky/templates/organizations/organization_member_list.html
@@ -57,7 +56,7 @@ msgstr "Email"
 
 #: account/forms/account_setup.py
 msgid "Enter an email address."
-msgstr ""
+msgstr "Introdusí un adrès di email."
 
 #: account/forms/account_setup.py
 msgid "Password"
@@ -65,7 +64,7 @@ msgstr "Password"
 
 #: account/forms/account_setup.py
 msgid "Choose a super secret password"
-msgstr ""
+msgstr "Skohe un kontraseña super sekreto"
 
 #: account/forms/account_setup.py
 msgid "Choose another email."
@@ -77,7 +76,7 @@ msgstr "--- Por fabor selektá ún di e opcionnan disponibel ----"
 
 #: account/forms/account_setup.py
 msgid "Account type"
-msgstr ""
+msgstr "Tipo di kuenta"
 
 #: account/forms/account_setup.py
 msgid "Please select an account type to proceed."
@@ -108,7 +107,7 @@ msgstr "splikashon-nomber-organisashon"
 #: account/forms/account_setup.py
 #, python-brace-format
 msgid "A unique code of maximum {code_length} characters in length."
-msgstr ""
+msgstr "Un kódigo úniko di máksimo {code_length} karakter di largura."
 
 #: account/forms/account_setup.py
 msgid "explanation-organization-code"
@@ -136,6 +135,9 @@ msgid ""
 "have permission to scan these assets. I am aware of the implications a scan "
 "(with a higher scan level) brings on my systems."
 msgstr ""
+"Mi ta deklará ku OpenKAT por skan e aktivonan di mi organisashon i ku mi tin"
+" pèrmit pa skan e aktivonan aki. Mi ta konsiente di e implikashonnan ku un "
+"skan (ku un nivel di skan mas haltu) ta trese riba mi sistemanan."
 
 #: account/forms/account_setup.py
 msgid ""
@@ -143,6 +145,9 @@ msgid ""
 "organization. I have the experience and knowledge to know what the "
 "consequences might be and can be held responsible for them."
 msgstr ""
+"Mi ta deklará ku mi ta outorisá pa duna e indemnisashon aki na nòmber di mi "
+"organisashon. Mi tin e eksperensia i konosementu pa sa kiko e "
+"konsekuensianan por ta i por wòrdu tené responsabel pa nan."
 
 #: account/forms/account_setup.py
 msgid "Trusted to change Clearance Levels."
@@ -185,7 +190,7 @@ msgstr "Password nobo"
 
 #: account/forms/account_setup.py
 msgid "Enter a new password"
-msgstr ""
+msgstr "Introdusí un kontraseña nobo"
 
 #: account/forms/account_setup.py
 msgid "New password confirmation"
@@ -193,11 +198,11 @@ msgstr "Konfirmashon password nobo"
 
 #: account/forms/account_setup.py
 msgid "Repeat the new password"
-msgstr ""
+msgstr "Ripití e kontraseña nobo"
 
 #: account/forms/account_setup.py
 msgid "Confirm the new password"
-msgstr ""
+msgstr "Konfirmá e kontraseña nobo"
 
 #: account/forms/login.py
 msgid "Please enter a correct email address and password."
@@ -256,14 +261,16 @@ msgstr "Backup token"
 
 #: account/mixins.py
 msgid "Clearance level has been set."
-msgstr ""
+msgstr "Nivel di limpiesa a wòrdu fihá."
 
 #: account/mixins.py
 #, python-format
 msgid ""
-"Could not raise clearance level of %s to L%s. Indemnification not present at "
-"organization %s."
+"Could not raise clearance level of %s to L%s. Indemnification not present at"
+" organization %s."
 msgstr ""
+"No por a hisa e nivel di limpiesa di %s pa L%s. Indemnisashon no ta presente"
+" na organisashon %s."
 
 #: account/mixins.py
 #, python-format
@@ -288,7 +295,7 @@ msgstr ""
 
 #: account/models.py
 msgid "The email must be set"
-msgstr ""
+msgstr "E email mester ta set"
 
 #: account/models.py
 msgid "Superuser must have is_staff=True."
@@ -332,11 +339,11 @@ msgstr "fecha di registro"
 
 #: account/models.py
 msgid "The clearance level of the user for all organizations."
-msgstr ""
+msgstr "E nivel di limpiesa di e usuario pa tur organisashon."
 
 #: account/models.py
 msgid "name"
-msgstr ""
+msgstr "nòmber"
 
 #: account/templates/account_detail.html account/views/account.py
 msgid "Account details"
@@ -363,7 +370,7 @@ msgstr "Organisashon"
 
 #: account/templates/account_detail.html
 msgid "Permission to set OOI clearance levels"
-msgstr ""
+msgstr "Pèrmit pa pone OOI nivelnan di limpiesa"
 
 #: account/templates/account_detail.html
 msgid "OOI clearance"
@@ -371,16 +378,17 @@ msgstr "OOI autorisá"
 
 #: account/templates/account_detail.html
 msgid "You don't have any clearance to scan objects."
-msgstr ""
+msgstr "Bo no tin ningun pèrmit pa skan ophetonan."
 
 #: account/templates/account_detail.html
 msgid ""
 "Get in contact with the admin to give you the necessary clearance level."
 msgstr ""
+"Tuma kontakto ku e atministradó pa duna bo e nivel di limpiesa nesesario."
 
 #: account/templates/account_detail.html
 msgid "You have currently accepted clearance up to level"
-msgstr ""
+msgstr "Aktualmente bo a aseptá aprobashon te na nivel"
 
 #: account/templates/account_detail.html
 msgid "Explanation OOI Clearance"
@@ -397,7 +405,7 @@ msgstr ""
 #: account/templates/account_detail.html
 #, python-format
 msgid "Withdraw L%(acl)s clearance and responsibility"
-msgstr ""
+msgstr "Retiro L%(acl)s aprobashon i responsabilidat"
 
 #: account/templates/account_detail.html
 msgid "Explanation OOI clearance"
@@ -408,8 +416,8 @@ msgstr "Splikashon OOI autorisashon"
 msgid ""
 "You are granted clearance for level L%(tcl)s by your admin. Before you can "
 "change OOI clearance levels up to this level, you need to accept this "
-"permission. Remember: <strong>with great power comes great responsibility.</"
-"strong>"
+"permission. Remember: <strong>with great power comes great "
+"responsibility.</strong>"
 msgstr ""
 "Bo a haña nivel di autorisashon di L%(tcl)s for di bo administrador. Promé "
 "ku bo por kambia nivelnan di autorisashon di e OOI te na e nivel aki, bo "
@@ -420,7 +428,7 @@ msgstr ""
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 #, python-format
 msgid "Accept level L%(tcl)s clearance and responsibility"
-msgstr ""
+msgstr "Aseptá nivel L%(tcl)s aprobashon i responsabilidat"
 
 #: account/templates/password_reset.html
 msgid "Use the form below to reset your password."
@@ -503,6 +511,7 @@ msgstr "Ba lubida bo email adrès?"
 msgid ""
 "If you don’t remember the email address connected to your account, contact:"
 msgstr ""
+"Si bo no ta kòrda e adrès di email konektá na bo kuenta, tuma kontakto ku:"
 
 #: account/templates/recover_email.html
 msgid "Please contact the system administrator."
@@ -535,6 +544,8 @@ msgid ""
 "Your password must contain at least the following but longer passwords are "
 "recommended:"
 msgstr ""
+"Bo password mester kontené por lo ménos lo siguiente pero ta rekomendá pa "
+"passwordnan mas largu:"
 
 #: account/validators.py
 msgid " characters"
@@ -552,6 +563,7 @@ msgstr " lèternan"
 msgid ""
 " special characters such as: {str(validators.get('special_characters',''))}"
 msgstr ""
+"karakternan spesial manera: {str(validators.get('special_characters',''))}"
 
 #: account/validators.py
 msgid " lower case letters"
@@ -592,7 +604,7 @@ msgstr ""
 
 #: components/modal/template.html
 msgid "Close modal"
-msgstr ""
+msgstr "Sera modal"
 
 #: components/modal/template.html
 #: crisis_room/templates/partials/delete_dashboard_item_modal.html
@@ -619,114 +631,119 @@ msgstr "Kanselá"
 
 #: crisis_room/forms.py
 msgid "Title on dashboard"
-msgstr ""
+msgstr "Título riba dashboard"
 
 #: crisis_room/forms.py
 msgid "Dashboard item size"
-msgstr ""
+msgstr "Tamaño di artíkulo di dashboard"
 
 #: crisis_room/forms.py
 msgid "Full width"
-msgstr ""
+msgstr "Hanchura kompleto"
 
 #: crisis_room/forms.py
 msgid "Half width"
-msgstr ""
+msgstr "Mitar hanchura"
 
 #: crisis_room/forms.py
 msgid "An item with that name already exists. Try a different title."
 msgstr ""
+"Un artíkulo ku e nòmber ei ta eksistí kaba. Purba un título diferente."
 
 #: crisis_room/forms.py
 msgid "An error occurred while adding dashboard item."
-msgstr ""
+msgstr "Un eror a sosodé ora di agregá e artíkulo di dashboard."
 
 #: crisis_room/forms.py
 msgid "Number of rows in list"
-msgstr ""
+msgstr "Kantidat di fila den lista"
 
 #: crisis_room/forms.py
 msgid "List sorting by"
-msgstr ""
+msgstr "Klasamentu di lista pa"
 
 #: crisis_room/forms.py
 msgid "Type (A-Z)"
-msgstr ""
+msgstr "Tipo (A-Z)"
 
 #: crisis_room/forms.py
 msgid "Type (Z-A)"
-msgstr ""
+msgstr "Tipo (Z-A)"
 
 #: crisis_room/forms.py
 msgid "Clearance level (Low-High)"
-msgstr ""
+msgstr "Nivel di limpiesa (Abou-Haltu)"
 
 #: crisis_room/forms.py
 msgid "Clearance level (High-Low)"
-msgstr ""
+msgstr "Nivel di limpiesa (Haltu-Abou)"
 
 #: crisis_room/forms.py
 msgid "Show table columns"
-msgstr ""
+msgstr "Mustra kolumnanan di tabel"
 
 #: crisis_room/forms.py
 msgid "Severity (Low-High)"
-msgstr ""
+msgstr "Severidat (Abou-Haltu)"
 
 #: crisis_room/forms.py
 msgid "Severity (High-Low)"
-msgstr ""
+msgstr "Severidat (Haltu-Abou)"
 
 #: crisis_room/forms.py
 msgid "Finding (A-Z)"
-msgstr ""
+msgstr "Haña (A-Z)"
 
 #: crisis_room/forms.py
 msgid "Finding (Z-A)"
-msgstr ""
+msgstr "Hañamentu (Z-A)"
 
 #: crisis_room/models.py
 msgid "Findings Dashboard"
-msgstr ""
+msgstr "Dashboard di resultadonan"
 
 #: crisis_room/models.py
 msgid ""
-"Where on the dashboard do you want to show the data? Position {} is the most "
-"top level and the max position is {}."
+"Where on the dashboard do you want to show the data? Position {} is the most"
+" top level and the max position is {}."
 msgstr ""
+"Unda riba e dashboard bo ke mustra e datonan? Posishon {} ta e nivel mas "
+"haltu i e posishon máksimo ta {}."
 
 #: crisis_room/models.py
 msgid "Will be displayed on the general crisis room, for all organizations."
-msgstr ""
+msgstr "Lo wordo exhibi riba e sala di crisis general, pa tur organisacion."
 
 #: crisis_room/models.py
 msgid "Will be displayed on a single organization dashboard"
-msgstr ""
+msgstr "Lo wòrdu mustra riba un solo dashboard di organisashon"
 
 #: crisis_room/models.py
 msgid "Will be displayed on the findings dashboard for all organizations"
-msgstr ""
+msgstr "Lo wòrdu mustra riba e dashboard di resultadonan pa tur organisashon"
 
 #: crisis_room/models.py
 msgid "Can change position up or down of a dashboard item."
-msgstr ""
+msgstr "Por kambia posishon ariba òf abou di un artíkulo di dashboard."
 
 #: crisis_room/models.py
 msgid "You have to choose between a recipe or a query, but not both."
-msgstr ""
+msgstr "Bo mester skohe entre un reseta òf un konsulta, pero no tur dos."
 
 #: crisis_room/models.py
 msgid "You have set a query and not where it is from. Also set the source."
-msgstr ""
+msgstr "Bo a pone un konsulta i no di unda e ta bini. Tambe pone e fuente."
 
 #: crisis_room/models.py
 msgid ""
 "DashboardItem must contain at least a 'recipe' or a 'source' with a 'query'."
 msgstr ""
+"DashboardItem mester kontené por lo ménos un ‘reseta’ òf un ‘fuente’ ku un "
+"‘konsulta’."
 
 #: crisis_room/models.py
 msgid "Max dashboard items reached."
-msgstr ""
+msgstr "Artíkulonan di dashboard máksimo alkansá."
 
 #: crisis_room/templates/crisis_room.html
 #: crisis_room/templates/organization_crisis_room.html
@@ -736,25 +753,27 @@ msgstr "Sala di krísis"
 
 #: crisis_room/templates/crisis_room.html
 msgid "Crisis room overview for all organizations."
-msgstr ""
+msgstr "Bista di sala di krísis pa tur organisashon."
 
 #: crisis_room/templates/crisis_room_dashboards.html
 msgid "Dashboards"
-msgstr ""
+msgstr "Dashboardnan"
 
 #: crisis_room/templates/crisis_room_dashboards.html
 msgid ""
 "On this page you can see an overview of the dashboards for all "
 "organizations. **More context can be written here**"
 msgstr ""
+"Riba e página aki bo por mira un bista di e dashboardnan pa tur "
+"organisashon. **Mas konteksto por wòrdu skirbí aki**"
 
 #: crisis_room/templates/crisis_room_dashboards.html
 msgid "dashboards"
-msgstr ""
+msgstr "dashboardnan"
 
 #: crisis_room/templates/crisis_room_dashboards.html
 msgid "There are no dashboards to display."
-msgstr ""
+msgstr "No tin dashboard pa mustra."
 
 #: crisis_room/templates/crisis_room_findings.html
 #: crisis_room/templates/partials/crisis_room_findings_table.html
@@ -762,31 +781,38 @@ msgstr ""
 #: reports/templates/partials/report_findings_table.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Findings overview"
-msgstr ""
+msgstr "Bista general di e resultadonan"
 
 #: crisis_room/templates/crisis_room_findings.html
 msgid ""
 "\n"
-"                            This overview shows the total number of findings "
-"per\n"
-"                            severity that have been identified for all "
-"organizations.\n"
-"                            This data is based on the latest Crisis Room "
-"Findings Report\n"
+"                            This overview shows the total number of findings per\n"
+"                            severity that have been identified for all organizations.\n"
+"                            This data is based on the latest Crisis Room Findings Report\n"
 "                            of each organization.\n"
 "                        "
 msgstr ""
+"\n"
+"E bista general aki ta mustra e kantidat total di resultadonan pa\n"
+"                            severidat ku a keda identifiká pa tur organisashon.\n"
+"                            E datonan aki ta basá riba e último Rapport di Resultadonan di Sala di Krísis\n"
+"                            di kada organisashon."
 
 #: crisis_room/templates/crisis_room_findings.html
 msgid "Findings per organization"
-msgstr ""
+msgstr "Resultadonan pa organisashon"
 
 #: crisis_room/templates/crisis_room_findings.html
 msgid ""
 "This table shows the findings that have been identified for each "
-"organization, sorted by the finding types and grouped by organizations. This "
-"data is based on the latest Crisis Room Findings Report of each organization."
+"organization, sorted by the finding types and grouped by organizations. This"
+" data is based on the latest Crisis Room Findings Report of each "
+"organization."
 msgstr ""
+"E tabel aki ta mustra e resultadonan ku a wòrdu identifiká pa kada "
+"organisashon, ordená pa e tiponan di resultado i agrupá pa organisashonnan. "
+"E datonan aki ta basá riba e último Rapport di Resultadonan di Sala di "
+"Krísis di kada organisashon."
 
 #: crisis_room/templates/crisis_room_findings.html
 #: reports/report_types/findings_report/report.html
@@ -794,17 +820,21 @@ msgid ""
 "No findings have been identified yet. As soon as they have been identified, "
 "they will be shown on this page."
 msgstr ""
+"No a identifiká ningun resultado ainda. Asina ku nan a wòrdu identifiká, nan"
+" lo wòrdu mustra riba e página aki."
 
 #: crisis_room/templates/crisis_room_findings.html
 msgid ""
 "There are no organizations yet. After creating an organization, the "
 "identified findings will be shown here."
 msgstr ""
+"No tin niun organisashon ainda. Despues di krea un organisashon, e "
+"resultadonan identifiká lo wòrdu mustra aki."
 
 #: crisis_room/templates/crisis_room_header.html
 #: crisis_room/templates/organization_crisis_room_header.html
 msgid "Crisis room navigation"
-msgstr ""
+msgstr "Navegashon di sala di krísis"
 
 #: crisis_room/templates/crisis_room_header.html
 #: crisis_room/templates/partials/new_dashboard_item_action_button.html
@@ -820,8 +850,8 @@ msgstr ""
 #: reports/report_types/web_system_report/report.html
 #: reports/templates/partials/report_findings_table.html
 #: reports/templates/partials/report_sidemenu.html
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
-#: rocky/templates/header.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
 #: rocky/templates/oois/ooi_detail_findings_list.html
 #: rocky/templates/oois/ooi_detail_findings_overview.html
 #: rocky/templates/oois/ooi_page_tabs.html
@@ -834,26 +864,28 @@ msgstr "Diskubrimentu"
 
 #: crisis_room/templates/organization_crisis_room.html
 msgid "Options for dashboard"
-msgstr ""
+msgstr "Opshonnan pa dashboard"
 
 #: crisis_room/templates/organization_crisis_room.html
 msgid "Show all descriptions"
-msgstr ""
+msgstr "Mustra tur deskripshon"
 
 #: crisis_room/templates/organization_crisis_room.html
 msgid "Hide all descriptions"
-msgstr ""
+msgstr "Skonde tur deskripshon"
 
 #: crisis_room/templates/organization_crisis_room.html
 #: crisis_room/templates/partials/delete_dashboard_modal.html
 msgid "Delete dashboard"
-msgstr ""
+msgstr "Elimina e dashboard"
 
 #: crisis_room/templates/organization_crisis_room.html
 msgid ""
 "There are no dashboards yet. Click on \"Add dashboard\" to create a new "
 "dashboard."
 msgstr ""
+"No tin dashboard ainda. Klik riba “Agregá dashboard” pa krea un dashboard "
+"nobo."
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 #: katalogus/templates/partials/objects_to_scan.html
@@ -864,43 +896,45 @@ msgstr "Lista di opheto"
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid "Finding list"
-msgstr ""
+msgstr "Lista di buskamentu"
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 #: crisis_room/templates/partials/new_dashboard_item_action_button.html
 msgid "Report section"
-msgstr ""
+msgstr "Sekshon di rapòrt"
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid "There are no dashboard items added yet."
-msgstr ""
+msgstr "No tin artíkulonan di dashboard agregá ainda."
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid ""
-"You can add dashboard items via the filters on the objects and findings page "
-"or you can add a report section."
+"You can add dashboard items via the filters on the objects and findings page"
+" or you can add a report section."
 msgstr ""
+"Bo por agregá artíkulonan di dashboard via e filternan riba e página di "
+"ophetonan i resultadonan òf bo por agregá un sekshon di rapòrt."
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid "Add objects"
-msgstr ""
+msgstr "Agregá ophetonan"
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid "Add findings"
-msgstr ""
+msgstr "Agregá resultadonan"
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid "Add report section"
-msgstr ""
+msgstr "Agregá sekshon di rapòrt"
 
 #: crisis_room/templates/organization_crisis_room_header.html
 #: crisis_room/templates/partials/new_dashboard_modal.html
 msgid "Add dashboard"
-msgstr ""
+msgstr "Agregá dashboard"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid "Findings per organization overview"
-msgstr ""
+msgstr "Resultadonan pa bista general di organisashon"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: reports/templates/partials/report_findings_table.html
@@ -922,11 +956,11 @@ msgstr "Occurencianan"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid "Highest risk level"
-msgstr ""
+msgstr "Nivel di riesgo mas haltu"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid "Critical finding types"
-msgstr ""
+msgstr "Tiponan di hañamentu krítiko"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
@@ -974,57 +1008,63 @@ msgstr "Habri detayes"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid ""
-"This overview shows the total number of findings per severity that have been "
-"identified for this organization."
+"This overview shows the total number of findings per severity that have been"
+" identified for this organization."
 msgstr ""
+"E bista general aki ta mustra e kantidat total di resultadonan pa severidat "
+"ku a wòrdu identifiká pa e organisashon aki."
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: reports/report_types/findings_report/report.html
 msgid "Critical and high findings"
-msgstr ""
+msgstr "Resultadonan krítiko i haltu"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: reports/report_types/findings_report/report.html
 msgid ""
 "This table shows the top 25 critical and high findings that have been "
-"identified for this organization, grouped by finding types. A table with all "
-"the identified findings can be found in the Findings Report."
+"identified for this organization, grouped by finding types. A table with all"
+" the identified findings can be found in the Findings Report."
 msgstr ""
+"E tabel aki ta mustra e 25 mihó resultadonan krítiko i haltu ku a wòrdu "
+"identifiká pa e organisashon aki, agrupá pa tipo di resultadonan. Un tabel "
+"ku tur e resultadonan identifiká por wòrdu hañá den e Rapport di "
+"Resultadonan."
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid "No findings have been identified. Check report for more details."
-msgstr ""
+msgstr "No a identifiká ningun resultado. Kontrolá e rapòrt pa mas detaye."
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid "View findings report"
-msgstr ""
+msgstr "Wak e rapòrt di resultadonan"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Edit report recipe"
-msgstr ""
+msgstr "Editá reseta di rapòrt"
 
 #: crisis_room/templates/partials/dashboard_finding_list.html
 #, python-format
 msgid "Showing %(length)s findings"
-msgstr ""
+msgstr "Mustrando %(length)s resultadonan"
 
 #: crisis_room/templates/partials/dashboard_finding_list.html
 msgid "Go to findings"
-msgstr ""
+msgstr "Bai na e resultadonan"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
 msgid "Findings table "
-msgstr ""
+msgstr "Tabel di resultadonan"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: crisis_room/templates/partials/dashboard_ooi_list_table.html
 #: rocky/templates/findings/finding_list.html
 #: rocky/templates/oois/ooi_list.html
 msgid "column headers with buttons are sortable"
-msgstr ""
+msgstr "kabes di kolumna ku boton ta ordenabel"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
@@ -1053,7 +1093,8 @@ msgstr "Grafa"
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: reports/report_types/dns_report/report.html
 #: rocky/templates/oois/ooi_detail_findings_list.html
-#: rocky/templates/oois/ooi_detail_findings_overview.html rocky/views/mixins.py
+#: rocky/templates/oois/ooi_detail_findings_overview.html
+#: rocky/views/mixins.py
 msgid "Severity"
 msgstr "Nivél di severedat"
 
@@ -1091,7 +1132,7 @@ msgstr "Mustra %(ooi_type)s ophetonan"
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/views/mixins.py
 msgid "Location"
-msgstr ""
+msgstr "Lugá"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #, python-format
@@ -1101,7 +1142,7 @@ msgstr "Mustra detayes pa %(ooi)s"
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
 msgid "Risk score"
-msgstr ""
+msgstr "Skor di riesgo"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: katalogus/templates/normalizer_detail.html
@@ -1112,7 +1153,8 @@ msgstr ""
 #: reports/templates/summary/report_asset_overview.html tools/forms/boefje.py
 #: tools/forms/finding_type.py rocky/templates/findings/finding_list.html
 #: rocky/templates/oois/ooi_detail.html
-#: rocky/templates/oois/ooi_detail_findings_list.html rocky/templates/scan.html
+#: rocky/templates/oois/ooi_detail_findings_list.html
+#: rocky/templates/scan.html
 msgid "Description"
 msgstr "Deklarashon"
 
@@ -1122,7 +1164,7 @@ msgstr "Deklarashon"
 #: reports/templates/partials/report_severity_totals_table.html
 #: rocky/templates/findings/finding_list.html
 msgid "Recommendation"
-msgstr ""
+msgstr "Rekomendashon"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: reports/report_types/vulnerability_report/report.py
@@ -1138,55 +1180,55 @@ msgstr "Orígen"
 #: reports/templates/partials/report_findings_table.html
 #: rocky/templates/findings/finding_list.html
 msgid "Impact"
-msgstr ""
+msgstr "Impakto"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Options for dashboard items"
-msgstr ""
+msgstr "Opshonnan pa artíkulonan di dashboard"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Show description"
-msgstr ""
+msgstr "Mustra deskripshon"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Hide description"
-msgstr ""
+msgstr "Skonde deskripshon"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Position up"
-msgstr ""
+msgstr "Posishon ariba"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Position down"
-msgstr ""
+msgstr "Posishon abou"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Rerun report"
-msgstr ""
+msgstr "Rapòrt di re-ehekushon"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 #: crisis_room/templates/partials/delete_dashboard_item_modal.html
 msgid "Delete item"
-msgstr ""
+msgstr "Elimina e artíkulo"
 
 #: crisis_room/templates/partials/dashboard_ooi_list.html
 #, python-format
 msgid "Showing %(length)s objects"
-msgstr ""
+msgstr "Mustrando ophetonan %(length)s"
 
 #: crisis_room/templates/partials/dashboard_ooi_list.html
 msgid "Go to objects"
-msgstr ""
+msgstr "Bai na ophetonan"
 
 #: crisis_room/templates/partials/dashboard_ooi_list_table.html
 #: rocky/templates/oois/ooi_list.html
 msgid "Objects "
-msgstr ""
+msgstr "Ophetonan"
 
 #: crisis_room/templates/partials/delete_dashboard_item_modal.html
 #, python-format
 msgid "Are you sure you want to delete '%(name)s' from this dashboard?"
-msgstr ""
+msgstr "Bo ta sigur ku bo ke eliminá '%(name)s' for di e dashboard aki?"
 
 #: crisis_room/templates/partials/delete_dashboard_item_modal.html
 #: crisis_room/templates/partials/delete_dashboard_modal.html
@@ -1207,14 +1249,16 @@ msgid ""
 "Are you sure you want to delete dashboard '%(dashboard)s'? All the items on "
 "the dashboard will be deleted as well."
 msgstr ""
+"Bo ta sigur ku bo ke eliminá e dashboard '%(dashboard)s'? Tur e artíkulonan "
+"riba e dashboard lo wòrdu eliminá tambe."
 
 #: crisis_room/templates/partials/new_dashboard_item_action_button.html
 msgid "Actions for adding dashboard items"
-msgstr ""
+msgstr "Akshonnan pa agregá artíkulonan di dashboard"
 
 #: crisis_room/templates/partials/new_dashboard_item_action_button.html
 msgid "Add item"
-msgstr ""
+msgstr "Agregá artíkulo"
 
 #: crisis_room/templates/partials/new_dashboard_item_action_button.html
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
@@ -1223,26 +1267,32 @@ msgstr ""
 #: reports/templates/summary/ooi_selection.html tools/forms/ooi.py
 #: tools/view_helpers.py rocky/templates/admin/delete_confirmation.html
 #: rocky/templates/admin/delete_selected_confirmation.html
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
-#: rocky/templates/header.html rocky/views/ooi_add.py rocky/views/ooi_list.py
-#: rocky/views/ooi_view.py rocky/views/upload_csv.py rocky/views/upload_raw.py
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
+#: rocky/views/ooi_add.py rocky/views/ooi_list.py rocky/views/ooi_view.py
+#: rocky/views/upload_csv.py rocky/views/upload_raw.py
 msgid "Objects"
 msgstr "Ophetonan"
 
 #: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
 msgid "Add dashboard item"
-msgstr ""
+msgstr "Agregá artíkulo di dashboard"
 
 #: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
 msgid ""
-"To  add a <strong>report section</strong>, go to the history page and open a "
-"report. Then go to the section that you want to add to your dashboard and "
-"press the options button next to the section name to create a dashboard item."
+"To  add a <strong>report section</strong>, go to the history page and open a"
+" report. Then go to the section that you want to add to your dashboard and "
+"press the options button next to the section name to create a dashboard "
+"item."
 msgstr ""
+"Pa agregá un <strong>sekshon di rapòrt</strong>, bai na e página di historia"
+" i habri un rapòrt. Despues bai na e sekshon ku bo ke agregá na bo dashboard"
+" i primi e boton di opshonnan banda di e nòmber di e sekshon pa krea un "
+"artíkulo di dashboard."
 
 #: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
 msgid "Go to report history"
-msgstr ""
+msgstr "Bai na historia di rapòrt"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #, python-format
@@ -1250,6 +1300,8 @@ msgid ""
 "\n"
 "    Add %(item_type)s to dashboard\n"
 msgstr ""
+"\n"
+"Agregá %(item_type)s na dashboard\n"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #, python-format
@@ -1257,6 +1309,8 @@ msgid ""
 "Add these %(item_type)s with the selected filters to the dashboard of your "
 "choice."
 msgstr ""
+"Agregá e %(item_type)s aki ku e filternan selektá na e dashboard di bo "
+"eskoho."
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
@@ -1272,56 +1326,68 @@ msgstr "explikashon"
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid "You do not have a custom dashboard yet"
-msgstr ""
+msgstr "Bo no tin un dashboard personalisá ainda"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #, python-format
 msgid ""
-"In order to add these %(item_type)s to a dashboard, you first need to create "
-"a dashboard. Please add a dashboard in the crisis room of your organization."
+"In order to add these %(item_type)s to a dashboard, you first need to create"
+" a dashboard. Please add a dashboard in the crisis room of your "
+"organization."
 msgstr ""
+"Pa por agregá e %(item_type)s aki na un dashboard, bo mester krea un "
+"dashboard promé. Por fabor agregá un dashboard den e sala di krísis di bo "
+"organisashon."
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 #: rocky/templates/findings/finding_list.html
 #: rocky/templates/oois/ooi_list.html
 msgid "Add to dashboard"
-msgstr ""
+msgstr "Agregá na dashboard"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid "Go to crisis room"
-msgstr ""
+msgstr "Bai sala di krísis"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid "Add report section to dashboard"
-msgstr ""
+msgstr "Agregá sekshon di rapòrt na dashboard"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid ""
-"In order to add this report section to a dashboard, you first need to create "
-"a dashboard. Please create a dashboard in the crisis room of your "
+"In order to add this report section to a dashboard, you first need to create"
+" a dashboard. Please create a dashboard in the crisis room of your "
 "organization."
 msgstr ""
+"Pa por agregá e sekshon di rapòrt aki na un dashboard, bo mester krea un "
+"dashboard promé. Por fabor krea un dashboard den e sala di krísis di bo "
+"organisashon."
 
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid "Report must be scheduled for dashboard items"
-msgstr ""
+msgstr "Rapòrt mester ta programá pa artíkulonan di dashboard"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid ""
 "In order for dashboard information to be updated on a regular basis instead "
-"of showing static data, the report should be scheduled. The frequency of the "
-"schedules recurrence determines how fresh the data on the dashboard will be."
+"of showing static data, the report should be scheduled. The frequency of the"
+" schedules recurrence determines how fresh the data on the dashboard will "
+"be."
 msgstr ""
+"Pa informashon di e dashboard por wòrdu aktualisá riba un base regular en "
+"bes di mustra datonan státiko, e rapòrt mester wòrdu programá. E frekuensha "
+"di e rekurensia di e skema ta determiná kon fresku e datonan riba e "
+"dashboard lo ta."
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 msgid "Applied filters"
-msgstr ""
+msgstr "Filternan apliká"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 msgid "Object types"
-msgstr ""
+msgstr "Tipo di opheto"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 #: katalogus/templates/change_clearance_level.html onboarding/forms.py
@@ -1329,7 +1395,8 @@ msgstr ""
 #: reports/templates/summary/ooi_selection.html tools/forms/boefje.py
 #: tools/forms/ooi.py rocky/templates/oois/ooi_page_tabs.html
 #: rocky/templates/partials/explanations.html
-#: rocky/templates/scan_profiles/scan_profile_detail.html rocky/views/mixins.py
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+#: rocky/views/mixins.py
 msgid "Clearance level"
 msgstr "Nivél di autorisashon"
 
@@ -1338,7 +1405,7 @@ msgstr "Nivél di autorisashon"
 #: reports/templates/summary/ooi_selection.html tools/forms/ooi.py
 #: rocky/views/mixins.py
 msgid "Clearance type"
-msgstr ""
+msgstr "Tipo di limpiesa"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 #: reports/templates/report_overview/modal_partials/delete_modal.html
@@ -1346,82 +1413,83 @@ msgstr ""
 #: reports/templates/report_overview/report_history_table.html
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Input objects"
-msgstr ""
+msgstr "Ophetonan di entrada"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 msgid "Show all objects"
-msgstr ""
+msgstr "Mustra tur opheto"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 #: reports/templates/partials/report_types_selection.html
 msgid "No filters applied"
-msgstr ""
+msgstr "No a apliká filternan"
 
 #: crisis_room/templates/partials/report_section_action_button.html
 msgid "Add section to dashboard"
-msgstr ""
+msgstr "Agregá sekshon na dashboard"
 
 #: katalogus/client.py
 msgid ""
 "The KATalogus has an unexpected error. Check the logs for further details."
 msgstr ""
+"E KATalogus tin un eror inesperá. Kontrolá e registronan pa mas detaye."
 
 #: katalogus/client.py
 #, python-format
 msgid "An HTTP %d error occurred. Check logs for more info."
-msgstr ""
+msgstr "Un eror HTTP %d a sosodé. Kontrolá e registronan pa mas informashon."
 
 #: katalogus/client.py
 msgid "An HTTP error occurred. Check logs for more info."
-msgstr ""
+msgstr "Un eror HTTP a sosodé. Kontrolá e registronan pa mas informashon."
 
 #: katalogus/client.py
 msgid "Boefje with this name already exists."
-msgstr ""
+msgstr "Boefje ku e nòmber aki ta eksistí kaba."
 
 #: katalogus/client.py
 msgid "Boefje with this ID already exists."
-msgstr ""
+msgstr "Boefje ku e ID aki ta eksistí kaba."
 
 #: katalogus/client.py
 msgid "Access to resource not allowed"
-msgstr ""
+msgstr "Akseso na rekurso no ta permití"
 
 #: katalogus/client.py
 msgid "User is not allowed to see plugin settings"
-msgstr ""
+msgstr "E usuario no ta permití pa wak e settingnan di e plugin"
 
 #: katalogus/client.py
 msgid "User is not allowed to set plugin settings"
-msgstr ""
+msgstr "Usuario no ta permití pa pone e settingnan di plugin"
 
 #: katalogus/client.py
 msgid "User is not allowed to delete plugin settings"
-msgstr ""
+msgstr "E usuario no ta permití pa eliminá e settingnan di e plugin"
 
 #: katalogus/client.py
 msgid "User is not allowed to view plugin settings"
-msgstr ""
+msgstr "E usuario no ta permití pa wak e settingnan di e plugin"
 
 #: katalogus/client.py
 msgid "User is not allowed to access the other organization"
-msgstr ""
+msgstr "Usuario no ta permití pa haña akseso na e otro organisashon"
 
 #: katalogus/client.py
 msgid "User is not allowed to enable plugins"
-msgstr ""
+msgstr "Usuario no ta permití pa aktivá plugins"
 
 #: katalogus/client.py
 msgid "User is not allowed to disable plugins"
-msgstr ""
+msgstr "Usuario no ta permití pa desabilitá plugins"
 
 #: katalogus/client.py
 msgid "User is not allowed to create plugins"
-msgstr ""
+msgstr "Usuario no ta permití pa krea plugins"
 
 #: katalogus/client.py
 msgid "User is not allowed to edit plugins"
-msgstr ""
+msgstr "Usuario no ta permití pa editá plugins"
 
 #: katalogus/forms/katalogus_filter.py
 msgid "Show all"
@@ -1472,13 +1540,13 @@ msgstr "Tokante plug-innan"
 
 #: katalogus/templates/about_plugins.html katalogus/templates/katalogus.html
 msgid ""
-"Plugins gather data, objects and insight. Each plugin has its own focus area "
-"and strengths and may be able to work with other plugins to gain even more "
+"Plugins gather data, objects and insight. Each plugin has its own focus area"
+" and strengths and may be able to work with other plugins to gain even more "
 "insights."
 msgstr ""
-"Plugins ta reuni informashon, obhetonan i komprènhenshon. Kada plugin tin su "
-"mes área di enfoke i fortalezanan i por ta kapás pa traha ku otro plugins pa "
-"hanja ainda mas komprènhenshon."
+"Plugins ta reuni informashon, obhetonan i komprènhenshon. Kada plugin tin su"
+" mes área di enfoke i fortalezanan i por ta kapás pa traha ku otro plugins "
+"pa hanja ainda mas komprènhenshon."
 
 #: katalogus/templates/about_plugins.html katalogus/templates/boefjes.html
 msgid ""
@@ -1486,6 +1554,9 @@ msgid ""
 "issues, and give insight. Each boefje is a separate scan that can run on a "
 "selection of objects."
 msgstr ""
+"Boefjes ta wòrdu usá pa skan pa ophetonan. Nan ta detektá vulnerabilidatnan,"
+" problemanan di seguridat, i ta duna bista. Cada boefje ta un scan apart cu "
+"por core riba un seleccion di obheto."
 
 #: katalogus/templates/about_plugins.html katalogus/templates/normalizers.html
 msgid ""
@@ -1497,8 +1568,8 @@ msgstr ""
 
 #: katalogus/templates/about_plugins.html
 msgid ""
-"Bits are business rules that look for insight within the current dataset and "
-"search for specific insight and draw conclusions."
+"Bits are business rules that look for insight within the current dataset and"
+" search for specific insight and draw conclusions."
 msgstr ""
 "Bits ta reglanan di negoshi ku ta buska bista den e dataset aktual i ta "
 "buska bista spesífiko i trese konklushonnan."
@@ -1541,11 +1612,11 @@ msgstr "%(plugin_name)s por produsi lo sigiente:"
 #: katalogus/templates/boefje_detail.html
 #, python-format
 msgid "%(plugin_name)s doesn't produce any output mime types."
-msgstr ""
+msgstr "%(plugin_name)s no ta produsí ningun tipo di mime di salida."
 
 #: katalogus/templates/boefje_setup.html
 msgid "Boefje variant setup"
-msgstr ""
+msgstr "Boefje setup di variante"
 
 #: katalogus/templates/boefje_setup.html
 #: rocky/templates/organizations/organization_member_list.html
@@ -1556,43 +1627,46 @@ msgstr "Editá"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Boefje setup"
-msgstr ""
+msgstr "Boefje setup"
 
 #: katalogus/templates/boefje_setup.html
 msgid ""
 "You can create a new Boefje. If you want more information on this, you can "
-"check out the <a href=\"https://docs.openkat.nl/developer_documentation/"
-"development_tutorial/creating_a_boefje.html\">documentation</a>."
+"check out the <a "
+"href=\"https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html\">documentation</a>."
 msgstr ""
+"Bo por krea un Boefje nobo. Si bo ke mas informashon tokante esaki, bo por "
+"wak e <a "
+"href=\"https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html\">dokumentashon</a>."
 
 #: katalogus/templates/boefje_setup.html
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 msgid "Save changes"
-msgstr ""
+msgstr "Warda kambionan"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Discard changes"
-msgstr ""
+msgstr "Descartá kambionan"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Create variant"
-msgstr ""
+msgstr "Krea variante"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Discard variant"
-msgstr ""
+msgstr "Variante di descartá"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Create new Boefje"
-msgstr ""
+msgstr "Krea Boefje nobo"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Discard new Boefje"
-msgstr ""
+msgstr "Descartá nobo Boefje"
 
 #: katalogus/templates/boefjes.html
 msgid "Add Boefje"
-msgstr ""
+msgstr "Agregá Boefje"
 
 #: katalogus/templates/boefjes.html katalogus/templates/katalogus.html
 #: katalogus/templates/normalizers.html
@@ -1616,7 +1690,7 @@ msgstr ""
 
 #: katalogus/templates/change_clearance_level.html
 msgid "Scan object"
-msgstr ""
+msgstr "Skan opheto"
 
 #: katalogus/templates/change_clearance_level.html
 #, python-format
@@ -1633,7 +1707,7 @@ msgstr ""
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/summary/report_asset_overview.html
 msgid "Selected objects"
-msgstr ""
+msgstr "Ophetonan selektá"
 
 #: katalogus/templates/change_clearance_level.html
 #: reports/templates/report_overview/report_history_table.html
@@ -1659,10 +1733,14 @@ msgstr "Klone settings"
 #, python-format
 msgid ""
 "Use the form below to clone the settings from "
-"<strong>%(current_organization)s</strong> to the selected organization. This "
-"includes both the KAT-alogus settings as well as enabled and disabled "
+"<strong>%(current_organization)s</strong> to the selected organization. This"
+" includes both the KAT-alogus settings as well as enabled and disabled "
 "plugins."
 msgstr ""
+"Usa e formulario aki bou pa klon e settingnan for di "
+"<strong>%(current_organization)s</strong> pa e organisashon selektá. Esaki "
+"ta inkluí tantu e settingnan di KAT-alogus komo e pluginnan aktivá i "
+"deshabilitá."
 
 #: katalogus/templates/confirmation_clone_settings.html
 msgid "Clone"
@@ -1674,13 +1752,15 @@ msgstr "Tur plug-ins"
 
 #: katalogus/templates/katalogus_settings.html
 msgid "KAT-alogus settings"
-msgstr ""
+msgstr "KAT-alogus settings"
 
 #: katalogus/templates/katalogus_settings.html
 msgid ""
 "There are currently no settings defined. Add settings at the plugin detail "
 "page."
 msgstr ""
+"No tin ningun setting definí aktualmente. Agregá settingnan na e página di "
+"detaye di e plugin."
 
 #: katalogus/templates/katalogus_settings.html
 #: rocky/templates/two_factor/core/otp_required.html
@@ -1693,7 +1773,7 @@ msgstr "Esaki ta un lista di e settings mas reciente pa tur plugins."
 
 #: katalogus/templates/katalogus_settings.html
 msgid "Latest plugin settings"
-msgstr ""
+msgstr "E último konfigurashon di plugin"
 
 #: katalogus/templates/katalogus_settings.html
 #: rocky/templates/tasks/ooi_detail_task_list.html
@@ -1709,11 +1789,11 @@ msgstr "Balor"
 #: katalogus/templates/normalizer_detail.html
 #, python-format
 msgid "%(plugin_name)s is able to process the following mime types:"
-msgstr ""
+msgstr "%(plugin_name)s ta kapas pa prosesá e siguiente tiponan di mime:"
 
 #: katalogus/templates/partials/boefje_tile.html
 msgid "This object type is required"
-msgstr ""
+msgstr "E tipo di opheto aki ta nesesario"
 
 #: katalogus/templates/partials/boefje_tile.html
 msgid "Scan level:"
@@ -1721,7 +1801,7 @@ msgstr "Nivél di skan:"
 
 #: katalogus/templates/partials/boefje_tile.html
 msgid "Publisher:"
-msgstr ""
+msgstr "Editor:"
 
 #: katalogus/templates/partials/boefje_tile.html
 #: katalogus/templates/partials/plugin_tile.html
@@ -1760,7 +1840,7 @@ msgstr "Mustra filters"
 #: rocky/templates/partials/organization_member_list_filters.html
 #: rocky/templates/tasks/partials/task_filter.html
 msgid "applied"
-msgstr ""
+msgstr "apliká"
 
 #: katalogus/templates/partials/katalogus_filter.html
 msgid "Filter plugins"
@@ -1775,8 +1855,8 @@ msgstr "Kita filters"
 #: katalogus/views/katalogus_settings.py katalogus/views/plugin_detail.py
 #: katalogus/views/plugin_settings_add.py
 #: katalogus/views/plugin_settings_delete.py
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
-#: rocky/templates/header.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
 msgid "KAT-alogus"
 msgstr "KAT-alogus"
 
@@ -1803,26 +1883,26 @@ msgstr "Aparensia tablatura"
 
 #: katalogus/templates/partials/modal_report_types.html
 msgid "Required for"
-msgstr ""
+msgstr "Rekeri pa"
 
 #: katalogus/templates/partials/modal_report_types.html
 msgid "report types"
-msgstr ""
+msgstr "tiponan di rapòrt"
 
 #: katalogus/templates/partials/modal_report_types.html
 msgid "Report types for "
-msgstr ""
+msgstr "Tipo di rapòrt pa"
 
 #: katalogus/templates/partials/no_enabling_permission_message.html
 msgid "No permission to enable/disable plugins"
-msgstr ""
+msgstr "No tin pèrmit pa aktivá/deshabilitá pluginnan"
 
 #: katalogus/templates/partials/no_enabling_permission_message.html
 msgid "Contact your administrator to request permission."
-msgstr ""
+msgstr "Tuma kontakto ku bo atministradó pa pidi pèrmit."
 
 #: katalogus/templates/partials/objects_to_scan.html
-#, fuzzy, python-format
+#, python-format
 msgid ""
 "This Boefje will only scan objects with a corresponding clearance level of "
 "<strong>L%(scan_level)s</strong> or higher. There is no indemnification for "
@@ -1830,15 +1910,15 @@ msgid ""
 "<strong>L%(scan_level)s</strong>. Use the filter to show OOI's with a lower "
 "clearance level."
 msgstr ""
-"E boefje aki ta skan solamente ophetonan ku un nivél di autorisashon di "
-"<strong>L%(scan_level)s</strong> òf mas haltu. No tin indemnizashon pa e "
-"boefje pa skan un OOI ku un nivél di autorisashon mas abou ku "
-"<strong>L%(scan_level)s</strong>. Uza e filter pa mustra OOI's ku un nivél "
-"di autorisashon mas abou."
+"E Boefje aki lo skan solamente ophetonan ku un nivel di autorisashon "
+"korespondiente di <strong>L%(scan_level)s</strong> òf mas haltu. No tin "
+"indemnisashon pa e Boefje aki pa skan un OOI ku un nivel di autorisashon mas"
+" abou ku <strong>L%(scan_level)s</strong>. Usa e filter pa mustra OOI-nan ku"
+" un nivel di autorisashon mas abou."
 
 #: katalogus/templates/partials/objects_to_scan.html
 msgid "Warning scan level:"
-msgstr ""
+msgstr "Nivel di skan di atvertensia:"
 
 #: katalogus/templates/partials/objects_to_scan.html
 msgid ""
@@ -1847,32 +1927,32 @@ msgid ""
 "now on out, until it manually gets set to something else again. This means "
 "that all other enabled Boefjes will use this higher clearance level aswel."
 msgstr ""
+"Skan OOI's ku un nivel di limpiesa mas abou lo resultá den OpenKAT oumentá e"
+" nivel di limpiesa riba e OOI ei, no solamente pa e skan aki pero for di "
+"awor padilanti, te ora ku e wòrdu set manualmente na algu otro atrobe. Esaki"
+" ta nifiká ku tur otro Boefjes aktivá lo usa e nivel di limpiesa mas haltu "
+"aki tambe."
 
 #: katalogus/templates/partials/objects_to_scan.html
-#, fuzzy, python-format
+#, python-format
 msgid ""
 "You currently don't have any objects that meet the scan level of %(name)s. "
 "Add objects with a complying clearance level, or alter the clearance level "
 "of existing objects."
 msgstr ""
-"\n"
-"              Na e momento aki bo no tin ophetonan ku ta kwarda ku e nivel "
-"di autorisashon di %(name)s. \n"
-"              Añadi ophetonan ku un nivel di authorisashon adequa, òf kambia "
-"e nivel di authorisashon di ophetonan eksistente.\n"
-"            "
+"Aktualmente bo no tin ningun opheto ku ta kumpli ku e nivel di skan di "
+"%(name)s. Agregá ophetonan ku un nivel di limpiesa ku ta kumpli, òf alterá e"
+" nivel di limpiesa di ophetonan eksistente."
 
 #: katalogus/templates/partials/objects_to_scan.html
-#, fuzzy, python-format
+#, python-format
 msgid ""
 "You currently don't have scannable objects for %(name)s. Add objects to use "
 "this Boefje. This Boefje is able to scan objects of the following types:"
 msgstr ""
-"\n"
-"              Na e momento aki bo no tin ophetonan pa skan pa %(name)s. \n"
-"              Añadi ophetonan pa uza e boefje. E boefje aki ta dispuesto di "
-"skan ophetonan di e sigiente tiponan:\n"
-"            "
+"Aktualmente bo no tin ophetonan ku por wòrdu skan pa %(name)s. Agregá "
+"ophetonan pa usa esaki Boefje. E Boefje aki por skan ophetonan di e "
+"siguiente tiponan:"
 
 #: katalogus/templates/partials/plugin_settings_required.html
 msgid "The form could not be initialized."
@@ -1889,24 +1969,24 @@ msgstr "Añadí"
 
 #: katalogus/templates/partials/plugin_tile.html
 msgid "Required for:"
-msgstr ""
+msgstr "Rekerí pa:"
 
 #: katalogus/templates/partials/plugin_tile_modal.html
 msgid "Boefje details"
-msgstr ""
+msgstr "Detayenan di Boefje"
 
 #: katalogus/templates/partials/plugin_tile_modal.html reports/forms.py
 #: reports/templates/report_overview/report_history_table.html
 msgid "Report types"
-msgstr ""
+msgstr "Tipo di rapòrt"
 
 #: katalogus/templates/partials/plugin_tile_modal.html
 msgid "This boefje is required by the following report types."
-msgstr ""
+msgstr "E boefje aki ta wordo exigi pa e siguiente tiponan di rapport."
 
 #: katalogus/templates/partials/plugin_tile_modal.html
 msgid "Go to boefje detail page"
-msgstr ""
+msgstr "Bai na e página di detaye di boefje"
 
 #: katalogus/templates/partials/plugins.html
 msgid "Plugins overview:"
@@ -1937,7 +2017,7 @@ msgstr "Akshonnan"
 
 #: katalogus/templates/partials/plugins.html
 msgid "Detail page"
-msgstr ""
+msgstr "Página di detaye"
 
 #: katalogus/templates/partials/plugins_navigation.html
 #: reports/templates/report_overview/report_overview_navigation.html
@@ -1963,25 +2043,27 @@ msgstr "Tur"
 
 #: katalogus/templates/plugin_container_image.html tools/forms/boefje.py
 msgid "Container image"
-msgstr ""
+msgstr "Imágen di kònteiner"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "The container image for this Boefje is:"
-msgstr ""
+msgstr "E imágen di e kònteiner pa e Boefje aki ta:"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Variants"
-msgstr ""
+msgstr "Variantenan"
 
 #: katalogus/templates/plugin_container_image.html
 msgid ""
 "Boefje variants that use the same container image. For more information "
 "about Boefje variants you can read the documentation."
 msgstr ""
+"Boefje variantenan ku ta usa e mesun imágen di kònteiner. Pa mas informashon"
+" tokante variantenan di Boefje bo por lesa e dokumentashon."
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Add variant"
-msgstr ""
+msgstr "Agregá variante"
 
 #: katalogus/templates/plugin_container_image.html
 #: rocky/templates/partials/notifications_block.html
@@ -1991,15 +2073,15 @@ msgstr "konfirmashon"
 #: katalogus/templates/plugin_container_image.html
 #, python-format
 msgid "Variant %(plugin.name)s created."
-msgstr ""
+msgstr "Variante %(plugin.name)s kreá."
 
 #: katalogus/templates/plugin_container_image.html
 msgid "The Boefje variant is successfully created and can now be used."
-msgstr ""
+msgstr "E variante Boefje a wòrdu kreá ku éksito i awor por wòrdu usá."
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Overview of variants"
-msgstr ""
+msgstr "Bista general di variantenan"
 
 #: katalogus/templates/plugin_container_image.html
 #: reports/report_types/tls_report/report.html
@@ -2014,32 +2096,32 @@ msgstr "Estádo"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Age"
-msgstr ""
+msgstr "Edat"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Scan interval"
-msgstr ""
+msgstr "Intervalo di skan"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Run on"
-msgstr ""
+msgstr "Kore riba"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "current"
-msgstr ""
+msgstr "aktual"
 
 #: katalogus/templates/plugin_container_image.html
 #: reports/report_types/dns_report/report.html
 msgid "minutes"
-msgstr ""
+msgstr "minütnan"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Default system scan frequency"
-msgstr ""
+msgstr "Frekuensha di skan di sistema predeterminá"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Boefje ID"
-msgstr ""
+msgstr "Boefje ID"
 
 #: katalogus/templates/plugin_container_image.html
 #: reports/templates/report_overview/modal_partials/delete_modal.html
@@ -2048,51 +2130,53 @@ msgstr ""
 #: reports/templates/report_overview/subreports_table.html
 #: rocky/templates/tasks/reports.html
 msgid "Creation date"
-msgstr ""
+msgstr "Fecha di kreashon"
 
 #: katalogus/templates/plugin_container_image.html tools/forms/boefje.py
 msgid "Arguments"
-msgstr ""
+msgstr "Argumentonan"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "The following arguments are used for this Boefje variant:"
-msgstr ""
+msgstr "E siguiente argumentonan ta wòrdu usá pa e variante Boefje aki:"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "There are no arguments used for this Boefje variant."
-msgstr ""
+msgstr "No tin argumentonan usá pa e variante Boefje aki."
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Edit variant"
-msgstr ""
+msgstr "Variante di edishon"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "This Boefje has no variants yet."
-msgstr ""
+msgstr "Esaki Boefje no tin variante ainda."
 
 #: katalogus/templates/plugin_container_image.html
 msgid ""
-"You can make a variant and change the arguments and JSON Schema to customize "
-"it to fit your needs."
+"You can make a variant and change the arguments and JSON Schema to customize"
+" it to fit your needs."
 msgstr ""
+"Bo por traha un variante i kambia e argumentonan i JSON Schema pa "
+"personalisá esaki pa kuadra ku bo nesesidatnan."
 
 #: katalogus/templates/plugin_settings_add.html
 msgid "Add setting"
 msgid_plural "Add settings"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Agregá settingnan"
+msgstr[1] "Agregá settingnan"
 
 #: katalogus/templates/plugin_settings_add.html
 msgid "Setting"
 msgid_plural "Settings"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Ahustonan"
+msgstr[1] "Ahustonan"
 
 #: katalogus/templates/plugin_settings_add.html
 msgid "Add setting and enable boefje"
 msgid_plural "Add settings and enable boefje"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Agregá settingnan i aktivá boefje"
+msgstr[1] "Agregá settingnan i aktivá boefje"
 
 #: katalogus/templates/plugin_settings_delete.html
 msgid "Delete settings"
@@ -2106,25 +2190,27 @@ msgstr "Segur bo ke bo ke eliminá tur ajuste pa e plug-in %(plugin_name)s?"
 
 #: katalogus/templates/plugin_settings_list.html
 msgid ""
-"In the table below the settings for this specific Boefje can be seen. Set or "
-"change the value of the variables by editing the settings."
+"In the table below the settings for this specific Boefje can be seen. Set or"
+" change the value of the variables by editing the settings."
 msgstr ""
+"Den e tabel aki bou por mira e settingnan pa e Boefje spesífiko aki. Pone òf"
+" kambia e balor di e variabelnan dor di editá e settingnan."
 
 #: katalogus/templates/plugin_settings_list.html
 msgid "Configure Settings"
-msgstr ""
+msgstr "Konfigurá Ahustonan"
 
 #: katalogus/templates/plugin_settings_list.html
 msgid "Overview of settings"
-msgstr ""
+msgstr "Bista general di e settingnan"
 
 #: katalogus/templates/plugin_settings_list.html
 msgid "Variable"
-msgstr ""
+msgstr "Variabel"
 
 #: katalogus/views/change_clearance_level.py
 msgid "Session has terminated, please select objects again."
-msgstr ""
+msgstr "Seshon a terminá, por fabor selektá ophetonan atrobe."
 
 #: katalogus/views/change_clearance_level.py
 msgid "Change clearance level"
@@ -2167,6 +2253,8 @@ msgid ""
 "You have not acknowledged your clearance level. Go to your profile page to "
 "acknowledge your clearance level."
 msgstr ""
+"Bo no a rekonosé bo nivel di limpiesa. Bai na bo página di profil pa "
+"rekonosé bo nivel di limpiesa."
 
 #: katalogus/views/plugin_enable_disable.py
 msgid ""
@@ -2182,6 +2270,8 @@ msgid ""
 "Your clearance level is L{}. Contact your administrator to get a higher "
 "clearance level."
 msgstr ""
+"Bo nivel di limpiesa ta L{}. Tuma kontakto ku bo atministradó pa haña un "
+"nivel di aprobashon mas haltu."
 
 #: katalogus/views/plugin_enable_disable.py
 msgid "To enable {} you need at least a clearance level of L{}. "
@@ -2238,6 +2328,9 @@ msgid ""
 "The clearance level determines how aggressive the object can be scanned by "
 "plugins. A higher clearance level means more aggressive scans are allowed."
 msgstr ""
+"E nivel di limpiesa ta determiná kon agresivo e opheto por wòrdu skan pa "
+"plugins. Un nivel di limpiesa mas haltu ta nifiká ku skannan mas agresivo ta"
+" permití."
 
 #: onboarding/forms.py tools/forms/ooi.py
 msgid "explanation-clearance-level"
@@ -2246,30 +2339,35 @@ msgstr "splikashon-nivel-di-autorisashon"
 #: onboarding/forms.py
 msgid "Please enter a valid URL starting with 'http://' or 'https://'."
 msgstr ""
+"Por fabor introdusí un URL bálido kuminsando ku ‘http://’ òf ‘https://’."
 
 #: onboarding/templates/partials/onboarding_header.html
 msgid "Onboarding"
-msgstr ""
+msgstr "Onboarding"
 
 #: onboarding/templates/partials/step_1_introduction_text.html
 msgid "Welcome to OpenKAT!"
-msgstr ""
+msgstr "Bon Bini na OpenKAT!"
 
 #: onboarding/templates/partials/step_1_introduction_text.html
 msgid ""
-"Welcome to the onboarding of OpenKAT. We will walk you through some steps to "
-"set everything up."
+"Welcome to the onboarding of OpenKAT. We will walk you through some steps to"
+" set everything up."
 msgstr ""
+"Bon Bini na e onboarding di OpenKAT. Nos lo guia bo dor di algun paso pa set"
+" up tur kos."
 
 #: onboarding/templates/partials/step_1_introduction_text.html
 msgid ""
-"At the end of this onboarding you have added your first object, created your "
-"first DNS report and learned about some basic concepts used within OpenKAT."
+"At the end of this onboarding you have added your first object, created your"
+" first DNS report and learned about some basic concepts used within OpenKAT."
 msgstr ""
+"Na final di e onboarding aki bo a agregá bo promé opheto, a krea bo promé "
+"DNS rapòrt i a siña tokante algun konsepto básiko usá den OpenKAT."
 
 #: onboarding/templates/partials/step_1_introduction_text.html
 msgid "The full documentation for OpenKAT can be found at:"
-msgstr ""
+msgstr "E dokumentashon kompletu pa OpenKAT por wòrdu hañá na:"
 
 #: onboarding/templates/partials/step_2_organization_text.html
 #: rocky/templates/organizations/organization_add.html
@@ -2282,6 +2380,10 @@ msgid ""
 "be changed later in the interface. The organization code cannot be changed "
 "as this is used by the database."
 msgstr ""
+"Por fabor introdusí e siguiente detayenan di organisashon. E nòmber di e "
+"organisashon por wòrdu kambia despues den e interfase. E kódigo di "
+"organisashon no por wòrdu kambia ya ku esaki ta wòrdu usá dor di e base di "
+"dato."
 
 #: onboarding/templates/step_10_report.html
 #: reports/report_types/concatenated_report/report.py
@@ -2297,16 +2399,20 @@ msgid ""
 "The enabled Boefjes are running in the background to gather the data for "
 "your DNS Report. This may take a few minutes."
 msgstr ""
+"E Boefjes aktivá ta kore den e fondo pa rekohé e datonan pa bo DNS Rapport. "
+"Esaki por tuma algun minüt."
 
 #: onboarding/templates/step_10_report.html
 msgid ""
 "In the meantime you can explore OpenKAT and view your DNS Report on the "
 "Reports page once it has been generated."
 msgstr ""
+"Miéntras tantu bo por eksplorá OpenKAT i wak bo DNS Rapòrt riba e página di "
+"Rapportnan unabes ku el a wòrdu generá."
 
 #: onboarding/templates/step_10_report.html
 msgid "Continue to OpenKAT"
-msgstr ""
+msgstr "Sigui pa OpenKAT"
 
 #: onboarding/templates/step_1_introduction_registration.html
 #: onboarding/templates/step_1a_introduction.html
@@ -2354,27 +2460,38 @@ msgstr "Indemnizashon riba e organisashon ta presente kaba."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 msgid "User clearance level"
-msgstr ""
+msgstr "Nivel di limpiesa di usuario"
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 msgid ""
-"The user clearance level specifies the maximum scan level for security scans "
-"and the maximum clearance level you can assign to objects (e.g. a URL)."
+"The user clearance level specifies the maximum scan level for security scans"
+" and the maximum clearance level you can assign to objects (e.g. a URL)."
 msgstr ""
+"E nivel di limpiesa di usuario ta spesifiká e nivel máksimo di skan pa "
+"skannan di seguridat i e nivel máksimo di limpiesa ku bo por asigná na "
+"ophetonan (p.e. un URL)."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 msgid ""
 "The administrator assigns a maximum user clearance level to each user. This "
 "will make sure that only trusted users can start more aggressive scans."
 msgstr ""
+"E atministradó ta asigná un nivel máksimo di limpiesa di usuario na kada "
+"usuario. Esaki lo hasi sigur ku solamente usuarionan di konfiansa por "
+"kuminsá ku skannan mas agresivo."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 msgid ""
 "A user must accept a clearance level, before they perform actions in "
 "OpenKAT. Here you may accept the maximum trusted clearance level, as "
-"assigned by your administrator. On your user settings page you can choose to "
-"lower your accepted clearance level after completing the onboarding."
+"assigned by your administrator. On your user settings page you can choose to"
+" lower your accepted clearance level after completing the onboarding."
 msgstr ""
+"Un usuario mester aseptá un nivel di limpiesa, promé ku nan hasi akshonnan "
+"den OpenKAT. Aki bo por aseptá e nivel máksimo di limpiesa di konfiansa, "
+"manera asigná pa bo atministradó. Riba bo página di setting di usuario bo "
+"por skohe pa baha bo nivel di aprobashon aseptá despues di kompletá e "
+"onboarding."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 msgid "What is my clearance level?"
@@ -2390,6 +2507,12 @@ msgid ""
 "<strong>%(ooi)s</strong> </br> Contact your administrator to receive a "
 "higher clearance."
 msgstr ""
+"Lamentablemente bo no por sigui ku e onboarding. </br> Bo atministradó a "
+"konfia bo ku un nivel di limpiesa di <strong>L%(tcl)s</strong>. </br> Bo "
+"mester por lo ménos un nivel di aprobashon di "
+"<strong>L%(dns_report_least_clearance_level)s</strong> pa skan "
+"<strong>%(ooi)s</strong> </br> Tuma kontakto ku bo atministradó pa risibí un"
+" aprobashon mas haltu."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 #: onboarding/templates/step_5_add_scan_ooi.html
@@ -2408,6 +2531,9 @@ msgid ""
 "<strong>L%(tcl)s</strong>. </br> You must first accept this clearance level "
 "to continue."
 msgstr ""
+"Bo atministradó a konfia bo ku un nivel di limpiesa di "
+"<strong>L%(tcl)s</strong>. </br> Bo mester aseptá e nivel di limpiesa aki "
+"promé pa sigui."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 #, python-format
@@ -2415,10 +2541,12 @@ msgid ""
 "Your administrator has <strong>trusted</strong> you with a clearance level "
 "of <strong>L%(tcl)s</strong>."
 msgstr ""
+"Bo atministradó a <strong>konfia</strong> bo ku un nivel di limpiesa di "
+"<strong>L%(tcl)s</strong>."
 
 #: onboarding/templates/step_5_add_scan_ooi.html
 msgid "Add an object"
-msgstr ""
+msgstr "Agregá un opheto"
 
 #: onboarding/templates/step_5_add_scan_ooi.html
 msgid ""
@@ -2426,6 +2554,9 @@ msgid ""
 "URLs. In the onboarding we will add an URL object, such as our vulnerable "
 "OpenKAT website: https://mispo.es."
 msgstr ""
+"OpenKAT ta usa vários tipo di opheto, manera IP adrès, nòmber di anfitrion i"
+" URLs. Den e onboarding nos lo agregá un opheto URL, manera nos wèpsait "
+"OpenKAT vulnerabel: https://mispo.es."
 
 #: onboarding/templates/step_5_add_scan_ooi.html
 #: rocky/templates/partials/ooi_detail_related_object.html
@@ -2440,6 +2571,12 @@ msgid ""
 "collects and adds these related objects by running scans. Objects can also "
 "be manually added."
 msgstr ""
+"Mayoria di ophetonan tin dependensia riba e eksistensia di ophetonan "
+"relashoná. Por ehèmpel un URL mester ta konektá na un ret, nòmber di "
+"anfitrion, fqdn (nòmber di dominio kompletamente kualifiká) i IP adrès. Ora "
+"ta posibel OpenKAT ta rekohé i agregá e ophetonan relashoná aki "
+"outomatikamente dor di kore skan. Ophetonan tambe por wòrdu agregá "
+"manualmente."
 
 #: onboarding/templates/step_5_add_scan_ooi.html
 msgid "Create object"
@@ -2447,15 +2584,19 @@ msgstr "Krea opheto"
 
 #: onboarding/templates/step_6_set_clearance_level.html
 msgid "Set object clearance level"
-msgstr ""
+msgstr "Pone nivel di limpiesa di opheto"
 
 #: onboarding/templates/step_6_set_clearance_level.html
 msgid ""
-"After creating a new object you can set a clearance level for this object. A "
-"clearance level determines how aggressive the object can be scanned. A "
+"After creating a new object you can set a clearance level for this object. A"
+" clearance level determines how aggressive the object can be scanned. A "
 "higher clearance level, means that more aggressive scans are allowed. "
 "Clearance levels can always be adjusted later on."
 msgstr ""
+"Despues di krea un opheto nobo bo por pone un nivel di espasio pa e opheto "
+"aki. Un nivel di espasio ta determiná kon agresivo e opheto por wòrdu skan. "
+"Un nivel di limpiesa mas haltu, ta nifiká ku skannan mas agresivo ta "
+"permití. Nivelnan di limpiesa semper por wòrdu ahusta despues."
 
 #: onboarding/templates/step_6_set_clearance_level.html
 #, python-format
@@ -2464,6 +2605,9 @@ msgid ""
 "L%(dns_report_least_clearance_level)s, meaning only informational scans are "
 "allowed."
 msgstr ""
+"Pa e onboarding nos ta usa un nivel di limpiesa di "
+"L%(dns_report_least_clearance_level)s, loke ta nifiká ku solamente skannan "
+"informativo ta permití."
 
 #: onboarding/templates/step_6_set_clearance_level.html
 msgid "Set clearance level"
@@ -2471,15 +2615,20 @@ msgstr "Pone nivél di autorisashon"
 
 #: onboarding/templates/step_7_clearance_level_introduction.html
 msgid "Plugin introduction"
-msgstr ""
+msgstr "Introdukshon di plugin"
 
 #: onboarding/templates/step_7_clearance_level_introduction.html
 msgid ""
 "OpenKAT uses plugins to scan your objects. Each plugin has a scan level to "
-"specify how aggressive the scan is. Plugins can only scan those objects with "
-"a clearance level that is equal to, or higher than the scan level of the "
+"specify how aggressive the scan is. Plugins can only scan those objects with"
+" a clearance level that is equal to, or higher than the scan level of the "
 "plugin. Plugin scan level are indicated by the number of cat paws."
 msgstr ""
+"OpenKAT ta usa plugins pa skan bo ophetonan. Kada plugin tin un nivel di "
+"skan pa spesifiká kon agresivo e skan ta. Plugins por skan solamente e "
+"ophetonan ei ku un nivel di limpiesa ku ta igual na, òf mas haltu ku e nivel"
+" di skan di e plugin. Nivel di skan di plugin ta wòrdu indiká dor di e "
+"kantidat di pata di pushi."
 
 #: onboarding/templates/step_7_clearance_level_introduction.html
 msgid ""
@@ -2487,6 +2636,9 @@ msgid ""
 "performs non-intrusive scans which look for publicly available information. "
 "It scans objects with a clearance level of 1 or higher."
 msgstr ""
+"E plugin <strong>DNS Zone</strong> tin un nivel di skan di 1, loke ta nifiká"
+" ku e ta hasi skannan no-intrusivo ku ta buska informashon disponibel pa "
+"públiko. E ta skan ophetonan ku un nivel di limpiesa di 1 òf mas haltu."
 
 #: onboarding/templates/step_7_clearance_level_introduction.html
 msgid ""
@@ -2494,46 +2646,60 @@ msgid ""
 "more aggressive and could potentially break things. It scans objects with a "
 "clearance level of 3 or higher."
 msgstr ""
+"E plugin <strong>Fierce</strong> tin un nivel di skan di 3, loke ta nifiká "
+"ku e ta mas agresivo i por kibra kosnan potensialmente. E ta skan ophetonan "
+"ku un nivel di limpiesa di 3 òf mas haltu."
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid "Enabling plugins and start scanning"
-msgstr ""
+msgstr "Habilitando plugins i kuminsá skan"
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid ""
 "OpenKAT uses plugins to scan, check and analyze. There are three types of "
 "plugins."
 msgstr ""
+"OpenKAT ta usa plugins pa skan, kontrolá i analisá. Tin tres tipo di plugin."
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid ""
 "The first plugin are <b>Boefjes</b>, which scan objects for data. These are "
 "security tools like nmap, LeakIX and WPscan. </p>"
 msgstr ""
+"E promé plugin ta <b>Boefjes</b>, ku ta skan ophetonan pa dato. Esakinan ta "
+"hermentnan di seguridat manera nmap, LeakIX i WPscan. </p>"
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid ""
-"The other two plugins are <b>Normalizers</b> and <b>Bits</b>, which are used "
-"to process the output of Boefjes. They can create findings and related "
+"The other two plugins are <b>Normalizers</b> and <b>Bits</b>, which are used"
+" to process the output of Boefjes. They can create findings and related "
 "objects. Bits are also used to create organization specific findings, based "
 "on policy requirements. </p>"
 msgstr ""
+"E otro dos pluginnan ta <b>Normalizers</b> i <b>Bits</b>, ku ta wòrdu usá pa"
+" prosesá e salida di Boefjes. Nan por krea resultadonan i ophetonan "
+"relashoná. Bits tambe ta wòrdu usá pa krea resultadonan spesífiko di "
+"organisashon, basá riba rekisitonan di polítika. </p>"
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid ""
 "For the onboarding we will enable the Boefjes shown below. Once enabled "
-"these Boefjes gather publicly available information on suitable objects with "
-"a clearance level of 1 or higher. Normalizers and Bits are enabled by "
+"these Boefjes gather publicly available information on suitable objects with"
+" a clearance level of 1 or higher. Normalizers and Bits are enabled by "
 "default."
 msgstr ""
+"Pa e onboarding nos lo aktivá e Boefjes mustra abou. Unabes aktivá esakinan "
+"Boefjes ta rekohé informashon disponibel pa públiko riba ophetonan adekuá ku"
+" un nivel di limpiesa di 1 òf mas haltu. Normalizers i Bits ta aktivá pa "
+"default."
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid "Enable and continue"
-msgstr ""
+msgstr "Habilitá i sigui"
 
 #: onboarding/templates/step_9_choose_report_type.html
 msgid "Generate a report"
-msgstr ""
+msgstr "Generá un rapòrt"
 
 #: onboarding/templates/step_9_choose_report_type.html
 msgid ""
@@ -2541,20 +2707,25 @@ msgid ""
 "can generate different types of reports in OpenKAT. Each report may require "
 "one or more plugins that provide the input for the report."
 msgstr ""
+"Rapportnan por wòrdu usá pa haña mas informashon den e aktivonan di bo "
+"organisashon. Bo por generá diferente tipo di rapòrt den OpenKAT. Kada "
+"rapòrt por rekerí un òf mas plugin ku ta proveé ​​e entrada pa e rapòrt."
 
 #: onboarding/templates/step_9_choose_report_type.html
 msgid ""
 "For the onboarding we will generate a DNS report for your added URL. In the "
 "previous step you enabled the required plugins for this report."
 msgstr ""
+"Pa e onboarding nos lo generá un DNS rapòrt pa bo URL agregá. Den e paso "
+"anterior bo a aktivá e pluginnan nesesario pa e rapòrt aki."
 
 #: onboarding/templates/step_9_choose_report_type.html
 msgid "Generate DNS Report"
-msgstr ""
+msgstr "Generá DNS Rapòrt"
 
 #: onboarding/view_helpers.py
 msgid "1: Welcome"
-msgstr ""
+msgstr "1: Bon Bini"
 
 #: onboarding/view_helpers.py
 msgid "2: Organization setup"
@@ -2562,15 +2733,15 @@ msgstr "Konfiguráß organisashon"
 
 #: onboarding/view_helpers.py
 msgid "3: Add object"
-msgstr ""
+msgstr "3: Agregá opheto"
 
 #: onboarding/view_helpers.py
 msgid "4: Plugins"
-msgstr ""
+msgstr "4: Plugins"
 
 #: onboarding/view_helpers.py
 msgid "5: Generating report"
-msgstr ""
+msgstr "5: Generando rapòrt"
 
 #: onboarding/views.py
 #, python-brace-format
@@ -2588,32 +2759,32 @@ msgstr "Kreando un opheto"
 
 #: onboarding/views.py
 msgid "Fetch the parent DNS zone of a hostname"
-msgstr ""
+msgstr "Buska e zona mayor DNS di un nòmber di anfitrion"
 
 #: onboarding/views.py
 msgid "Finds subdomains by brute force"
-msgstr ""
+msgstr "Ta haña subdominionan pa forsa brutu"
 
 #: onboarding/views.py
 msgid "Please select a plugin to proceed."
-msgstr ""
+msgstr "Por fabor selektá un plugin pa sigui."
 
 #: onboarding/views.py
 msgid "Please select all required plugins to proceed."
-msgstr ""
+msgstr "Por fabor selektá tur e pluginnan nesesario pa sigui."
 
 #: onboarding/views.py reports/views/aggregate_report.py
 #: reports/views/generate_report.py
 msgid "An error occurred while enabling {}. The plugin is not available."
-msgstr ""
+msgstr "Un eror a sosodé ora di abilitá {}. E plugin no ta disponibel."
 
 #: onboarding/views.py
 msgid "Plugins successfully enabled."
-msgstr ""
+msgstr "Plugins a wòrdu aktivá ku éksito."
 
 #: onboarding/views.py
 msgid "Web URL not found."
-msgstr ""
+msgstr "Web URL no a haña."
 
 #: onboarding/views.py
 msgid ""
@@ -2621,6 +2792,9 @@ msgid ""
 "waiting for Boefjes to complete. In the meantime get familiar with OpenKAT "
 "and visit the Reports History tab later."
 msgstr ""
+"Bo rapòrt ta programá pa generashon den mas o ménos 3 minüt, ya ku nos ta "
+"wardando pa Boefjes kompletá. Miéntras tantu sera konosí ku OpenKAT i "
+"bishitá e tab di Historia di Rapportnan despues."
 
 #: reports/forms.py tools/forms/ooi_form.py
 msgid "Filter by OOI types"
@@ -2628,104 +2802,104 @@ msgstr "Filtra pa tiponan di OOI"
 
 #: reports/forms.py
 msgid "Today"
-msgstr ""
+msgstr "Awe"
 
 #: reports/forms.py
 msgid "Different date"
-msgstr ""
+msgstr "Fecha diferente"
 
 #: reports/forms.py
 msgid "No, just once"
-msgstr ""
+msgstr "No, djis un biaha"
 
 #: reports/forms.py
 msgid "Yes, repeat"
-msgstr ""
+msgstr "Si, ripití"
 
 #: reports/forms.py
 msgid "Start date"
-msgstr ""
+msgstr "Fecha di inisio"
 
 #: reports/forms.py
 msgid "Start time (UTC)"
-msgstr ""
+msgstr "Ora di kuminsá (UTC)"
 
 #: reports/forms.py
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Recurrence"
-msgstr ""
+msgstr "Rekurensia"
 
 #: reports/forms.py
 msgid "No recurrence, just once"
-msgstr ""
+msgstr "No tin rekuerensia, djis un biaha"
 
 #: reports/forms.py
 msgid "Daily"
-msgstr ""
+msgstr "Tur dia"
 
 #: reports/forms.py
 msgid "Weekly"
-msgstr ""
+msgstr "Semanalmente"
 
 #: reports/forms.py
 msgid "Monthly"
-msgstr ""
+msgstr "Mensualmente"
 
 #: reports/forms.py
 msgid "Yearly"
-msgstr ""
+msgstr "Anualmente"
 
 #: reports/forms.py
 msgid "day"
-msgstr ""
+msgstr "dia"
 
 #: reports/forms.py
 msgid "week"
-msgstr ""
+msgstr "siman"
 
 #: reports/forms.py
 msgid "month"
-msgstr ""
+msgstr "luna"
 
 #: reports/forms.py
 msgid "year"
-msgstr ""
+msgstr "aña"
 
 #: reports/forms.py
 msgid "Never"
-msgstr ""
+msgstr "Nunka"
 
 #: reports/forms.py
 msgid "On"
-msgstr ""
+msgstr "Riba"
 
 #: reports/forms.py
 msgid "After"
-msgstr ""
+msgstr "Despues"
 
 #: reports/forms.py
 msgid "Report name format"
-msgstr ""
+msgstr "Formato di nòmber di rapòrt"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/report_types/multi_organization_report/appendix.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Appendix"
-msgstr ""
+msgstr "Apèndiks"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Currently filtered on"
-msgstr ""
+msgstr "Aktualmente ta filtra riba"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/partials/report_sidemenu.html
 #: reports/templates/summary/report_asset_overview.html
 msgid "Selected Report Types"
-msgstr ""
+msgstr "Tiponan di Rapòrt Selektá"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Selected report types"
-msgstr ""
+msgstr "Tiponan di rapòrt selektá"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/partials/plugin_overview_table.html
@@ -2735,16 +2909,16 @@ msgstr ""
 #: reports/templates/report_overview/subreports_table.html
 #: reports/templates/summary/report_asset_overview.html
 msgid "Report type"
-msgstr ""
+msgstr "Tipo di rapòrt"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Service Versions and Health"
-msgstr ""
+msgstr "Vershonnan di Servisio i Salú"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Service, version and health"
-msgstr ""
+msgstr "Servisio, vershon i salú"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/summary/service_health.html rocky/templates/footer.html
@@ -2769,31 +2943,31 @@ msgstr "Salú"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Unhealthy"
-msgstr ""
+msgstr "Insaludabel"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Used Config objects"
-msgstr ""
+msgstr "Ophetonan di Config usá"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Used config objects"
-msgstr ""
+msgstr "Ophetonan di konfigurashon usá"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Primary Key"
-msgstr ""
+msgstr "Yabi Primario"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Bit ID"
-msgstr ""
+msgstr "ID di bit"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Config"
-msgstr ""
+msgstr "Konfigurashon"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "No config objects found."
-msgstr ""
+msgstr "No a haña ophetonan di konfigurashon."
 
 #: reports/report_types/aggregate_organisation_report/asset_overview.html
 #: reports/report_types/multi_organization_report/asset_overview.html
@@ -2801,20 +2975,23 @@ msgstr ""
 #: reports/templates/partials/report_sidemenu.html
 #: reports/templates/summary/report_asset_overview.html
 msgid "Asset overview"
-msgstr ""
+msgstr "Bista general di aktivo"
 
 #: reports/report_types/aggregate_organisation_report/asset_overview.html
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid ""
-"An overview of the manually released scanned assets. Assets in <strong>bold</"
-"strong> are taken as a starting point, assets that are not in bold were "
-"found by OpenKAT itself."
+"An overview of the manually released scanned assets. Assets in "
+"<strong>bold</strong> are taken as a starting point, assets that are not in "
+"bold were found by OpenKAT itself."
 msgstr ""
+"Un bista di e aktivonan skan ku a wòrdu lansa manualmente. Aktivonan den "
+"<strong>bold</strong> ta wòrdu tumá komo punto di salida, aktivonan ku no ta"
+" den bold a wòrdu hañá dor di OpenKAT mes."
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 #: reports/report_types/aggregate_organisation_report/report.html
 msgid "Overview of the basic security status"
-msgstr ""
+msgstr "Bista di e status básiko di seguridat"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 msgid ""
@@ -2822,39 +2999,42 @@ msgid ""
 "assets. Basic security in order. In principle, all values in this table "
 "should be checked off."
 msgstr ""
+"E tabel aki ta duna un bista di e status básiko di seguridat di e aktivonan "
+"konosí. Seguridat básiko na òrdu. En prinsipio, tur balor den e tabel aki "
+"mester ta marká."
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 msgid "Basic security status"
-msgstr ""
+msgstr "Status básiko di seguridat"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 #: reports/report_types/ipv6_report/report.html
 #: reports/report_types/multi_organization_report/ipv6.html
 #: reports/report_types/systems_report/report.html
 msgid "System type"
-msgstr ""
+msgstr "Tipo di sistema"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Safe connections"
-msgstr ""
+msgstr "Konekshonnan seif"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 msgid "System Specific"
-msgstr ""
+msgstr "Spesífiko di Sistema"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 msgid "RPKI"
-msgstr ""
+msgstr "RPKI"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/rpki_report/report.html
 #: reports/report_types/safe_connections_report/report.html
 msgid "server"
-msgstr ""
+msgstr "servidor"
 
 #: reports/report_types/aggregate_organisation_report/findings.html
 #: reports/report_types/aggregate_organisation_report/report.html
@@ -2862,53 +3042,58 @@ msgid ""
 "This chapter contains information about the findings that have been "
 "identified for this organization."
 msgstr ""
+"E kapítulo aki ta kontené informashon tokante e resultadonan ku a wòrdu "
+"identifiká pa e organisashon aki."
 
 #: reports/report_types/aggregate_organisation_report/recommendations.html
 #: reports/report_types/multi_organization_report/recommendations.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Recommendations"
-msgstr ""
+msgstr "Rekomendashonnan"
 
 #: reports/report_types/aggregate_organisation_report/recommendations.html
 #, python-format
 msgid "There is <i>%(total_findings)s</i> vulnerability"
 msgid_plural "There are <i>%(total_findings)s</i> vulnerabilities"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Tin vulnerabilidatnan <i>%(total_findings)s</i>"
+msgstr[1] "Tin vulnerabilidatnan <i>%(total_findings)s</i>"
 
 #: reports/report_types/aggregate_organisation_report/recommendations.html
 #, python-format
 msgid "found on <i>%(total_systems)s</i> system."
 msgid_plural "found on <i>%(total_systems)s</i> systems."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "hañá riba sistemanan <i>%(total_systems)s</i>."
+msgstr[1] "hañá riba sistemanan <i>%(total_systems)s</i>."
 
 #: reports/report_types/aggregate_organisation_report/recommendations.html
 #: reports/report_types/multi_organization_report/recommendations.html
 msgid "There are no recommendations."
-msgstr ""
+msgstr "No tin rekomendashon."
 
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Basic security"
-msgstr ""
+msgstr "Seguridat básiko"
 
 #: reports/report_types/aggregate_organisation_report/report.html
 msgid ""
 "In this chapter, first a table of compliance checks is displayed, followed "
 "by a detailed examination of compliance issues for each component."
 msgstr ""
+"Den e kapítulo aki, promé un tabel di kòntròl di kumplimentu ta wòrdu "
+"mustra, sigui pa un eksaminashon detayá di e asuntunan di kumplimentu pa "
+"kada komponente."
 
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "System specific"
-msgstr ""
+msgstr "Sistema spesífiko"
 
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Resource Public Key Infrastructure"
-msgstr ""
+msgstr "Rekurso Infrastruktura Klave Públiko"
 
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/report_types/aggregate_organisation_report/vulnerabilities.html
@@ -2916,16 +3101,16 @@ msgstr ""
 #: reports/report_types/vulnerability_report/report.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Vulnerabilities"
-msgstr ""
+msgstr "Vulnerabilidatnan"
 
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/report_types/aggregate_organisation_report/vulnerabilities.html
 msgid "Vulnerabilities found are grouped per system."
-msgstr ""
+msgstr "Vulnerabilidatnan hañá ta wòrdu agrupá pa sistema."
 
 #: reports/report_types/aggregate_organisation_report/report.py
 msgid "Aggregate Organisation Report"
-msgstr ""
+msgstr "Rapòrt di Organisashon Agregá"
 
 #: reports/report_types/aggregate_organisation_report/rpki.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
@@ -2936,6 +3121,12 @@ msgid ""
 "misconfigurations and malicious route intercepts through verified route "
 "announcements, ensuring reliable server access and secure internet traffic."
 msgstr ""
+"E sekshon aki ta kontené informashon básiko di seguridat tokante "
+"infrastruktura di yabi públiko di rekurso. Si bo servidor di wèp ta empleá "
+"RPKI pa su adrèsnan IP i servidornan di nòmber asosiá, e ora ei e ta mehorá "
+"protekshon di bishitante kontra mal konfigurashon i intersepshonnan di ruta "
+"malisioso a traves di anunsionan di ruta verifiká, garantisando akseso "
+"konfiabel na servidor i tráfiko di internèt sigur."
 
 #: reports/report_types/aggregate_organisation_report/safe_connections.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
@@ -2946,6 +3137,11 @@ msgid ""
 "strong encryption which protects the data from interception during "
 "communiction."
 msgstr ""
+"Den e kapítulo aki nos ta kontrolá si e konekshonnan di tur e portanan IP di"
+" e sistema ta sigur. Konekshonnan seif ta importante pa prevení akseso no "
+"outorisá i violashon di dato. Sifranan fuerte ta krusial pasobra nan ta "
+"garantisá enkripshon fuerte ku ta protehá e datonan di intersepshon durante "
+"komunikashon."
 
 #: reports/report_types/aggregate_organisation_report/summary.html
 #: reports/report_types/multi_organization_report/summary.html
@@ -2955,32 +3151,34 @@ msgstr "Resúmen"
 
 #: reports/report_types/aggregate_organisation_report/summary.html
 msgid "Critical Vulnerabilities"
-msgstr ""
+msgstr "Vulnerabilidatnan Krítiko"
 
 #: reports/report_types/aggregate_organisation_report/summary.html
 msgid "IPs scanned"
-msgstr ""
+msgstr "IPs skan"
 
 #: reports/report_types/aggregate_organisation_report/summary.html
 msgid "Hostnames scanned"
-msgstr ""
+msgstr "Nombernan di anfitrion a wòrdu skan"
 
 #: reports/report_types/aggregate_organisation_report/summary.html
 msgid "Terms in report"
-msgstr ""
+msgstr "Términonan den rapòrt"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/rpki_report/report.html
 #: reports/report_types/safe_connections_report/report.html
 #, python-format
 msgid ""
-"This table shows which checks were performed. Following that, the compliance "
-"issues, if any, are shown for each %(type)s Server."
+"This table shows which checks were performed. Following that, the compliance"
+" issues, if any, are shown for each %(type)s Server."
 msgstr ""
+"E tabel aki ta mustra kua kòntròlnan a wòrdu hasi. Despues di esei, e "
+"asuntunan di kumplimentu, si tin, ta wòrdu mustra pa kada %(type)s Server."
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 msgid "Check overview"
-msgstr ""
+msgstr "Kontrolá e bista general"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/mail_report/report.html
@@ -2990,7 +3188,7 @@ msgstr ""
 #: reports/report_types/safe_connections_report/report.html
 #: reports/report_types/web_system_report/report.html
 msgid "Check"
-msgstr ""
+msgstr "Chèk"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/mail_report/report.html
@@ -2999,18 +3197,18 @@ msgstr ""
 #: reports/report_types/safe_connections_report/report.html
 #: reports/report_types/web_system_report/report.html
 msgid "Compliance"
-msgstr ""
+msgstr "Kumplimentu"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/rpki_report/report.html
 msgid "IPs are compliant"
-msgstr ""
+msgstr "IPs ta kumpli"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/safe_connections_report/report.html
 #: reports/report_types/vulnerability_report/report.html
 msgid "Host:"
-msgstr ""
+msgstr "Anfitrion:"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/mail_report/report.html
@@ -3019,7 +3217,7 @@ msgstr ""
 #: reports/report_types/safe_connections_report/report.html
 #: reports/report_types/web_system_report/report.html
 msgid "Compliance issue"
-msgstr ""
+msgstr "Problema di kumplimentu"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/mail_report/report.html
@@ -3042,28 +3240,43 @@ msgid ""
 "security and compliance issues come into play for different systems. They "
 "are listed here under each other."
 msgstr ""
+"Aki ta kaminda ta hasi kòntròlnan ku ta spesífiko pa tiponan di sistema. "
+"Diferente asuntu di seguridat i kumplimentu ta bin den wega pa diferente "
+"sistema. Nan ta lista aki bou di otro."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Term Overview"
-msgstr ""
+msgstr "Bista General di Término"
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid "For definitions of terms used in this chapter, see the glossary below."
 msgstr ""
+"Pa definishonnan di términonan usá den e kapítulo aki, wak e glosario aki "
+"bou."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
 "Web servers and domains are examples of digital assets within this "
-"framework. Web servers are essential for hosting and serving websites or web "
-"applications, while domains represent the online addresses used to access "
-"these resources. Other examples of assets in the IT realm include databases, "
-"user accounts, software applications, and networking infrastructure. Asset "
+"framework. Web servers are essential for hosting and serving websites or web"
+" applications, while domains represent the online addresses used to access "
+"these resources. Other examples of assets in the IT realm include databases,"
+" user accounts, software applications, and networking infrastructure. Asset "
 "management is a critical aspect of cybersecurity, involving the "
 "identification, classification, and protection of these assets to safeguard "
 "against threats and ensure the overall security and functionality of an "
 "organization's IT environment."
 msgstr ""
+"Servidornan di wèp i dominionan ta ehèmpelnan di aktivonan digital denter di"
+" e kuadro aki. Servidornan di wèp ta esensial pa host i sirbi wèpsaitnan òf "
+"aplikashonnan di wèp, miéntras ku dominionan ta representá e adrèsnan online"
+" ku ta wòrdu usá pa akseso na e rekursonan aki. Otro ehèmpelnan di aktivo "
+"den e reino di IT ta inkluí basenan di dato, kuenta di usuario, "
+"aplikashonnan di software i infrastruktura di ret. Maneho di aktivo ta un "
+"aspekto kritiko di seguridat sibernétiko, ku ta enserá e identifikashon, "
+"klasifikashon i protekshon di e aktivonan aki pa protehá kontra menasanan i "
+"garantisá e seguridat i funshonalidat general di e ambiente di IT di un "
+"organisashon."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
@@ -3071,13 +3284,20 @@ msgid ""
 "hostnames or the IP address has a declared scan level that is at least L1. "
 "Type systems are web servers, mail servers and name servers (DNS)."
 msgstr ""
+"Múltiple nòmber di anfitrion ku ta resolvé na un adrès IP kaminda por lo "
+"ménos un di e nòmbernan di anfitrion òf e adrès IP tin un nivel di skan "
+"deklará ku ta por lo ménos L1. Sistemanan di tipo ta servidornan di wèp, "
+"servidornan di mail i servidornan di nòmber (DNS)."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
 "A fundamental component of the client-server model. A web server uses "
-"protocols like HTTP or HTTPS to facilitate communication between clients and "
-"the server."
+"protocols like HTTP or HTTPS to facilitate communication between clients and"
+" the server."
 msgstr ""
+"Un komponente fundamental di e modelo di kliente-servidor. Un servidor di "
+"wèp ta usa protokòlnan manera HTTP òf HTTPS pa fasilitá komunikashon entre "
+"klientenan i e servidor."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
@@ -3091,16 +3311,32 @@ msgid ""
 "emails, handling tasks such as authentication, spam filtering, and message "
 "storage."
 msgstr ""
+"Un mail server ta un aplikashon di software spesialisá òf un aparato di "
+"hardware ku ta fasilitá e mandamentu, risibí i almasenamentu di emailnan "
+"denter di un ret di kòmpiuter. Operando riba e Simple Mail Transfer Protocol"
+" (SMTP) pa mensahenan saliente i sea Internet Message Access Protocol (IMAP)"
+" òf Post Office Protocol (POP) pa mensahenan entrante, un servidor di mail "
+"ta manehá komunikashon di email dor di enrutá mensahenan entre usuarionan i "
+"nan ta wòrdu rekuperá te ora ku nan ta wòrdu rekuperá. E servidor ta "
+"garantisá e transferensia efisiente i sigur di emailnan, manehá tareanan "
+"manera outentikashon, filtrashon di spam i almasenamentu di mensahe."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
-"A nameserver, or Domain Name System (DNS) server, is a critical component of "
-"the internet infrastructure responsible for translating human-readable "
-"domain names into IP addresses, enabling the seamless navigation of the web. "
-"When a user enters a domain name in a web browser, the nameserver is queried "
-"to obtain the corresponding IP address of the server hosting the associated "
-"website or service."
+"A nameserver, or Domain Name System (DNS) server, is a critical component of"
+" the internet infrastructure responsible for translating human-readable "
+"domain names into IP addresses, enabling the seamless navigation of the web."
+" When a user enters a domain name in a web browser, the nameserver is "
+"queried to obtain the corresponding IP address of the server hosting the "
+"associated website or service."
 msgstr ""
+"Un servidor di nòmber, òf servidor di Sistema di Nòmber di Dominio (DNS), ta"
+" un komponente krítiko di e infrastruktura di internèt responsabel pa "
+"tradusí nòmbernan di dominio lesabel pa hende den adrèsnan IP, loke ta "
+"permití e navegashon sin problema di e wèp. Ora un usuario ta introdusí un "
+"nòmber di dominio den un navegador di wèp, e servidor di nòmber ta wòrdu "
+"konsultá pa optené e adrès korespondiente IP di e servidor ku ta hospedá e "
+"wèpsait òf servisio asosiá."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
@@ -3115,15 +3351,24 @@ msgid ""
 "medical images, like X-rays, CT scans, and MRIs, utilizing a standardized "
 "format."
 msgstr ""
+"Un servidor DICOM, ku ta nifiká Digital Imaging and Communications in "
+"Medicine, ta un servidor spesialisá diseñá pa warda, buska bèk i interkambiá"
+" imágennan médiko i informashon relashoná den e sektor di kuido di salú. "
+"DICOM ta un standard ampliamente adoptá ku ta garantisá interoperabilidat i "
+"konsistensia den komunikashon di imágennan médiko i datonan relashoná entre "
+"diferente aparato i sistema, manera ekipo di imágen médiko, sistemanan pa "
+"archivá i komuniká imágen (PACS), i sistemanan di informashon di radiologia "
+"(RIS). Servidornan DICOM ta warda i manehá imágennan médiko spesífiko pa "
+"pashènt, manera X-rays, CT scans i MRIs, usando un formato standardisá."
 
 #: reports/report_types/aggregate_organisation_report/vulnerabilities.html
 #: reports/report_types/multi_organization_report/vulnerabilities.html
 msgid "No CVEs have been found."
-msgstr ""
+msgstr "No a haña CVE."
 
 #: reports/report_types/dns_report/report.html
 msgid "Records found"
-msgstr ""
+msgstr "Registronan hañá"
 
 #: reports/report_types/dns_report/report.html
 msgid ""
@@ -3131,24 +3376,30 @@ msgid ""
 "DNSZone. Additionally the security measures table shows whether or not DNS "
 "relating security measures are enabled."
 msgstr ""
+"E rapòrt DNS ta duna un bista di e registronan DNS ku a wòrdu hañá pa e "
+"DNSZone. Adishonalmente e tabel di medidanan di seguridat ta mustra si DNS "
+"medidanan di seguridat relashoná ta aktivá òf nò."
 
 #: reports/report_types/dns_report/report.html
 msgid ""
 "<strong>Disclaimer:</strong> Not all DNSRecords are parsed in OpenKAT. DNS "
 "record types that are parsed and could be displayed in the table are:"
 msgstr ""
+"<strong>Disclaimer:</strong> No ta tur DNSRecords ta wòrdu analisá den "
+"OpenKAT. DNS tiponan di registro ku ta wòrdu analisá i por wòrdu mustra den "
+"e tabel ta:"
 
 #: reports/report_types/dns_report/report.html
 msgid "All existing DNS record types can be found here:"
-msgstr ""
+msgstr "Tur tipo di registro DNS eksistente por wòrdu hañá aki:"
 
 #: reports/report_types/dns_report/report.html
 msgid "Record"
-msgstr ""
+msgstr "Registro"
 
 #: reports/report_types/dns_report/report.html
 msgid "TTL"
-msgstr ""
+msgstr "TTL"
 
 #: reports/report_types/dns_report/report.html
 msgid "Data"
@@ -3156,17 +3407,20 @@ msgstr "Data"
 
 #: reports/report_types/dns_report/report.html
 msgid "No records have been found."
-msgstr ""
+msgstr "No a haña ningun registro."
 
 #: reports/report_types/dns_report/report.html
 msgid "Security measures"
-msgstr ""
+msgstr "Medidanan di seguridat"
 
 #: reports/report_types/dns_report/report.html
 msgid ""
-"The security measures table below shows which DNS relating security measures "
-"are enabled based on the contents of the DNS records."
+"The security measures table below shows which DNS relating security measures"
+" are enabled based on the contents of the DNS records."
 msgstr ""
+"E tabel di medidanan di seguridat abou ta mustra kua DNS medidanan di "
+"seguridat relashoná ta wòrdu aktivá a base di e kontenido di e registronan "
+"DNS."
 
 #: reports/report_types/dns_report/report.html
 #: reports/templates/partials/report_ooi_list.html
@@ -3192,11 +3446,11 @@ msgstr "Nò"
 #: reports/report_types/dns_report/report.html
 #: reports/templates/partials/report_findings_table.html
 msgid "Other findings found"
-msgstr ""
+msgstr "Otro resultadonan hañá"
 
 #: reports/report_types/dns_report/report.html
 msgid "Findings information"
-msgstr ""
+msgstr "Informashon di resultadonan"
 
 #: reports/report_types/dns_report/report.py
 msgid "DNS Report"
@@ -3207,20 +3461,24 @@ msgid ""
 "DNS reports focus on domain name system configuration and potential "
 "weaknesses."
 msgstr ""
+"DNS informenan ta enfoká riba konfigurashon di sistema di nòmber di dominio "
+"i debilidatnan potensial."
 
 #: reports/report_types/findings_report/report.html
 msgid ""
 "The Findings Report contains information about the findings that have been "
 "identified for the selected asset and organization."
 msgstr ""
+"E Rapport di Resultadonan ta kontené informashon tokante e resultadonan ku a"
+" wòrdu identifiká pa e aktivo i organisashon selektá."
 
 #: reports/report_types/findings_report/report.py
 msgid "Findings Report"
-msgstr ""
+msgstr "Rapòrt di resultadonan"
 
 #: reports/report_types/findings_report/report.py
 msgid "Shows all the finding types and their occurrences."
-msgstr ""
+msgstr "Ta mustra tur e tiponan di hañamentu i nan okashon."
 
 #: reports/report_types/ipv6_report/report.html
 msgid ""
@@ -3229,169 +3487,188 @@ msgid ""
 "over IPv6 or not. A green compliance check is shown if this is the case. A "
 "grey compliance cross is shown if no IPv6 address was detected."
 msgstr ""
+"E rapòrt IPv6 ta duna un bista general di e status aktual di IPv6 pa e "
+"sistema identifiká. E tabel aki bou ta mustra si e dominio ta alkansabel via"
+" IPv6 òf nò. Un mark di kumplimentu bèrdè ta wòrdu mustrá si esaki ta e "
+"kaso. Un krus di kumplimentu shinishi ta wòrdu mustrá si no a detektá ningun"
+" adrès IPv6."
 
 #: reports/report_types/ipv6_report/report.html
 msgid "IPv6 overview"
-msgstr ""
+msgstr "IPv6 bista general"
 
 #: reports/report_types/ipv6_report/report.html
 #: reports/report_types/systems_report/report.html
 msgid "Domain"
-msgstr ""
+msgstr "Dominio"
 
 #: reports/report_types/ipv6_report/report.py
 msgid "IPv6 Report"
-msgstr ""
+msgstr "IPv6 Raportá"
 
 #: reports/report_types/ipv6_report/report.py
 msgid "Check whether hostnames point to IPv6 addresses."
-msgstr ""
+msgstr "Kontrolá si e nòmbernan di anfitrion ta mustra riba adresnan IPv6."
 
 #: reports/report_types/mail_report/report.html
 msgid ""
 "The Mail Report provides an overview of the compliance checks associated "
 "with email servers. The current compliance checks the presence of SPF, DKIM "
 "and DMARC records. The table below shows for each of these checks how many "
-"of the identified mail servers are compliant, and if applicable a compliance "
-"issue description and risk level. The risk level may be different for your "
+"of the identified mail servers are compliant, and if applicable a compliance"
+" issue description and risk level. The risk level may be different for your "
 "specific environment."
 msgstr ""
+"E Mail Report ta duna un bista di e kòntròlnan di kumplimentu asosiá ku e "
+"servidornan di email. E kumplimentu aktual ta kontrolá e presensia di "
+"registronan SPF, DKIM i DMARC. E tabel aki bou ta mustra pa kada un di e "
+"kòntròlnan aki kuantu di e servidornan di mail identifiká ta kumpli, i si ta"
+" aplikabel un deskripshon di e asuntu di kumplimentu i nivel di riesgo. E "
+"nivel di riesgo por ta diferente pa bo ambiente spesífiko."
 
 #: reports/report_types/mail_report/report.html
 msgid "Mailserver compliance"
-msgstr ""
+msgstr "Kumplimentu di servidor di koreo"
 
 #: reports/report_types/mail_report/report.html
 msgid "mailservers compliant"
-msgstr ""
+msgstr "servidornan di pòst ta kumpli ku"
 
 #: reports/report_types/mail_report/report.html
 msgid "No mailservers have been found on this system."
-msgstr ""
+msgstr "No a haña ningun servidor di koreo riba e sistema aki."
 
 #: reports/report_types/mail_report/report.py
 msgid "Mail Report"
-msgstr ""
+msgstr "Rapport di Mail"
 
 #: reports/report_types/mail_report/report.py
 msgid ""
 "System specific Mail Report that focusses on IP addresses and hostnames."
 msgstr ""
+"Rapport di Mail spesífiko pa sistema ku ta enfoká riba IP adrèsnan i "
+"nòmbernan di host."
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Overview of included assets"
-msgstr ""
+msgstr "Bista di e aktivonan inkluí"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Asset"
-msgstr ""
+msgstr "Aktivo"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
 msgid "Amount"
-msgstr ""
+msgstr "Kantidat"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "IP addresses"
-msgstr ""
+msgstr "IP adrèsnan"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Domain names"
-msgstr ""
+msgstr "Nombernan di dominio"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Assets with most critical vulnerabilities"
-msgstr ""
+msgstr "Aktivonan ku mayoria di vulnerabilidatnan krítiko"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Vulnerability"
-msgstr ""
+msgstr "Vulnerabilidat"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Organisation"
-msgstr ""
+msgstr "Organisashon"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "No vulnerabilities found."
-msgstr ""
+msgstr "No a haña vulnerabilidatnan."
 
 #: reports/report_types/multi_organization_report/basic_security_details.html
 msgid "Overview of safe connections"
-msgstr ""
+msgstr "Bista di konekshonnan seif"
 
 #: reports/report_types/multi_organization_report/basic_security_details.html
 #: reports/report_types/safe_connections_report/report.html
 msgid "Only Safe Ciphers"
-msgstr ""
+msgstr "Solamente Cifranan Sigur"
 
 #: reports/report_types/multi_organization_report/basic_security_details.html
 #: reports/report_types/safe_connections_report/report.html
 msgid "services are compliant"
-msgstr ""
+msgstr "servisionan ta kumpli"
 
 #: reports/report_types/multi_organization_report/basic_security_details.html
 msgid "System specific checks"
-msgstr ""
+msgstr "Kontrolnan spesífiko di sistema"
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid "IPv6"
-msgstr ""
+msgstr "IPv6"
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid ""
-"IPv6 includes improvements in security features compared to IPv4. While IPv4 "
-"can implement security measures, IPv6 was designed with security in mind, "
+"IPv6 includes improvements in security features compared to IPv4. While IPv4"
+" can implement security measures, IPv6 was designed with security in mind, "
 "and its adoption can contribute to a more secure internet."
 msgstr ""
+"IPv6 ta inkluí mehorashonnan den karakterístikanan di seguridat kompará ku "
+"IPv4. Miéntras ku IPv4 por implementá medidanan di seguridat, IPv6 a wòrdu "
+"diseñá ku seguridat den mente, i su adopshon por kontribuí na un internet "
+"mas sigur."
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid "In total "
-msgstr ""
+msgstr "En total"
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid " out of "
-msgstr ""
+msgstr "for di"
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid " systems have an IPv6 connection."
-msgstr ""
+msgstr "sistemanan tin un konekshon IPv6."
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid "Overview of IP version compliance"
-msgstr ""
+msgstr "Bista general di IP vershon di kumplimentu"
 
 #: reports/report_types/multi_organization_report/open_ports.html
 msgid ""
 "See an overview of open ports found over all systems and the services these "
 "systems provide."
 msgstr ""
+"Wak un bista di e portanan habrí ku ta wòrdu hañá riba tur sistema i e "
+"servisionan ku e sistemanan aki ta proveé."
 
 #: reports/report_types/multi_organization_report/open_ports.html
 msgid "Overview of detected open ports"
-msgstr ""
+msgstr "Bista general di portanan habrí detektá"
 
 #: reports/report_types/multi_organization_report/open_ports.html
 #: reports/report_types/open_ports_report/report.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Open ports"
-msgstr ""
+msgstr "Habri portanan"
 
 #: reports/report_types/multi_organization_report/open_ports.html
 msgid "Occurrences (IP addresses)"
-msgstr ""
+msgstr "Suseso (IP adrèsnan)"
 
 #: reports/report_types/multi_organization_report/open_ports.html
 #: reports/templates/summary/service_health.html
 msgid "Services"
-msgstr ""
+msgstr "Servisio"
 
 #: reports/report_types/multi_organization_report/open_ports.html
 msgid "No open ports found."
-msgstr ""
+msgstr "No a haña portanan habrí."
 
 #: reports/report_types/multi_organization_report/recommendations.html
 msgid "Overview of recommendations"
-msgstr ""
+msgstr "Bista general di rekomendashonnan"
 
 #: reports/report_types/multi_organization_report/recommendations.html
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
@@ -3400,33 +3677,35 @@ msgstr "Occurencia"
 
 #: reports/report_types/multi_organization_report/report.html
 msgid "No findings have been identified yet."
-msgstr ""
+msgstr "No a identifiká ningun resultado ainda."
 
 #: reports/report_types/multi_organization_report/report.py
 msgid "Multi Organization Report"
-msgstr ""
+msgstr "Rapòrt di Multi Organisashon"
 
 #: reports/report_types/multi_organization_report/summary.html
 msgid "Best scoring security check"
-msgstr ""
+msgstr "Kòntròl di seguridat di mihó puntuashon"
 
 #: reports/report_types/multi_organization_report/summary.html
 msgid "Worst scoring security check"
-msgstr ""
+msgstr "Kontrol di seguridat ku ta puntra e pió"
 
 #: reports/report_types/multi_organization_report/vulnerabilities.html
 msgid ""
 "Vulnerabilities found are grouped per system. Here, we only consider CVE "
 "vulnerabilities."
 msgstr ""
+"Vulnerabilidatnan hañá ta wòrdu agrupá pa sistema. Aki, nos ta konsiderá "
+"solamente CVE vulnerabilidatnan."
 
 #: reports/report_types/multi_organization_report/vulnerabilities.html
 msgid "Vulnerabilities grouped per system"
-msgstr ""
+msgstr "Vulnerabilidatnan agrupá pa sistema"
 
 #: reports/report_types/multi_organization_report/vulnerabilities.html
 msgid "total"
-msgstr ""
+msgstr "total"
 
 #: reports/report_types/name_server_report/report.html
 msgid ""
@@ -3439,73 +3718,89 @@ msgid ""
 "identified are shown too. The risk level may be different for your specific "
 "environment."
 msgstr ""
+"E Rapòrt di Servidor di Nòmber ta duna un bista di e kòntròlnan di "
+"kumplimentu ku a wòrdu realisá kontra e Servidornan di Nòmber di Dominio "
+"identifiká (DNS). E kòntròlnan di kumplimentu ta verifiká e presensia i "
+"valides di DNSSEC i si no a identifiká portanan innesesario pa ta habrí. E "
+"tabel aki bou ta duna un bista di e kòntròlnan disponibel inkluyendo si e "
+"sistema a pasa e kòntròlnan realisá. E nivel di riesgo i e rasonamentu dikon"
+" un problema a wòrdu identifiká tambe ta wòrdu mustra. E nivel di riesgo por"
+" ta diferente pa bo ambiente spesífiko."
 
 #: reports/report_types/name_server_report/report.html
 msgid "Name server compliance"
-msgstr ""
+msgstr "Kumplimentu di servidor di nòmber"
 
 #: reports/report_types/name_server_report/report.html
 msgid "DNSSEC Present"
-msgstr ""
+msgstr "DNSSEC Presente"
 
 #: reports/report_types/name_server_report/report.html
 msgid "name servers compliant"
-msgstr ""
+msgstr "servidornan di nòmber ta kumpli ku"
 
 #: reports/report_types/name_server_report/report.html
 msgid "Valid DNSSEC"
-msgstr ""
+msgstr "Válido DNSSEC"
 
 #: reports/report_types/name_server_report/report.html
 #: reports/report_types/web_system_report/report.html
 msgid "No unnecessary ports open"
-msgstr ""
+msgstr "No habrí portanan innesesario"
 
 #: reports/report_types/name_server_report/report.html
 msgid "No nameservers have been found on this system."
-msgstr ""
+msgstr "No a haña ningun servidor di nòmber riba e sistema aki."
 
 #: reports/report_types/name_server_report/report.py
 msgid "Name Server Report"
-msgstr ""
+msgstr "Rapòrt di Servidor di Nòmber"
 
 #: reports/report_types/name_server_report/report.py
 msgid "Name Server Report checks name servers on basic security standards."
 msgstr ""
+"Name Server Report ta kontrolá e servidornan di nòmber riba normanan básiko "
+"di seguridat."
 
 #: reports/report_types/open_ports_report/report.html
 msgid ""
-"The Open Ports Report provides an overview of the open ports identified on a "
-"system. The ports that are marked as <b>bold</b> were identified by direct "
-"scans performed by OpenKAT (such as nmap). Ports that are not marked in bold "
-"were identified through external services and/or scans (such as Shodan). "
+"The Open Ports Report provides an overview of the open ports identified on a"
+" system. The ports that are marked as <b>bold</b> were identified by direct "
+"scans performed by OpenKAT (such as nmap). Ports that are not marked in bold"
+" were identified through external services and/or scans (such as Shodan). "
 "Scans with the same hostnames, ports and IPs are merged."
 msgstr ""
+"E Rapòrt di Hafnan Habrí ta duna un bista di e portanan habrí identifiká "
+"riba un sistema. E portanan ku ta marká komo <b>bold</b> a wòrdu identifiká "
+"dor di skan direkto realisá pa OpenKAT (manera nmap). Portnan ku no ta marká"
+" den letter grandi a wòrdu identifiká a traves di servisio eksterno i/òf "
+"skan (manera Shodan). Skannan ku e mesun nòmbernan di host, portanan i IPs "
+"ta wòrdu kombiná."
 
 #: reports/report_types/open_ports_report/report.html
 msgid "Overview of open ports found for the scanned assets"
-msgstr ""
+msgstr "Bista di portanan habrí hañá pa e aktivonan skan"
 
 #: reports/report_types/open_ports_report/report.html
 #: reports/report_types/systems_report/report.html
 msgid "IP address"
-msgstr ""
+msgstr "IP adrès"
 
 #: reports/report_types/open_ports_report/report.html
 msgid "Hostnames"
-msgstr ""
+msgstr "Nombernan di anfitrion"
 
 #: reports/report_types/open_ports_report/report.html
 msgid "Direct scan"
-msgstr ""
+msgstr "Skan direkto"
 
 #: reports/report_types/open_ports_report/report.py
 msgid "Open Ports Report"
-msgstr ""
+msgstr "Rapòrt di Hafnan Habrí"
 
 #: reports/report_types/open_ports_report/report.py
 msgid "Find open ports of IP addresses"
-msgstr ""
+msgstr "Buska portanan habrí di adresnan IP"
 
 #: reports/report_types/rpki_report/report.html
 msgid ""
@@ -3515,119 +3810,147 @@ msgid ""
 "misconfigurations and malicious route intercepts through verified route "
 "announcements, ensuring reliable server access and secure internet traffic."
 msgstr ""
+"E sekshon aki ta kontené informashon básiko di seguridat tokante "
+"Infrastruktura di Yabi Públiko di Rekurso (RPKI). Si bo servidor di wèp ta "
+"empleá RPKI pa su adrèsnan IP i servidornan di nòmber asosiá, e ora ei e ta "
+"mehorá protekshon di bishitante kontra mal konfigurashon i intersepshonnan "
+"di ruta malisioso a traves di anunsionan di ruta verifiká, garantisando "
+"akseso konfiabel na servidor i tráfiko di internèt sigur."
 
 #: reports/report_types/rpki_report/report.html
 msgid ""
 "The RPKI Report shows if an RPKI route announcement was available for the "
 "system and if this announcement is not expired."
 msgstr ""
+"E RPKI Rapport ta mustra si un anunsio di ruta RPKI tabata disponibel pa e "
+"sistema i si e anunsio aki no a kaduká."
 
 #: reports/report_types/rpki_report/report.html
 msgid "RPKI compliance"
-msgstr ""
+msgstr "RPKI kumplimentu"
 
 #: reports/report_types/rpki_report/report.html
 msgid "RPKI Available"
-msgstr ""
+msgstr "RPKI Disponibel"
 
 #: reports/report_types/rpki_report/report.html
 msgid "RPKI valid"
-msgstr ""
+msgstr "RPKI bálido"
 
 #: reports/report_types/rpki_report/report.html
 msgid "RPKI record is not valid."
-msgstr ""
+msgstr "RPKI e registro no ta bálido."
 
 #: reports/report_types/rpki_report/report.html
 msgid "RPKI record does not exist."
-msgstr ""
+msgstr "RPKI registro no ta eksistí."
 
 #: reports/report_types/rpki_report/report.html
 #: reports/report_types/safe_connections_report/report.html
 msgid "No IPs have been found on this system."
-msgstr ""
+msgstr "No a haña IPs riba e sistema aki."
 
 #: reports/report_types/rpki_report/report.py
 msgid "RPKI Report"
-msgstr ""
+msgstr "RPKI Raportá"
 
 #: reports/report_types/rpki_report/report.py
 msgid ""
-"Shows whether the IP is covered by a valid RPKI ROA. For a hostname it shows "
-"the IP addresses and whether they are covered by a valid RPKI ROA."
+"Shows whether the IP is covered by a valid RPKI ROA. For a hostname it shows"
+" the IP addresses and whether they are covered by a valid RPKI ROA."
 msgstr ""
+"Ta mustra si e IP ta kubri pa un RPKI ROA bálido. Pa un nòmber di anfitrion "
+"e ta mustra e adrèsnan IP i si nan ta kubri pa un RPKI ROA bálido."
 
 #: reports/report_types/safe_connections_report/report.html
 msgid ""
 "The Safe Connections report provides an overview of the performed checks "
 "with regard to encrypted communication channels such as HTTPS. The table "
-"below gives an overview of the available checks including whether the system "
-"passed the performed checks. The risk level and reasoning as to why an issue "
-"was identified are shown too. The risk level may be different for your "
-"specific environment."
+"below gives an overview of the available checks including whether the system"
+" passed the performed checks. The risk level and reasoning as to why an "
+"issue was identified are shown too. The risk level may be different for your"
+" specific environment."
 msgstr ""
+"E rapòrt di Konekshonnan Sigur ta duna un bista di e kòntròlnan realisá pa "
+"loke ta trata kanalnan di komunikashon enkriptá manera HTTPS. E tabel aki "
+"bou ta duna un bista di e kòntròlnan disponibel inkluyendo si e sistema a "
+"pasa e kòntròlnan realisá. E nivel di riesgo i e rasonamentu dikon un "
+"problema a wòrdu identifiká tambe ta wòrdu mustra. E nivel di riesgo por ta "
+"diferente pa bo ambiente spesífiko."
 
 #: reports/report_types/safe_connections_report/report.html
 msgid "Safe connections compliance"
-msgstr ""
+msgstr "Kumplimentu ku konekshonnan sigur"
 
 #: reports/report_types/safe_connections_report/report.py
 msgid "Safe Connections Report"
-msgstr ""
+msgstr "Rapport di Konekshonnan Sigur"
 
 #: reports/report_types/safe_connections_report/report.py
 msgid "Shows whether the IPService contains safe ciphers."
-msgstr ""
+msgstr "Ta mustra si e IPService ta kontené sifranan sigur."
 
 #: reports/report_types/systems_report/report.html
 msgid ""
-"The System Report provides an overview of the system types (types of similar "
-"services) that were identified for each system. The following system types "
+"The System Report provides an overview of the system types (types of similar"
+" services) that were identified for each system. The following system types "
 "can be identified: DNS servers, Web servers, Mail servers and those "
 "classified as 'Other' servers. Each hostname and/or IP address is given one "
 "or more system types depending on the identified ports and services. The "
 "table below gives an overview of these results."
 msgstr ""
+"E Rapòrt di Sistema ta duna un bista di e tiponan di sistema (tipo di "
+"servisio similar) ku a wòrdu identifiká pa kada sistema. E siguiente tiponan"
+" di sistema por wòrdu identifiká: DNS servidornan, servidornan di wèp, "
+"servidornan di mail i esnan klasifiká komo servidornan ‘Otro’. Kada nòmber "
+"di anfitrion i/òf adres IP ta haña un òf mas tipo di sistema dependiendo di "
+"e portanan i servisionan identifiká. E tabel aki bou ta duna un bista di e "
+"resultadonan aki."
 
 #: reports/report_types/systems_report/report.html
 msgid "Selected assets"
-msgstr ""
+msgstr "Aktivonan selektá"
 
 #: reports/report_types/systems_report/report.html
 msgid "No system types have been identified on this system."
-msgstr ""
+msgstr "No a identifiká ningun tipo di sistema riba e sistema aki."
 
 #: reports/report_types/systems_report/report.py
 msgid "System Report"
-msgstr ""
+msgstr "Rapport di Sistema"
 
 #: reports/report_types/systems_report/report.py
 msgid "Combine IP addresses, hostnames and services into systems."
 msgstr ""
+"Kombiná IP adrèsnan, nòmbernan di anfitrion i servisio den sistemanan."
 
 #: reports/report_types/tls_report/report.html
 msgid ""
 "The TLS Report shows which TLS protocols and ciphers were identified on the "
 "host for the provided port."
 msgstr ""
+"E TLS Rapport ta mustra kua TLS protokòl i sifra a wòrdu identifiká riba e "
+"host pa e pòrt suministrá."
 
 #: reports/report_types/tls_report/report.html
 msgid ""
 "The table below provides an overview of the identified TLS protocols and "
 "ciphers, including a status suggestion."
 msgstr ""
+"E tabel aki bou ta duna un bista di e protokòlnan i sifranan TLS identifiká,"
+" inkluyendo un sugerensia di status."
 
 #: reports/report_types/tls_report/report.html
 msgid "Ciphers"
-msgstr ""
+msgstr "Sifranan"
 
 #: reports/report_types/tls_report/report.html
 msgid "Protocol"
-msgstr ""
+msgstr "Protokòl"
 
 #: reports/report_types/tls_report/report.html
 msgid "Encryption Algorithm"
-msgstr ""
+msgstr "Algoritmo di Enkripshon"
 
 #: reports/report_types/tls_report/report.html
 msgid "Bits"
@@ -3635,7 +3958,7 @@ msgstr "Bits"
 
 #: reports/report_types/tls_report/report.html
 msgid "Key Size"
-msgstr ""
+msgstr "Tamaño di Yabi"
 
 #: reports/report_types/tls_report/report.html
 #: rocky/templates/organizations/organization_list.html
@@ -3645,37 +3968,42 @@ msgstr "Código"
 
 #: reports/report_types/tls_report/report.html
 msgid "Phase out"
-msgstr ""
+msgstr "Fase out"
 
 #: reports/report_types/tls_report/report.html
 msgid "Good"
-msgstr ""
+msgstr "Bon"
 
 #: reports/report_types/tls_report/report.html
 msgid ""
 "No ciphers were found for this combination of IP address, port and service."
-msgstr ""
+msgstr "No a haña sifra pa e kombinashon aki di IP adrès, pòrt i servisio."
 
 #: reports/report_types/tls_report/report.html
 msgid ""
-"The list below gives an overview of the findings based on the identified TLS "
-"protocols and ciphers. This includes the reasoning why the cipher or "
+"The list below gives an overview of the findings based on the identified TLS"
+" protocols and ciphers. This includes the reasoning why the cipher or "
 "protocol is marked as a finding."
 msgstr ""
+"E lista aki bou ta duna un bista di e resultadonan basá riba e protokòlnan i"
+" sifranan TLS identifiká. Esaki ta inkluí e rasonamentu dikon e sifra òf "
+"protokòl ta marká komo un hallazgo."
 
 #: reports/report_types/tls_report/report.py
 msgid "TLS Report"
-msgstr ""
+msgstr "TLS Raportá"
 
 #: reports/report_types/tls_report/report.py
 msgid ""
 "TLS Report assesses the security of data encryption and transmission "
 "protocols."
 msgstr ""
+"TLS E rapòrt ta evaluá e seguridat di enkripshon di dato i protokòlnan di "
+"transmishon."
 
 #: reports/report_types/vulnerability_report/report.html
 msgid "No vulnerabilities have been found on this system."
-msgstr ""
+msgstr "No a haña ningun vulnerabilidat riba e sistema aki."
 
 #: reports/report_types/vulnerability_report/report.html
 msgid ""
@@ -3684,127 +4012,154 @@ msgid ""
 "the table shows the CVE scoring, the number of occurrences, and the CVE "
 "details."
 msgstr ""
+"E Rapòrt di Vulnerabilidat ta duna un bista di tur e vulnerabilidatnan "
+"identifiká CVE ku a wòrdu identifiká riba e sistemanan selektá. Pa kada CVE "
+"e tabel ta mustra e puntuashon di CVE, e kantidat di okashon, i e detayenan "
+"di CVE."
 
 #: reports/report_types/vulnerability_report/report.html
 msgid "vulnerabilities on this system"
-msgstr ""
+msgstr "vulnerabilidatnan riba e sistema aki"
 
 #: reports/report_types/vulnerability_report/report.html
 msgid "Advice"
-msgstr ""
+msgstr "Konseho"
 
 #: reports/report_types/vulnerability_report/report.py
 msgid "Vulnerability Report"
-msgstr ""
+msgstr "Rapòrt di Vulnerabilidat"
 
 #: reports/report_types/vulnerability_report/report.py
 msgid "Vulnerabilities found are grouped for each system."
-msgstr ""
+msgstr "Vulnerabilidatnan hañá ta wòrdu agrupá pa kada sistema."
 
 #: reports/report_types/vulnerability_report/report.py
 msgid "First seen"
-msgstr ""
+msgstr "Promé mirá"
 
 #: reports/report_types/vulnerability_report/report.py
 msgid "Last seen"
-msgstr ""
+msgstr "Ultimo bista"
 
 #: reports/report_types/vulnerability_report/report.py
 msgid "Evidence"
-msgstr ""
+msgstr "Prueba"
 
 #: reports/report_types/web_system_report/report.html
 msgid ""
-"The Web System Report provides an overview of various web server checks that "
-"were performed against the scanned system(s). For each performed check the "
+"The Web System Report provides an overview of various web server checks that"
+" were performed against the scanned system(s). For each performed check the "
 "table below shows whether or not the server is compliant with the checks. A "
 "description of why this compliant check failed is also shown, including an "
 "general risk level. The risk level may be different for your specific "
 "environment."
 msgstr ""
+"E Rapòrt di Sistema di Wèp ta duna un bista di vários kòntròl di servidor di"
+" wèp ku a wòrdu realisá kontra e sistema(nan) ku a wòrdu skan. Pa kada "
+"kòntròl realisá e tabel aki bou ta mustra si e servidor ta kumpli ku e "
+"kòntròlnan òf nò. Un deskripshon di dikon e kòntròl di kumplimentu aki a "
+"faya tambe ta wòrdu mustra, inkluyendo un nivel di riesgo general. E nivel "
+"di riesgo por ta diferente pa bo ambiente spesífiko."
 
 #: reports/report_types/web_system_report/report.html
 msgid "Web system compliance"
-msgstr ""
+msgstr "Kumplimentu ku sistema di wèp"
 
 #: reports/report_types/web_system_report/report.html
 msgid "CSP Present"
-msgstr ""
+msgstr "CSP Presente"
 
 #: reports/report_types/web_system_report/report.html
 msgid "webservers compliant"
-msgstr ""
+msgstr "servidornan di wèp ta kumpli ku"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Secure CSP Header"
-msgstr ""
+msgstr "Kabes di CSP sigurá"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Redirects HTTP to HTTPS"
-msgstr ""
+msgstr "Ta redirigí HTTP pa HTTPS"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Offers HTTPS"
-msgstr ""
+msgstr "Ofertanan HTTPS"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Has a Security.txt"
-msgstr ""
+msgstr "Tin un Security.txt"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Has a certificate"
-msgstr ""
+msgstr "Tin un sertifikado"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Certificate is valid"
-msgstr ""
+msgstr "Sertifikado ta bálido"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Certificate is not expiring soon"
-msgstr ""
+msgstr "Sertifikado no ta kaduká pronto"
 
 #: reports/report_types/web_system_report/report.html
 msgid "No webservers have been found on this system."
-msgstr ""
+msgstr "No a haña ningun webserver riba e sistema aki."
 
 #: reports/report_types/web_system_report/report.py
 msgid "Web System Report"
-msgstr ""
+msgstr "Rapport di Sistema di Web"
 
 #: reports/report_types/web_system_report/report.py
 msgid "Web System Reports check web systems on basic security standards."
 msgstr ""
+"Rapòrtnan di Sistema di Wèp ta kontrolá sistemanan di wèp riba normanan "
+"básiko di seguridat."
 
 #: reports/templates/partials/export_report_settings.html
 msgid "Report schedule"
-msgstr ""
+msgstr "Orario di rapòrt"
 
 #: reports/templates/partials/export_report_settings.html
 msgid ""
 "When scheduling your report, you have two options. You can either choose to "
 "generate it just once now, or set it to run automatically at regular "
-"intervals, like daily, weekly, or monthly. If you need the report just for a "
-"single occasion, select the one-time option."
+"intervals, like daily, weekly, or monthly. If you need the report just for a"
+" single occasion, select the one-time option."
 msgstr ""
+"Ora di programá bo rapòrt, bo tin dos opshon. Bo por skohe pa generá esaki "
+"djis un biaha awor, òf pone esaki pa kore outomatikamente na intervalonan "
+"regular, manera diariamente, semanal òf mensual. Si bo mester di e rapòrt "
+"djis pa un solo okashon, selektá e opshon di un solo biaha."
 
 #: reports/templates/partials/export_report_settings.html
 #: reports/templates/report_overview/report_history_table.html
 msgid "Report name"
-msgstr ""
+msgstr "Nòmber di rapòrt"
 
 #: reports/templates/partials/export_report_settings.html
 #, python-format, python-brace-format
 msgid ""
 "When generating reports, it is possible to give the report a name. The name "
-"can be static or dynamic. The default format for a report is '${report_type} "
-"for ${oois_count} objects'. These placeholders automatically adapt based on "
-"the report details. This format could for example return 'Aggregate Report "
+"can be static or dynamic. The default format for a report is '${report_type}"
+" for ${oois_count} objects'. These placeholders automatically adapt based on"
+" the report details. This format could for example return 'Aggregate Report "
 "for 15 objects'. Another placeholder that can be used is '${ooi}', which "
-"will show the name of the object when there is only one object. You can also "
-"customize the name by adding prefixes, suffixes, or other formats like '%%W' "
-"for the week number, using options from <a href=\"https://strftime.org/\" "
-"target=\"_blank\" rel=\"noopener\">Python strftime code</a>."
+"will show the name of the object when there is only one object. You can also"
+" customize the name by adding prefixes, suffixes, or other formats like "
+"'%%W' for the week number, using options from <a "
+"href=\"https://strftime.org/\" target=\"_blank\" rel=\"noopener\">Python "
+"strftime code</a>."
 msgstr ""
+"Ora di generá rapòrtnan, ta posibel pa duna e rapòrt un nòmber. E nòmber por"
+" ta státiko òf dinámiko. E formato predeterminá pa un rapòrt ta "
+"‘${report_type} pa ${oois_count} ophetonan’. E placeholdernan aki ta adaptá "
+"outomatikamente a base di e detayenan di e rapòrt. E formato aki por por "
+"ehèmpel por debolbé ‘Rapport Agregá pa 15 opheto’. Un otro placeholder ku "
+"por wòrdu usá ta ‘${ooi}’, ku lo mustra e nòmber di e opheto ora tin "
+"solamente un opheto. Bo por personalisá e nòmber tambe dor di agregá "
+"prefiho, sufiho, òf otro formatonan manera ‘%%W’ pa e number di siman, "
+"usando opshonnan di <a href=\"https://strftime.org/\" target=\"_blank\" "
+"rel=\"noopener\">Python strftime code</a>."
 
 #: reports/templates/partials/export_report_settings.html
 #: reports/templates/partials/generate_report_header.html
@@ -3815,38 +4170,38 @@ msgstr "Generá rapòrt"
 
 #: reports/templates/partials/generate_report_header.html
 msgid "To generate an aggregate report, complete the following steps."
-msgstr ""
+msgstr "Pa generá un rapòrt agregá, kompletá e siguiente pasonan."
 
 #: reports/templates/partials/generate_report_header.html
 msgid "To generate a multi report, complete the following steps."
-msgstr ""
+msgstr "Pa generá un rapòrt multi, kompletá e siguiente pasonan."
 
 #: reports/templates/partials/generate_report_header.html
 msgid "To generate separate report(s), complete the following steps."
-msgstr ""
+msgstr "Pa generá rapòrt(nan) separá, kompletá e siguiente pasonan."
 
 #: reports/templates/partials/generate_report_sidemenu.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Table of contents"
-msgstr ""
+msgstr "Tabel di kontenido"
 
 #: reports/templates/partials/new_report_action_button.html
 msgid "Actions for creating a new report"
-msgstr ""
+msgstr "Akshonnan pa krea un rapòrt nobo"
 
 #: reports/templates/partials/new_report_action_button.html
 msgid "Separate report(s)"
-msgstr ""
+msgstr "Rapòrt(nan) separá"
 
 #: reports/templates/partials/new_report_action_button.html
 #: reports/views/aggregate_report.py
 msgid "Aggregate report"
-msgstr ""
+msgstr "Rapòrt agregá"
 
 #: reports/templates/partials/new_report_action_button.html
 #: reports/views/multi_report.py
 msgid "Multi report"
-msgstr ""
+msgstr "Rapport multi"
 
 #: reports/templates/partials/plugin_overview_table.html
 #: reports/templates/partials/report_sidemenu.html
@@ -3856,12 +4211,12 @@ msgstr "Resúmen"
 
 #: reports/templates/partials/plugin_overview_table.html
 msgid "Plugin overview table"
-msgstr ""
+msgstr "Tabel di bista di plugin"
 
 #: reports/templates/partials/plugin_overview_table.html
 #: reports/templates/partials/report_setup_scan.html
 msgid "Required plugins"
-msgstr ""
+msgstr "Pluginnan nesesario"
 
 #: reports/templates/partials/plugin_overview_table.html
 #: reports/templates/partials/report_setup_scan.html
@@ -3870,43 +4225,50 @@ msgstr "Plugins sugerí"
 
 #: reports/templates/partials/plugin_overview_table.html
 msgid "Action required"
-msgstr ""
+msgstr "Akshon ta nesesario"
 
 #: reports/templates/partials/plugin_overview_table.html
 msgid "Ready"
-msgstr ""
+msgstr "Klá"
 
 #: reports/templates/partials/report_findings_table.html
 msgid ""
 "This table provides an overview of the identified findings on the scanned "
 "systems. For each finding type it shows the risk level, the number of "
 "occurrences and the first known occurrence of the finding. The risk level "
-"may be different for your specific environment. The details can be seen when "
-"expanding a row. A description, the source, impact and recommendation of the "
-"finding can be found here. It also shows in which findings the finding type "
-"occurred."
+"may be different for your specific environment. The details can be seen when"
+" expanding a row. A description, the source, impact and recommendation of "
+"the finding can be found here. It also shows in which findings the finding "
+"type occurred."
 msgstr ""
+"E tabel aki ta duna un bista di e resultadonan identifiká riba e sistemanan "
+"skan. Pa kada tipo di hallazgo e ta mustra e nivel di riesgo, e kantidat di "
+"okashon i e promé okashon konosí di e hallazgo. E nivel di riesgo por ta "
+"diferente pa bo ambiente spesífiko. E detayenan por wòrdu mira ora di "
+"ekspandé un liña. Un deskripshon, e fuente, impakto i rekomendashon di e "
+"resultado por wòrdu hañá aki. E ta mustra tambe den kua resultadonan e tipo "
+"di resultado a tuma lugá."
 
 #: reports/templates/partials/report_findings_table.html
 msgid "First known occurrence"
-msgstr ""
+msgstr "Promé suseso konosí"
 
 #: reports/templates/partials/report_findings_table.html
 msgid "Open in report"
-msgstr ""
+msgstr "Habri den rapòrt"
 
 #: reports/templates/partials/report_findings_table.html
 msgid ""
 "No critical and high findings have been identified for this organization."
-msgstr ""
+msgstr "No a identifiká resultadonan krítiko i haltu pa e organisashon aki."
 
 #: reports/templates/partials/report_findings_table.html
 msgid "No findings have been identified for this organization."
-msgstr ""
+msgstr "No a identifiká ningun resultado pa e organisashon aki."
 
 #: reports/templates/partials/report_header.html
 msgid "Download as PDF"
-msgstr ""
+msgstr "Download komo PDF"
 
 #: reports/templates/partials/report_header.html
 #: rocky/templates/partials/ooi_list_toolbar.html
@@ -3915,55 +4277,57 @@ msgstr "Download komo JSON"
 
 #: reports/templates/partials/report_header.html
 msgid "Open asset reports"
-msgstr ""
+msgstr "Habri rapòrtnan di aktivo"
 
 #: reports/templates/partials/report_header.html
 msgid "This is the OpenKAT report for organization"
-msgstr ""
+msgstr "Esaki ta e OpenKAT rapòrt pa organisashon"
 
 #: reports/templates/partials/report_header.html
 msgid ""
 "All selected report types for the selected objects are displayed one below "
 "the other."
 msgstr ""
+"Tur tipo di rapòrt selektá pa e ophetonan selektá ta wòrdu mustra un bou di "
+"otro."
 
 #: reports/templates/partials/report_header.html
 msgid "Created with data from:"
-msgstr ""
+msgstr "Kreá ku dato di:"
 
 #: reports/templates/partials/report_header.html
 msgid "Created on:"
-msgstr ""
+msgstr "Kreá riba:"
 
 #: reports/templates/partials/report_header.html
 msgid "Created from recipe:"
-msgstr ""
+msgstr "Kreá for di reseta:"
 
 #: reports/templates/partials/report_header.html
 msgid "Recipe created by:"
-msgstr ""
+msgstr "Reseta kreá pa:"
 
 #: reports/templates/partials/report_header.html
 #, python-format
 msgid "This sector contains %(length)s scanned organizations."
-msgstr ""
+msgstr "E sektor aki ta kontené %(length)s organisashonnan skan."
 
 #: reports/templates/partials/report_header.html
 msgid "Of these organizations"
-msgstr ""
+msgstr "Di e organisashonnan aki"
 
 #: reports/templates/partials/report_header.html
 msgid "organizations have tag"
-msgstr ""
+msgstr "organisashonnan tin tag"
 
 #: reports/templates/partials/report_header.html
 msgid "The basic security scores are around "
-msgstr ""
+msgstr "E puntuashonnan básiko di seguridat ta alrededor di"
 
 #: reports/templates/partials/report_header.html
 #, python-format
 msgid "A total of %(total)s critical vulnerabilities have been identified."
-msgstr ""
+msgstr "Un total di %(total)s vulnerabilidatnan krítiko a wòrdu identifiká."
 
 #: reports/templates/partials/report_introduction.html
 msgid "Introduction"
@@ -3972,14 +4336,18 @@ msgstr "Introdukshon"
 #: reports/templates/partials/report_introduction.html
 msgid ""
 "This report gives an overview of the current state of security for your "
-"organisation for the selected date. The summary section provides an overview "
-"of the selected systems (objects), plugins and reports. This is followed "
+"organisation for the selected date. The summary section provides an overview"
+" of the selected systems (objects), plugins and reports. This is followed "
 "with the findings for each report."
 msgstr ""
+"E rapòrt aki ta duna un bista di e estado aktual di seguridat pa bo "
+"organisashon pa e fecha selektá. E sekshon di resúmen ta duna un bista di e "
+"sistemanan (ophetonan), plugins i rapòrtnan selektá. Esaki ta sigui ku e "
+"resultadonan pa kada rapòrt."
 
 #: reports/templates/partials/report_names_form.html
 msgid "Report names:"
-msgstr ""
+msgstr "Nòmbernan di rapòrt:"
 
 #: reports/templates/partials/report_names_form.html
 #: rocky/templates/forms/widgets/checkbox_group_table.html
@@ -3994,7 +4362,7 @@ msgstr "Requerido"
 
 #: reports/templates/partials/report_names_form.html
 msgid "Add reference date"
-msgstr ""
+msgstr "Agregá fecha di referensia"
 
 #: reports/templates/partials/report_names_form.html
 #: reports/templates/report_overview/modal_partials/rename_modal.html
@@ -4003,27 +4371,27 @@ msgstr "Resèt"
 
 #: reports/templates/partials/report_names_form.html
 msgid "No reference date"
-msgstr ""
+msgstr "No tin fecha di referensia"
 
 #: reports/templates/partials/report_names_form.html
 msgid "Day"
-msgstr ""
+msgstr "Dia"
 
 #: reports/templates/partials/report_names_form.html
 msgid "Week"
-msgstr ""
+msgstr "Siman"
 
 #: reports/templates/partials/report_names_form.html
 msgid "Month"
-msgstr ""
+msgstr "Luna"
 
 #: reports/templates/partials/report_names_form.html
 msgid "Year"
-msgstr ""
+msgstr "Aña"
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "Object selection"
-msgstr ""
+msgstr "Selekshon di opheto"
 
 #: reports/templates/partials/report_ooi_list.html
 msgid ""
@@ -4031,31 +4399,43 @@ msgid ""
 "continue with a live set or you can select the objects manually from the "
 "table below."
 msgstr ""
+"Selektá kua ophetonan bo ke inkluí den bo rapòrt. Bo por sigui ku un set "
+"bibu òf bo por selektá e ophetonan manualmente for di e tabel aki bou."
 
 #: reports/templates/partials/report_ooi_list.html
 msgid ""
-"A live set is a set of objects based on the applied filters. Any object that "
-"matches this applied filter (now or in the future) will be used as input for "
-"the scheduled report. If your live set filter (e.g. 'hostnames' with 'L2 "
-"clearance' that are 'declared') shows 2 hostnames that match the filter "
+"A live set is a set of objects based on the applied filters. Any object that"
+" matches this applied filter (now or in the future) will be used as input "
+"for the scheduled report. If your live set filter (e.g. 'hostnames' with 'L2"
+" clearance' that are 'declared') shows 2 hostnames that match the filter "
 "today, the scheduled report will run for those 2 hostnames. If you add 3 "
-"more hostnames tomorrow (with the same filter criteria), your next scheduled "
-"report will contain 5 hostnames. Your live set will update as you go."
+"more hostnames tomorrow (with the same filter criteria), your next scheduled"
+" report will contain 5 hostnames. Your live set will update as you go."
 msgstr ""
+"Un sèt bibu ta un sèt di ophetonan basá riba e filternan apliká. Kualke "
+"opheto ku ta kuadra ku e filter apliká aki (awor òf den futuro) lo wòrdu usá"
+" komo entrada pa e rapòrt programá. Si bo filter di set bibu (p.e. "
+"‘hostnames’ ku ‘L2 clearance’ ku ta ‘deklará’) ta mustra 2 hostname ku ta "
+"kuadra ku e filter di awe, e rapòrt programá lo kore pa e 2 hostnames ei. Si"
+" bo agregá 3 nòmber di host mas mañan (ku e mesun kriterionan di filtro), bo"
+" siguiente rapòrt programá lo kontené 5 nòmber di host. Bo set bibu lo wòrdu"
+" aktualisá segun ku bo ta bai."
 
 #: reports/templates/partials/report_ooi_list.html
 msgid ""
 "Based on the current dataset, your selected filters result in the following "
 "objects."
 msgstr ""
+"A base di e sèt di dato aktual, bo filternan selektá ta resultá den e "
+"siguiente ophetonan."
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "objects selected"
-msgstr ""
+msgstr "ophetonan selektá"
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "Deselect all objects"
-msgstr ""
+msgstr "Deselektá tur opheto"
 
 #: reports/templates/partials/report_ooi_list.html
 #: rocky/templates/oois/ooi_list.html
@@ -4067,16 +4447,17 @@ msgstr "Mustrando %(length)s di %(total)s ophetonan"
 #, python-format
 msgid "Select all %(total_oois)s object"
 msgid_plural "Select all %(total_oois)s objects"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Selektá tur opheto %(total_oois)s"
+msgstr[1] "Selektá tur opheto %(total_oois)s"
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "Object name"
-msgstr ""
+msgstr "Nòmber di opheto"
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "Report(s) may be empty due to no objects in the selected filters."
 msgstr ""
+"Rapòrt(nan) por ta bashi debí ku no tin ophetonan den e filternan selektá."
 
 #: reports/templates/partials/report_ooi_list.html
 msgid ""
@@ -4084,53 +4465,63 @@ msgid ""
 "Future reports may contain data. It is still possible to generate the "
 "(potentially empty) report."
 msgstr ""
+"E rapòrtnan ku ta kuadra ku e filternan selektá lo ta bashi na e momentunan "
+"aki. Futuro rapòrtnan por kontené dato. Ainda ta posibel pa generá e rapòrt "
+"(potensialmente bashi)."
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "Continue with live set"
-msgstr ""
+msgstr "Sigui ku set bibu"
 
 #: reports/templates/partials/report_ooi_list.html
 #: reports/templates/partials/report_types_selection.html
 msgid "Continue with selection"
-msgstr ""
+msgstr "Sigui ku selekshon"
 
 #: reports/templates/partials/report_setup_scan.html
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 #: reports/views/multi_report.py
 msgid "Configuration"
-msgstr ""
+msgstr "Konfigurashon"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Set up the required plugins for this report."
-msgstr ""
+msgstr "Konfigura e pluginnan nesesario pa e rapòrt aki."
 
 #: reports/templates/partials/report_setup_scan.html
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugins"
-msgstr ""
+msgstr "Plugins"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid ""
 "KAT will be able to generate a full report when all the required and "
 "suggested boefjes are enabled."
 msgstr ""
+"KAT lo por generá un rapòrt kompletu ora tur e boefjes rekerí i sugerí ta "
+"aktivá."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid ""
 "If you choose not to enable a plugin, the data that plugin would collect or "
-"produce will be left out of the report which will then be generated based on "
-"the available data collected by the enabled plugins."
+"produce will be left out of the report which will then be generated based on"
+" the available data collected by the enabled plugins."
 msgstr ""
+"Si bo skohe pa no aktivá un plugin, e datonan ku e plugin lo rekohé òf "
+"produsí lo keda pafó di e rapòrt ku despues lo wòrdu generá a base di e "
+"datonan disponibel rekohé pa e pluginnan aktivá."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid ""
 "Some plugins are mandatory as they are crucial for a report type. Reports "
 "that don't have their requirements met will be skipped."
 msgstr ""
+"Algun plugin ta obligatorio ya ku nan ta krusial pa un tipo di rapòrt. "
+"Rapportnan ku no tin nan rekisitonan kumpli lo wòrdu saltá."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Warning! Before you proceed read the following points:"
-msgstr ""
+msgstr "Atvertensia! Promé ku bo sigui lesa e siguiente puntonan:"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid ""
@@ -4138,57 +4529,63 @@ msgid ""
 "enabled plugins and set clearance levels. This means that scans will run "
 "automatically. Be patient; plugins may take some time before they have "
 "collected all their data. Enabling them just before report generation will "
-"likely result in inaccurate reports, as plugins have not finished collecting "
-"data."
+"likely result in inaccurate reports, as plugins have not finished collecting"
+" data."
 msgstr ""
+"OpenKAT ta diseñá pa skan tur opheto konosí riba un base regular usando e "
+"pluginnan aktivá i pone nivelnan di limpiesa. Esaki ta nifiká ku e skannan "
+"lo kore outomatikamente. Tene pasenshi; plugins por tuma algun tempu promé "
+"ku nan a rekohé tur nan datonan. Habilitá nan djis promé ku generashon di "
+"rapòrt probablemente lo resultá den rapòrtnan ineksakto, ya ku pluginnan no "
+"a kaba di rekohé dato."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Good job! All required plugins are enabled."
-msgstr ""
+msgstr "Bon trabou! Tur e pluginnan nesesario ta aktivá."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "This report type requires the following plugins to be enabled:"
-msgstr ""
+msgstr "E tipo di rapòrt aki ta rekerí pa e siguiente pluginnan ta aktivá:"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Toggle all required plugins"
-msgstr ""
+msgstr "Kambiá tur e pluginnan nesesario"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Show enabled plugins"
-msgstr ""
+msgstr "Mustra pluginnan aktivá"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "There are no required plugins."
-msgstr ""
+msgstr "No tin plugins nesesario."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Good job! All suggested plugins are enabled."
-msgstr ""
+msgstr "Bon trabou! Tur e pluginnan sugerí ta aktivá."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "The following plugins are optional to generate the report:"
-msgstr ""
+msgstr "E siguiente pluginnan ta opshonal pa generá e rapòrt:"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Toggle all optional plugins"
-msgstr ""
+msgstr "Kambia tur plugin opshonal"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Hide suggested plugins"
-msgstr ""
+msgstr "Skonde pluginnan sugerí"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Show more suggested plugins"
-msgstr ""
+msgstr "Mustra mas plugin sugerí"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "There are no optional plugins."
-msgstr ""
+msgstr "No tin plugin opshonal."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Enable selected plugins and continue"
-msgstr ""
+msgstr "Habilitá pluginnan selektá i sigui"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid ""
@@ -4197,26 +4594,29 @@ msgid ""
 "            severity that have been identified for this organization.\n"
 "        "
 msgstr ""
+"\n"
+"E bista general aki ta mustra e kantidat total di resultadonan pa\n"
+"            severidat ku a keda identifiká pa e organisashon aki."
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Total per severity overview"
-msgstr ""
+msgstr "Total pa severidat bista general"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Critical"
-msgstr ""
+msgstr "Krítiko"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "High"
-msgstr ""
+msgstr "Haltu"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Medium"
-msgstr ""
+msgstr "Mediano"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Low"
-msgstr ""
+msgstr "Abou"
 
 #: reports/templates/partials/report_severity_totals_table.html
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
@@ -4225,44 +4625,51 @@ msgstr "Pendiente"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Unknown"
-msgstr ""
+msgstr "Deskonosí"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Total"
-msgstr ""
+msgstr "Total"
 
 #: reports/templates/partials/report_sidemenu.html
 msgid "Selected Objects"
-msgstr ""
+msgstr "Obhetonan Selektá"
 
 #: reports/templates/partials/report_sidemenu.html
 msgid "Selected Plugins"
-msgstr ""
+msgstr "Pluginnan selektá"
 
 #: reports/templates/partials/report_sidemenu.html
 msgid "Used Config Objects"
-msgstr ""
+msgstr "Ophetonan di Konfigurashon Usá"
 
 #: reports/templates/partials/report_types_selection.html
 msgid "Choose report types"
-msgstr ""
+msgstr "Skohe tipo di rapòrt"
 
 #: reports/templates/partials/report_types_selection.html
 msgid ""
-"Various types of reports, such as DNS reports and TLS reports, are essential "
-"for identifying vulnerabilities in different aspects of a system's security. "
-"DNS reports focus on domain name system configuration and potential "
-"weaknesses, while TLS reports assess the security of data encryption and "
-"transmission protocols, helping organizations pinpoint areas where security "
-"improvements are needed."
+"Various types of reports, such as DNS reports and TLS reports, are essential"
+" for identifying vulnerabilities in different aspects of a system's "
+"security. DNS reports focus on domain name system configuration and "
+"potential weaknesses, while TLS reports assess the security of data "
+"encryption and transmission protocols, helping organizations pinpoint areas "
+"where security improvements are needed."
 msgstr ""
+"Varios tipo di rapòrt, manera DNS rapòrt i TLS rapòrt, ta esensial pa "
+"identifiká vulnerabilidatnan den diferente aspekto di seguridat di un "
+"sistema. DNS informenan ta enfoká riba konfigurashon di sistema di nòmber di"
+" dominio i debilidatnan potensial, miéntras ku TLS informenan ta evaluá e "
+"seguridat di enkripshon di dato i protokòlnan di transmishon, yudando "
+"organisashonnan señalá áreanan kaminda mehorashonnan di seguridat ta "
+"nesesario."
 
 #: reports/templates/partials/report_types_selection.html
 #, python-format
 msgid "Selected object (%(total_oois)s)"
 msgid_plural "Selected objects (%(total_oois)s)"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Ophetonan selektá (%(total_oois)s)"
+msgstr[1] "Ophetonan selektá (%(total_oois)s)"
 
 #: reports/templates/partials/report_types_selection.html
 #, python-format
@@ -4270,43 +4677,45 @@ msgid ""
 "You have selected a live set in the previous step. Based on the current "
 "dataset, this live set results in %(total_oois)s objects."
 msgstr ""
+"Bo a selektá un set bibu den e paso anterior. A base di e sèt di dato "
+"aktual, e sèt bibu aki ta resultá den ophetonan %(total_oois)s."
 
 #: reports/templates/partials/report_types_selection.html
 msgid "Applied filters:"
-msgstr ""
+msgstr "Filternan apliká:"
 
 #: reports/templates/partials/report_types_selection.html
 #, python-format
 msgid "You have selected %(total_oois)s object in the previous step."
 msgid_plural "You have selected %(total_oois)s objects in the previous step."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Bo a selektá %(total_oois)s ophetonan den e paso anterior."
+msgstr[1] "Bo a selektá %(total_oois)s ophetonan den e paso anterior."
 
 #: reports/templates/partials/report_types_selection.html
 msgid "Change selection"
-msgstr ""
+msgstr "Kambia selekshon"
 
 #: reports/templates/partials/report_types_selection.html
 msgid "Available report types"
-msgstr ""
+msgstr "Tiponan di rapòrt disponibel"
 
 #: reports/templates/partials/report_types_selection.html
 msgid "All report types that are available for your selection."
-msgstr ""
+msgstr "Tur tipo di rapòrt ku ta disponibel pa bo selekshon."
 
 #: reports/templates/partials/report_types_selection.html
 msgid "Toggle all report types"
-msgstr ""
+msgstr "Kambiá tur tipo di rapòrt"
 
 #: reports/templates/partials/return_button.html
 #, python-format
 msgid "%(btn_text)s"
-msgstr ""
+msgstr "%(btn_text)s"
 
 #: reports/templates/report_overview/modal_partials/delete_modal.html
 #: reports/templates/report_overview/modal_partials/share_modal.html
 msgid "Delete the following report(s):"
-msgstr ""
+msgstr "Elimina e siguiente rapòrt(nan):"
 
 #: reports/templates/report_overview/modal_partials/delete_modal.html
 #: reports/templates/report_overview/modal_partials/share_modal.html
@@ -4315,6 +4724,10 @@ msgid ""
 "report can still be accessed on timestamps before the deletion. Only the "
 "report is removed from the view, not the data it is based on."
 msgstr ""
+"Rapòrtnan eliminá ta wòrdu kita den e bista for di e momentu di eliminá. E "
+"rapòrt por wòrdu aksesá ainda riba seyo di tempu promé ku e eliminashon. "
+"Solamente e rapòrt ta wòrdu kita for di e bista, no e datonan ku e ta basá "
+"riba dje."
 
 #: reports/templates/report_overview/modal_partials/delete_modal.html
 #: reports/templates/report_overview/modal_partials/share_modal.html
@@ -4323,6 +4736,8 @@ msgid ""
 "is part of a combined report, it will remain available in the combined "
 "report."
 msgstr ""
+"Ainda ta posibel pa generá un rapòrt nobo pa e mesun fecha. Si e rapòrt ta "
+"parti di un rapòrt kombiná, e lo keda disponibel den e rapòrt kombiná."
 
 #: reports/templates/report_overview/modal_partials/delete_modal.html
 #: reports/templates/report_overview/modal_partials/rerun_modal.html
@@ -4330,81 +4745,88 @@ msgstr ""
 #: reports/templates/report_overview/scheduled_reports_table.html
 #: reports/templates/report_overview/subreports_table.html
 msgid "Reference date"
-msgstr ""
+msgstr "Fecha di referensia"
 
 #: reports/templates/report_overview/modal_partials/enable_disable_schedule_modal.html
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Disable schedule"
-msgstr ""
+msgstr "Deshabilitá orario"
 
 #: reports/templates/report_overview/modal_partials/enable_disable_schedule_modal.html
 #, python-format
 msgid ""
-"Are you sure you want to disable the schedule for <strong>%(report_name)s</"
-"strong>? The recipe will still exist and the schedule can be enabled later "
-"on."
+"Are you sure you want to disable the schedule for "
+"<strong>%(report_name)s</strong>? The recipe will still exist and the "
+"schedule can be enabled later on."
 msgstr ""
+"Bo ta sigur ku bo ke desabilitá e orario pa "
+"<strong>%(report_name)s</strong>? E reseta lo eksistí ainda i e skema por "
+"wòrdu aktivá despues."
 
 #: reports/templates/report_overview/modal_partials/rename_modal.html
 msgid "Rename the following report(s):"
-msgstr ""
+msgstr "Renombra e siguiente rapòrt(nan):"
 
 #: reports/templates/report_overview/modal_partials/rename_modal.html
 #: reports/templates/report_overview/report_history_table.html
 msgid "Rename"
-msgstr ""
+msgstr "Renombra"
 
 #: reports/templates/report_overview/modal_partials/rerun_modal.html
 msgid "Rerun the following report(s):"
-msgstr ""
+msgstr "Rerun e siguiente rapòrt(nan):"
 
 #: reports/templates/report_overview/modal_partials/rerun_modal.html
 msgid ""
 "By submitting you're generating the selected reports again, using the "
 "current data."
 msgstr ""
+"Dor di entregá bo ta generá e rapòrtnan selektá atrobe, usando e datonan "
+"aktual."
 
 #: reports/templates/report_overview/modal_partials/rerun_modal.html
 #: reports/templates/report_overview/report_history_table.html
 msgid "Rerun"
-msgstr ""
+msgstr "Rerun"
 
 #: reports/templates/report_overview/report_history.html
 msgid "Reports history"
-msgstr ""
+msgstr "Historia di informe"
 
 #: reports/templates/report_overview/report_history.html
 msgid ""
 "On this page you can see all the reports that have been generated in the "
 "past. To create a new report, click the 'Generate Report' button."
 msgstr ""
+"Riba e pagina aki por mira tur e rapportnan cu a wordo genera den pasado. Pa"
+" krea un rapòrt nobo, klik e boton ‘Generá Rapòrt’."
 
 #: reports/templates/report_overview/report_history_table.html
 #: reports/templates/report_overview/subreports.html
 #, python-format
 msgid "Showing %(length)s of %(total)s reports"
-msgstr ""
+msgstr "Mustrando %(length)s di %(total)s rapòrtnan"
 
 #: reports/templates/report_overview/report_history_table.html
 #: rocky/templates/tasks/reports.html
 msgid "Reports:"
-msgstr ""
+msgstr "Informenan:"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "Shows parent report details"
-msgstr ""
+msgstr "Ta mustra detayenan di rapòrt di mayor"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "Close asset report object details"
-msgstr ""
+msgstr "Sera detayenan di opheto di rapòrt di aktivo"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "Open asset report object details"
-msgstr ""
+msgstr "Habri detayenan di opheto di rapòrt di aktivo"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "Asset reports details"
-msgstr ""
+msgstr "Detayenan di rapòrtnan di aktivo"
 
 #: reports/templates/report_overview/report_history_table.html
 #, python-format
@@ -4415,26 +4837,30 @@ msgid_plural ""
 "This report consists of %(counter)s asset reports with the following report "
 "types and objects:"
 msgstr[0] ""
+"E rapòrt aki ta konsistí di %(counter)s rapòrtnan di aktivo ku e siguiente "
+"tiponan di rapòrt i ophetonan:"
 msgstr[1] ""
+"E rapòrt aki ta konsistí di %(counter)s rapòrtnan di aktivo ku e siguiente "
+"tiponan di rapòrt i ophetonan:"
 
 #: reports/templates/report_overview/report_history_table.html
 #: reports/templates/report_overview/subreports_header.html
 #: reports/templates/report_overview/subreports_table.html
 #: reports/views/report_overview.py
 msgid "Asset reports"
-msgstr ""
+msgstr "Rapportnan di aktivo"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "Shows asset report details"
-msgstr ""
+msgstr "Ta mustra detayenan di rapòrt di aktivo"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "View all asset reports"
-msgstr ""
+msgstr "Wak tur e rapòrtnan di aktivo"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "No reports have been generated yet."
-msgstr ""
+msgstr "No a generá ningun rapòrt ainda."
 
 #: reports/templates/report_overview/report_overview_header.html
 #: reports/views/base.py rocky/templates/header.html
@@ -4445,84 +4871,87 @@ msgstr "Rapport"
 
 #: reports/templates/report_overview/report_overview_header.html
 msgid "An overview of reports that are scheduled or have been generated."
-msgstr ""
+msgstr "Un bista di rapòrtnan ku ta programá òf a wòrdu generá."
 
 #: reports/templates/report_overview/report_overview_navigation.html
 msgid "Scheduled"
-msgstr ""
+msgstr "Programá"
 
 #: reports/templates/report_overview/report_overview_navigation.html
 msgid "History"
-msgstr ""
+msgstr "Historia"
 
 #: reports/templates/report_overview/scheduled_reports.html
 msgid "Scheduled reports"
-msgstr ""
+msgstr "Rapòrtnan programá"
 
 #: reports/templates/report_overview/scheduled_reports.html
 msgid ""
-"On this page you can see all the reports that are or have been scheduled. To "
-"schedule a report, select a start date and recurrence while generating a "
+"On this page you can see all the reports that are or have been scheduled. To"
+" schedule a report, select a start date and recurrence while generating a "
 "report."
 msgstr ""
+"Riba e pagina aki por mira tur e rapportnan cu ta of a wordo programa. Pa "
+"programá un rapòrt, selektá un fecha di inisio i rekurensia miéntras ta "
+"generá un rapòrt."
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 #, python-format
 msgid "Showing %(length)s of %(total)s schedules"
-msgstr ""
+msgstr "Mustrando %(length)s di %(total)s orarionan"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Scheduled reports:"
-msgstr ""
+msgstr "Rapòrtnan programá:"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Scheduled for"
-msgstr ""
+msgstr "Programá pa"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Schedule status"
-msgstr ""
+msgstr "Status di orario"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Once"
-msgstr ""
+msgstr "Un biá"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Recent reports"
-msgstr ""
+msgstr "Informenan resien"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Scheduled Reports:"
-msgstr ""
+msgstr "Rapòrtnan programá:"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Show report details"
-msgstr ""
+msgstr "Mustra detayenan di rapòrt"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "objects"
-msgstr ""
+msgstr "ophetonan"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Enable schedule"
-msgstr ""
+msgstr "Habilitá skema"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "No scheduled reports have been generated yet."
-msgstr ""
+msgstr "No a generá rapòrtnan programá ainda."
 
 #: reports/templates/report_overview/subreports_header.html
 msgid "Back to Reports History"
-msgstr ""
+msgstr "Bek na Historia di Rapportnan"
 
 #: reports/templates/report_overview/subreports_header.html
 msgid "An overview of all underlying reports of"
-msgstr ""
+msgstr "Un bista di tur e rapòrtnan subyacente di"
 
 #: reports/templates/report_overview/subreports_header.html
 #: reports/templates/report_overview/subreports_table.html
 msgid "Shows report details"
-msgstr ""
+msgstr "Ta mustra detayenan di rapòrt"
 
 #: reports/templates/report_overview/subreports_table.html
 #: rocky/templates/tasks/boefjes.html
@@ -4532,12 +4961,12 @@ msgstr "Opheto di entrada"
 
 #: reports/templates/report_schedules/delete_recipe_modal.html
 msgid "Delete report recipe"
-msgstr ""
+msgstr "Elimina reseta di rapòrt"
 
 #: reports/templates/report_schedules/delete_recipe_modal.html
 #, python-format
 msgid "Are you sure you want to delete report recipe \"%(name)s\"?"
-msgstr ""
+msgstr "Bo ta sigur ku bo ke eliminá e reseta di rapòrt \"%(name)s\"?"
 
 #: reports/templates/report_schedules/delete_recipe_modal.html
 msgid ""
@@ -4545,164 +4974,185 @@ msgid ""
 "not be possible anymore to see or enable the schedule. You will find "
 "previously generated reports in the report history tab."
 msgstr ""
+"Eliminando e reseta di rapòrt aki ta nifiká ku e lo wòrdu eliminá "
+"permanentemente. Lo no ta posibel mas pa wak òf aktivá e orario. Bo ta haña "
+"rapòrtnan generá anteriormente den e tab di historia di rapòrt."
 
 #: reports/templates/summary/report_asset_overview.html
 msgid ""
-"The objects listed in the table below were used to generate this report. For "
-"each object in the table it additionally shows the clearance level and "
+"The objects listed in the table below were used to generate this report. For"
+" each object in the table it additionally shows the clearance level and "
 "whether or not the object was added by a user ('Declared') or indirectly "
 "identified through another service or system ('Inherited')."
 msgstr ""
+"E ophetonan lista den e tabel aki bou a wòrdu usá pa generá e rapòrt aki. Pa"
+" kada opheto den e tabel e ta mustra adishonalmente e nivel di limpiesa i si"
+" e opheto a wòrdu agregá dor di un usuario (‘Deklará’) òf indirektamente "
+"identifiká a traves di un otro servisio òf sistema (‘Heredá’)."
 
 #: reports/templates/summary/report_asset_overview.html
 msgid "No objects found."
-msgstr ""
+msgstr "No a haña ophetonan."
 
 #: reports/templates/summary/report_asset_overview.html
 msgid ""
 "The table below shows which reports were chosen to generate this report, "
 "including a report description."
 msgstr ""
+"E tabel aki bou ta mustra kua rapòrtnan a wòrdu skohé pa generá e rapòrt "
+"aki, inkluyendo un deskripshon di rapòrt."
 
 #: reports/templates/summary/report_asset_overview.html
 msgid "No report types found."
-msgstr ""
+msgstr "No a haña tipo di rapòrt."
 
 #: reports/templates/summary/selected_plugins.html
 msgid ""
 "The table below shows all required or optional plugins for the selected "
 "reports."
 msgstr ""
+"E tabel aki bou ta mustra tur e pluginnan nesesario òf opshonal pa e "
+"rapòrtnan selektá."
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Required and optional plugins"
-msgstr ""
+msgstr "Pluginnan nesesario i opshonal"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugin enabled"
-msgstr ""
+msgstr "Plugin ta aktivá"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugin options"
-msgstr ""
+msgstr "Opshonnan di plugin"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugin scan level"
-msgstr ""
+msgstr "Nivel di skan di plugin"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Enabled."
-msgstr ""
+msgstr "Habilitá."
 
 #: reports/templates/summary/selected_plugins.html
 msgid "required"
-msgstr ""
+msgstr "rekerí"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "optional"
-msgstr ""
+msgstr "opshonal"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugin extra info"
-msgstr ""
+msgstr "Informashon èkstra di plugin"
 
 #: reports/templates/summary/selected_plugins.html
 msgid ""
 "There are no required or optional plugins needed for the selected report "
 "types."
 msgstr ""
+"No tin pluginnan nesesario òf opshonal pa e tiponan di rapòrt selektá."
 
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 #: reports/views/multi_report.py
 msgid "Select objects"
-msgstr ""
+msgstr "Selektá ophetonan"
 
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 #: reports/views/multi_report.py
 msgid "Select report types"
-msgstr ""
+msgstr "Selektá tiponan di rapòrt"
 
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 #: reports/views/multi_report.py
 msgid "Export setup"
-msgstr ""
+msgstr "Konfigurashon di eksportashon"
 
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 msgid "Save report"
-msgstr ""
+msgstr "Warda rapòrt"
 
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 msgid "You do not have the required permissions to enable plugins."
-msgstr ""
+msgstr "Bo no tin e pèrmitnan nesesario pa aktivá plugins."
 
 #: reports/views/base.py
 msgid "Select at least one OOI to proceed."
-msgstr ""
+msgstr "Selektá por lo ménos un OOI pa sigui."
 
 #: reports/views/base.py
 msgid "Select at least one report type to proceed."
-msgstr ""
+msgstr "Selektá por lo ménos un tipo di rapòrt pa sigui."
 
 #: reports/views/mixins.py
 msgid ""
 "No data could be found for %(report_types). Object(s) did not exist on "
 "%(date)s."
 msgstr ""
+"No por a haña dato pa %(report_types). Opheto(nan) no tabata eksistí riba "
+"%(date)s."
 
 #: reports/views/multi_report.py
 msgid "View report"
-msgstr ""
+msgstr "Wak e rapòrt"
 
 #: reports/views/report_overview.py
 msgid "Not enough permissions"
-msgstr ""
+msgstr "No tin sufisiente pèrmit"
 
 #: reports/views/report_overview.py
 msgid "Recipe '{}' deleted successfully"
-msgstr ""
+msgstr "Reseta '{}' a wòrdu eliminá ku éksito"
 
 #: reports/views/report_overview.py
 msgid "Recipe not found."
-msgstr ""
+msgstr "Reseta no a haña."
 
 #: reports/views/report_overview.py
 msgid "No schedule or recipe selected"
-msgstr ""
+msgstr "No tin orario òf reseta selektá"
 
 #: reports/views/report_overview.py
 msgid ""
 "Schedule disabled successfully. '{}' will not be generated automatically "
 "until the schedule is enabled again."
 msgstr ""
+"Orario a desabilitá ku éksito. '{}' lo no wòrdu generá outomatikamente te "
+"ora ku e skema wòrdu aktivá atrobe."
 
 #: reports/views/report_overview.py
 msgid ""
 "Schedule enabled successfully. '{}' will be generated according to schedule."
-msgstr ""
+msgstr "Orario a wòrdu aktivá ku éksito. '{}' lo wòrdu generá segun skema."
 
 #: reports/views/report_overview.py
 msgid "An unexpected error occurred, please check logs for more info."
 msgstr ""
+"Un eror inesperá a sosodé, por fabor wak e registronan pa mas informashon."
 
 #: reports/views/report_overview.py
 msgid "Other OOI type selected than Report"
-msgstr ""
+msgstr "Otro tipo OOI selektá ku Rapòrt"
 
 #: reports/views/report_overview.py
 msgid "Deletion successful."
-msgstr ""
+msgstr "Eliminashon eksitoso."
 
 #: reports/views/report_overview.py
 msgid ""
 "Multi organization reports cannot be rescheduled. It consists of imported "
 "data from different organizations and is not based on newly generated data."
 msgstr ""
+"Rapòrtnan di vários organisashon no por wòrdu reprogramá. E ta konsistí di "
+"datonan importá di diferente organisashon i no ta basá riba datonan nobo "
+"generá."
 
 #: reports/views/report_overview.py
 msgid ""
 "Rerun successful. It may take a moment before the new report has been "
 "generated."
 msgstr ""
+"Rerun eksitoso. E por tuma un ratu promé ku e rapòrt nobo a wòrdu generá."
 
 #: reports/views/report_overview.py
 #, python-format
@@ -4710,94 +5160,95 @@ msgid ""
 "Couldn't rerun %s, since the recipe for this report has been disabled or "
 "deleted."
 msgstr ""
+"No por a bolbe kore %s, ya ku e reseta pa e rapòrt aki a wòrdu desabilitá òf"
+" eliminá."
 
 #: reports/views/report_overview.py
 msgid "Renaming failed. Empty report name found."
-msgstr ""
+msgstr "Renombramentu no a logra. Nomber di rapòrt bashi a haña."
 
 #: reports/views/report_overview.py
 msgid "Report names and reports does not match."
-msgstr ""
+msgstr "Nòmbernan di rapòrt i rapòrtnan no ta kuadra."
 
 #: reports/views/report_overview.py
 msgid "Reports successfully renamed."
-msgstr ""
+msgstr "Rapportnan a kambia nòmber ku éksito."
 
 #: reports/views/report_overview.py
 msgid "Report {} could not be renamed."
-msgstr ""
+msgstr "Rapport {} no por a wòrdu renobá."
 
 #: reports/views/view_helpers.py
 msgid "1: Select objects"
-msgstr ""
+msgstr "1: Selektá ophetonan"
 
 #: reports/views/view_helpers.py
 msgid "2: Choose report types"
-msgstr ""
+msgstr "2: Skohe tipo di rapòrt"
 
 #: reports/views/view_helpers.py
 msgid "3: Configuration"
-msgstr ""
+msgstr "3: Konfigurashon"
 
 #: reports/views/view_helpers.py
 msgid "4: Export setup"
-msgstr ""
+msgstr "4: Konfigurashon di eksportashon"
 
 #: reports/views/view_helpers.py
 msgid "3: Export setup"
-msgstr ""
+msgstr "3: Konfigurashon di eksportashon"
 
 #: tools/forms/base.py
 msgid "Date"
 msgstr "Fecha"
 
-#: tools/forms/base.py tools/forms/scheduler.py
-msgid "The selected date is in the future. Please select a different date."
-msgstr ""
-
 #: tools/forms/boefje.py
 msgid "For example: -sTU --top-ports 1000"
-msgstr ""
+msgstr "Por ehèmpel: -sTU --top-ports 1000"
 
 #: tools/forms/boefje.py
 msgid "JSON Schema"
-msgstr ""
+msgstr "JSON Skema"
 
 #: tools/forms/boefje.py
 msgid "Input object type"
-msgstr ""
+msgstr "Tipo di opheto di entrada"
 
 #: tools/forms/boefje.py
 msgid "Output mime types"
-msgstr ""
+msgstr "Tiponan di mimo di salida"
 
 #: tools/forms/boefje.py
 msgid "Scan type"
-msgstr ""
+msgstr "Tipo di skan"
 
 #: tools/forms/boefje.py
 msgid "Interval amount"
-msgstr ""
+msgstr "Kantidat di intervalo"
 
 #: tools/forms/boefje.py
 msgid ""
 "Specify the scanning interval for this Boefje. The default is 24 hours. For "
 "example: 5 minutes will let the Boefje scan every 5 minutes."
 msgstr ""
+"Spesifiká e intervalo di skan pa e Boefje aki. E default ta 24 ora. Por "
+"ehèmpel: 5 minüt lo laga e Boefje skan kada 5 minüt."
 
 #: tools/forms/boefje.py
 msgid "Interval frequency"
-msgstr ""
+msgstr "Frekuensha di intervalo"
 
 #: tools/forms/boefje.py
 msgid "Object creation/change"
-msgstr ""
+msgstr "Kreashon/kambio di opheto"
 
 #: tools/forms/boefje.py
 msgid ""
 "Choose weather the Boefje should run after creating and/or changing an "
 "object. "
 msgstr ""
+"Skohe e wer ku e Boefje mester kore despues di krea i/òf kambia un opheto."
 
 #: tools/forms/finding_type.py
 msgid "KAT-ID"
@@ -4938,7 +5389,7 @@ msgstr "Buska"
 
 #: tools/forms/findings.py
 msgid "Object ID contains (case sensitive)"
-msgstr ""
+msgstr "ID di opheto ta kontené (sensitivo na letter grandi)"
 
 #: tools/forms/ooi.py
 msgid "Filter types"
@@ -4950,27 +5401,27 @@ msgstr "Nivél di Autorisashon"
 
 #: tools/forms/ooi.py
 msgid "Next scan"
-msgstr ""
+msgstr "Siguiente skan"
 
 #: tools/forms/ooi.py
-#, fuzzy
 msgid "Show objects that don't meet the Boefjes scan level."
-msgstr "Mustra ophetonan ku no tin nivel di skan pa Boefjes"
+msgstr "Mustra ophetonan ku no ta kumpli ku e nivel di skan Boefjes."
 
 #: tools/forms/ooi.py
-#, fuzzy
 msgid "Show Boefjes that exceed the objects clearance level."
-msgstr "Mustra Boefjes ku ku a surpasa OOI's su nivel di autorisashon"
+msgstr "Mustra Boefjes ku ta surpasá e nivel di limpiesa di e ophetonan."
 
 #: tools/forms/ooi.py
 msgid ""
-"All the boefjes with a scan level below or equal to the clearance level will "
-"be allowed to scan this object."
+"All the boefjes with a scan level below or equal to the clearance level will"
+" be allowed to scan this object."
 msgstr ""
+"Tur e boefjes ku un nivel di skan bou òf igual na e nivel di limpiesa lo "
+"wòrdu permití pa skan e opheto aki."
 
 #: tools/forms/ooi.py
 msgid "Expires by (UTC)"
-msgstr ""
+msgstr "Ta kaduká pa (UTC)"
 
 #: tools/forms/ooi_form.py
 msgid "option"
@@ -5004,7 +5455,7 @@ msgstr "Pa"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Cancelled"
-msgstr ""
+msgstr "Kanselá"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Completed"
@@ -5016,7 +5467,7 @@ msgstr "Despachá"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Failed"
-msgstr ""
+msgstr "A faya"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Queued"
@@ -5024,11 +5475,15 @@ msgstr "Enfila"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Running"
-msgstr ""
+msgstr "Koriendo"
 
 #: tools/forms/scheduler.py
 msgid "Search by object name"
 msgstr "Buska riba nómber di opheto"
+
+#: tools/forms/scheduler.py
+msgid "The selected date is in the future. Please select a different date."
+msgstr "E fecha selektá ta den futuro. Por fabor selektá un fecha diferente."
 
 #: tools/forms/settings.py
 msgid "--- Show all ----"
@@ -5084,7 +5539,7 @@ msgstr "Agrega e fecha y ora di bo diskubrimentu (UTC)"
 
 #: tools/forms/settings.py
 msgid "Add the date and time of when the raw file was generated (UTC)"
-msgstr ""
+msgstr "Agregá e fecha i ora di ki dia e archivo brutu a wòrdu generá (UTC)"
 
 #: tools/forms/settings.py
 msgid ""
@@ -5098,17 +5553,23 @@ msgstr ""
 
 #: tools/forms/settings.py
 msgid ""
-"<p>The name of the Docker image. For example: <i>'ghcr.io/minvws/openkat/"
-"nmap'</i>. In OpenKAT, all Boefjes with the same container image will be "
-"seen as 'variants' and will be shown together on the Boefje detail page. </"
-"p> "
+"<p>The name of the Docker image. For example: "
+"<i>'ghcr.io/minvws/openkat/nmap'</i>. In OpenKAT, all Boefjes with the same "
+"container image will be seen as 'variants' and will be shown together on the"
+" Boefje detail page. </p> "
 msgstr ""
+"<p>E nòmber di e imágen di Docker. Por ehèmpel: "
+"<i>'ghcr.io/minvws/openkat/nmap'</i>. Den OpenKAT, tur Boefjes ku e mesun "
+"imágen di kònteiner lo wòrdu mira komo 'variante' i lo wòrdu mustra huntu "
+"riba e página di detaye Boefje. </p>"
 
 #: tools/forms/settings.py
 msgid ""
 "A description of the Boefje explaining in short what it can do. This will "
 "both be displayed inside the KAT-alogus and on the Boefje details page."
 msgstr ""
+"Un deskripshon di e Boefje splikando en breve kiko e por hasi. Esaki lo "
+"wòrdu mustra tantu den e KAT-alogus komo riba e página di detaye Boefje."
 
 #: tools/forms/settings.py
 msgid ""
@@ -5116,40 +5577,61 @@ msgid ""
 "objects, press and hold the 'ctrl'/'command' key and then click the items "
 "you want to select. "
 msgstr ""
+"Selektá e tipo(nan) di opheto ku bo Boefje ta konsumí. Pa selektá vários "
+"opheto, primi i tene e boton ‘ctrl’/‘command’ i despues klik e artíkulonan "
+"ku bo ke selektá."
 
 #: tools/forms/settings.py
 msgid ""
 "<p>If any other settings are needed for your Boefje, add these as a JSON "
 "Schema, otherwise, leave the field empty or 'null'.</p> <p> This JSON is "
-"used as the basis for a form for the user. When the user enables this Boefje "
-"they can get the option to give extra information. For example, it can "
+"used as the basis for a form for the user. When the user enables this Boefje"
+" they can get the option to give extra information. For example, it can "
 "contain an API key that the script requires.</p> <p>More information about "
-"what the schema.json file looks like can be found <a href='https://docs."
-"openkat.nl/developer_documentation/development_tutorial/creating_a_boefje."
-"html'> here</a>.</p> "
+"what the schema.json file looks like can be found <a "
+"href='https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html'>"
+" here</a>.</p> "
 msgstr ""
+"<p>Si mester di kualke otro setting pa bo Boefje, agregá esakinan komo un "
+"JSON Skema, di otro manera, laga e kampo bashi òf 'nulo'.</p> <p> E JSON aki"
+" ta wòrdu usá komo e base pa e formulario pa e usuario. Ora e usuario "
+"habilitá esaki Boefje nan por haña e opshon pa duna informashon èkstra. Por "
+"ehèmpel, e por kontené un API yabi ku e skript ta rekerí.</p> <p>Mas "
+"informashon tokante kon e archivo schema.json ta parse por wòrdu hañá <a "
+"href='https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html'>"
+" aki</a>.</p>"
 
 #: tools/forms/settings.py
 msgid ""
 "<p>Add a set of mime types that are produced by this Boefje, separated by "
-"commas. For example: <i>'text/html'</i>, <i>'image/jpeg'</i> or <i>'boefje/"
-"{boefje-id}'</i></p> <p>These output mime types will be shown on the Boefje "
-"detail page as information for other users. </p> "
+"commas. For example: <i>'text/html'</i>, <i>'image/jpeg'</i> or "
+"<i>'boefje/{boefje-id}'</i></p> <p>These output mime types will be shown on "
+"the Boefje detail page as information for other users. </p> "
 msgstr ""
+"<p>Agregá un set di tipo MIME ku e Boefje aki ta produsí, separá ku kòma. "
+"Por ehèmpel: <i>'text/html'</i>, <i>'image/jpeg'</i> òf <i>'boefje/{boefje-"
+"id}'</i></p> <p>E tipo MIME di salida aki lo wòrdu mustrá riba e página di "
+"detaye di Boefje komo informashon pa otro usuarionan. </p> "
 
 #: tools/forms/settings.py
 msgid ""
 "<p>Select a clearance level for your Boefje. For more information about the "
-"different clearance levels please check the <a href='https://docs.openkat.nl/"
-"manual/usermanual.html#scan-levels-clearance-indemnities'> documentation</a>."
-"</p> "
+"different clearance levels please check the <a "
+"href='https://docs.openkat.nl/manual/usermanual.html#scan-levels-clearance-"
+"indemnities'> documentation</a>.</p> "
 msgstr ""
+"<p>Selektá un nivel di limpiesa pa bo Boefje. Pa mas informashon tokante e "
+"diferente nivelnan di limpiesa por fabor wak e <a "
+"href='https://docs.openkat.nl/manual/usermanual.html#scan-levels-clearance-"
+"indemnities'> dokumentashon</a>.</p>"
 
 #: tools/forms/settings.py
 msgid ""
-"Choose when this Boefje will scan objects. It can run on a given interval or "
-"it can run every time an object has been created or changed. "
+"Choose when this Boefje will scan objects. It can run on a given interval or"
+" it can run every time an object has been created or changed. "
 msgstr ""
+"Skohe ki ora e Boefje aki lo skan ophetonan. E por kore riba un intervalo "
+"duná òf e por kore kada bes ku un opheto a wòrdu kreá òf kambia."
 
 #: tools/forms/settings.py
 msgid "Depth of the tree."
@@ -5205,17 +5687,18 @@ msgstr "Mime types"
 
 #: tools/forms/upload_raw.py
 msgid ""
-"<p>Add a set of mime types, separated by commas, for example:</"
-"p><p><i>\"text/html, image/jpeg\"</i> or <i>\"boefje/dns-records\"</i>.</"
-"p><p>Mime types are used to match the correct normalizer to a raw file. When "
-"the mime type \"boefje/dns-records\" is added, the normalizer expects the "
-"raw file to contain dns scan information.</p>"
+"<p>Add a set of mime types, separated by commas, for "
+"example:</p><p><i>\"text/html, image/jpeg\"</i> or <i>\"boefje/dns-"
+"records\"</i>.</p><p>Mime types are used to match the correct normalizer to "
+"a raw file. When the mime type \"boefje/dns-records\" is added, the "
+"normalizer expects the raw file to contain dns scan information.</p>"
 msgstr ""
-"<p>Agregá un grupo di mime types, separá ku komas, por ehèmpel:</"
-"p><p><i>\"text/html, image/jpeg\"</i> òf <i>\"boefje/dns-records\"</i>.</"
-"p><p>Tipo mime ta wordu usá pa activa e normalizador korekto na un arkivo "
-"Ora e tipo mime \"boefje/dns-records\" ta wordu agregá, e normalizador ta "
-"spera ku e arkivo ta kontené informashon di skaneo di dns.</p>"
+"<p>Agregá un grupo di mime types, separá ku komas, por "
+"ehèmpel:</p><p><i>\"text/html, image/jpeg\"</i> òf <i>\"boefje/dns-"
+"records\"</i>.</p><p>Tipo mime ta wordu usá pa activa e normalizador korekto"
+" na un arkivo Ora e tipo mime \"boefje/dns-records\" ta wordu agregá, e "
+"normalizador ta spera ku e arkivo ta kontené informashon di skaneo di "
+"dns.</p>"
 
 #: tools/forms/upload_raw.py rocky/templates/partials/ooi_list_toolbar.html
 #: rocky/templates/upload_raw.html
@@ -5224,21 +5707,23 @@ msgstr "Subi arkivo"
 
 #: tools/forms/upload_raw.py
 msgid "Input or Scan OOI"
-msgstr ""
+msgstr "Input òf Scan OOI"
 
 #: tools/forms/upload_raw.py
 msgid "Click to select one of the available options, or type one yourself"
-msgstr ""
+msgstr "Klik pa selektá un di e opshonnan disponibel, òf skirbi un bo mes"
 
 #: tools/forms/upload_raw.py
 msgid "OOI doesn't exist, try another valid time"
-msgstr ""
+msgstr "OOI no ta eksistí, purba un otro ora bálido"
 
 #: tools/models.py
 msgid ""
-"A short code containing only lower-case unicode letters, numbers, hyphens or "
-"underscores that will be used in URLs and paths."
+"A short code containing only lower-case unicode letters, numbers, hyphens or"
+" underscores that will be used in URLs and paths."
 msgstr ""
+"Un kódigo kòrtiku ku ta kontené solamente lèternan di unicode chikí, "
+"sifranan, guion òf strepi ku lo wòrdu usá den URLs i trayekto."
 
 #: tools/models.py
 msgid ""
@@ -5254,7 +5739,7 @@ msgstr "nobo"
 
 #: tools/templatetags/ooi_extra.py
 msgid "Unknown user"
-msgstr ""
+msgstr "Usuario deskonosí"
 
 #: tools/view_helpers.py rocky/templates/header.html
 #: rocky/templates/organizations/organization_member_list.html
@@ -5264,7 +5749,7 @@ msgstr "Miembronan"
 
 #: rocky/forms.py
 msgid "Current status"
-msgstr ""
+msgstr "Status aktual"
 
 #: rocky/forms.py rocky/templates/organizations/organization_member_list.html
 msgid "Active"
@@ -5276,7 +5761,7 @@ msgstr "Nobo"
 
 #: rocky/forms.py
 msgid "Account status"
-msgstr ""
+msgstr "Status di kuenta"
 
 #: rocky/forms.py
 msgid "Not blocked"
@@ -5289,65 +5774,71 @@ msgid ""
 "Edit this member and change the clearance level if necessary."
 msgstr ""
 "Bo a konfia e miembro aki ku un nivel di autorisashon di L{}. E miembro aki\n"
-"mester tin almenos un nivel di autorisashon di L{} pa por hasi un adaptashon "
-"adekuá.\n"
+"mester tin almenos un nivel di autorisashon di L{} pa por hasi un adaptashon adekuá.\n"
 "Editá e miembro aki i kambia e nivel di autorisashon si ta nesesario."
 
 #: rocky/paginator.py
 msgid "That page number is not an integer"
-msgstr ""
+msgstr "E number di página ei no ta un number kompletu"
 
 #: rocky/paginator.py
 msgid "That page number is less than 1"
-msgstr ""
+msgstr "E number di página ei ta ménos ku 1"
 
 #: rocky/paginator.py
 msgid "That page contains no results"
-msgstr ""
+msgstr "E página ei no ta kontené resultado"
 
 #: rocky/scheduler.py
 msgid ""
 "The Scheduler has an unexpected error. Check the Scheduler logs for further "
 "details."
 msgstr ""
+"E Scheduler tin un eror inesperá. Kontrolá e registronan di Scheduler pa mas"
+" detaye."
 
 #: rocky/scheduler.py
 msgid "Could not connect to Scheduler. Service is possibly down."
-msgstr ""
+msgstr "No por a konektá na Scheduler. Servisio posiblemente ta abou."
 
 #: rocky/scheduler.py
 msgid "Your request could not be validated."
-msgstr ""
+msgstr "Bo petishon no por a wòrdu validá."
 
 #: rocky/scheduler.py
 msgid "Task could not be found."
-msgstr ""
+msgstr "No por a haña e tarea."
 
 #: rocky/scheduler.py
 msgid ""
 "Scheduler is receiving too many requests. Increase SCHEDULER_PQ_MAXSIZE or "
 "wait for task to finish."
 msgstr ""
+"Scheduler ta risibí muchu hopi petishon. Oumentá SCHEDULER_PQ_MAXSIZE òf "
+"warda pa e tarea kaba."
 
 #: rocky/scheduler.py
 msgid "Bad request. Your request could not be interpreted by the Scheduler."
 msgstr ""
+"Mal petishon. Bo petishon no por a wòrdu interpretá dor di e Programadó."
 
 #: rocky/scheduler.py
 msgid "The Scheduler has received a conflict. Your task is already in queue."
-msgstr ""
+msgstr "E Programadó a risibí un konflikto. Bo tarea ta den rij kaba."
 
 #: rocky/scheduler.py
 msgid "A HTTPError occurred. See Scheduler logs for more info."
 msgstr ""
+"Un eror HTTPE a sosodé. Wak e registronan di programashon pa mas "
+"informashon."
 
 #: rocky/scheduler.py
 msgid "Schedule list: "
-msgstr ""
+msgstr "Lista di orario:"
 
 #: rocky/scheduler.py
 msgid "Task list: "
-msgstr ""
+msgstr "Lista di tarea:"
 
 #: rocky/settings.py
 msgid "Blue light"
@@ -5470,27 +5961,27 @@ msgstr ""
 
 #: rocky/templates/admin/base.html
 msgid "Skip to main content"
-msgstr ""
+msgstr "Salta pa kontenido prinsipal"
 
 #: rocky/templates/admin/base.html
 msgid "Welcome,"
-msgstr ""
+msgstr "Bon bini,"
 
 #: rocky/templates/admin/base.html
 msgid "View site"
-msgstr ""
+msgstr "Wak e wèpsait"
 
 #: rocky/templates/admin/base.html
 msgid "Documentation"
-msgstr ""
+msgstr "Dokumentashon"
 
 #: rocky/templates/admin/base.html
 msgid "Change password"
-msgstr ""
+msgstr "Kambia kontraseña"
 
 #: rocky/templates/admin/base.html
 msgid "Log out"
-msgstr ""
+msgstr "Log out"
 
 #: rocky/templates/admin/base.html rocky/templates/header.html
 msgid "Breadcrumbs"
@@ -5501,19 +5992,19 @@ msgstr "Breadcrumbs"
 #: rocky/templates/admin/delete_confirmation.html
 #: rocky/templates/admin/delete_selected_confirmation.html
 msgid "Home"
-msgstr ""
+msgstr "Kas"
 
 #: rocky/templates/admin/change_form.html
 #, python-format
 msgid "Add %(name)s"
-msgstr ""
+msgstr "Agregá %(name)s"
 
 #: rocky/templates/admin/change_form.html
 #: rocky/templates/admin/change_list.html
 msgid "Please correct the error below."
 msgid_plural "Please correct the errors below."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Por fabor drecha e erornan aki bou."
+msgstr[1] "Por fabor drecha e erornan aki bou."
 
 #: rocky/templates/admin/change_list.html
 msgid "Filter"
@@ -5521,15 +6012,15 @@ msgstr "Filtrá"
 
 #: rocky/templates/admin/change_list.html
 msgid "Hide counts"
-msgstr ""
+msgstr "Skonde kontanan"
 
 #: rocky/templates/admin/change_list.html
 msgid "Show counts"
-msgstr ""
+msgstr "Mustra konteo"
 
 #: rocky/templates/admin/change_list.html
 msgid "Clear all filters"
-msgstr ""
+msgstr "Limpia tur filter"
 
 #: rocky/templates/admin/delete_confirmation.html
 #, python-format
@@ -5538,13 +6029,18 @@ msgid ""
 "related objects, but your account doesn't have permission to delete the "
 "following types of objects"
 msgstr ""
+"Eliminando e %(object_name)s '%(escaped_object)s' lo resultá den eliminá "
+"ophetonan relashoná, pero bo kuenta no tin pèrmit pa eliminá e siguiente "
+"tipo di ophetonan"
 
 #: rocky/templates/admin/delete_confirmation.html
 #, python-format
 msgid ""
-"Deleting the %(object_name)s '%(escaped_object)s' would require deleting the "
-"following protected related objects"
+"Deleting the %(object_name)s '%(escaped_object)s' would require deleting the"
+" following protected related objects"
 msgstr ""
+"Eliminando e %(object_name)s '%(escaped_object)s' lo rekerí pa eliminá e "
+"siguiente ophetonan relashoná protehá"
 
 #: rocky/templates/admin/delete_confirmation.html
 #, python-format
@@ -5552,20 +6048,22 @@ msgid ""
 "Are you sure you want to delete the %(object_name)s \"%(escaped_object)s\"? "
 "All of the following related items will be deleted"
 msgstr ""
+"Bo ta sigur ku bo ke eliminá e %(object_name)s \"%(escaped_object)s\"? Tur e"
+" siguiente artíkulonan relashoná lo wòrdu eliminá"
 
 #: rocky/templates/admin/delete_confirmation.html
 #: rocky/templates/admin/delete_selected_confirmation.html
 msgid "Yes, I’m sure"
-msgstr ""
+msgstr "Si, mi ta sigur"
 
 #: rocky/templates/admin/delete_confirmation.html
 #: rocky/templates/admin/delete_selected_confirmation.html
 msgid "No, take me back"
-msgstr ""
+msgstr "No, tuma mi bèk"
 
 #: rocky/templates/admin/delete_selected_confirmation.html
 msgid "Delete multiple objects"
-msgstr ""
+msgstr "Elimina vários opheto"
 
 #: rocky/templates/admin/delete_selected_confirmation.html
 #, python-format
@@ -5574,6 +6072,9 @@ msgid ""
 "objects, but your account doesn't have permission to delete the following "
 "types of objects"
 msgstr ""
+"Eliminando e %(objects_name)s selektá lo resultá den eliminá ophetonan "
+"relashoná, pero bo kuenta no tin pèrmit pa eliminá e siguiente tipo di "
+"ophetonan"
 
 #: rocky/templates/admin/delete_selected_confirmation.html
 #, python-format
@@ -5581,6 +6082,8 @@ msgid ""
 "Deleting the selected %(objects_name)s would require deleting the following "
 "protected related objects"
 msgstr ""
+"Eliminando e %(objects_name)s selektá lo rekerí pa eliminá e siguiente "
+"ophetonan relashoná protehá"
 
 #: rocky/templates/admin/delete_selected_confirmation.html
 #, python-format
@@ -5588,18 +6091,20 @@ msgid ""
 "Are you sure you want to delete the selected %(objects_name)s? All of the "
 "following objects and their related items will be deleted"
 msgstr ""
+"Bo ta sigur ku bo ke eliminá e %(objects_name)s selektá? Tur e siguiente "
+"ophetonan i nan artíkulonan relashoná lo wòrdu eliminá"
 
 #: rocky/templates/admin/popup_response.html
 msgid "Popup closing…"
-msgstr ""
+msgstr "Popup ta seramentu…"
 
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
-#: rocky/templates/header.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
 msgid "Close menu"
 msgstr "Sera mènu"
 
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
-#: rocky/templates/header.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
 msgid "Main navigation"
 msgstr "Nagegashon principal"
 
@@ -5607,18 +6112,21 @@ msgstr "Nagegashon principal"
 msgid "Indemnifications"
 msgstr "Indemnizashon"
 
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html
 #: rocky/templates/partials/secondary-menu.html
 msgid "Logout"
 msgstr "Logout"
 
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html
 msgid "Welcome"
 msgstr "Bon Biní"
 
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html
 msgid "User overview"
-msgstr ""
+msgstr "Bista general di usuario"
 
 #: rocky/templates/dashboard_redteam.html
 #: rocky/templates/partials/notifications_block.html
@@ -5631,7 +6139,7 @@ msgstr "advertensia"
 #: rocky/templates/partials/notifications_block.html
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "Warning:"
-msgstr ""
+msgstr "Atvertensia:"
 
 #: rocky/templates/dashboard_redteam.html
 msgid "Organization code missing"
@@ -5656,25 +6164,24 @@ msgid "Add finding"
 msgstr "Añadí diskubrimentu"
 
 #: rocky/templates/findings/finding_list.html
-#, fuzzy
-msgid "Findings @ "
-msgstr "Diskubrimentu"
+msgid "Findings "
+msgstr "Resultadonan"
 
 #: rocky/templates/findings/finding_list.html
-#, fuzzy, python-format
+#, python-format
 msgid ""
 "An overview of all findings OpenKAT found for organization "
 "<strong>%(organization_name)s</strong>. Each finding relates to an object. "
 "Click a finding for additional information."
 msgstr ""
-"Un relato general di tur diskubrimentu OpenKAT á enkontrá riba %(date)s. "
-"Kada diskubrimentu ta relatá na un opheto. Klék un diskubrimentu pa "
-"informashon adishonál."
+"Un bista di tur e resultadonan OpenKAT hañá pa organisashon "
+"<strong>%(organization_name)s</strong>. Kada hañamentu ta relashoná ku un "
+"opheto. Klik riba un hallazgo pa informashon adishonal."
 
 #: rocky/templates/findings/finding_list.html
 #, python-format
 msgid "Showing %(length)s of %(total)s findings"
-msgstr ""
+msgstr "Mustrando %(length)s di %(total)s resultadonan"
 
 #: rocky/templates/findings/finding_list.html
 #: rocky/templates/partials/mute_findings_modal.html
@@ -5683,7 +6190,7 @@ msgstr "Muta diskubrimentu"
 
 #: rocky/templates/findings/finding_list.html
 msgid "Unmute findings"
-msgstr ""
+msgstr "Desmute resultadonan"
 
 #: rocky/templates/findings/findings_filter.html
 #: rocky/templates/partials/elements/ooi_list_settings_form.html
@@ -5703,7 +6210,7 @@ msgstr "Deklarashon di privasidat"
 
 #: rocky/templates/forms/json_schema_form.html
 msgid "Fill out this form to answer the Question (again):"
-msgstr ""
+msgstr "Yena e formulario aki pa kontestá e Pregunta (di nobo):"
 
 #: rocky/templates/graph-d3.html
 msgid ""
@@ -5738,7 +6245,7 @@ msgstr "Checknan di salubridat"
 
 #: rocky/templates/health.html
 msgid "Health checks"
-msgstr ""
+msgstr "Kontrolnan di salú"
 
 #: rocky/templates/health.html
 msgid "Additional"
@@ -5758,7 +6265,7 @@ msgstr ""
 
 #: rocky/templates/indemnification_present.html
 msgid "Go to Objects"
-msgstr ""
+msgstr "Bai na Ophetonan"
 
 #: rocky/templates/indemnification_present.html
 msgid "Go to"
@@ -5782,8 +6289,8 @@ msgid ""
 "by the Ministry of Health, Welfare and Sport to make your and our world "
 "safer."
 msgstr ""
-"OpenKAT ta un tool pa analisá vulnerabilidat. Un Open Source projekto diseña "
-"dor di Ministerio di Salubridat, bienestar i spòrt pa hasi bo i nos mundu "
+"OpenKAT ta un tool pa analisá vulnerabilidat. Un Open Source projekto diseña"
+" dor di Ministerio di Salubridat, bienestar i spòrt pa hasi bo i nos mundu "
 "mas sigur."
 
 #: rocky/templates/landing_page.html
@@ -5795,10 +6302,12 @@ msgid ""
 "Dozens of tools are integrated in OpenKAT to view the world (digital and "
 "analog)."
 msgstr ""
+"Desenas di hèrmènt ta integrá den OpenKAT pa mira mundu (digital i "
+"analógiko)."
 
 #: rocky/templates/landing_page.html
 msgid "Our motto is therefore: I see, I see, what you do not see."
-msgstr ""
+msgstr "Nos lema pues ta: Mi ta mira, mi ta mira, loke bo no ta mira."
 
 #: rocky/templates/landing_page.html
 msgid "OpenKAT knows"
@@ -5809,8 +6318,8 @@ msgid ""
 "OpenKAT does not forget (just like that), and can be queried without "
 "scanning again. Also about a historical situation."
 msgstr ""
-"OpenKAT no ta lubida (simplemente asina), i por kore sin mester skan atrobe. "
-"Tambe tokante situashonnan historiko."
+"OpenKAT no ta lubida (simplemente asina), i por kore sin mester skan atrobe."
+" Tambe tokante situashonnan historiko."
 
 #: rocky/templates/landing_page.html
 msgid "OpenKAT is secure"
@@ -5829,8 +6338,8 @@ msgstr "OpenKAT ta dushi"
 
 #: rocky/templates/landing_page.html
 msgid ""
-"OpenKAT thinks about privacy, and stores what is necessary, within the rules "
-"of your organization and the law."
+"OpenKAT thinks about privacy, and stores what is necessary, within the rules"
+" of your organization and the law."
 msgstr ""
 "OpenKAT ta pensa riba privacy, i ta warda loke ta nesesario, den e reglanan "
 "di bo organisashon i e lèi."
@@ -5841,10 +6350,11 @@ msgstr "Un vèld grandi pa hunga"
 
 #: rocky/templates/landing_page.html
 msgid ""
-"OpenKAT makes a copy of the actual reality by means of the integrated tools. "
-"Within this copy you can search for answers to countless security and policy "
-"questions. Expected and unexpected changes in the world are made visible, "
-"and where necessary reported or made known directly to the right people."
+"OpenKAT makes a copy of the actual reality by means of the integrated tools."
+" Within this copy you can search for answers to countless security and "
+"policy questions. Expected and unexpected changes in the world are made "
+"visible, and where necessary reported or made known directly to the right "
+"people."
 msgstr ""
 "OpenKAT ta traha un kopia di e realidat aktual dor di e tools nan integrá. "
 "Den e kopianan aki bo por buska pa kontestanan pa yen di preguntanan di "
@@ -5859,14 +6369,14 @@ msgstr "OpenKAT Deklarashon di Privasidat"
 #: rocky/templates/legal/privacy_statement.html
 msgid ""
 "OpenKAT is dedicated to protecting the confidentiality and privacy of "
-"information entrusted to it. As part of this fundamental obligation, OpenKAT "
-"is committed to the appropriate protection and use of personal information "
+"information entrusted to it. As part of this fundamental obligation, OpenKAT"
+" is committed to the appropriate protection and use of personal information "
 "(sometimes referred to as \"personal data\", \"personally identifiable "
 "information\" or \"PII\") that has been collected online."
 msgstr ""
 "OpenKAT is dedicated to protecting the confidentiality and privacy of "
-"information entrusted to it. As part of this fundamental obligation, OpenKAT "
-"is committed to the appropriate protection and use of personal information "
+"information entrusted to it. As part of this fundamental obligation, OpenKAT"
+" is committed to the appropriate protection and use of personal information "
 "(sometimes referred to as \"personal data\", \"personally identifiable "
 "information\" or \"PII\") that has been collected online."
 
@@ -5924,7 +6434,7 @@ msgstr "Akinan bo por kita e %(display_type)s."
 
 #: rocky/templates/oois/ooi_delete.html
 msgid "To be deleted object(s)"
-msgstr ""
+msgstr "Opheto(nan) pa wòrdu eliminá"
 
 #: rocky/templates/oois/ooi_delete.html
 #: rocky/templates/partials/elements/ooi_tree_condensed_table.html
@@ -5954,38 +6464,47 @@ msgstr "advertensia di indemnisashon"
 #: rocky/templates/oois/ooi_detail.html
 #, python-format
 msgid ""
-"<strong>Warning:</strong> There is no indemnification for this organization. "
-"Go to the <a href=\"%(organization_settings)s\">organization settings page</"
-"a> to add one."
+"<strong>Warning:</strong> There is no indemnification for this organization."
+" Go to the <a href=\"%(organization_settings)s\">organization settings "
+"page</a> to add one."
 msgstr ""
+"<strong>Advertensia:</strong> No tin indemnisashon pa e organisashon aki. "
+"Bai na e <a href=\"%(organization_settings)s\">página di konfigurashon di "
+"organisashon</a> pa agregá un."
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "Permission warning"
-msgstr ""
+msgstr "Atvertensia di pèrmit"
 
 #: rocky/templates/oois/ooi_detail.html
 msgid ""
 "<strong>Warning:</strong> You don't have the proper permission at the "
 "organizational level to scan objects. Contact your administrator."
 msgstr ""
+"<strong>Atvertensia:</strong> Bo no tin e pèrmit apropiá na nivel "
+"organisatorio pa skan ophetonan. Tuma kontakto ku bo atministradó."
 
 #: rocky/templates/oois/ooi_detail.html
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Scan warning"
-msgstr ""
+msgstr "Atvertensia di skan"
 
 #: rocky/templates/oois/ooi_detail.html
 #, python-format
 msgid ""
-"<strong>Warning:</strong> You are not allowed to scan this OOI. Your maximum "
-"clearance level is %(member_clearance_level)s and this OOI has level "
+"<strong>Warning:</strong> You are not allowed to scan this OOI. Your maximum"
+" clearance level is %(member_clearance_level)s and this OOI has level "
 "%(boefje_scan_level)s. Go to your <a href=\"%(account_details)s\">account "
 "details</a> to manage your clearance level."
 msgstr ""
+"<strong>Atvertensia:</strong> Bo no mag di skan esaki OOI. Bo nivel di "
+"limpiesa máksimo ta %(member_clearance_level)s i esaki OOI tin nivel "
+"%(boefje_scan_level)s. Bai na bo <a href=\"%(account_details)s\">detayenan "
+"di kuenta</a> pa manehá bo nivel di limpiesa."
 
 #: rocky/templates/oois/ooi_detail.html rocky/templates/scan.html
 msgid "Boefjes overview"
-msgstr ""
+msgstr "Boefjes bista general"
 
 #: rocky/templates/oois/ooi_detail.html
 #: rocky/templates/oois/ooi_detail_origins_observations.html
@@ -6000,11 +6519,11 @@ msgstr "Investigá profíl"
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "Unable to start scan. See the warning for more details."
-msgstr ""
+msgstr "No por kuminsá skan. Wak e atvertensia pa mas detaye."
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "Start scan"
-msgstr ""
+msgstr "Kuminsá skan"
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "There are no boefjes enabled to scan an OOI of type"
@@ -6045,7 +6564,7 @@ msgstr "Eskohé un tipo di opheto pa agregá"
 
 #: rocky/templates/oois/ooi_detail_findings_list.html
 msgid "Overview of findings for"
-msgstr ""
+msgstr "Bista general di resultadonan pa"
 
 #: rocky/templates/oois/ooi_detail_findings_list.html
 msgid "Score"
@@ -6081,7 +6600,7 @@ msgstr "Totál diskubrimentu"
 #: rocky/templates/oois/ooi_detail_object.html
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Inactive"
-msgstr ""
+msgstr "Inaktivo"
 
 #: rocky/templates/oois/ooi_detail_origins_declarations.html
 msgid "Declarations"
@@ -6101,7 +6620,7 @@ msgstr "Parameternan"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "Last observed by"
-msgstr ""
+msgstr "Ultimo opservá pa"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "Task ID"
@@ -6109,7 +6628,7 @@ msgstr "Tarea ID"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "When"
-msgstr ""
+msgstr "Ki ora"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 #: rocky/templates/tasks/normalizers.html
@@ -6118,15 +6637,16 @@ msgstr "Normalizer"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "This scan was manually created."
-msgstr ""
+msgstr "E skan aki a wòrdu kreá manualmente."
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "The boefje has since been deleted or disabled."
-msgstr ""
+msgstr "E boefje a wòrdu eliminá òf desabilitá for di e tempu ei."
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "No Raw file could be found, this might point to an error in OpenKAT"
 msgstr ""
+"No por a haña ningun archivo Raw, esaki por mustra riba un eror den OpenKAT"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 #: rocky/templates/scan_profiles/scan_profile_detail.html
@@ -6149,27 +6669,28 @@ msgstr "Save %(display_type)s"
 
 #: rocky/templates/oois/ooi_findings.html
 msgid "Currently no findings have been identified for OOI"
-msgstr ""
+msgstr "Aktualmente no a identifiká ningun resultado pa OOI"
 
 #: rocky/templates/oois/ooi_list.html
-#, fuzzy, python-format
+#, python-format
 msgid ""
-"An overview of objects found for organization <strong>%(organization_name)s</"
-"strong>. Objects can be added manually or by running Boefjes. Click an "
-"object for additional information."
+"An overview of objects found for organization "
+"<strong>%(organization_name)s</strong>. Objects can be added manually or by "
+"running Boefjes. Click an object for additional information."
 msgstr ""
-"Un bista general di bo lista di ophetonan. Ophetonan por wòrdu añadí "
-"manualmente òf dor di ehekutá boefjes. </br> Klik riba un opheto pa mas "
-"informashon."
+"Un bista di ophetonan hañá pa organisashon "
+"<strong>%(organization_name)s</strong>. Ophetonan por wòrdu agregá "
+"manualmente òf dor di kore Boefjes. Klik riba un opheto pa informashon "
+"adishonal."
 
 #: rocky/templates/oois/ooi_list.html
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Edit clearance level"
-msgstr ""
+msgstr "Editá nivel di limpiesa"
 
 #: rocky/templates/oois/ooi_mute_finding.html
 msgid "Mute finding:"
-msgstr ""
+msgstr "Hañamentu di silensio:"
 
 #: rocky/templates/oois/ooi_mute_finding.html
 msgid "Give a reason below why you want to mute this finding."
@@ -6257,8 +6778,8 @@ msgstr "mustrando e mesun ophetonan."
 
 #: rocky/templates/organizations/organization_add.html
 msgid ""
-"Please enter the following organization details. These details can be edited "
-"within the organization page within OpenKAT when necessary."
+"Please enter the following organization details. These details can be edited"
+" within the organization page within OpenKAT when necessary."
 msgstr ""
 "Por fabor pone e detayenan di e siguiente organisashon. E detayenan aki por "
 "wordu editá den e página di organisashon den OpenKAT si ta nesesario."
@@ -6273,7 +6794,7 @@ msgstr "Warda organisashon"
 
 #: rocky/templates/organizations/organization_list.html
 msgid "An overview of all organizations you are a member of."
-msgstr ""
+msgstr "Un bista di tur organisashon ku bo ta miembro di dje."
 
 #: rocky/templates/organizations/organization_list.html
 msgid "Add new organization"
@@ -6286,6 +6807,8 @@ msgid ""
 "                            Showing %(total)s organizations\n"
 "                        "
 msgstr ""
+"\n"
+"Mustrando %(total)s organisashonnan"
 
 #: rocky/templates/organizations/organization_list.html
 msgid "Organization overview:"
@@ -6302,7 +6825,7 @@ msgstr "No a haña organisashonnan pa bo kuenta di usario"
 
 #: rocky/templates/organizations/organization_list.html
 msgid "Actions to perform for all of your organizations."
-msgstr ""
+msgstr "Akshonnan pa hasi pa tur bo organisashonnan."
 
 #: rocky/templates/organizations/organization_list.html
 #: rocky/templates/organizations/organization_settings.html
@@ -6311,21 +6834,25 @@ msgstr "Pone bits kore atrobe"
 
 #: rocky/templates/organizations/organization_member_add.html
 msgid "Change account type"
-msgstr ""
+msgstr "Kambia tipo di kuenta"
 
 #: rocky/templates/organizations/organization_member_add_header.html
 #: rocky/views/organization_member_add.py
 msgid "Add member"
-msgstr ""
+msgstr "Agregá miembro"
 
 #: rocky/templates/organizations/organization_member_add_header.html
 #, python-format
 msgid ""
-"Creating a new member of organization <strong>%(organization)s</strong>. For "
-"detailed information about the different account types, check the <a "
+"Creating a new member of organization <strong>%(organization)s</strong>. For"
+" detailed information about the different account types, check the <a "
 "href=\"https://docs.openkat.nl/basics/users-and-organisations.html#users\" "
 "target=\"_blank\" rel=\"noopener\">documentation</a>."
 msgstr ""
+"Kreando un miembro nobo di organisashon <strong>%(organization)s</strong>. "
+"Pa informashon detayá tokante e diferente tipo di kuenta, wak e <a "
+"href=\"https://docs.openkat.nl/basics/users-and-organisations.html#users\" "
+"target=\"_blank\" rel=\"noopener\">dokumentashon</a>."
 
 #: rocky/templates/organizations/organization_member_edit.html
 #: rocky/views/organization_member_edit.py
@@ -6339,7 +6866,7 @@ msgstr "Warda miembronan"
 #: rocky/templates/organizations/organization_member_list.html
 #, python-format
 msgid "An overview of members of <strong>%(organization_name)s</strong>."
-msgstr ""
+msgstr "Un bista di miembronan di <strong>%(organization_name)s</strong>."
 
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Add member(s)"
@@ -6360,6 +6887,8 @@ msgid ""
 "                        Showing %(total)s members\n"
 "                    "
 msgstr ""
+"\n"
+"Mustrando %(total)s miembronan"
 
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Member overview:"
@@ -6380,7 +6909,7 @@ msgstr "Super usario"
 #: rocky/templates/organizations/organization_member_upload.html
 #: rocky/views/organization_member_add.py
 msgid "Add members"
-msgstr ""
+msgstr "Agregá miembronan"
 
 #: rocky/templates/organizations/organization_member_upload.html
 #, python-format
@@ -6388,10 +6917,15 @@ msgid ""
 "To upload multiple members at once, you can upload a CSV file or you can <a "
 "href=\"%(download_url)s\">download the template</a>."
 msgstr ""
+"Pa subi vários miembro pareu, bo por subi un CSV archivo òf bo por <a "
+"href=\"%(download_url)s\">download e plantilla</a>."
 
 #: rocky/templates/organizations/organization_member_upload.html
-msgid "To create a custom CSV file, make sure it meets the following criteria:"
+msgid ""
+"To create a custom CSV file, make sure it meets the following criteria:"
 msgstr ""
+"Pa krea un archivo CSV personalisá, hasi sigur ku e ta kumpli ku e siguiente"
+" kriterionan:"
 
 #: rocky/templates/organizations/organization_member_upload.html
 msgid "Upload"
@@ -6403,11 +6937,15 @@ msgid ""
 "An overview of general information and settings for "
 "<strong>%(organization_name)s</strong>."
 msgstr ""
+"Un bista di informashon general i settingnan pa "
+"<strong>%(organization_name)s</strong>."
 
 #: rocky/templates/organizations/organization_settings.html
 msgid ""
 "<strong>Warning:</strong> Indemnification is not set for this organization."
 msgstr ""
+"<strong>Advertensia:</strong> Indemnisashon no ta fihá pa e organisashon "
+"aki."
 
 #: rocky/templates/organizations/organization_settings.html
 #: rocky/views/indemnification_add.py
@@ -6416,37 +6954,43 @@ msgstr "Añadi indemnisashon"
 
 #: rocky/templates/partials/current_config.html
 msgid "Current configuration"
-msgstr ""
+msgstr "Konfigurashon aktual"
 
 #: rocky/templates/partials/delete_ooi_modal.html
 msgid "Delete objects"
-msgstr ""
+msgstr "Elimina ophetonan"
 
 #: rocky/templates/partials/delete_ooi_modal.html
 msgid ""
-"Are you sure you want to delete all the selected objects? The history of the "
-"deleted objects will still be available."
+"Are you sure you want to delete all the selected objects? The history of the"
+" deleted objects will still be available."
 msgstr ""
+"Bo ta sigur ku bo ke eliminá tur e ophetonan selektá? E historia di e "
+"ophetonan eliminá lo ta disponibel ainda."
 
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 msgid "Edit clearance level settings"
-msgstr ""
+msgstr "Editá e settingnan di nivel di limpiesa"
 
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 msgid "You are editing clearance level of all the selected objects."
-msgstr ""
+msgstr "Bo ta editando e nivel di limpiesa di tur e ophetonan selektá."
 
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 msgid "Switching between declare and inherit"
-msgstr ""
+msgstr "Kambiando entre deklará i heredá"
 
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 msgid ""
 "Clearance levels can be automatically inherited or you can manually declare "
-"the clearance level for an object. Switching to inherit clearance level will "
-"also recalculate the clearance levels of objects that inherit from these "
+"the clearance level for an object. Switching to inherit clearance level will"
+" also recalculate the clearance levels of objects that inherit from these "
 "clearance levels."
 msgstr ""
+"Nivelnan di limpiesa por wòrdu heredá outomatikamente òf bo por deklará "
+"manualmente e nivel di limpiesa pa un opheto. Kambiando pa heredá nivel di "
+"limpiesa tambe lo rekalkulá e nivelnan di limpiesa di ophetonan ku ta heredá"
+" for di e nivelnan di limpiesa aki."
 
 #: rocky/templates/partials/elements/ooi_detail_settings.html
 msgid "Observed at"
@@ -6525,8 +7069,20 @@ msgid "OOI"
 msgstr "OOI"
 
 #: rocky/templates/partials/explanations.html
+msgid "This OOI"
+msgstr "Esaki OOI"
+
+#: rocky/templates/partials/explanations.html
 msgid "Origin"
 msgstr "Origen"
+
+#: rocky/templates/partials/explanations.html
+msgid "declared"
+msgstr "a deklará"
+
+#: rocky/templates/partials/explanations.html
+msgid "inherited from ↓"
+msgstr "heredá for di ↓"
 
 #: rocky/templates/partials/explanations.html
 msgid "Show clearance level inheritance"
@@ -6537,9 +7093,8 @@ msgid "Reproduction"
 msgstr "Reprodusí"
 
 #: rocky/templates/partials/form/checkbox_group_table_form.html
-#, fuzzy
 msgid "Please enable plugin to start scanning."
-msgstr "Por fabor sende plugin prome ku kuminsa start ku skan"
+msgstr "Por fabor, aktivá e plugin pa kuminsá skan."
 
 #: rocky/templates/partials/form/field_input.html
 msgid "Not set"
@@ -6562,7 +7117,7 @@ msgstr "error"
 #: rocky/templates/partials/form/form_errors.html
 #: rocky/templates/partials/notifications_block.html
 msgid "Error:"
-msgstr ""
+msgstr "Eror:"
 
 #: rocky/templates/partials/form/field_input_help_text.html
 msgid "Open explanation"
@@ -6576,7 +7131,7 @@ msgstr "Sera deklarashon"
 #: rocky/templates/partials/notifications_block.html
 #: rocky/templates/two_factor/core/login.html
 msgid "Explanation:"
-msgstr ""
+msgstr "Eksplikashon:"
 
 #: rocky/templates/partials/form/indemnification_add_form.html
 msgid ""
@@ -6585,17 +7140,24 @@ msgid ""
 "negative impact on (your) assets. Therefore it is important to know and be "
 "aware of the impact of security scans."
 msgstr ""
+"Realisá skannan di seguridat kontra di aktivonan ta generalmente solamente "
+"permití si bo tin pèrmit pa skan e aktivonan ei. Sierto skan tambe por tin "
+"un impakto negativo riba (bo) aktivonan. P’esei ta importante pa sa i ta "
+"konsiente di e impakto di skannan di seguridat."
 
 #: rocky/templates/partials/form/indemnification_add_form.html
 msgid ""
-"An organization indemnification is required before you can use OpenKAT. With "
-"the indemnification you declare that you, as a person, can be held "
+"An organization indemnification is required before you can use OpenKAT. With"
+" the indemnification you declare that you, as a person, can be held "
 "accountable."
 msgstr ""
+"Un indemnisashon di organisashon ta nesesario promé ku bo por usa OpenKAT. "
+"Cu e indemnisacion bo ta declara cu abo, como persona, por wordo poni "
+"responsabel."
 
 #: rocky/templates/partials/form/indemnification_add_form.html
 msgid "Set an indemnification"
-msgstr ""
+msgstr "Pone un indemnisashon"
 
 #: rocky/templates/partials/hyperlink_ooi_type.html
 #, python-format
@@ -6632,6 +7194,10 @@ msgid "Page"
 msgstr "Página"
 
 #: rocky/templates/partials/list_paginator.html
+msgid "Current"
+msgstr "Aktual"
+
+#: rocky/templates/partials/list_paginator.html
 msgid "Five Pages Forward"
 msgstr "Sinku pagina dilanti"
 
@@ -6645,27 +7211,27 @@ msgstr "Sigiénte"
 
 #: rocky/templates/partials/mute_findings_modal.html
 msgid "You are muting the selected findings."
-msgstr ""
+msgstr "Bo ta silensiá e resultadonan selektá."
 
 #: rocky/templates/partials/mute_findings_modal.html
 msgid "Reason:"
-msgstr ""
+msgstr "Rason:"
 
 #: rocky/templates/partials/mute_findings_modal.html
 msgid "Expires by (UTC):"
-msgstr ""
+msgstr "Ta kaduká pa (UTC):"
 
 #: rocky/templates/partials/notifications_block.html
 msgid "Confirmation:"
-msgstr ""
+msgstr "Konfirmashon:"
 
 #: rocky/templates/partials/ooi_detail_related_object.html
 msgid "No related object known for"
-msgstr ""
+msgstr "No tin opheto relashoná konosí pa"
 
 #: rocky/templates/partials/ooi_detail_toolbar.html
 msgid "Generate Report"
-msgstr ""
+msgstr "Generá Rapòrt"
 
 #: rocky/templates/partials/ooi_detail_toolbar.html
 #, python-format
@@ -6673,12 +7239,12 @@ msgid "Edit %(display_type)s"
 msgstr "Editá %(display_type)s"
 
 #: rocky/templates/partials/ooi_head.html
-#, python-format
-msgid ""
-"An overview of \"%(ooi)s\", object type \"%(type)s\". This shows general "
-"information and its related objects. It also gives the possibility to add "
-"additional related objects, or to scan for them."
-msgstr ""
+msgid "Data from:"
+msgstr "Datonan di:"
+
+#: rocky/templates/partials/ooi_head.html
+msgid "(Now)"
+msgstr "(Aworaki)"
 
 #: rocky/templates/partials/ooi_list_toolbar.html
 msgid "Scan for objects"
@@ -6721,8 +7287,8 @@ msgid ""
 "The severity of this findingtype has not (yet) been determined by the data "
 "source. This situation requires manual investigation of the severity."
 msgstr ""
-"Gravedat di e tìpo di diskubrimentu aki ainda no a ser determiná pa e fuente "
-"di dato. E situashon aki ta requeri investigashon manual di e gravedat."
+"Gravedat di e tìpo di diskubrimentu aki ainda no a ser determiná pa e fuente"
+" di dato. E situashon aki ta requeri investigashon manual di e gravedat."
 
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "Total occurrences"
@@ -6758,7 +7324,7 @@ msgstr "Tur organisashon"
 
 #: rocky/templates/partials/page-meta.html
 msgid "Logged in as:"
-msgstr ""
+msgstr "A drenta komo:"
 
 #: rocky/templates/partials/pagination.html
 msgid "of"
@@ -6807,50 +7373,58 @@ msgid ""
 "This means that the clearance level might stay the same, increase or "
 "decrease, depending on other declared clearance levels."
 msgstr ""
+"E nivel di limpiesa ta determiná e nivel di skan di boefje permití riba e "
+"opheto aki. Un opheto ta heredá su nivel di limpiesa for di ophetonan "
+"bisiña. Esaki ta nifiká ku e nivel di limpiesa por keda meskos, oumentá òf "
+"baha, dependiendo di otro nivelnan di limpiesa deklará."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Empty clearance level explanation"
-msgstr ""
+msgstr "Splikashon di nivel di limpiesa bashi"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Empty:"
-msgstr ""
+msgstr "Bashí:"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid ""
 "This object has a clearance level of \"empty\". This means that this object "
 "has no clearance level."
 msgstr ""
+"E opheto aki tin un nivel di limpiesa di “bashi”. Esaki ta nifiká ku e "
+"opheto aki no tin un nivel di limpiesa."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Indemnification warning"
-msgstr ""
+msgstr "Atvertensia di indemnisashon"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Indemnification is not set for this organization."
-msgstr ""
+msgstr "Indemnisashon no ta fihá pa e organisashon aki."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Go to the"
-msgstr ""
+msgstr "Bai na e"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "organization settings page"
-msgstr ""
+msgstr "página di setting di organisashon"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "to add one."
-msgstr ""
+msgstr "pa agregá un."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Set clearance level warning"
-msgstr ""
+msgstr "Pone atvertensia di nivel di limpiesa"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid ""
 "You don't have permissions to set the clearance level. Contact your "
 "administrator."
 msgstr ""
+"Bo no tin pèrmit pa pone e nivel di limpiesa. Tuma kontakto ku bo "
+"atministradó."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 #, python-format
@@ -6859,29 +7433,32 @@ msgid ""
 "clearance level is %(member_clearance_level)s and this OOI has level "
 "%(boefje_scan_level)s."
 msgstr ""
+"Bo no mag di pone e nivel di limpiesa di esaki OOI. Bo nivel di limpiesa "
+"máksimo ta %(member_clearance_level)s i esaki OOI tin nivel "
+"%(boefje_scan_level)s."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Go to your"
-msgstr ""
+msgstr "Bai na bo"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "account details"
-msgstr ""
+msgstr "detayenan di kuenta"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "to manage your clearance level."
-msgstr ""
+msgstr "pa manehá bo nivel di limpiesa."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Current clearance level"
-msgstr ""
+msgstr "Nivel di limpiesa aktual"
 
 #: rocky/templates/tasks/boefje_task_detail.html
 msgid ""
 "An overview of the boefje task, the input OOI and the RAW data it generated."
 msgstr ""
-"Un bista general di e tarea boefje, e opheto di entrada OOI, y e datonan RAW "
-"cu el a generá."
+"Un bista general di e tarea boefje, e opheto di entrada OOI, y e datonan RAW"
+" cu el a generá."
 
 #: rocky/templates/tasks/boefje_task_detail.html
 #: rocky/templates/tasks/partials/task_actions.html
@@ -6898,15 +7475,15 @@ msgstr "Opheto di entrada"
 
 #: rocky/templates/tasks/boefjes.html
 msgid "There are no tasks for boefjes."
-msgstr ""
+msgstr "No tin tarea pa boefjes."
 
 #: rocky/templates/tasks/boefjes.html
 msgid "List of tasks for boefjes."
-msgstr ""
+msgstr "Lista di tareanan pa boefjes."
 
 #: rocky/templates/tasks/boefjes.html rocky/templates/tasks/reports.html
 msgid "Organization Code"
-msgstr ""
+msgstr "Kódigo di Organisashon"
 
 #: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
 #: rocky/templates/tasks/ooi_detail_task_list.html
@@ -6917,15 +7494,15 @@ msgstr "Fecha kreá"
 #: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
 #: rocky/templates/tasks/reports.html
 msgid "Modified date"
-msgstr ""
+msgstr "Fecha modifiká"
 
 #: rocky/templates/tasks/normalizers.html
 msgid "There are no tasks for normalizers."
-msgstr ""
+msgstr "No tin tarea pa normalisadónan."
 
 #: rocky/templates/tasks/normalizers.html
 msgid "List of tasks for normalizers."
-msgstr ""
+msgstr "Lista di tareanan pa normalisadónan."
 
 #: rocky/templates/tasks/normalizers.html
 msgid "Boefje input OOI"
@@ -6933,35 +7510,43 @@ msgstr "Opheto di Entrada \"Boefje\""
 
 #: rocky/templates/tasks/normalizers.html
 msgid "Manually added"
-msgstr ""
+msgstr "Agregá manualmente"
 
 #: rocky/templates/tasks/ooi_detail_task_list.html
 msgid "There have been no tasks."
-msgstr ""
+msgstr "No tabatin tarea."
 
 #: rocky/templates/tasks/partials/stats.html
 msgid "Task statistics - Last 24 hours"
-msgstr ""
+msgstr "Estadístika di tarea - Ultimo 24 ora"
 
 #: rocky/templates/tasks/partials/stats.html
 msgid "All times in UTC, blocks of 1 hour."
-msgstr ""
+msgstr "Tur tempu den UTC, blòki di 1 ora."
 
 #: rocky/templates/tasks/partials/stats.html
 msgid "Timeslot"
-msgstr ""
+msgstr "Slot di tempu"
 
 #: rocky/templates/tasks/partials/stats.html
 msgid "Could not load stats, Scheduler error."
-msgstr ""
+msgstr "No por a karga estadístika, eror di e programadó."
 
 #: rocky/templates/tasks/partials/tab_navigation.html
 msgid "List of tasks"
 msgstr "Lista di tareanan"
 
 #: rocky/templates/tasks/partials/task_actions.html
+msgid "Loading..."
+msgstr "Ta karga..."
+
+#: rocky/templates/tasks/partials/task_actions.html
 msgid "Yielded objects"
 msgstr "Ophetonan generá"
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Yielded raw files"
+msgstr "A duna archivonan krudo"
 
 #: rocky/templates/tasks/partials/task_actions.html
 msgid "Reschedule"
@@ -6980,26 +7565,31 @@ msgid ""
 "Report tasks. This task aggregates and presents findings from both Boefjes "
 "and Normalizers."
 msgstr ""
+"Un bista di e tareanan pa <strong>%(organization)s</strong>. Tareanan ta "
+"wòrdu dividí den Boefjes, Normalizers i Rapòrtnan. Boefjes skan ophetonan i "
+"Normalizers despachá riba e tipo di mime di salida. Adishonalmente, tin un "
+"tareanan di Rapòrt. E tarea aki ta agregá i presentá resultadonan di tantu "
+"Boefjes komo Normalizers."
 
 #: rocky/templates/tasks/plugin_detail_task_list.html
 msgid "There are no tasks for"
-msgstr ""
+msgstr "No tin tarea pa"
 
 #: rocky/templates/tasks/plugin_detail_task_list.html
 msgid "List of tasks for"
-msgstr ""
+msgstr "Lista di tareanan pa"
 
 #: rocky/templates/tasks/reports.html
 msgid "There are no tasks for reports."
-msgstr ""
+msgstr "No tin tarea pa rapòrt."
 
 #: rocky/templates/tasks/reports.html
 msgid "List of tasks for reports."
-msgstr ""
+msgstr "Lista di tareanan pa rapòrtnan."
 
 #: rocky/templates/tasks/reports.html
 msgid "Recipe ID"
-msgstr ""
+msgstr "ID di reseta"
 
 #: rocky/templates/two_factor/_wizard_actions.html
 msgid "Log in"
@@ -7102,8 +7692,8 @@ msgstr ""
 #: rocky/templates/two_factor/core/otp_required.html
 #: rocky/templates/two_factor/profile/profile.html
 msgid ""
-"Two-factor authentication is not enabled for your account. Enable two-factor "
-"authentication for enhanced account security."
+"Two-factor authentication is not enabled for your account. Enable two-factor"
+" authentication for enhanced account security."
 msgstr ""
 "Two-factor authentication no ta aktivá pa bo account. Aktivá two-factor "
 "authentication pa mejorá seguridat di account."
@@ -7138,12 +7728,12 @@ msgstr ""
 #: rocky/templates/two_factor/core/setup.html
 msgid ""
 "To start using a token generator, please use your smartphone to scan the QR "
-"code below or use the setup key. For example, use GoogleAuthenticator. Then, "
-"enter the token generated by the app."
+"code below or use the setup key. For example, use GoogleAuthenticator. Then,"
+" enter the token generated by the app."
 msgstr ""
 "Pa kuminsa uza un generadó di token, por favor uza bo smartphone pa skan e "
-"QR codigo abou. Por ehempel, uza Google Authenticator. Despues, yena e token "
-"ku e app a generá."
+"QR codigo abou. Por ehempel, uza Google Authenticator. Despues, yena e token"
+" ku e app a generá."
 
 #: rocky/templates/two_factor/core/setup.html
 msgid "QR code"
@@ -7155,8 +7745,8 @@ msgstr "Jabi sekreto"
 
 #: rocky/templates/two_factor/core/setup.html
 msgid ""
-"The secret key is a 32 characters representation of the QR code. There are 2 "
-"options to setup the two factor authtentication. You can scan the QR code "
+"The secret key is a 32 characters representation of the QR code. There are 2"
+" options to setup the two factor authtentication. You can scan the QR code "
 "above or you can insert this key using the secret key option of the "
 "authenticator app."
 msgstr ""
@@ -7166,7 +7756,8 @@ msgstr ""
 "di autentifikashon."
 
 #: rocky/templates/two_factor/core/setup_complete.html
-msgid "Congratulations, you've successfully enabled two-factor authentication."
+msgid ""
+"Congratulations, you've successfully enabled two-factor authentication."
 msgstr "Pabién, bo á activá two-factor authentication ku èksito."
 
 #: rocky/templates/two_factor/core/setup_complete.html
@@ -7256,8 +7847,8 @@ msgstr "Desaktivá Two-Factor Authentication"
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid ""
-"However we strongly discourage you to do so, you can also disable two-factor "
-"authentication for your account."
+"However we strongly discourage you to do so, you can also disable two-factor"
+" authentication for your account."
 msgstr ""
 "Sin embargo, nos no ta rekomendá bo hasi esaki, tambe bo por desaktivá two-"
 "factor authentication pa bo account."
@@ -7282,12 +7873,18 @@ msgstr "Automatizá e kreo di varios ophetonan dor di karga un arkivo."
 
 #: rocky/templates/upload_raw.html
 msgid ""
-"An input OOI can be selected for the normalizer to attach newly yielded OOIs "
-"to. If no input OOI was used for the raw file, a placeholder ExternalScan "
+"An input OOI can be selected for the normalizer to attach newly yielded OOIs"
+" to. If no input OOI was used for the raw file, a placeholder ExternalScan "
 "OOI can be used. ExternalScan OOIs can be created from the objects page. "
 "When a new version of the raw file is generated, the same ExternalScan OOI "
 "should be chosen to ensure that old results are overwritten."
 msgstr ""
+"Un entrada OOI por wòrdu selektá pa e normalisadó por atachá OOIs nobo na "
+"dje. Si no a usa ningun entrada OOI pa e archivo brutu, por usa un "
+"placeholder ExternalScan OOI. ExternalScan OOIs por wòrdu kreá for di e "
+"página di ophetonan. Ora un vershon nobo di e archivo brutu ta wòrdu generá,"
+" e mesun ExternalScan OOI mester wòrdu skohé pa sigurá ku resultadonan bieu "
+"ta wòrdu sobreskirbí."
 
 #: rocky/templates/upload_raw.html rocky/views/upload_raw.py
 msgid "Upload raw"
@@ -7295,11 +7892,11 @@ msgstr "Karga CSV"
 
 #: rocky/views/bytes_raw.py
 msgid "Getting raw data failed."
-msgstr ""
+msgstr "Hañamentu di dato brutu a frakasá."
 
 #: rocky/views/bytes_raw.py
 msgid "The task does not have any raw data."
-msgstr ""
+msgstr "E tarea no tin ningun dato brutu."
 
 #: rocky/views/finding_list.py rocky/views/ooi_list.py
 msgid "Unknown action."
@@ -7315,19 +7912,33 @@ msgstr "Indemnizashon pone ku èxito."
 
 #: rocky/views/mixins.py
 msgid "The selected date is in the future."
-msgstr ""
+msgstr "E fecha selektá ta den futuro."
 
 #: rocky/views/mixins.py
 msgid "Can not parse date, falling back to show current date."
-msgstr ""
+msgstr "No por analisá fecha, ta kai bèk pa mustra fecha aktual."
+
+#: rocky/views/mixins.py
+#, python-format
+msgid "Could not load origins for OOI: %s from octopoes"
+msgstr "No por a karga orígennan pa OOI: %s for di oktopoes"
+
+#: rocky/views/mixins.py
+msgid "Could not load normalizer metas from bytes"
+msgstr "No por a karga meta di normalisadó for di byte"
+
+#: rocky/views/mixins.py
+#, python-format
+msgid "Could not load boefje %s from katalogus"
+msgstr "No por a karga boefje %s for di katalogus"
 
 #: rocky/views/mixins.py
 msgid "You do not have the permission to add items to a dashboard."
-msgstr ""
+msgstr "Bo no tin e pèrmit pa agregá artíkulonan na un dashboard."
 
 #: rocky/views/mixins.py
 msgid "Dashboard item has been added."
-msgstr ""
+msgstr "E artíkulo di dashboard a wòrdu agregá."
 
 #: rocky/views/ooi_add.py
 #, python-format
@@ -7338,6 +7949,8 @@ msgstr "Añadí %(ooi_type)s"
 msgid ""
 "Cannot set clearance level. It must be provided and must be a valid number."
 msgstr ""
+"No por pone nivel di limpiesa. E mester ta suministrá i mester ta un number "
+"bálido."
 
 #: rocky/views/ooi_detail.py
 msgid "Only Question OOIs can be answered."
@@ -7345,7 +7958,7 @@ msgstr "Solamente Question OOIs por ser respondí."
 
 #: rocky/views/ooi_detail.py
 msgid "Question has been answered."
-msgstr ""
+msgstr "Pregunta a wòrdu kontestá."
 
 #: rocky/views/ooi_detail_related_object.py
 msgid " (as "
@@ -7399,7 +8012,7 @@ msgstr "Un di e OOI nan no ta eksistí."
 #: rocky/views/ooi_list.py
 #, python-format
 msgid "Successfully set scan profile to %s for %d OOIs."
-msgstr ""
+msgstr "Pone e profil di skan na %s pa %d OOIs ku éksito."
 
 #: rocky/views/ooi_list.py
 msgid "An error occurred while setting clearance levels to inherit."
@@ -7408,16 +8021,16 @@ msgstr ""
 
 #: rocky/views/ooi_list.py
 msgid ""
-"An error occurred while setting clearance levels to inherit: one of the OOIs "
-"doesn't exist."
+"An error occurred while setting clearance levels to inherit: one of the OOIs"
+" doesn't exist."
 msgstr ""
-"Un error a sosodé durante e ajuste di nivelnan di autorisashon pa heredá: un "
-"di e OOI nan no ta eksistí."
+"Un error a sosodé durante e ajuste di nivelnan di autorisashon pa heredá: un"
+" di e OOI nan no ta eksistí."
 
 #: rocky/views/ooi_list.py
 #, python-format
 msgid "Successfully set %d OOI(s) clearance level to inherit."
-msgstr ""
+msgstr "Pone %d OOI(s) nivel di limpiesa pa heredá ku éksito."
 
 #: rocky/views/ooi_list.py
 msgid "An error occurred while deleting oois."
@@ -7425,7 +8038,7 @@ msgstr "Un error a sosodé durante e eliminashon di OOI nan."
 
 #: rocky/views/ooi_list.py
 msgid "An error occurred while deleting OOIs: one of the OOIs doesn't exist."
-msgstr ""
+msgstr "Un eror a sosodé ora di eliminá OOIs: un di e OOIs no ta eksistí."
 
 #: rocky/views/ooi_list.py
 #, python-format
@@ -7442,7 +8055,7 @@ msgstr "Por fabor, selektá al menos un diskubrimentu."
 
 #: rocky/views/ooi_mute.py
 msgid "Finding(s) successfully unmuted."
-msgstr ""
+msgstr "Hañamentu(nan) ku a desmutá ku éksito."
 
 #: rocky/views/ooi_mute.py
 msgid "Finding(s) successfully muted."
@@ -7458,7 +8071,7 @@ msgstr "Visualisá grafa"
 
 #: rocky/views/ooi_view.py
 msgid "Observed_at: "
-msgstr ""
+msgstr "Opservá_na:"
 
 #: rocky/views/ooi_view.py
 msgid "OOI types: "
@@ -7474,7 +8087,7 @@ msgstr "Tipo di autorisashon: "
 
 #: rocky/views/ooi_view.py
 msgid "Searching for: "
-msgstr ""
+msgstr "Buskando pa:"
 
 #: rocky/views/organization_add.py
 msgid "Setup"
@@ -7495,7 +8108,7 @@ msgstr "Organisashon %s a wordu kambia ku éksito."
 
 #: rocky/views/organization_member_add.py
 msgid "Add column titles, followed by each object on a new line."
-msgstr ""
+msgstr "Agregá títulonan di kolumna, sigui pa kada opheto riba un liña nobo."
 
 #: rocky/views/organization_member_add.py
 msgid "The columns are: "
@@ -7553,8 +8166,8 @@ msgid ""
 "level L%s. For this reason the acknowledged clearance level has been set at "
 "the same level as trusted clearance level."
 msgstr ""
-"E nivel di autorisashon di konfiansa ku a wordu kambia pa L%s ta mas abou ku "
-"e nivel di autorisashon di L%s di e miembro. E miembro aki solamente tin "
+"E nivel di autorisashon di konfiansa ku a wordu kambia pa L%s ta mas abou ku"
+" e nivel di autorisashon di L%s di e miembro. E miembro aki solamente tin "
 "autorisashon pa nivel L%s. Pa e motibu aki, e nivel di autorisashon a wordu "
 "ajustá na e mesun nivel ku e nivel di autorisashon di konfiansa."
 
@@ -7563,8 +8176,8 @@ msgid ""
 "You have trusted this member with a higher trusted level than member "
 "acknowledged. Member must first accept this level to use it."
 msgstr ""
-"Bo a konfia riba e miembro aki ku un nivel di konfiansa mas haltu ku e nivel "
-"ku e miembro a rekonosé. E miembro mester akseptá promé e nivel aki pa por "
+"Bo a konfia riba e miembro aki ku un nivel di konfiansa mas haltu ku e nivel"
+" ku e miembro a rekonosé. E miembro mester akseptá promé e nivel aki pa por "
 "us'é."
 
 #: rocky/views/organization_member_list.py
@@ -7584,12 +8197,15 @@ msgstr "Reskalkulá {number_of_bits} bits. Durashon: {duration}"
 
 #: rocky/views/page_actions.py
 msgid "Could not process your request, action required."
-msgstr ""
+msgstr "No por a prosesá bo petishon, akshon ta nesesario."
 
 #: rocky/views/scan_profile.py
 msgid ""
-"Cannot set clearance level. The clearance type must be inherited or declared."
+"Cannot set clearance level. The clearance type must be inherited or "
+"declared."
 msgstr ""
+"No por pone nivel di limpiesa. E tipo di limpiesa mester ta heredá òf "
+"deklará."
 
 #: rocky/views/scans.py
 msgid "Scans"
@@ -7597,7 +8213,7 @@ msgstr "Skènnan"
 
 #: rocky/views/scheduler.py
 msgid "Your report has been scheduled."
-msgstr ""
+msgstr "Bo rapòrt a wòrdu programá."
 
 #: rocky/views/scheduler.py
 msgid ""
@@ -7605,15 +8221,19 @@ msgid ""
 "will be added to the object list when they are in. It may take some time, a "
 "refresh of the page may be needed to show the results."
 msgstr ""
+"Bo tarea ta programá i pronto lo kuminsá den fondo. Resultadonan lo wòrdu "
+"agregá na e lista di opheto ora nan ta aden. E por tuma algun tempu, un "
+"refresh di e página por ta nesesario pa mustra e resultadonan."
 
 #: rocky/views/tasks.py
 #, python-brace-format
 msgid "Fetching tasks failed: no connection with scheduler: {error}"
 msgstr ""
+"Tareanan di buskamentu a frakasá: no tin konekshon ku programadó: {error}"
 
 #: rocky/views/tasks.py
 msgid "All Tasks"
-msgstr ""
+msgstr "Tur Tarea"
 
 #: rocky/views/upload_csv.py
 msgid "Add column titles. Followed by each object on a new line."
@@ -7624,8 +8244,9 @@ msgid ""
 "For URL object type, a column 'raw' with URL values is required, starting "
 "with http:// or https://, optionally a second column 'network' is supported "
 msgstr ""
-"Pa tipo di opheto URL, un kòlòm 'raw' ku balornan URL ta requerí, kuminsando "
-"ku http:// òf https://, optionalmente un siguinte kòlòm 'network' ta atmiti "
+"Pa tipo di opheto URL, un kòlòm 'raw' ku balornan URL ta requerí, kuminsando"
+" ku http:// òf https://, optionalmente un siguinte kòlòm 'network' ta atmiti"
+" "
 
 #: rocky/views/upload_csv.py
 msgid ""
@@ -7646,9 +8267,12 @@ msgstr ""
 #: rocky/views/upload_csv.py
 msgid ""
 "Clearance levels can be controlled by a column 'clearance' taking numerical "
-"values 0, 1, 2, 3, and 4 for the corresponding clearance level (other values "
-"are ignored) "
+"values 0, 1, 2, 3, and 4 for the corresponding clearance level (other values"
+" are ignored) "
 msgstr ""
+"Nivelnan di limpiesa por wòrdu kontrolá dor di un kolumna ‘limpiesa’ tumando"
+" balornan numeriko 0, 1, 2, 3, i 4 pa e nivel di limpiesa korespondiente "
+"(otro balornan ta wòrdu ignorá)"
 
 #: rocky/views/upload_csv.py
 msgid "Object(s) could not be created for row number(s): "
@@ -7661,16 +8285,20 @@ msgstr "Opheto(nan) añadi ku èxito."
 #: rocky/views/upload_raw.py
 #, python-format
 msgid "Raw file could not be uploaded to Bytes: status code %d"
-msgstr ""
+msgstr "No por a subi e archivo brutu na Bytes: kódigo di estado %d"
 
 #: rocky/views/upload_raw.py
 #, python-format
 msgid "Raw file could not be uploaded to Bytes: %s"
-msgstr ""
+msgstr "No por a subi e archivo brutu na Bytes: %s"
 
 #: rocky/views/upload_raw.py
 msgid "Raw file successfully added."
 msgstr "Arkivo crudo añadi ku èxito."
+
+#, fuzzy
+#~ msgid "Findings @ "
+#~ msgstr "Diskubrimentu"
 
 #~ msgid "Clearance level has been set"
 #~ msgstr "Nivel di autorisashon a ser poni"
@@ -7711,16 +8339,14 @@ msgstr "Arkivo crudo añadi ku èxito."
 #~ msgid "Successfully set %d ooi(s) clearance level to inherit."
 #~ msgstr "Éksito den ajustá %d OOI(s) nivel di autorisashon pa heredá."
 
-#~ msgid ""
-#~ "An error occurred while deleting oois: one of the OOIs doesn't exist."
+#~ msgid "An error occurred while deleting oois: one of the OOIs doesn't exist."
 #~ msgstr ""
 #~ "Un error a sosodé durante e eliminashon di OOI nan: un di e OOI nan no ta "
 #~ "eksistí."
 
 #, python-brace-format
 #~ msgid "Can not reset scan level. Scan level of {ooi_name} not declared"
-#~ msgstr ""
-#~ "No por resèt nivél di skan. Nivél di skan òf {ooi_name} no ta deklará"
+#~ msgstr "No por resèt nivél di skan. Nivél di skan òf {ooi_name} no ta deklará"
 
 #~ msgid "The Email must be set"
 #~ msgstr "E email adrès mester wordu yena"
@@ -7744,12 +8370,12 @@ msgstr "Arkivo crudo añadi ku èxito."
 
 #~ msgid ""
 #~ "I declare that OpenKAT may scan the assets of my organization and that I "
-#~ "have permission to scan these assets. I am aware of the implications a "
-#~ "scan with a higher scan level brings on my systems."
+#~ "have permission to scan these assets. I am aware of the implications a scan "
+#~ "with a higher scan level brings on my systems."
 #~ msgstr ""
-#~ "Mi ta deklara ku OpenKAT por skan e propiedatnan di mi organisashon i ku "
-#~ "mi tin pèrmit pa skan e propiedatnan aki. Mi ta konsiente di e "
-#~ "implikashonnan un skan ku nivel di skan haltu tin riba mi sistemanan."
+#~ "Mi ta deklara ku OpenKAT por skan e propiedatnan di mi organisashon i ku mi "
+#~ "tin pèrmit pa skan e propiedatnan aki. Mi ta konsiente di e implikashonnan "
+#~ "un skan ku nivel di skan haltu tin riba mi sistemanan."
 
 #~ msgid ""
 #~ "I declare that I am authorized to give this indemnification within my "
@@ -7757,8 +8383,8 @@ msgstr "Arkivo crudo añadi ku èxito."
 #~ "consequences might be and can be held responsible for them."
 #~ msgstr ""
 #~ "Mi ta deklará ku mi tin autorisashon pa duna e indemnisashon aki den mi "
-#~ "organisashon. Mi tin e eksperensia i konosementu pa sa e konsekensianan i "
-#~ "mi por ta responsabel pa nan."
+#~ "organisashon. Mi tin e eksperensia i konosementu pa sa e konsekensianan i mi"
+#~ " por ta responsabel pa nan."
 
 #~ msgid "Register"
 #~ msgstr "Registrá"
@@ -7769,45 +8395,45 @@ msgstr "Arkivo crudo añadi ku èxito."
 #~ msgid ""
 #~ "All user  accounts are part of an organization. So if you’re new and your "
 #~ "company is also new to OpenKAT you can register here to create a OpenKAT "
-#~ "account for your company including an admin account for you. If you like "
-#~ "a user account that is connected to an already existing organization "
-#~ "within OpenKAT you can ask the admin to create an account for you."
+#~ "account for your company including an admin account for you. If you like a "
+#~ "user account that is connected to an already existing organization within "
+#~ "OpenKAT you can ask the admin to create an account for you."
 #~ msgstr ""
-#~ "Tur account ta parti di un organisashon. Kèmèn si bo ta nobo i bo "
-#~ "kompania tambe ta nobo na OpenKAT bo por registrá akinan pa krea un "
-#~ "OpenKAT account pa bo kompania inkluéndo un admin account pa bo. Si bo ke "
-#~ "un account ku ta konekta ku un organisashon ku ta èksisti kaba na KAT bo "
-#~ "por puntra e admin pa krea un account pa bo."
+#~ "Tur account ta parti di un organisashon. Kèmèn si bo ta nobo i bo kompania "
+#~ "tambe ta nobo na OpenKAT bo por registrá akinan pa krea un OpenKAT account "
+#~ "pa bo kompania inkluéndo un admin account pa bo. Si bo ke un account ku ta "
+#~ "konekta ku un organisashon ku ta èksisti kaba na KAT bo por puntra e admin "
+#~ "pa krea un account pa bo."
 
 #~ msgid "How does OpenKAT work"
 #~ msgstr "Kon OpenKAT ta functiona?"
 
 #~ msgid ""
-#~ "OpenKAT is able to give insight into security risks on your online "
-#~ "objects. For example, your websites, mailservers or online data. OpenKAT "
-#~ "uses scans to find and assess the area's that might be at risk and "
-#~ "reports these back to you. As a user you decide which insight you would "
-#~ "like and OpenKAT guides you to through the process. During this "
-#~ "introduction you will be guided through the steps to create a report."
+#~ "OpenKAT is able to give insight into security risks on your online objects. "
+#~ "For example, your websites, mailservers or online data. OpenKAT uses scans "
+#~ "to find and assess the area's that might be at risk and reports these back "
+#~ "to you. As a user you decide which insight you would like and OpenKAT guides"
+#~ " you to through the process. During this introduction you will be guided "
+#~ "through the steps to create a report."
 #~ msgstr ""
 #~ "OpenKAT tin e posibilidàt di duna informashon mas detaya den riésgonan di "
-#~ "siguridát di bo online ophetonan. Por ehempel, bo websites, mailservers "
-#~ "òf online data. OpenKAT ta úza scans pa enkontra i asertà areanan ku por "
-#~ "kore riésgo i rapòrta esaki bèk na abo. Komo kliente bo ta skohè ki "
-#~ "informashon bo ke i OpenKAT ta guiá'bu dor di e proceso Durante e "
-#~ "introdukshon aki bo lo wòrdu guiá dor di e stapnan pa traha un rapòrt."
+#~ "siguridát di bo online ophetonan. Por ehempel, bo websites, mailservers òf "
+#~ "online data. OpenKAT ta úza scans pa enkontra i asertà areanan ku por kore "
+#~ "riésgo i rapòrta esaki bèk na abo. Komo kliente bo ta skohè ki informashon "
+#~ "bo ke i OpenKAT ta guiá'bu dor di e proceso Durante e introdukshon aki bo lo"
+#~ " wòrdu guiá dor di e stapnan pa traha un rapòrt."
 
 #~ msgid "OpenKAT setup"
 #~ msgstr "OpenKAT setup"
 
 #~ msgid ""
-#~ "Please enter the following organization details. These details can be "
-#~ "edited within the organization page within OpenKAT when necessary. Adding "
-#~ "a new organization requires a new database."
+#~ "Please enter the following organization details. These details can be edited"
+#~ " within the organization page within OpenKAT when necessary. Adding a new "
+#~ "organization requires a new database."
 #~ msgstr ""
-#~ "Por fabor pone e detayenan di e siguiente organisashon. E detayenan aki "
-#~ "por wordu editá den e página di organisashon den OpenKAT si ta nesesario. "
-#~ "Agregá un organisashon nobo ta requeri un base di datos nobo."
+#~ "Por fabor pone e detayenan di e siguiente organisashon. E detayenan aki por "
+#~ "wordu editá den e página di organisashon den OpenKAT si ta nesesario. Agregá"
+#~ " un organisashon nobo ta requeri un base di datos nobo."
 
 #~ msgid "Account setup"
 #~ msgstr "Account setup"
@@ -7817,31 +8443,30 @@ msgstr "Arkivo crudo añadi ku èxito."
 
 #~ msgid ""
 #~ "Within OpenKAT it is possible to create separate user accounts with the "
-#~ "specific roles. Each with their own functionalities and permissions. This "
-#~ "is useful when multiple people will be working with the same OpenKAT-"
-#~ "setup. You can choose to create the separate accounts during this "
-#~ "introduction or when you’re ready from the OpenKAT users page."
+#~ "specific roles. Each with their own functionalities and permissions. This is"
+#~ " useful when multiple people will be working with the same OpenKAT-setup. "
+#~ "You can choose to create the separate accounts during this introduction or "
+#~ "when you’re ready from the OpenKAT users page."
 #~ msgstr ""
-#~ "Den OpenKAT ta posibel pa krea accountnan separá ku e ròlnan specìfiko "
-#~ "kada un ku nan mes functionalidat ì pèrmitnan. Esaki ta útil ora mayoria "
-#~ "hende ke traha ku e mesun OpenKAT-setup. Bo por skohé pa krea e "
-#~ "accountnan separá durante e introdukshon aki of ora bo ta kla."
+#~ "Den OpenKAT ta posibel pa krea accountnan separá ku e ròlnan specìfiko kada "
+#~ "un ku nan mes functionalidat ì pèrmitnan. Esaki ta útil ora mayoria hende ke"
+#~ " traha ku e mesun OpenKAT-setup. Bo por skohé pa krea e accountnan separá "
+#~ "durante e introdukshon aki of ora bo ta kla."
 
 #~ msgid "Single account setup:"
 #~ msgstr "Setup account pa mi mes:"
 
 #~ msgid ""
 #~ "Alternatively it is also an option to run OpenKAT from a single user "
-#~ "account. Which is useful when you are the only user in the account. You "
-#~ "will be able to access the functionality of the different roles from your "
-#~ "account. You can always add additional user accounts If you’re team "
-#~ "expands in the future."
+#~ "account. Which is useful when you are the only user in the account. You will"
+#~ " be able to access the functionality of the different roles from your "
+#~ "account. You can always add additional user accounts If you’re team expands "
+#~ "in the future."
 #~ msgstr ""
-#~ "Alternativamente tambe ta un opshón pa huza OpenKAT for di un solo "
-#~ "account. Ku ta útil si bo ta e úniko usadó di e account. Bo lo por tin e "
-#~ "posibilidát pa tin accesso na functionalidatnan di e diferente ròlnan for "
-#~ "di bo account. Abo por semper añadi accountnan adishonál si bo tìm "
-#~ "expandé den futuro."
+#~ "Alternativamente tambe ta un opshón pa huza OpenKAT for di un solo account. "
+#~ "Ku ta útil si bo ta e úniko usadó di e account. Bo lo por tin e posibilidát "
+#~ "pa tin accesso na functionalidatnan di e diferente ròlnan for di bo account."
+#~ " Abo por semper añadi accountnan adishonál si bo tìm expandé den futuro."
 
 #~ msgid "Create separate accounts"
 #~ msgstr "Krea accountnan separá"
@@ -7863,11 +8488,11 @@ msgstr "Arkivo crudo añadi ku èxito."
 #~ msgstr "Admin"
 
 #~ msgid ""
-#~ "Each organization must have an admin. The admin can create and manage "
-#~ "user accounts as well as organization details."
+#~ "Each organization must have an admin. The admin can create and manage user "
+#~ "accounts as well as organization details."
 #~ msgstr ""
-#~ "Kada organisashon mester tin un admin. E admin por krea i manehá "
-#~ "accountnan pa usudonan i tambe detayes di organisashon."
+#~ "Kada organisashon mester tin un admin. E admin por krea i manehá accountnan "
+#~ "pa usudonan i tambe detayes di organisashon."
 
 #~ msgid "Red teamer"
 #~ msgstr "Tìm kòrá"
@@ -7882,13 +8507,13 @@ msgstr "Arkivo crudo añadi ku èxito."
 #~ msgstr "Un account pa kliénte por tin accesso na rapòrtnan."
 
 #~ msgid ""
-#~ "Each organization requires at least one admin and one red teamer account "
-#~ "to function. This introduction will guide you through the setup of both. "
-#~ "After that you can choose to add a client account as well."
+#~ "Each organization requires at least one admin and one red teamer account to "
+#~ "function. This introduction will guide you through the setup of both. After "
+#~ "that you can choose to add a client account as well."
 #~ msgstr ""
 #~ "Kada organisashon ta requerì sikiera ún admin ì ún tìm kòrá account pa "
-#~ "functioná. É introdukshon aki ta guiabu pa setup tur dós. Despues ku bo "
-#~ "por skohé pa añadi ún account pa kliénte tambe."
+#~ "functioná. É introdukshon aki ta guiabu pa setup tur dós. Despues ku bo por "
+#~ "skohé pa añadi ún account pa kliénte tambe."
 
 #~ msgid "Let's add accounts"
 #~ msgstr "Laga nos añadi accounts"
@@ -7929,36 +8554,36 @@ msgstr "Arkivo crudo añadi ku èxito."
 
 #~ msgid ""
 #~ "OpenKAT is the \"Kwetsbaarheden Analyse Tool\" (Vulnerabilities Analysis "
-#~ "Tool). An Open-Source-project developed by the Ministry of Health, "
-#~ "Welfare and Sport to make your and our world a safer place."
+#~ "Tool). An Open-Source-project developed by the Ministry of Health, Welfare "
+#~ "and Sport to make your and our world a safer place."
 #~ msgstr ""
 #~ "OpenKAT ta e \"Kwetsbaarheden Analyse Tool\" (tool pa hasi análisis di "
 #~ "bulerabilidat). Un proyekto Open Source desaroyá pa Ministerio di Salú "
 #~ "Públiko, Salú i Deporte pa hasi nos mundu un lugar mas sigur pa bo i nos."
 
 #~ msgid ""
-#~ "OpenKAT is able to give insight into security risks on your online "
-#~ "objects. For example, your websites, mailservers or online data."
+#~ "OpenKAT is able to give insight into security risks on your online objects. "
+#~ "For example, your websites, mailservers or online data."
 #~ msgstr ""
 #~ "OpenKAT tin e abilidát di duna revelashon di riésgonan di siguridát di bo "
 #~ "online ophetonan. Por ehèmpel, bo website nan, mailservers òf online data."
 
 #~ msgid ""
-#~ "OpenKAT uses plugins to find and assess the area's that might be at risk "
-#~ "and reports these back to you. Each plugin has its own skillset which "
-#~ "could be scanning, normalizing or analyzing data. As a user you decide "
-#~ "which areas you would like to monitor or scan and which insight you would "
-#~ "like to receive."
+#~ "OpenKAT uses plugins to find and assess the area's that might be at risk and"
+#~ " reports these back to you. Each plugin has its own skillset which could be "
+#~ "scanning, normalizing or analyzing data. As a user you decide which areas "
+#~ "you would like to monitor or scan and which insight you would like to "
+#~ "receive."
 #~ msgstr ""
-#~ "OpenKAT ta huza plugins pa deskubrì i evalúa e areanan ku por ta un "
-#~ "riésgo i rapòrta esaki bèk na bo. Kada plugin tin nan mes sèt di abilidát "
-#~ "ku por ta scan, nòrmalisá òf analisá data. Komo usario bo ta disidì kwa "
-#~ "area bo tin gana di monitoriá òf skan i tambe ki tipo di revelashon bo "
-#~ "tin gana di recibí."
+#~ "OpenKAT ta huza plugins pa deskubrì i evalúa e areanan ku por ta un riésgo i"
+#~ " rapòrta esaki bèk na bo. Kada plugin tin nan mes sèt di abilidát ku por ta "
+#~ "scan, nòrmalisá òf analisá data. Komo usario bo ta disidì kwa area bo tin "
+#~ "gana di monitoriá òf skan i tambe ki tipo di revelashon bo tin gana di "
+#~ "recibí."
 
 #~ msgid ""
-#~ "Within OpenKAT you can view the insights as well as all the data OpenKAT "
-#~ "has found. You can choose to browse through the data or view reports."
+#~ "Within OpenKAT you can view the insights as well as all the data OpenKAT has"
+#~ " found. You can choose to browse through the data or view reports."
 #~ msgstr ""
 #~ "Den OpenKAT bo por mira e insights i tambe tur data ku KAT a deskubrì. Bo "
 #~ "por skohé pa buska den e data òf wak rapòrt nan."
@@ -7979,24 +8604,23 @@ msgstr "Arkivo crudo añadi ku èxito."
 #~ msgid ""
 #~ "Reports within OpenKAT contain an overview of the scanned objects, issues "
 #~ "found within them and known security risks that the object might be "
-#~ "vulnerable to. Each report gives a high overview of the state of the "
-#~ "object as well as detailed information on what OpenKAT found and possible "
+#~ "vulnerable to. Each report gives a high overview of the state of the object "
+#~ "as well as detailed information on what OpenKAT found and possible "
 #~ "solutions."
 #~ msgstr ""
-#~ "Rapòrtnan den OpenKAT ta kontene un lista di ophetonan di skan, "
-#~ "problemanan haña serka nan i riesgo di siguridat nan ku e opheto por ta "
-#~ "vulnerabel na dje. Kada rapòrt ta duna un lista prioritá di e estado di e "
-#~ "opheto i tambe informashon detaya di tur loke KAT a enkontra i "
-#~ "solushonanan posibel."
+#~ "Rapòrtnan den OpenKAT ta kontene un lista di ophetonan di skan, problemanan "
+#~ "haña serka nan i riesgo di siguridat nan ku e opheto por ta vulnerabel na "
+#~ "dje. Kada rapòrt ta duna un lista prioritá di e estado di e opheto i tambe "
+#~ "informashon detaya di tur loke KAT a enkontra i solushonanan posibel."
 
 #~ msgid ""
-#~ "OpenKAT can scan and analyze by using plugins. Each plugin has it's "
-#~ "unique skillset and will collect specific data or give specific insights. "
-#~ "You manage the plugins within your account which let's OpenKAT know which "
+#~ "OpenKAT can scan and analyze by using plugins. Each plugin has it's unique "
+#~ "skillset and will collect specific data or give specific insights. You "
+#~ "manage the plugins within your account which let's OpenKAT know which "
 #~ "plugins to run and on which objects or areas."
 #~ msgstr ""
-#~ "OpenKAT por skan i analisá dor di huza plugins. Kada plugin tin nan mas "
-#~ "sèt di skills uniko i lo kolekta data spesifiko of duna mas informashon "
+#~ "OpenKAT por skan i analisá dor di huza plugins. Kada plugin tin nan mas sèt "
+#~ "di skills uniko i lo kolekta data spesifiko of duna mas informashon "
 #~ "spesifiko. Bo ta maneha plugins den bo account ku ta laga OpenKAT sa kwa "
 #~ "plugins mester huza riba kwa opheto òf areanan."
 
@@ -8009,19 +8633,19 @@ msgstr "Arkivo crudo añadi ku èxito."
 #~ "needs, as well as asks for permission to run plugins that you haven’t "
 #~ "enabled yet but are needed to collect or analyze the data."
 #~ msgstr ""
-#~ "Ora bo selektá un tipo di informe, OpenKAT lo guia bo den e ajuste. "
-#~ "OpenKAT lo hasi e preguntanan necesario basá riba e entrada ku e informe "
-#~ "ta nesesitá, tambe lo pidi permiso pa eksekutá plug-innan ku ainda bo no "
-#~ "a habilidá, pero ku ta nesesario pa kolektá òf analisá e datonan."
+#~ "Ora bo selektá un tipo di informe, OpenKAT lo guia bo den e ajuste. OpenKAT "
+#~ "lo hasi e preguntanan necesario basá riba e entrada ku e informe ta "
+#~ "nesesitá, tambe lo pidi permiso pa eksekutá plug-innan ku ainda bo no a "
+#~ "habilidá, pero ku ta nesesario pa kolektá òf analisá e datonan."
 
 #~ msgid ""
-#~ "You can also choose to look at the collected data directly or generate "
-#~ "your own report by selecting and running plugins on objects of your "
-#~ "choice. OpenKAT will present the results."
+#~ "You can also choose to look at the collected data directly or generate your "
+#~ "own report by selecting and running plugins on objects of your choice. "
+#~ "OpenKAT will present the results."
 #~ msgstr ""
 #~ "Bo por tambe skohé pa mira e data kolekta direktamente òf genera bo mes "
-#~ "rapòrt dor di selekta i start plugins riba ophetonan si bo eskoho. "
-#~ "OpenKAT lo presentabu ku e resultadonan."
+#~ "rapòrt dor di selekta i start plugins riba ophetonan si bo eskoho. OpenKAT "
+#~ "lo presentabu ku e resultadonan."
 
 #~ msgid "Permission"
 #~ msgstr "Permiso Nenga"
@@ -8031,8 +8655,8 @@ msgstr "Arkivo crudo añadi ku èxito."
 #~ "community. Before a plugin can run, you need to give it permission by "
 #~ "enabling it."
 #~ msgstr ""
-#~ "Plugins ta bin di OpenKAT pero nan tambe por bini dor di e komunidát. "
-#~ "Promé un plugin por wordu huza, bo mester dunele pèrmiso dor di activé"
+#~ "Plugins ta bin di OpenKAT pero nan tambe por bini dor di e komunidát. Promé "
+#~ "un plugin por wordu huza, bo mester dunele pèrmiso dor di activé"
 
 #~ msgid ""
 #~ "When you generate a report. OpenKAT will let you know which plugins it "
@@ -8048,8 +8672,8 @@ msgstr "Arkivo crudo añadi ku èxito."
 #~ msgstr "Skohé un rapòrt - Tipo"
 
 #~ msgid ""
-#~ "When you start to generate this report. OpenKAT will guide you through "
-#~ "the necessary steps."
+#~ "When you start to generate this report. OpenKAT will guide you through the "
+#~ "necessary steps."
 #~ msgstr ""
 #~ "Ora bo kuminsa generá e rapòrt aki. OpenKAT lo guiá'bu dor di e stapnan "
 #~ "necesario."
@@ -8061,9 +8685,9 @@ msgstr "Arkivo crudo añadi ku èxito."
 #~ msgstr "Laga OpenKAT sa kwa opheto e tinku skan"
 
 #~ msgid ""
-#~ "Plugins scan and analyze objects. OpenKAT needs to know which object(s) "
-#~ "you would like to scan and analyze for the DNS-report. So it can tell you "
-#~ "which plugins are available for the chosen object."
+#~ "Plugins scan and analyze objects. OpenKAT needs to know which object(s) you "
+#~ "would like to scan and analyze for the DNS-report. So it can tell you which "
+#~ "plugins are available for the chosen object."
 #~ msgstr ""
 #~ "Plug-innan skan i analisá objektonan. OpenKAT mester sa kua objèkto(s) bo "
 #~ "kier skan i analisá pa e informe DNS. Asina ku por bisa bo ku kuál plug-"
@@ -8079,22 +8703,22 @@ msgstr "Arkivo crudo añadi ku èxito."
 #~ "Within OpenKAT you can view, add and edit objects from the organization’s "
 #~ "object page."
 #~ msgstr ""
-#~ "Den OpenKAT bo por mira, añadi i editá ophetonan di e organisashon su "
-#~ "page di opheto."
+#~ "Den OpenKAT bo por mira, añadi i editá ophetonan di e organisashon su page "
+#~ "di opheto."
 
 #~ msgid ""
 #~ "Let’s add an object to scan for the DNS-Report. For this introduction we "
 #~ "suggest adding a URL."
 #~ msgstr ""
-#~ "Ban añadi un opheto pa skan pa traha e DNS-rapòrt. Pa e introdukshon aki "
-#~ "nos ta sugerí añadi un URL."
+#~ "Ban añadi un opheto pa skan pa traha e DNS-rapòrt. Pa e introdukshon aki nos"
+#~ " ta sugerí añadi un URL."
 
 #~ msgid "Create your first object, a URL by filling out the form below."
 #~ msgstr "Krea bo promé opheto, un URL dor di yena e formulario abou."
 
 #~ msgid ""
-#~ "Additional details and examples can be found by pressing on the help "
-#~ "button next to the input field."
+#~ "Additional details and examples can be found by pressing on the help button "
+#~ "next to the input field."
 #~ msgstr ""
 #~ "Detayesnan i ehempelnan adishonal bo por haña dor di primi e help botón "
 #~ "banda di e vèld."
@@ -8107,13 +8731,13 @@ msgstr "Arkivo crudo añadi ku èxito."
 #~ "list as separate objects. If OpenKAT can’t add them automatically it will "
 #~ "guide you through the process of creating them manually."
 #~ msgstr ""
-#~ "E ophetonan adishonal ku OpenKAT á krea lo wordu agregá na e lista di "
-#~ "opehto komo ophetonan separá. Si OpenKAT no por agregá esakinan "
-#~ "automatikamente e ta guia'bu dor di e processo pa kreanan manualmente."
+#~ "E ophetonan adishonal ku OpenKAT á krea lo wordu agregá na e lista di opehto"
+#~ " komo ophetonan separá. Si OpenKAT no por agregá esakinan automatikamente e "
+#~ "ta guia'bu dor di e processo pa kreanan manualmente."
 
 #~ msgid ""
-#~ "Based on the url you provided OpenKAT added the necessary additional "
-#~ "objects to create a url object."
+#~ "Based on the url you provided OpenKAT added the necessary additional objects"
+#~ " to create a url object."
 #~ msgstr ""
 #~ "Basá riba e URL ku bo a duna, OpenKAT a agrega e ophetonan adishonal "
 #~ "necesario pa krea un opheto di URL."
@@ -8143,17 +8767,17 @@ msgstr "Arkivo crudo añadi ku èxito."
 #~ msgstr "Sètup skan- OOI autorisashon pa"
 
 #~ msgid ""
-#~ "Some scans are lightweight while others might be a bit more aggressive "
-#~ "with their scanning. OpenKAT requires you to set a clearance level for "
-#~ "each object to prevent you from unintentionally running aggressive scans. "
-#~ "For example you might have the right to run any type of scan on your own "
-#~ "server but you probably don’t have the right to do so for objects owned "
-#~ "by other people of companies."
+#~ "Some scans are lightweight while others might be a bit more aggressive with "
+#~ "their scanning. OpenKAT requires you to set a clearance level for each "
+#~ "object to prevent you from unintentionally running aggressive scans. For "
+#~ "example you might have the right to run any type of scan on your own server "
+#~ "but you probably don’t have the right to do so for objects owned by other "
+#~ "people of companies."
 #~ msgstr ""
 #~ "Algun skan ta ligero, i otro por ta un tiki mas agresivo den nan skaneo. "
-#~ "OpenKAT ta requeri bo pa ajustá un nivel di autorisashon pa kada opheto "
-#~ "pa evitá ku b'a sende skan agresivo sin intenshón. Por ehèmpel, bo por "
-#~ "tin e derechi pa skan kualkier tipo di opheto riba bo propio server, pero "
+#~ "OpenKAT ta requeri bo pa ajustá un nivel di autorisashon pa kada opheto pa "
+#~ "evitá ku b'a sende skan agresivo sin intenshón. Por ehèmpel, bo por tin e "
+#~ "derechi pa skan kualkier tipo di opheto riba bo propio server, pero "
 #~ "probabelmente bo no tin e derechi pa hasi meskos ku ophetonan ku ta "
 #~ "pertenese na otro personanan of kompanianan."
 
@@ -8164,29 +8788,29 @@ msgstr "Arkivo crudo añadi ku èxito."
 #~ "Each plugin that scans will have a scan intensity score. The intensity of "
 #~ "the scan must be equal to or below the clearance level you set for your "
 #~ "object. If the scan has an intensity level that is too high, OpenKAT will "
-#~ "notify you before running it. Visually clearance levels and intensity "
-#~ "scores are indicated with little cat paws."
+#~ "notify you before running it. Visually clearance levels and intensity scores"
+#~ " are indicated with little cat paws."
 #~ msgstr ""
-#~ "Kada plug-in ku skan ta tin un puntu di intensidat di skaneo. E "
-#~ "intensidat di e skaneo mester ta igual òf mas abou ku e nivel di "
-#~ "autorisashon ku bo a ajustá pa bo opheto. Si e skaneo tin un nivel di "
-#~ "intensidat ku ta hopi haltu, OpenKAT lo notifiká bo promé di eksekutá e "
-#~ "skaneo. Visualmente, nivelnan di autorisashon i punto di intensidat ta "
-#~ "indiká ku patanan di pushi."
+#~ "Kada plug-in ku skan ta tin un puntu di intensidat di skaneo. E intensidat "
+#~ "di e skaneo mester ta igual òf mas abou ku e nivel di autorisashon ku bo a "
+#~ "ajustá pa bo opheto. Si e skaneo tin un nivel di intensidat ku ta hopi "
+#~ "haltu, OpenKAT lo notifiká bo promé di eksekutá e skaneo. Visualmente, "
+#~ "nivelnan di autorisashon i punto di intensidat ta indiká ku patanan di "
+#~ "pushi."
 
 #~ msgid ""
 #~ "This scan has a scan intensity score of 1, requiring a level 1 clearance "
-#~ "level to be run. This means that the scan does not touch the object "
-#~ "itself, but only searches for information about the object."
+#~ "level to be run. This means that the scan does not touch the object itself, "
+#~ "but only searches for information about the object."
 #~ msgstr ""
 #~ "E skan tin un score di nivél di intensidat di 1, ku ta requerí nivél 1 di "
 #~ "autorisashon pa start. Esaki ta nifika ku e skan no ta mishi ku e opheto "
 #~ "riba su mes, pero solamente ta buska informashon tokante e opheto."
 
 #~ msgid ""
-#~ "An example of a more aggressive scan. Which has a scan intensity score of "
-#~ "3. Meaning it requires at least a level 3 clearance level to be set on "
-#~ "your object."
+#~ "An example of a more aggressive scan. Which has a scan intensity score of 3."
+#~ " Meaning it requires at least a level 3 clearance level to be set on your "
+#~ "object."
 #~ msgstr ""
 #~ "Un ehèmpel di un skaneo mas agresivo. Ku tin un puntu di intensidat di "
 #~ "skaneo di 3. Esaki ta nifiká ku mester tin por lo menos un nivel di "
@@ -8200,9 +8824,9 @@ msgstr "Arkivo crudo añadi ku èxito."
 
 #, python-format
 #~ msgid ""
-#~ "After creating a new object OpenKAT will ask you to set a clearance "
-#~ "level. On the object detail page you can always change the clearance "
-#~ "level. For the onboarding we will suggest to set the clearance level to "
+#~ "After creating a new object OpenKAT will ask you to set a clearance level. "
+#~ "On the object detail page you can always change the clearance level. For the"
+#~ " onboarding we will suggest to set the clearance level to "
 #~ "L%(dns_report_least_clearance_level)s."
 #~ msgstr ""
 #~ "Despues di krea un opheto nobo, OpenKAT lo puntra bo pa pone un nivel di "
@@ -8222,16 +8846,15 @@ msgstr "Arkivo crudo añadi ku èxito."
 #~ "types of plugins."
 #~ msgstr ""
 #~ "OpenKAT ta huza plugins pa scan, check i analisá. Kada plugin ta trese un "
-#~ "abilidát specifikó ku lo juda pa generá bo rapòrt. Tin tres tipo di "
-#~ "plugins."
+#~ "abilidát specifikó ku lo juda pa generá bo rapòrt. Tin tres tipo di plugins."
 
 #~ msgid ""
 #~ "Scan objects for data. Each boefje has a scan intensity score to prevent "
 #~ "invasive scanning on objects where you don’t have the clearance to do so."
 #~ msgstr ""
 #~ "Skèn ophetonan pa data. Kada boefje tin un intesidát score pa skan pa "
-#~ "prevení scannan invasivo riba opheto kaminda bo no tin autorisashon pa "
-#~ "hasi esaki."
+#~ "prevení scannan invasivo riba opheto kaminda bo no tin autorisashon pa hasi "
+#~ "esaki."
 
 #~ msgid ""
 #~ "Check the data for specific objects and add these object to your object "
@@ -8241,37 +8864,34 @@ msgstr "Arkivo crudo añadi ku èxito."
 #~ "opheto."
 
 #~ msgid "Analyze the available data to come to insights and conclusions."
-#~ msgstr ""
-#~ "Analisá e data disponibel pa yega na konklushonnan i perspectivanan."
+#~ msgstr "Analisá e data disponibel pa yega na konklushonnan i perspectivanan."
 
 #~ msgid ""
 #~ "OpenKAT will be able to generate a full report when all the required and "
-#~ "suggested plugins are enabled. If you choose not to give a plugin "
-#~ "permission to run, the data that plugin would collect or produce will be "
-#~ "left out of the report which will then be generated based on the "
-#~ "available data collected by the enabled plugins. Below are the suggested "
-#~ "and required plugins for this report."
+#~ "suggested plugins are enabled. If you choose not to give a plugin permission"
+#~ " to run, the data that plugin would collect or produce will be left out of "
+#~ "the report which will then be generated based on the available data "
+#~ "collected by the enabled plugins. Below are the suggested and required "
+#~ "plugins for this report."
 #~ msgstr ""
-#~ "OpenKAT ta dispuesto pa generá un fúl rapòrt ora tur e plugins nan "
-#~ "requerí i sugerá ta aktivá. Si bo skohé pa no duna un plugin pèrmiso  pa "
-#~ "start, e data ku e plugin lo mester kolektá òf produsí lo wordu saka for "
-#~ "di e rapòrt ku lo generá a base di e data ku tin disponibel kolektá pa e "
-#~ "plugins aktivo. Abou bo por mira e plugins nan ku ta requerí pa e rapòrt "
-#~ "aki."
+#~ "OpenKAT ta dispuesto pa generá un fúl rapòrt ora tur e plugins nan requerí i"
+#~ " sugerá ta aktivá. Si bo skohé pa no duna un plugin pèrmiso  pa start, e "
+#~ "data ku e plugin lo mester kolektá òf produsí lo wordu saka for di e rapòrt "
+#~ "ku lo generá a base di e data ku tin disponibel kolektá pa e plugins aktivo."
+#~ " Abou bo por mira e plugins nan ku ta requerí pa e rapòrt aki."
 
 #~ msgid "Let’s setup your scan by enabling the plugins of your choice below."
-#~ msgstr ""
-#~ "Laga nos ban setup e skan dor di aktivá e plugins di bo eskoho abou."
+#~ msgstr "Laga nos ban setup e skan dor di aktivá e plugins di bo eskoho abou."
 
 #~ msgid ""
 #~ "The enabled boefjes are collecting the data needed to generate the DNS-"
-#~ "report. This may take some time based on the type of scans and the number "
-#~ "of objects found. For the current scan we expect boefjes to take about 3 "
+#~ "report. This may take some time based on the type of scans and the number of"
+#~ " objects found. For the current scan we expect boefjes to take about 3 "
 #~ "minutes."
 #~ msgstr ""
 #~ "E Boefjes nan aktivá ta bezig ta kolektando e data necesario pa generá e "
-#~ "DNS-rapòrt. Esaki ta bai tuma tempu a base di e tipo di scannan i e "
-#~ "kantidát di ophetonan enkontrá."
+#~ "DNS-rapòrt. Esaki ta bai tuma tempu a base di e tipo di scannan i e kantidát"
+#~ " di ophetonan enkontrá."
 
 #~ msgid ""
 #~ "During this introduction we ask you to wait till the scan is ready. After "
@@ -8281,14 +8901,14 @@ msgstr "Arkivo crudo añadi ku èxito."
 #~ "Despues bo por mira e rapòrt."
 
 #~ msgid ""
-#~ "After the onboarding, boefjes run in the background. This enables you to "
-#~ "use OpenKAT in the meantime without waiting for scans to finish. When you "
-#~ "would like to see the status of a scan you can open the \"tasks\" page."
+#~ "After the onboarding, boefjes run in the background. This enables you to use"
+#~ " OpenKAT in the meantime without waiting for scans to finish. When you would"
+#~ " like to see the status of a scan you can open the \"tasks\" page."
 #~ msgstr ""
-#~ "Despues di e onboarding, boefjes nan ta sigi den background. Esaki ta "
-#~ "pone ku bo por uza OpenKAT mientras tantu sin mester warda te ora e "
-#~ "skannan kaba. Kaminda bo lo por ke mira e status di un skan bo por habri "
-#~ "e pagina di \"tarea\". "
+#~ "Despues di e onboarding, boefjes nan ta sigi den background. Esaki ta pone "
+#~ "ku bo por uza OpenKAT mientras tantu sin mester warda te ora e skannan kaba."
+#~ " Kaminda bo lo por ke mira e status di un skan bo por habri e pagina di "
+#~ "\"tarea\". "
 
 #~ msgid "Open my DNS-report"
 #~ msgstr "Habri mi DNS-rapòrt"
@@ -8325,17 +8945,17 @@ msgstr "Arkivo crudo añadi ku èxito."
 #~ "A slug containing only lower-case unicode letters, numbers, hyphens or "
 #~ "underscores that will be used in URLs and paths"
 #~ msgstr ""
-#~ "Un slug ta kontene solamente lower-case unicode letras, numbernan, "
-#~ "hyphens òf underscores ku lo wordu huza den URLs i paths"
+#~ "Un slug ta kontene solamente lower-case unicode letras, numbernan, hyphens "
+#~ "òf underscores ku lo wordu huza den URLs i paths"
 
 #~ msgid ""
-#~ "Before you're able to add assets to OpenKAT and to assign clearance "
-#~ "levels, you have to give indemnification on the organization and declare "
-#~ "that you as a person can be held accountable."
+#~ "Before you're able to add assets to OpenKAT and to assign clearance levels, "
+#~ "you have to give indemnification on the organization and declare that you as"
+#~ " a person can be held accountable."
 #~ msgstr ""
 #~ "Prome ku bo por añadi propiedatnan na OpenKAT i pone nivelnan di "
-#~ "authorisashon, bo mester duna indemnizashon na e organisashon i deklara "
-#~ "ku abo komo persona por wordu pone responsabel."
+#~ "authorisashon, bo mester duna indemnizashon na e organisashon i deklara ku "
+#~ "abo komo persona por wordu pone responsabel."
 
 #~ msgid "Register an indemnification"
 #~ msgstr "Registrá un indemnizashon"
@@ -8404,8 +9024,8 @@ msgstr "Arkivo crudo añadi ku èxito."
 #~ "An overview of the top 10 most severe findings OpenKAT found. Check the "
 #~ "detail section for additional severity information."
 #~ msgstr ""
-#~ "Un bista general di e 10 diskubrimentunan mas serio ku OpenKAT a haña. "
-#~ "Chèk den seccion di detaye pa informashon adishonal tokante severidat."
+#~ "Un bista general di e 10 diskubrimentunan mas serio ku OpenKAT a haña. Chèk "
+#~ "den seccion di detaye pa informashon adishonal tokante severidat."
 
 #~ msgid "Top 10 most severe Findings"
 #~ msgstr "Top 10 di e diskubrimentunan mas serio."
@@ -8429,21 +9049,20 @@ msgstr "Arkivo crudo añadi ku èxito."
 #~ msgstr "KAT-alogus Settings"
 
 #~ msgid ""
-#~ "There are currently no settings defined. Add settings at plugin detail "
-#~ "page."
+#~ "There are currently no settings defined. Add settings at plugin detail page."
 #~ msgstr ""
-#~ "Na e momentonan aki no tin settings pone. Añadi settings na e página "
-#~ "detaya di plugin."
+#~ "Na e momentonan aki no tin settings pone. Añadi settings na e página detaya "
+#~ "di plugin."
 
 #, python-format
 #~ msgid ""
 #~ "These are the findings of a OpenKAT-analysis (%(observed_at)s). Click a "
-#~ "finding for more detailed information about the issue, its origin, "
-#~ "severity and possible solutions."
+#~ "finding for more detailed information about the issue, its origin, severity "
+#~ "and possible solutions."
 #~ msgstr ""
 #~ "Esakinan ta e resultadonan di un OpenKAT-analysis riba %(observed_at)s. "
-#~ "Click un resultadopa mas informashon detayá tokante e problema, su "
-#~ "orígen, severidat i posibel solushonnan."
+#~ "Click un resultadopa mas informashon detayá tokante e problema, su orígen, "
+#~ "severidat i posibel solushonnan."
 
 #~ msgid "DNS Tree"
 #~ msgstr "DNS Mapa"
@@ -8461,9 +9080,8 @@ msgstr "Arkivo crudo añadi ku èxito."
 #~ "This shows general information and its related objects. It also gives the "
 #~ "possibility to add additional related objects, or to scan for them."
 #~ msgstr ""
-#~ "Esaki ta mustra informashon general i e ophetonan relashoná. Tambe ta "
-#~ "brinda e posibilidat pa agrega ophetonan relashoná adishonal, òf pa skan "
-#~ "pa nan."
+#~ "Esaki ta mustra informashon general i e ophetonan relashoná. Tambe ta brinda"
+#~ " e posibilidat pa agrega ophetonan relashoná adishonal, òf pa skan pa nan."
 
 #~ msgid "Unique"
 #~ msgstr "Úniko"
@@ -8497,8 +9115,8 @@ msgstr "Arkivo crudo añadi ku èxito."
 #~ "An overview of all (critical) findings OpenKAT found. Check the detail "
 #~ "section for additional severity information."
 #~ msgstr ""
-#~ "Un relato general di tur diskubrimentu (krítiko) ku OpenKAT a enkontrá. "
-#~ "Chèk e sekshon detayá pa informashon addishonal severo."
+#~ "Un relato general di tur diskubrimentu (krítiko) ku OpenKAT a enkontrá. Chèk"
+#~ " e sekshon detayá pa informashon addishonal severo."
 
 #~ msgid "Total Findings"
 #~ msgstr "Diskubrimentu Totál"
@@ -8523,32 +9141,25 @@ msgstr "Arkivo crudo añadi ku èxito."
 
 #~ msgid ""
 #~ "\n"
-#~ "                            You don't have any clearance to scan objects."
-#~ "<br>\n"
-#~ "                            Get in contact with the admin to give you the "
-#~ "necessary clearance level.\n"
+#~ "                            You don't have any clearance to scan objects.<br>\n"
+#~ "                            Get in contact with the admin to give you the necessary clearance level.\n"
 #~ "                        "
 #~ msgstr ""
 #~ "\n"
 #~ " Bo no tin ningun nivel di autorisashon pa skan ophetonan.<br>\n"
-#~ " Tuma kontakto ku e administradó pa duna bo e nivel di autorisashon "
-#~ "nesesario.\n"
+#~ " Tuma kontakto ku e administradó pa duna bo e nivel di autorisashon nesesario.\n"
 #~ " "
 
 #, python-format
 #~ msgid ""
 #~ "\n"
-#~ "        Use the form below to clone the settings from "
-#~ "<i>%(current_organization)s</i> to the selected organization.\n"
-#~ "        This includes both the KAT-alogus settings as well as enabled and "
-#~ "disabled plugins.\n"
+#~ "        Use the form below to clone the settings from <i>%(current_organization)s</i> to the selected organization.\n"
+#~ "        This includes both the KAT-alogus settings as well as enabled and disabled plugins.\n"
 #~ "      "
 #~ msgstr ""
 #~ "\n"
-#~ " Uza e formulario abou pa kopia e konfigurashon di "
-#~ "<i>%(current_organization)s</i> pa e organisashon selektá.\n"
-#~ " Esaki ta inkluí tanto e konfigurashonnan di KAT-alogus manera tambe e "
-#~ "plug-innan aktivá i desaktivá.\n"
+#~ " Uza e formulario abou pa kopia e konfigurashon di <i>%(current_organization)s</i> pa e organisashon selektá.\n"
+#~ " Esaki ta inkluí tanto e konfigurashonnan di KAT-alogus manera tambe e plug-innan aktivá i desaktivá.\n"
 #~ "      "
 
 #~ msgid ""
@@ -8621,98 +9232,69 @@ msgstr "Arkivo crudo añadi ku èxito."
 
 #~ msgid ""
 #~ "\n"
-#~ "                    OpenKAT has a permission system that allows "
-#~ "administrators to\n"
-#~ "                    configure which users can set a certain clearance "
-#~ "level. The will make sure\n"
-#~ "                    that only users that are trusted can start the more "
-#~ "aggressive scans.\n"
+#~ "                    OpenKAT has a permission system that allows administrators to\n"
+#~ "                    configure which users can set a certain clearance level. The will make sure\n"
+#~ "                    that only users that are trusted can start the more aggressive scans.\n"
 #~ "                "
 #~ msgstr ""
 #~ "\n"
 #~ "OpenKAT tin un sistema di permiso ku ta laga administratornan\n"
-#~ "configure kua usuarionan por pone un nivel di autorisashon determiná. "
-#~ "Esaki lo segurá\n"
-#~ "ku solamente usuarionan ku ta konfiable por inisiá e skaneonan mas "
-#~ "agresivo.\n"
+#~ "configure kua usuarionan por pone un nivel di autorisashon determiná. Esaki lo segurá\n"
+#~ "ku solamente usuarionan ku ta konfiable por inisiá e skaneonan mas agresivo.\n"
 #~ " "
 
 #~ msgid ""
 #~ "\n"
-#~ "                    Before a member is granted the ability to set "
-#~ "clearance levels on an object,\n"
-#~ "                    they must first acknowledge and accept the clearance "
-#~ "level set by the administrators.\n"
-#~ "                    The maximum scanning level permitted for a member is "
-#~ "aligned with the trusted clearance level.\n"
-#~ "                    By acknowledging the trusted clearance level, this "
-#~ "member formally agrees to abide by\n"
-#~ "                    this permission and gains the capability to perform "
-#~ "scans only up to this trusted clearance level.\n"
-#~ "                    This two-step process ensures that the member "
-#~ "operates within authorized boundaries.\n"
+#~ "                    Before a member is granted the ability to set clearance levels on an object,\n"
+#~ "                    they must first acknowledge and accept the clearance level set by the administrators.\n"
+#~ "                    The maximum scanning level permitted for a member is aligned with the trusted clearance level.\n"
+#~ "                    By acknowledging the trusted clearance level, this member formally agrees to abide by\n"
+#~ "                    this permission and gains the capability to perform scans only up to this trusted clearance level.\n"
+#~ "                    This two-step process ensures that the member operates within authorized boundaries.\n"
 #~ "                "
 #~ msgstr ""
 #~ "\n"
-#~ "Promé ku un miembro ta otorgá e habilidat pa pone nivelnan di "
-#~ "autorisashon riba un opheto,\n"
-#~ "promé nan mester reconosé i aseptá e nivel di autorisashon poni pa e "
-#~ "administratornan.\n"
-#~ "E nivel máksimo di skaneo permití pa un miembro ta aliná ku e nivel di "
-#~ "autorisashon konfiable.\n"
-#~ "Pa reconosé e nivel di autorisashon konfiable, e miembro aki formalmente "
-#~ "ta akordá pa kumpli ku\n"
-#~ "e permiso aki i ta haña e kapasidat pa realizá skaneonan solamente te na "
-#~ "e nivel di autorisashon konfiable aki.\n"
-#~ "E proheso di dos pason aki ta garantisá ku e miembro ta operá den "
-#~ "fronteranan autorisá.\n"
+#~ "Promé ku un miembro ta otorgá e habilidat pa pone nivelnan di autorisashon riba un opheto,\n"
+#~ "promé nan mester reconosé i aseptá e nivel di autorisashon poni pa e administratornan.\n"
+#~ "E nivel máksimo di skaneo permití pa un miembro ta aliná ku e nivel di autorisashon konfiable.\n"
+#~ "Pa reconosé e nivel di autorisashon konfiable, e miembro aki formalmente ta akordá pa kumpli ku\n"
+#~ "e permiso aki i ta haña e kapasidat pa realizá skaneonan solamente te na e nivel di autorisashon konfiable aki.\n"
+#~ "E proheso di dos pason aki ta garantisá ku e miembro ta operá den fronteranan autorisá.\n"
 #~ " "
 
 #, python-format
 #~ msgid ""
 #~ "\n"
-#~ "                                Unfortunately you cannot continue the "
-#~ "onboarding. </br>\n"
-#~ "                                Your administrator has trusted you with a "
-#~ "clearance level of <strong>L%(tcl)s</strong>.</br>\n"
-#~ "                                You need at least a clearance level of "
-#~ "<strong>L%(dns_report_least_clearance_level)s</strong> to scan "
-#~ "<strong>%(ooi)s</strong></br>\n"
-#~ "                                Contact your administrator to receive a "
-#~ "higher clearance.\n"
+#~ "                                Unfortunately you cannot continue the onboarding. </br>\n"
+#~ "                                Your administrator has trusted you with a clearance level of <strong>L%(tcl)s</strong>.</br>\n"
+#~ "                                You need at least a clearance level of <strong>L%(dns_report_least_clearance_level)s</strong> to scan <strong>%(ooi)s</strong></br>\n"
+#~ "                                Contact your administrator to receive a higher clearance.\n"
 #~ "                            "
 #~ msgstr ""
 #~ "\n"
 #~ " Desafortunadamente bo no por sigui ku e proceso di onboarding. </br>\n"
-#~ " Bo administrator a konfia bo ku un nivel di autorisashon di "
-#~ "<strong>L%(tcl)s</strong>.</br>\n"
-#~ " Bo mester tin almenos un nivel di autorisashon di "
-#~ "<strong>L%(dns_report_least_clearance_level)s</strong> pa skaneá\n"
+#~ " Bo administrator a konfia bo ku un nivel di autorisashon di <strong>L%(tcl)s</strong>.</br>\n"
+#~ " Bo mester tin almenos un nivel di autorisashon di <strong>L%(dns_report_least_clearance_level)s</strong> pa skaneá\n"
 #~ " <strong>%(ooi)s</strong></br>\n"
-#~ " Tuma kontakto ku bo administrator pa risibí un nivel di autorisashon mas "
-#~ "haltu.\n"
+#~ " Tuma kontakto ku bo administrator pa risibí un nivel di autorisashon mas haltu.\n"
 #~ " "
 
 #, python-format
 #~ msgid ""
 #~ "\n"
-#~ "                            Your administrator has trusted you with a "
-#~ "clearance level of <strong>L%(tcl)s</strong>.</br>\n"
-#~ "                            You must first accept this clearance level to "
-#~ "continue.\n"
+#~ "                            Your administrator has trusted you with a clearance level of <strong>L%(tcl)s</strong>.</br>\n"
+#~ "                            You must first accept this clearance level to continue.\n"
 #~ "                            "
 #~ msgstr ""
 #~ "\n"
-#~ " Bo administrator a konfia bo ku un nivel di autorisashon di "
-#~ "<strong>L%(tcl)s</strong>.</br>\n"
+#~ " Bo administrator a konfia bo ku un nivel di autorisashon di <strong>L%(tcl)s</strong>.</br>\n"
 #~ " Promé bo mester aseptá e nivel di autorisashon aki pa por sigui.\n"
 #~ " "
 
 #, python-format
 #~ msgid ""
 #~ "\n"
-#~ "                            Accept level L%(tcl)s clearance and "
-#~ "responsibility\n"
+#~ "                            Accept level L%(tcl)s clearance and responsibility\n"
 #~ "                        "
 #~ msgstr ""
 #~ "\n"
@@ -8722,42 +9304,33 @@ msgstr "Arkivo crudo añadi ku èxito."
 #, python-format
 #~ msgid ""
 #~ "\n"
-#~ "                            Your administrator has <strong>trusted</"
-#~ "strong> you with a clearance level of <strong>L%(tcl)s</strong>.</br>\n"
-#~ "                            You have also <strong>acknowledged</strong> "
-#~ "to use this clearance level of <strong>L%(acl)s</strong>.\n"
+#~ "                            Your administrator has <strong>trusted</strong> you with a clearance level of <strong>L%(tcl)s</strong>.</br>\n"
+#~ "                            You have also <strong>acknowledged</strong> to use this clearance level of <strong>L%(acl)s</strong>.\n"
 #~ "                            "
 #~ msgstr ""
 #~ "\n"
-#~ " Bo administrator a <strong>konfia</strong> bo ku un nivel di "
-#~ "autorisashon di <strong>L%(tcl)s</strong>.</br>\n"
-#~ " Bo tambe a <strong>rekonosé</strong> pa usa e nivel di autorisashon aki "
-#~ "di <strong>L%(acl)s</strong>.\n"
+#~ " Bo administrator a <strong>konfia</strong> bo ku un nivel di autorisashon di <strong>L%(tcl)s</strong>.</br>\n"
+#~ " Bo tambe a <strong>rekonosé</strong> pa usa e nivel di autorisashon aki di <strong>L%(acl)s</strong>.\n"
 #~ " "
 
 #, python-format
 #~ msgid ""
 #~ "\n"
 #~ "                            <strong>Warning:</strong>\n"
-#~ "                            Indemnification is not set for this "
-#~ "organization.\n"
-#~ "                            Go to the <a "
-#~ "href=\"%(organization_settings)s\">organization settings page</a> to add "
-#~ "one.\n"
+#~ "                            Indemnification is not set for this organization.\n"
+#~ "                            Go to the <a href=\"%(organization_settings)s\">organization settings page</a> to add one.\n"
 #~ "                        "
 #~ msgstr ""
 #~ "\n"
 #~ " <strong>Advertensia:</strong>\n"
 #~ " Indemnisashon no ta ajustá pa e organisashon aki.\n"
-#~ " Bishitá e <a href=\"%(organization_settings)s\">página di ajuste di "
-#~ "organisashon</a> pa agregá un.\n"
+#~ " Bishitá e <a href=\"%(organization_settings)s\">página di ajuste di organisashon</a> pa agregá un.\n"
 #~ "                        "
 
 #, python-format
 #~ msgid ""
 #~ "\n"
-#~ "                    An overview of \"%(organization_name)s\" its "
-#~ "members.\n"
+#~ "                    An overview of \"%(organization_name)s\" its members.\n"
 #~ "                "
 #~ msgstr ""
 #~ "\n"
@@ -8767,13 +9340,11 @@ msgstr "Arkivo crudo añadi ku èxito."
 #, python-format
 #~ msgid ""
 #~ "\n"
-#~ "            An overview of \"%(organization_name)s\". This shows general "
-#~ "information and its settings.\n"
+#~ "            An overview of \"%(organization_name)s\". This shows general information and its settings.\n"
 #~ "          "
 #~ msgstr ""
 #~ "\n"
-#~ " Un bista general di \"%(organization_name)s\". Esaki ta mustra "
-#~ "informashon general i su ajustenan.\n"
+#~ " Un bista general di \"%(organization_name)s\". Esaki ta mustra informashon general i su ajustenan.\n"
 #~ "          "
 
 #~ msgid ""
@@ -8790,52 +9361,33 @@ msgstr "Arkivo crudo añadi ku èxito."
 #, python-format
 #~ msgid ""
 #~ "\n"
-#~ "              This means that this object will be scanned by Boefjes with "
-#~ "scan level\n"
-#~ "              %(scan_level)s and lower. Setting the clearance level from "
-#~ "“declared”\n"
-#~ "              to “inherit” means that this object will inherit its level "
-#~ "from neighbouring\n"
-#~ "              objects. This means that the clearance level might stay the "
-#~ "same, increase,\n"
-#~ "              or decrease depending on other declared clearance levels. "
-#~ "Clearance levels\n"
-#~ "              of objects that inherit from this clearance level will also "
-#~ "be recalculated.\n"
+#~ "              This means that this object will be scanned by Boefjes with scan level\n"
+#~ "              %(scan_level)s and lower. Setting the clearance level from “declared”\n"
+#~ "              to “inherit” means that this object will inherit its level from neighbouring\n"
+#~ "              objects. This means that the clearance level might stay the same, increase,\n"
+#~ "              or decrease depending on other declared clearance levels. Clearance levels\n"
+#~ "              of objects that inherit from this clearance level will also be recalculated.\n"
 #~ "            "
 #~ msgstr ""
 #~ "\n"
-#~ "              Esaki ta nifiká ku e opheto aki lo wordu di skan dor di "
-#~ "Boefjes ku nivél di skan\n"
-#~ "              %(scan_level)s i mas abou. Pone e nivél di autorisashon for "
-#~ "di deklará\n"
-#~ "              na “heredá” ta nifiká ku e opheto aki lo heredá su nivél "
-#~ "for di ophetonan den bisindario.\n"
-#~ "              Esaki ta nifiká ku e nivél di autorisashon por keda meskos, "
-#~ "subi,\n"
-#~ "              òf baha depende di e otro nivél di autorisashonnan. Nivél "
-#~ "di autorisashonnan\n"
-#~ "              di ophetonan ku ta heredá for di e nivél di autorisashon "
-#~ "tambe lo wordu rekalkulá.\n"
+#~ "              Esaki ta nifiká ku e opheto aki lo wordu di skan dor di Boefjes ku nivél di skan\n"
+#~ "              %(scan_level)s i mas abou. Pone e nivél di autorisashon for di deklará\n"
+#~ "              na “heredá” ta nifiká ku e opheto aki lo heredá su nivél for di ophetonan den bisindario.\n"
+#~ "              Esaki ta nifiká ku e nivél di autorisashon por keda meskos, subi,\n"
+#~ "              òf baha depende di e otro nivél di autorisashonnan. Nivél di autorisashonnan\n"
+#~ "              di ophetonan ku ta heredá for di e nivél di autorisashon tambe lo wordu rekalkulá.\n"
 #~ "            "
 
 #~ msgid ""
 #~ "\n"
-#~ "                This object has a clearance level of \"L0\". This means "
-#~ "that this object will not be scanned by any Boefje until that\n"
-#~ "                Boefje is run manually for this object again. Objects "
-#~ "with a clearance level higher than \"L0\" will be scanned automatically "
-#~ "by Boefjes with\n"
+#~ "                This object has a clearance level of \"L0\". This means that this object will not be scanned by any Boefje until that\n"
+#~ "                Boefje is run manually for this object again. Objects with a clearance level higher than \"L0\" will be scanned automatically by Boefjes with\n"
 #~ "                corresponding scan levels.\n"
 #~ "            "
 #~ msgstr ""
 #~ "\n"
-#~ "                E opheto aki tin un nivel di authorisashon di \"L0\". "
-#~ "Esaki ta nifika ku e opheto aki no por wòrdu di skan dor di ningun Boefje "
-#~ "te ora\n"
-#~ "                e Boefje aki ta wordu di skan manualmente atrobe pe e "
-#~ "opheto. Ophetonan ku un nivel di authorisashon mas haltu ku \"L0\" ta "
-#~ "wòrdu di skan automatikamente dor di Boefjes ku\n"
+#~ "                E opheto aki tin un nivel di authorisashon di \"L0\". Esaki ta nifika ku e opheto aki no por wòrdu di skan dor di ningun Boefje te ora\n"
+#~ "                e Boefje aki ta wordu di skan manualmente atrobe pe e opheto. Ophetonan ku un nivel di authorisashon mas haltu ku \"L0\" ta wòrdu di skan automatikamente dor di Boefjes ku\n"
 #~ "                nivelnan di skan korespondiente.\n"
 #~ "            "
 
@@ -8869,12 +9421,12 @@ msgstr "Arkivo crudo añadi ku èxito."
 #, python-format
 #~ msgid ""
 #~ "These are the findings of a OpenKAT-analysis on %(observed_at)s. Click a "
-#~ "finding for more detailed information about the issue, its origin, "
-#~ "severity and possible solutions."
+#~ "finding for more detailed information about the issue, its origin, severity "
+#~ "and possible solutions."
 #~ msgstr ""
 #~ "Esakinan ta e resultadonan di un OpenKAT-analysis riba %(observed_at)s. "
-#~ "Click un resultadopa mas informashon detayá tokante e problema, su "
-#~ "orígen, severidat i posibel solushonnan."
+#~ "Click un resultadopa mas informashon detayá tokante e problema, su orígen, "
+#~ "severidat i posibel solushonnan."
 
 #, python-format
 #~ msgid "A report for %(name)s wasn't found."
@@ -8882,8 +9434,8 @@ msgstr "Arkivo crudo añadi ku èxito."
 
 #, python-format
 #~ msgid ""
-#~ "Perhaps it never was, perhaps it just didn't exist on %(observed_at)s "
-#~ "<br> Try some other dates!"
+#~ "Perhaps it never was, perhaps it just didn't exist on %(observed_at)s <br> "
+#~ "Try some other dates!"
 #~ msgstr ""
 #~ "Probablemente e no tabata, probablemente e nunka a eksistí riba "
 #~ "%(observed_at)s<br> Purba algun otro fechanan!"
@@ -8901,15 +9453,15 @@ msgstr "Arkivo crudo añadi ku èxito."
 #~ msgid ""
 #~ "Timeout reached generating report. See Keiko logs for more information."
 #~ msgstr ""
-#~ "Tempo di espera a yega na su fin den generashon di rapòrt. Wak e Keiko "
-#~ "logs pa mas informashon."
+#~ "Tempo di espera a yega na su fin den generashon di rapòrt. Wak e Keiko logs "
+#~ "pa mas informashon."
 
 #~ msgid ""
-#~ "Boefjes gather factual information, such as by calling an external "
-#~ "scanning tool like nmap or using a database like shodan."
+#~ "Boefjes gather factual information, such as by calling an external scanning "
+#~ "tool like nmap or using a database like shodan."
 #~ msgstr ""
-#~ "Boefjes ta reuni informashon faktuál, huzando tools manera nmap òf usando "
-#~ "un base di datos manera shodan."
+#~ "Boefjes ta reuni informashon faktuál, huzando tools manera nmap òf usando un"
+#~ " base di datos manera shodan."
 
 #~ msgid " Details"
 #~ msgstr "Detayes"
@@ -8983,38 +9535,37 @@ msgstr "Arkivo crudo añadi ku èxito."
 #~ msgid ""
 #~ "Within OpenKAT you can view reports for each of your current objects. For "
 #~ "specific reports you can choose one of the available report types and "
-#~ "generate a report. Such as a pen-test, a DNS-report or a mail report to "
-#~ "give some examples."
+#~ "generate a report. Such as a pen-test, a DNS-report or a mail report to give"
+#~ " some examples."
 #~ msgstr ""
-#~ "Den OpenKAT bo por mira rapòrtnan pa kada un di bo ophetonan. Pa "
-#~ "rapòrtnan specifikó bo por skohé un di e tipo rapòrtnan obtenibel i "
-#~ "generá un rapòrt. Manera un pen-test, un DNS-rapòrt òf un mail rapòrt pa "
-#~ "duna algun ehempel."
+#~ "Den OpenKAT bo por mira rapòrtnan pa kada un di bo ophetonan. Pa rapòrtnan "
+#~ "specifikó bo por skohé un di e tipo rapòrtnan obtenibel i generá un rapòrt. "
+#~ "Manera un pen-test, un DNS-rapòrt òf un mail rapòrt pa duna algun ehempel."
 
 #~ msgid ""
-#~ "A lot of things can be an object within the scope of OpenKAT. For example "
-#~ "a mailserver, an ip-address, a URL, a DNS record, a hostname or a network "
-#~ "to name a few.  While these objects can be related to each other they are "
-#~ "all objects within OpenKAT that can be scanned to gain valuable insight."
+#~ "A lot of things can be an object within the scope of OpenKAT. For example a "
+#~ "mailserver, an ip-address, a URL, a DNS record, a hostname or a network to "
+#~ "name a few.  While these objects can be related to each other they are all "
+#~ "objects within OpenKAT that can be scanned to gain valuable insight."
 #~ msgstr ""
 #~ "Hopi kos por ta un opheto den di e alkanse di OpenKAT. Por ehempel un "
-#~ "mailserver, un ip-adrès, un URL, un DNS record, un hostname òf un netwèrk "
-#~ "pa nombra un par. Mientras tantu e ophetonan aki por ta relatá na otro "
-#~ "nan tur ta ophetonan den di OpenKAT ku por wordu di skan pa haña "
-#~ "informashon balioso."
+#~ "mailserver, un ip-adrès, un URL, un DNS record, un hostname òf un netwèrk pa"
+#~ " nombra un par. Mientras tantu e ophetonan aki por ta relatá na otro nan tur"
+#~ " ta ophetonan den di OpenKAT ku por wordu di skan pa haña informashon "
+#~ "balioso."
 
 #~ msgid ""
 #~ "Most objects have dependencies on the existence of other objects. For "
 #~ "example a URL needs to be connected to a network, hostname, fqdn (fully "
 #~ "qualified domain name) and ip-address. OpenKAT collects these additional "
-#~ "object automatically when possible. By running plugins to collect or "
-#~ "extract this data."
+#~ "object automatically when possible. By running plugins to collect or extract"
+#~ " this data."
 #~ msgstr ""
 #~ "Mayoria ophetonan tin dependesianan riba e exsistencia di otro ophetonan. "
 #~ "Por ehempel un URL mester ta konektá ku un nètwèrk, hostname, fqdn (fúl "
 #~ "kwalifiká nòmber di domèin) i ip-adrès. OpenKAT ta kolektá e ophetonan "
-#~ "adishonal automatikamente si ta posibel. Dor di start plugins pa kolektá "
-#~ "òf extrahé data."
+#~ "adishonal automatikamente si ta posibel. Dor di start plugins pa kolektá òf "
+#~ "extrahé data."
 
 #~ msgid "Risk score:"
 #~ msgstr "Puntuashon di riesgo:"
@@ -9026,8 +9577,7 @@ msgstr "Arkivo crudo añadi ku èxito."
 #~ msgstr "Bo aktualmente a aseptá e nivel di autorisashon te na nivel "
 
 #~ msgid ""
-#~ "If you don’t remember the email address connected to your account, "
-#~ "contact: "
+#~ "If you don’t remember the email address connected to your account, contact: "
 #~ msgstr ""
 #~ "Si bo no ta kòrda e email adrès konektá ku bo account, tuma kontákto ku: "
 
@@ -9039,20 +9589,17 @@ msgstr "Arkivo crudo añadi ku èxito."
 
 #, fuzzy
 #~ msgid ""
-#~ "<span>Warning scan level:</span> Scanning OOI's with a lower clearance "
-#~ "level will result in OpenKAT increasing the clearance level on that OOI, "
-#~ "not only for this scan but from now on out, until it manually gets set to "
-#~ "something else again. This means that all other enabled Boefjes will use "
-#~ "this higher clearance level aswel."
+#~ "<span>Warning scan level:</span> Scanning OOI's with a lower clearance level"
+#~ " will result in OpenKAT increasing the clearance level on that OOI, not only"
+#~ " for this scan but from now on out, until it manually gets set to something "
+#~ "else again. This means that all other enabled Boefjes will use this higher "
+#~ "clearance level aswel."
 #~ msgstr ""
 #~ "\n"
 #~ "          <span>Advertensia nivel di skan:</span>\n"
-#~ "          Skèn OOI's ku nivel di authorisashon mas abou lo resulta ku "
-#~ "OpenKAT mester subi e nivel di authorisashon pa e OOI,\n"
-#~ "          no solamente pa e skan aki for di awor i adelante, te ora "
-#~ "manualmente e wordu pone na algu otro atrobe.\n"
-#~ "          Esaki ta nifika ku tur otro Boefjes aktivo lo huza e nivel di "
-#~ "authorisashon  aki tambe.\n"
+#~ "          Skèn OOI's ku nivel di authorisashon mas abou lo resulta ku OpenKAT mester subi e nivel di authorisashon pa e OOI,\n"
+#~ "          no solamente pa e skan aki for di awor i adelante, te ora manualmente e wordu pone na algu otro atrobe.\n"
+#~ "          Esaki ta nifika ku tur otro Boefjes aktivo lo huza e nivel di authorisashon  aki tambe.\n"
 #~ "        "
 
 #~ msgid "Reason"
@@ -9094,11 +9641,11 @@ msgstr "Arkivo crudo añadi ku èxito."
 #~ msgstr "Zona DNS"
 
 #~ msgid ""
-#~ "OpenKAT added the following required object to your object list to "
-#~ "complete your request: {}"
+#~ "OpenKAT added the following required object to your object list to complete "
+#~ "your request: {}"
 #~ msgstr ""
-#~ "OpenKAT a añadi e siguinte opheton na bo lista di ophetonan pa kompleta "
-#~ "bo petishon: {}"
+#~ "OpenKAT a añadi e siguinte opheton na bo lista di ophetonan pa kompleta bo "
+#~ "petishon: {}"
 
 #, python-format
 #~ msgid ""
@@ -9124,13 +9671,12 @@ msgstr "Arkivo crudo añadi ku èxito."
 
 #, python-format
 #~ msgid ""
-#~ "Could not raise clearance level of %s to L%s. You acknowledged a "
-#~ "clearance level of L%s. Please accept the clearance level below to "
-#~ "proceed."
+#~ "Could not raise clearance level of %s to L%s. You acknowledged a clearance "
+#~ "level of L%s. Please accept the clearance level below to proceed."
 #~ msgstr ""
-#~ "No por a subi e nivel di autorisashon di %s pa L%s. Bo a rekonosé un "
-#~ "nivel di autorisashon di L%s. Por fabor, akseptá e nivel di autorisashon "
-#~ "mas abou pa por sigui."
+#~ "No por a subi e nivel di autorisashon di %s pa L%s. Bo a rekonosé un nivel "
+#~ "di autorisashon di L%s. Por fabor, akseptá e nivel di autorisashon mas abou "
+#~ "pa por sigui."
 
 #~ msgid "Choose a valid level"
 #~ msgstr "Skohé un nivél balido"
@@ -9158,18 +9704,18 @@ msgstr "Arkivo crudo añadi ku èxito."
 #~ msgstr "Reprodusí búskeda"
 
 #~ msgid ""
-#~ "From 1 to 5, how often does this failure mode occurs. 1: Almost "
-#~ "unthinkable and 5: occurs daily."
+#~ "From 1 to 5, how often does this failure mode occurs. 1: Almost unthinkable "
+#~ "and 5: occurs daily."
 #~ msgstr ""
-#~ "Di 1 te 5, kwantu biaha e failure mode aki ta occurí. 1: Kasi imposibeli "
-#~ "5: occurí diariamente."
+#~ "Di 1 te 5, kwantu biaha e failure mode aki ta occurí. 1: Kasi imposibeli 5: "
+#~ "occurí diariamente."
 
 #~ msgid ""
-#~ "Is this failure mode easy detectable? Give it a score from 1 to 5. 1: "
-#~ "always detectable and 5: almost undetectable."
+#~ "Is this failure mode easy detectable? Give it a score from 1 to 5. 1: always"
+#~ " detectable and 5: almost undetectable."
 #~ msgstr ""
-#~ "E failure mode aki por wordu detektá fasil? Duné un score for di 1 te 5. "
-#~ "1: semper detektábel i 5: kasi imposibel."
+#~ "E failure mode aki por wordu detektá fasil? Duné un score for di 1 te 5. 1: "
+#~ "semper detektábel i 5: kasi imposibel."
 
 #~ msgid "Describe the type of failure mode"
 #~ msgstr "Deskribi e tipo di failure mode"
@@ -9303,14 +9849,13 @@ msgstr "Arkivo crudo añadi ku èxito."
 #~ "Level 1: Always Detectable. Incident (almost) never occurs, almost "
 #~ "unthinkable."
 #~ msgstr ""
-#~ "Nivel 1: Semper Detektabel. Insidente (kasi) nunka ta okuri, kasi "
-#~ "imposibel."
+#~ "Nivel 1: Semper Detektabel. Insidente (kasi) nunka ta okuri, kasi imposibel."
 
 #~ msgid ""
 #~ "Level 2: Usually Detectable. Incidents occur less than once a year (3-5)."
 #~ msgstr ""
-#~ "Nivel 2: Normalmente Dektetabel. Insidente ta okuri menos ku un biaha pa "
-#~ "aña (3-5)."
+#~ "Nivel 2: Normalmente Dektetabel. Insidente ta okuri menos ku un biaha pa aña"
+#~ " (3-5)."
 
 #~ msgid "Level 3: Detectable. Failure mode is detectable with effort."
 #~ msgstr "Nivel 3: Detektabel. Faillure mode ta detektabel ku eksfuerzo."
@@ -9322,8 +9867,8 @@ msgstr "Arkivo crudo añadi ku èxito."
 #~ "Level 5: Almost Undetectable. Failure mode detection is very difficult or "
 #~ "nearly impossible."
 #~ msgstr ""
-#~ "Nivel 5: Pobremente Detektabel. Faillure mode detekshon ta hopi difisil "
-#~ "òf kasi imposibel."
+#~ "Nivel 5: Pobremente Detektabel. Faillure mode detekshon ta hopi difisil òf "
+#~ "kasi imposibel."
 
 #~ msgid "Failure modes"
 #~ msgstr "Failure modes"
@@ -9537,20 +10082,20 @@ msgstr "Arkivo crudo añadi ku èxito."
 #~ "manufacturing process, product or service."
 #~ msgstr ""
 #~ "FMEA (failure mode and effective analysis) ta un enfoque paso a paso pa "
-#~ "kolekta konosimentu tokante puntonan posibel di fayo den un diseño, "
-#~ "proseso fabriká, produkto òf servicio."
+#~ "kolekta konosimentu tokante puntonan posibel di fayo den un diseño, proseso "
+#~ "fabriká, produkto òf servicio."
 
 #~ msgid ""
-#~ "Failure mode (FM) refers to the way in which something might break down "
-#~ "and includes potential errors that may occur, especially errors that may "
-#~ "affect a system. Effective analysis (EA) involves deciphering the "
-#~ "consequences of those break downs by making sure that all failures can be "
-#~ "detected, determining how frequently a failure might occur and "
-#~ "identifying which potential failures should be prioritized."
+#~ "Failure mode (FM) refers to the way in which something might break down and "
+#~ "includes potential errors that may occur, especially errors that may affect "
+#~ "a system. Effective analysis (EA) involves deciphering the consequences of "
+#~ "those break downs by making sure that all failures can be detected, "
+#~ "determining how frequently a failure might occur and identifying which "
+#~ "potential failures should be prioritized."
 #~ msgstr ""
-#~ "Failure mode (FM) ta referi na e manera kaminda algu por posibelmente "
-#~ "kibra i inkluí errornan potenshal ku por okuri, speshalmente errornan ku "
-#~ "por afektá un sistema. Effective analysis (EA) ta envolvi den buska e "
+#~ "Failure mode (FM) ta referi na e manera kaminda algu por posibelmente kibra "
+#~ "i inkluí errornan potenshal ku por okuri, speshalmente errornan ku por "
+#~ "afektá un sistema. Effective analysis (EA) ta envolvi den buska e "
 #~ "konsekuensiasnan di loke por kibra dor di detekta tur failure modes, "
 #~ "determiná kon frequente failure modes ta okuri i identifiká kwa failure "
 #~ "modes mester wordu prioritisa."
@@ -9600,20 +10145,17 @@ msgstr "Arkivo crudo añadi ku èxito."
 #, python-format
 #~ msgid ""
 #~ "\n"
-#~ "                            \"Withdraw acceptance of level L%(acl)s "
-#~ "clearance and responsibility\"\n"
+#~ "                            \"Withdraw acceptance of level L%(acl)s clearance and responsibility\"\n"
 #~ "                    "
 #~ msgstr ""
 #~ "\n"
-#~ "\"Retirá aseptashon di nivel di autorisashon L%(acl)s i "
-#~ "responsabilidat\"\n"
+#~ "\"Retirá aseptashon di nivel di autorisashon L%(acl)s i responsabilidat\"\n"
 #~ " "
 
 #, python-format
 #~ msgid ""
 #~ "\n"
-#~ "                        \"Accept level L%(tcl)s clearance and "
-#~ "responsibility\"\n"
+#~ "                        \"Accept level L%(tcl)s clearance and responsibility\"\n"
 #~ "                    "
 #~ msgstr ""
 #~ "\n"
@@ -9695,11 +10237,9 @@ msgstr "Arkivo crudo añadi ku èxito."
 #~ msgstr "No tin entrada OOI"
 
 #~ msgid ""
-#~ "Can not parse observed_at parameter, falling back to showing current "
-#~ "object"
+#~ "Can not parse observed_at parameter, falling back to showing current object"
 #~ msgstr ""
-#~ "No por parse e parametro observed_at, regresando na munstra e opheto "
-#~ "aktual"
+#~ "No por parse e parametro observed_at, regresando na munstra e opheto aktual"
 
 #~ msgid "Scanning successfully scheduled."
 #~ msgstr "Skèn a start ku èxito."


### PR DESCRIPTION
## Summary
- update the Papiamento Django translation catalog from the current Weblate template
- fill previously untranslated and fuzzy strings using machine translation with protected placeholders and OpenKAT domain terms
- update translation metadata

## Validation
- msgfmt --statistics --check rocky/rocky/locale/pap/LC_MESSAGES/django.po

Note: these translations were machine-assisted and should be reviewed by a Papiamento/Papiamentu speaker before release.