### PR TITLE
Add Polish, Indonesian, and Latin translations

### DIFF
--- a/rocky/rocky/locale/django.pot
+++ b/rocky/rocky/locale/django.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-12 11:17+0000\n"
+"POT-Creation-Date: 2026-09-03 08:59+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -5829,7 +5829,7 @@ msgstr ""
 #: rocky/templates/oois/ooi_add_type_select.html
 #: rocky/templates/oois/ooi_detail_add_related_object.html
 #: rocky/templates/partials/elements/ooi_add_type_select_form.html
-#: rocky/templates/partials/ooi_list_toolbar.html rocky/views/ooi_add.py
+#: rocky/templates/partials/ooi_list_toolbar.html
 msgid "Add object"
 msgstr ""
 

--- a/rocky/rocky/locale/id/LC_MESSAGES/django.po
+++ b/rocky/rocky/locale/id/LC_MESSAGES/django.po
@@ -1,0 +1,10240 @@
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenKAT\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-03-28 14:22+0000\n"
+"PO-Revision-Date: 2026-07-14 00:00+0000\n"
+"Last-Translator: Brenno de Winter <brenno@dewinter.com>\n"
+"Language-Team: Indonesian <https://hosted.weblate.org/projects/openkat/nl-kat-coordination/id/>\n"
+"Language: id\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 5.13\n"
+
+#: account/admin.py
+msgid "Permissions"
+msgstr "Izin"
+
+#: account/admin.py
+msgid "Important dates"
+msgstr "Tanggal-tanggal penting"
+
+#: account/forms/account_setup.py crisis_room/forms.py
+#: katalogus/templates/katalogus_settings.html
+#: katalogus/templates/plugin_container_image.html
+#: reports/report_types/dns_report/report.html
+#: reports/report_types/tls_report/report.html
+#: reports/templates/partials/report_names_form.html
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/modal_partials/rename_modal.html
+#: reports/templates/report_overview/modal_partials/rerun_modal.html
+#: reports/templates/report_overview/modal_partials/share_modal.html
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+#: reports/templates/report_overview/subreports_table.html
+#: tools/forms/boefje.py rocky/templates/organizations/organization_list.html
+#: rocky/templates/organizations/organization_settings.html
+#: rocky/templates/partials/ooi_detail_related_object.html
+msgid "Name"
+msgstr "Nama"
+
+#: account/forms/account_setup.py
+msgid "The name that will be used in order to communicate."
+msgstr "Nama yang akan digunakan untuk berkomunikasi."
+
+#: account/forms/account_setup.py
+msgid "Please provide username"
+msgstr "Harap berikan nama pengguna"
+
+#: account/forms/account_setup.py
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Email"
+msgstr "E-mail"
+
+#: account/forms/account_setup.py
+msgid "Enter an email address."
+msgstr "Masukkan alamat email."
+
+#: account/forms/account_setup.py
+msgid "Password"
+msgstr "Kata sandi"
+
+#: account/forms/account_setup.py
+msgid "Choose a super secret password"
+msgstr "Pilih kata sandi super rahasia"
+
+#: account/forms/account_setup.py
+msgid "Choose another email."
+msgstr "Pilih email lain."
+
+#: account/forms/account_setup.py tools/forms/settings.py
+msgid "--- Please select one of the available options ----"
+msgstr "--- Silakan pilih salah satu opsi yang tersedia ----"
+
+#: account/forms/account_setup.py
+msgid "Account type"
+msgstr "Jenis akun"
+
+#: account/forms/account_setup.py
+msgid "Please select an account type to proceed."
+msgstr "Silakan pilih jenis akun untuk melanjutkan."
+
+#: account/forms/account_setup.py
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+msgid "Trusted clearance level"
+msgstr "Tingkat izin tepercaya"
+
+#: account/forms/account_setup.py
+msgid "Select a clearance level you trust this member with."
+msgstr "Pilih tingkat izin yang Anda percayai pada anggota ini."
+
+#: account/forms/account_setup.py onboarding/forms.py tools/forms/ooi.py
+msgid "Please select a clearance level to proceed."
+msgstr "Silakan pilih tingkat izin untuk melanjutkan."
+
+#: account/forms/account_setup.py tools/models.py
+msgid "The name of the organization."
+msgstr "Nama organisasi."
+
+#: account/forms/account_setup.py
+msgid "explanation-organization-name"
+msgstr "penjelasan-nama-organisasi"
+
+#: account/forms/account_setup.py
+#, python-brace-format
+msgid "A unique code of maximum {code_length} characters in length."
+msgstr "Kode unik dengan panjang maksimal {code_length} karakter."
+
+#: account/forms/account_setup.py
+msgid "explanation-organization-code"
+msgstr "penjelasan-kode-organisasi"
+
+#: account/forms/account_setup.py
+msgid "Organization name is required to proceed."
+msgstr "Nama organisasi diperlukan untuk melanjutkan."
+
+#: account/forms/account_setup.py
+msgid "Choose another organization."
+msgstr "Pilih organisasi lain."
+
+#: account/forms/account_setup.py
+msgid "Organization code is required to proceed."
+msgstr "Kode organisasi diperlukan untuk melanjutkan."
+
+#: account/forms/account_setup.py
+msgid "Choose another code for your organization."
+msgstr "Pilih kode lain untuk organisasi Anda."
+
+#: account/forms/account_setup.py
+msgid ""
+"I declare that OpenKAT may scan the assets of my organization and that I "
+"have permission to scan these assets. I am aware of the implications a scan "
+"(with a higher scan level) brings on my systems."
+msgstr ""
+"Saya menyatakan bahwa OpenKAT dapat memindai aset organisasi saya dan saya "
+"memiliki izin untuk memindai aset tersebut. Saya menyadari dampak pemindaian"
+" (dengan tingkat pemindaian yang lebih tinggi) pada sistem saya."
+
+#: account/forms/account_setup.py
+msgid ""
+"I declare that I am authorized to give this indemnification on behalf of my "
+"organization. I have the experience and knowledge to know what the "
+"consequences might be and can be held responsible for them."
+msgstr ""
+"Saya menyatakan bahwa saya berwenang untuk memberikan ganti rugi ini atas "
+"nama organisasi saya. Saya memiliki pengalaman dan pengetahuan untuk "
+"mengetahui apa konsekuensinya dan dapat bertanggung jawab atas "
+"konsekuensinya."
+
+#: account/forms/account_setup.py
+msgid "Trusted to change Clearance Levels."
+msgstr "Dipercaya untuk mengubah Level Izin."
+
+#: account/forms/account_setup.py
+msgid "Acknowledged to change Clearance Levels."
+msgstr "Diakui untuk mengubah Tingkat Izin."
+
+#: account/forms/account_setup.py rocky/forms.py
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Blocked"
+msgstr "Diblokir"
+
+#: account/forms/account_setup.py
+msgid ""
+"Set the members status to blocked, so they don't have access to the "
+"organization anymore."
+msgstr ""
+"Tetapkan status anggota menjadi diblokir, sehingga mereka tidak memiliki "
+"akses lagi ke organisasi."
+
+#: account/forms/account_setup.py
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Accepted clearance level"
+msgstr "Tingkat izin yang diterima"
+
+#: account/forms/account_setup.py
+msgid "Enter tags separated by comma."
+msgstr "Masukkan tag yang dipisahkan dengan koma."
+
+#: account/forms/account_setup.py
+msgid "The two password fields didn’t match."
+msgstr "Kedua bidang kata sandi tidak cocok."
+
+#: account/forms/account_setup.py
+msgid "New password"
+msgstr "Kata sandi baru"
+
+#: account/forms/account_setup.py
+msgid "Enter a new password"
+msgstr "Masukkan kata sandi baru"
+
+#: account/forms/account_setup.py
+msgid "New password confirmation"
+msgstr "Konfirmasi kata sandi baru"
+
+#: account/forms/account_setup.py
+msgid "Repeat the new password"
+msgstr "Ulangi kata sandi baru"
+
+#: account/forms/account_setup.py
+msgid "Confirm the new password"
+msgstr "Konfirmasikan kata sandi baru"
+
+#: account/forms/login.py
+msgid "Please enter a correct email address and password."
+msgstr "Silakan masukkan alamat email dan kata sandi yang benar."
+
+#: account/forms/login.py
+msgid "This account is inactive."
+msgstr "Akun ini tidak aktif."
+
+#: account/forms/login.py
+msgid "Insert the email you registered with or got at OpenKAT installation."
+msgstr ""
+"Masukkan email yang Anda daftarkan atau dapatkan pada instalasi OpenKAT."
+
+#: account/forms/organization.py
+msgid "Organization is required."
+msgstr "Organisasi diperlukan."
+
+#: account/forms/organization.py tools/view_helpers.py
+#: rocky/templates/dashboard_redteam.html
+#: rocky/templates/organizations/organization_list.html
+#: rocky/views/organization_add.py
+msgid "Organizations"
+msgstr "Organisasi"
+
+#: account/forms/organization.py
+msgid "The organization from which to clone settings."
+msgstr "Organisasi tempat mengkloning pengaturan."
+
+#: account/forms/password_reset.py account/templates/account_detail.html
+msgid "Email address"
+msgstr "Alamat email"
+
+#: account/forms/password_reset.py
+msgid "A reset link will be sent to this email"
+msgstr "Tautan reset akan dikirim ke email ini"
+
+#: account/forms/password_reset.py
+msgid "The email address connected to your OpenKAT-account"
+msgstr "Alamat email yang terhubung ke akun OpenKAT Anda"
+
+#: account/forms/token.py
+msgid ""
+"Insert the token generated by the authenticator app to setup the two factor "
+"authentication."
+msgstr ""
+"Masukkan token yang dihasilkan oleh aplikasi autentikator untuk menyiapkan "
+"autentikasi dua faktor."
+
+#: account/forms/token.py
+msgid "Insert the token generated by your token authenticator app."
+msgstr ""
+"Masukkan token yang dihasilkan oleh aplikasi pengautentikasi token Anda."
+
+#: account/forms/token.py
+msgid "Backup token"
+msgstr "Token cadangan"
+
+#: account/mixins.py
+msgid "Clearance level has been set."
+msgstr "Tingkat izin telah ditetapkan."
+
+#: account/mixins.py
+#, python-format
+msgid ""
+"Could not raise clearance level of %s to L%s. Indemnification not present at"
+" organization %s."
+msgstr ""
+"Tidak dapat menaikkan tingkat izin %s ke L%s. Ganti rugi tidak ada di "
+"organisasi %s."
+
+#: account/mixins.py
+#, python-format
+msgid ""
+"Could not raise clearance level of %s to L%s. You were trusted a clearance "
+"level of L%s. Contact your administrator to receive a higher clearance."
+msgstr ""
+"Tidak dapat menaikkan tingkat izin %s ke L%s. Anda dipercaya dengan tingkat "
+"izin L%s. Hubungi administrator Anda untuk menerima izin yang lebih tinggi."
+
+#: account/mixins.py
+#, python-format
+msgid ""
+"Could not raise clearance level of %s to L%s. You acknowledged a clearance "
+"level of L%s. Please accept the clearance level first on your profile page "
+"to proceed."
+msgstr ""
+"Tidak dapat menaikkan tingkat izin %s ke L%s. Anda mengakui tingkat izin "
+"L%s. Harap setujui tingkat izin terlebih dahulu di halaman profil Anda untuk"
+" melanjutkan."
+
+#: account/models.py
+msgid "The email must be set"
+msgstr "Email harus disetel"
+
+#: account/models.py
+msgid "Superuser must have is_staff=True."
+msgstr "Pengguna super harus memiliki is_staff=True."
+
+#: account/models.py
+msgid "Superuser must have is_superuser=True."
+msgstr "Pengguna super harus memiliki is_superuser=True."
+
+#: account/models.py
+msgid "full name"
+msgstr "nama lengkap"
+
+#: account/models.py
+msgid "email"
+msgstr "e-mail"
+
+#: account/models.py
+msgid "staff status"
+msgstr "status staf"
+
+#: account/models.py
+msgid "Designates whether the user can log into this admin site."
+msgstr "Menentukan apakah pengguna dapat masuk ke situs admin ini."
+
+#: account/models.py tools/models.py
+msgid "active"
+msgstr "aktif"
+
+#: account/models.py
+msgid ""
+"Designates whether this user should be treated as active. Unselect this "
+"instead of deleting accounts."
+msgstr ""
+"Menentukan apakah pengguna ini harus dianggap aktif. Batalkan pilihan ini "
+"daripada menghapus akun."
+
+#: account/models.py
+msgid "date joined"
+msgstr "tanggal bergabung"
+
+#: account/models.py
+msgid "The clearance level of the user for all organizations."
+msgstr "Tingkat izin pengguna untuk semua organisasi."
+
+#: account/models.py
+msgid "name"
+msgstr "nama"
+
+#: account/templates/account_detail.html account/views/account.py
+msgid "Account details"
+msgstr "Detail akun"
+
+#: account/templates/account_detail.html account/templates/password_reset.html
+#: account/views/password_reset.py
+msgid "Reset password"
+msgstr "Setel ulang kata sandi"
+
+#: account/templates/account_detail.html
+msgid "Full name"
+msgstr "Nama lengkap"
+
+#: account/templates/account_detail.html
+msgid "Member type"
+msgstr "Tipe anggota"
+
+#: account/templates/account_detail.html
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: rocky/templates/tasks/normalizers.html
+msgid "Organization"
+msgstr "Organisasi"
+
+#: account/templates/account_detail.html
+msgid "Permission to set OOI clearance levels"
+msgstr "Izin untuk menetapkan tingkat izin OOI"
+
+#: account/templates/account_detail.html
+msgid "OOI clearance"
+msgstr "OOI izin"
+
+#: account/templates/account_detail.html
+msgid "You don't have any clearance to scan objects."
+msgstr "Anda tidak memiliki izin untuk memindai objek."
+
+#: account/templates/account_detail.html
+msgid ""
+"Get in contact with the admin to give you the necessary clearance level."
+msgstr "Hubungi admin untuk memberi Anda tingkat izin yang diperlukan."
+
+#: account/templates/account_detail.html
+msgid "You have currently accepted clearance up to level"
+msgstr "Saat ini Anda telah menerima izin hingga level"
+
+#: account/templates/account_detail.html
+msgid "Explanation OOI Clearance"
+msgstr "Penjelasan OOI Izin"
+
+#: account/templates/account_detail.html
+msgid ""
+"You can withdraw this at anytime you like, but know that you won't be able "
+"to change clearance levels anymore when you do."
+msgstr ""
+"Anda dapat menariknya kapan pun Anda mau, namun ketahuilah bahwa Anda tidak "
+"akan dapat mengubah tingkat izin lagi saat Anda melakukannya."
+
+#: account/templates/account_detail.html
+#, python-format
+msgid "Withdraw L%(acl)s clearance and responsibility"
+msgstr "Menarik izin dan tanggung jawab L%(acl)s"
+
+#: account/templates/account_detail.html
+msgid "Explanation OOI clearance"
+msgstr "Penjelasan OOI izin"
+
+#: account/templates/account_detail.html
+#, python-format
+msgid ""
+"You are granted clearance for level L%(tcl)s by your admin. Before you can "
+"change OOI clearance levels up to this level, you need to accept this "
+"permission. Remember: <strong>with great power comes great "
+"responsibility.</strong>"
+msgstr ""
+"Anda diberikan izin untuk level L%(tcl)s oleh admin Anda. Sebelum Anda dapat"
+" mengubah tingkat izin OOI hingga tingkat ini, Anda harus menerima izin ini."
+" Ingat: <strong>dengan kekuatan yang besar, ada pula tanggung jawab yang "
+"besar.</strong>"
+
+#: account/templates/account_detail.html
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+#, python-format
+msgid "Accept level L%(tcl)s clearance and responsibility"
+msgstr "Terima izin dan tanggung jawab tingkat L%(tcl)s"
+
+#: account/templates/password_reset.html
+msgid "Use the form below to reset your password."
+msgstr "Gunakan formulir di bawah ini untuk mengatur ulang kata sandi Anda."
+
+#: account/templates/password_reset.html
+#: account/templates/password_reset_confirm.html
+msgid "Send"
+msgstr "Mengirim"
+
+#: account/templates/password_reset.html
+#: account/templates/password_reset_confirm.html
+msgid "Back"
+msgstr "Kembali"
+
+#: account/templates/password_reset_confirm.html
+msgid "Confirm reset password"
+msgstr "Konfirmasikan pengaturan ulang kata sandi"
+
+#: account/templates/password_reset_confirm.html
+msgid "Use the form below to confirm resetting your password"
+msgstr ""
+"Gunakan formulir di bawah ini untuk mengonfirmasi pengaturan ulang kata "
+"sandi Anda"
+
+#: account/templates/password_reset_confirm.html
+msgid "Confirm password"
+msgstr "Konfirmasikan kata sandi"
+
+#: account/templates/password_reset_confirm.html
+msgid "The link is invalid"
+msgstr "Tautan tidak valid"
+
+#: account/templates/password_reset_confirm.html
+msgid ""
+"The password reset link was invalid, possibly because it has already been "
+"used.  Please request a new password reset."
+msgstr ""
+"Tautan pengaturan ulang kata sandi tidak valid, mungkin karena sudah pernah "
+"digunakan.  Silakan meminta pengaturan ulang kata sandi baru."
+
+#: account/templates/password_reset_email.html
+#, python-format
+msgid ""
+"You're receiving this email because you requested a password reset for your "
+"user account at %(site_name)s."
+msgstr ""
+"Anda menerima email ini karena Anda meminta pengaturan ulang kata sandi "
+"untuk akun pengguna Anda di %(site_name)s."
+
+#: account/templates/password_reset_email.html
+#: account/templates/registration_email.html
+msgid "Please go to the following page and choose a new password:"
+msgstr "Silakan buka halaman berikut dan pilih kata sandi baru:"
+
+#: account/templates/password_reset_email.html
+#: account/templates/registration_email.html
+msgid "Sincerely,"
+msgstr "Sungguh-sungguh,"
+
+#: account/templates/password_reset_email.html
+#: account/templates/registration_email.html
+msgid "The OpenKAT team"
+msgstr "Tim OpenKAT"
+
+#: account/templates/password_reset_subject.txt
+#, python-format
+msgid "Password reset on %(site_name)s"
+msgstr "Reset kata sandi pada %(site_name)s"
+
+#: account/templates/recover_email.html account/views/recover_email.py
+msgid "Recover email address"
+msgstr "Pulihkan alamat email"
+
+#: account/templates/recover_email.html
+msgid "Information on how to recover your connected email address"
+msgstr "Informasi tentang cara memulihkan alamat email Anda yang terhubung"
+
+#: account/templates/recover_email.html
+msgid "Forgotten email address?"
+msgstr "Lupa alamat email?"
+
+#: account/templates/recover_email.html
+msgid ""
+"If you don’t remember the email address connected to your account, contact:"
+msgstr ""
+"Jika Anda tidak ingat alamat email yang terhubung ke akun Anda, hubungi:"
+
+#: account/templates/recover_email.html
+msgid "Please contact the system administrator."
+msgstr "Silakan hubungi administrator sistem."
+
+#: account/templates/recover_email.html
+msgid "Back to login"
+msgstr "Kembali untuk masuk"
+
+#: account/templates/recover_email.html
+msgid "Back to Home"
+msgstr "Kembali ke Rumah"
+
+#: account/templates/registration_email.html
+#, python-format
+msgid ""
+"Welcome to OpenKAT. You're receiving this email because you have been added "
+"to organization \"%(organization)s\" at %(site_name)s."
+msgstr ""
+"Selamat datang di OpenKAT. Anda menerima email ini karena Anda telah "
+"ditambahkan ke organisasi \"%(organization)s\" di %(site_name)s."
+
+#: account/templates/registration_subject.txt
+#, python-format
+msgid "Verify OpenKAT account on %(site_name)s"
+msgstr "Verifikasi akun OpenKAT di %(site_name)s"
+
+#: account/validators.py
+msgid ""
+"Your password must contain at least the following but longer passwords are "
+"recommended:"
+msgstr ""
+"Kata sandi Anda harus berisi setidaknya yang berikut ini, tetapi disarankan "
+"untuk menggunakan kata sandi yang lebih panjang:"
+
+#: account/validators.py
+msgid " characters"
+msgstr "karakter"
+
+#: account/validators.py
+msgid " digits"
+msgstr "angka"
+
+#: account/validators.py
+msgid " letters"
+msgstr "surat"
+
+#: account/validators.py
+msgid ""
+" special characters such as: {str(validators.get('special_characters',''))}"
+msgstr ""
+"karakter khusus seperti: {str(validators.get('special_characters',''))}"
+
+#: account/validators.py
+msgid " lower case letters"
+msgstr "huruf kecil"
+
+#: account/validators.py
+msgid " upper case letters"
+msgstr "huruf besar"
+
+#: account/views/login.py
+msgid "Your session has timed out. Please login again."
+msgstr "Sesi Anda telah habis waktunya. Silakan masuk kembali."
+
+#: account/views/login.py rocky/templates/header.html
+msgid "OpenKAT"
+msgstr "OpenKAT"
+
+#: account/views/login.py account/views/password_reset.py
+#: account/views/recover_email.py rocky/templates/partials/secondary-menu.html
+#: rocky/templates/two_factor/core/login.html
+msgid "Login"
+msgstr "Login"
+
+#: account/views/login.py
+msgid "Two factor authentication"
+msgstr "Otentikasi dua faktor"
+
+#: account/views/password_reset.py
+msgid "We couldn't send a password reset link. Contact "
+msgstr ""
+"Kami tidak dapat mengirimkan tautan pengaturan ulang kata sandi. Kontak"
+
+#: account/views/password_reset.py
+msgid ""
+"We couldn't send a password reset link. Contact your system administrator."
+msgstr ""
+"Kami tidak dapat mengirimkan tautan pengaturan ulang kata sandi. Hubungi "
+"administrator sistem Anda."
+
+#: components/modal/template.html
+msgid "Close modal"
+msgstr "Tutup modal"
+
+#: components/modal/template.html
+#: crisis_room/templates/partials/delete_dashboard_item_modal.html
+#: crisis_room/templates/partials/delete_dashboard_modal.html
+#: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
+#: crisis_room/templates/partials/new_dashboard_item_modal.html
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+#: crisis_room/templates/partials/new_dashboard_modal.html
+#: katalogus/templates/change_clearance_level.html
+#: katalogus/templates/confirmation_clone_settings.html
+#: katalogus/templates/plugin_settings_delete.html
+#: reports/templates/report_overview/modal_partials/enable_disable_schedule_modal.html
+#: reports/templates/report_schedules/delete_recipe_modal.html
+#: rocky/templates/oois/ooi_delete.html
+#: rocky/templates/oois/ooi_mute_finding.html
+#: rocky/templates/organizations/organization_edit.html
+#: rocky/templates/organizations/organization_member_edit.html
+#: rocky/templates/partials/delete_ooi_modal.html
+#: rocky/templates/partials/edit_ooi_clearance_level_modal.html
+#: rocky/templates/partials/mute_findings_modal.html
+#: rocky/templates/two_factor/_wizard_actions.html
+msgid "Cancel"
+msgstr "Membatalkan"
+
+#: crisis_room/forms.py
+msgid "Title on dashboard"
+msgstr "Judul di dasbor"
+
+#: crisis_room/forms.py
+msgid "Dashboard item size"
+msgstr "Ukuran item dasbor"
+
+#: crisis_room/forms.py
+msgid "Full width"
+msgstr "Lebar penuh"
+
+#: crisis_room/forms.py
+msgid "Half width"
+msgstr "Setengah lebar"
+
+#: crisis_room/forms.py
+msgid "An item with that name already exists. Try a different title."
+msgstr "Item dengan nama tersebut sudah ada. Coba judul lain."
+
+#: crisis_room/forms.py
+msgid "An error occurred while adding dashboard item."
+msgstr "Terjadi kesalahan saat menambahkan item dasbor."
+
+#: crisis_room/forms.py
+msgid "Number of rows in list"
+msgstr "Jumlah baris dalam daftar"
+
+#: crisis_room/forms.py
+msgid "List sorting by"
+msgstr "Daftar diurutkan berdasarkan"
+
+#: crisis_room/forms.py
+msgid "Type (A-Z)"
+msgstr "Tipe (A-Z)"
+
+#: crisis_room/forms.py
+msgid "Type (Z-A)"
+msgstr "Tipe (ZA)"
+
+#: crisis_room/forms.py
+msgid "Clearance level (Low-High)"
+msgstr "Tingkat izin (Rendah-Tinggi)"
+
+#: crisis_room/forms.py
+msgid "Clearance level (High-Low)"
+msgstr "Tingkat izin (Tinggi-Rendah)"
+
+#: crisis_room/forms.py
+msgid "Show table columns"
+msgstr "Tampilkan kolom tabel"
+
+#: crisis_room/forms.py
+msgid "Severity (Low-High)"
+msgstr "Tingkat Keparahan (Rendah-Tinggi)"
+
+#: crisis_room/forms.py
+msgid "Severity (High-Low)"
+msgstr "Tingkat Keparahan (Tinggi-Rendah)"
+
+#: crisis_room/forms.py
+msgid "Finding (A-Z)"
+msgstr "Menemukan (A-Z)"
+
+#: crisis_room/forms.py
+msgid "Finding (Z-A)"
+msgstr "Menemukan (Z-A)"
+
+#: crisis_room/models.py
+msgid "Findings Dashboard"
+msgstr "Dasbor Temuan"
+
+#: crisis_room/models.py
+msgid ""
+"Where on the dashboard do you want to show the data? Position {} is the most"
+" top level and the max position is {}."
+msgstr ""
+"Di dasbor mana Anda ingin menampilkan datanya? Posisi {} adalah level paling"
+" atas dan posisi maksimalnya adalah {}."
+
+#: crisis_room/models.py
+msgid "Will be displayed on the general crisis room, for all organizations."
+msgstr "Akan ditampilkan di ruang krisis umum, untuk semua organisasi."
+
+#: crisis_room/models.py
+msgid "Will be displayed on a single organization dashboard"
+msgstr "Akan ditampilkan pada satu dashboard organisasi"
+
+#: crisis_room/models.py
+msgid "Will be displayed on the findings dashboard for all organizations"
+msgstr "Akan ditampilkan di dasbor temuan untuk semua organisasi"
+
+#: crisis_room/models.py
+msgid "Can change position up or down of a dashboard item."
+msgstr "Dapat mengubah posisi atas atau bawah item dashboard."
+
+#: crisis_room/models.py
+msgid "You have to choose between a recipe or a query, but not both."
+msgstr "Anda harus memilih antara resep atau kueri, namun tidak keduanya."
+
+#: crisis_room/models.py
+msgid "You have set a query and not where it is from. Also set the source."
+msgstr ""
+"Anda telah menetapkan kueri dan bukan dari mana asalnya. Atur juga "
+"sumbernya."
+
+#: crisis_room/models.py
+msgid ""
+"DashboardItem must contain at least a 'recipe' or a 'source' with a 'query'."
+msgstr ""
+"DashboardItem harus berisi setidaknya 'resep' atau 'sumber' dengan 'kueri'."
+
+#: crisis_room/models.py
+msgid "Max dashboard items reached."
+msgstr "Item dasbor maksimal telah tercapai."
+
+#: crisis_room/templates/crisis_room.html
+#: crisis_room/templates/organization_crisis_room.html
+#: rocky/templates/header.html
+msgid "Crisis room"
+msgstr "Ruang krisis"
+
+#: crisis_room/templates/crisis_room.html
+msgid "Crisis room overview for all organizations."
+msgstr "Ikhtisar ruang krisis untuk semua organisasi."
+
+#: crisis_room/templates/crisis_room_dashboards.html
+msgid "Dashboards"
+msgstr "Dasbor"
+
+#: crisis_room/templates/crisis_room_dashboards.html
+msgid ""
+"On this page you can see an overview of the dashboards for all "
+"organizations. **More context can be written here**"
+msgstr ""
+"Di halaman ini Anda dapat melihat ikhtisar dasbor untuk semua organisasi. "
+"**Konteks lebih lanjut dapat ditulis di sini**"
+
+#: crisis_room/templates/crisis_room_dashboards.html
+msgid "dashboards"
+msgstr "dasbor"
+
+#: crisis_room/templates/crisis_room_dashboards.html
+msgid "There are no dashboards to display."
+msgstr "Tidak ada dasbor untuk ditampilkan."
+
+#: crisis_room/templates/crisis_room_findings.html
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: reports/report_types/findings_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Findings overview"
+msgstr "Ikhtisar temuan"
+
+#: crisis_room/templates/crisis_room_findings.html
+msgid ""
+"\n"
+"                            This overview shows the total number of findings per\n"
+"                            severity that have been identified for all organizations.\n"
+"                            This data is based on the latest Crisis Room Findings Report\n"
+"                            of each organization.\n"
+"                        "
+msgstr ""
+"\n"
+"Ikhtisar ini menunjukkan jumlah total temuan per\n"
+"                            tingkat keparahan yang telah diidentifikasi untuk semua organisasi.\n"
+"                            Data ini berdasarkan Laporan Temuan Crisis Room terbaru\n"
+"                            dari masing-masing organisasi."
+
+#: crisis_room/templates/crisis_room_findings.html
+msgid "Findings per organization"
+msgstr "Temuan per organisasi"
+
+#: crisis_room/templates/crisis_room_findings.html
+msgid ""
+"This table shows the findings that have been identified for each "
+"organization, sorted by the finding types and grouped by organizations. This"
+" data is based on the latest Crisis Room Findings Report of each "
+"organization."
+msgstr ""
+"Tabel ini menunjukkan temuan-temuan yang telah diidentifikasi untuk setiap "
+"organisasi, diurutkan berdasarkan jenis temuan dan dikelompokkan berdasarkan"
+" organisasi. Data ini berdasarkan Laporan Temuan Crisis Room terkini masing-"
+"masing organisasi."
+
+#: crisis_room/templates/crisis_room_findings.html
+#: reports/report_types/findings_report/report.html
+msgid ""
+"No findings have been identified yet. As soon as they have been identified, "
+"they will be shown on this page."
+msgstr ""
+"Belum ada temuan yang teridentifikasi. Segera setelah mereka diidentifikasi,"
+" mereka akan ditampilkan di halaman ini."
+
+#: crisis_room/templates/crisis_room_findings.html
+msgid ""
+"There are no organizations yet. After creating an organization, the "
+"identified findings will be shown here."
+msgstr ""
+"Belum ada organisasi. Setelah membuat organisasi, temuan yang "
+"teridentifikasi akan ditampilkan di sini."
+
+#: crisis_room/templates/crisis_room_header.html
+#: crisis_room/templates/organization_crisis_room_header.html
+msgid "Crisis room navigation"
+msgstr "Navigasi ruang krisis"
+
+#: crisis_room/templates/crisis_room_header.html
+#: crisis_room/templates/partials/new_dashboard_item_action_button.html
+#: reports/report_types/aggregate_organisation_report/findings.html
+#: reports/report_types/aggregate_organisation_report/report.html
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/findings_report/report.html
+#: reports/report_types/mail_report/report.html
+#: reports/report_types/multi_organization_report/report.html
+#: reports/report_types/name_server_report/report.html
+#: reports/report_types/tls_report/report.html
+#: reports/report_types/vulnerability_report/report.html
+#: reports/report_types/web_system_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/partials/report_sidemenu.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
+#: rocky/templates/oois/ooi_detail_findings_list.html
+#: rocky/templates/oois/ooi_detail_findings_overview.html
+#: rocky/templates/oois/ooi_page_tabs.html
+#: rocky/templates/partials/ooi_report_findings_block.html
+#: rocky/templates/partials/ooi_report_findings_block_table.html
+#: rocky/views/finding_list.py rocky/views/finding_type_add.py
+#: rocky/views/ooi_view.py
+msgid "Findings"
+msgstr "Temuan"
+
+#: crisis_room/templates/organization_crisis_room.html
+msgid "Options for dashboard"
+msgstr "Pilihan untuk dasbor"
+
+#: crisis_room/templates/organization_crisis_room.html
+msgid "Show all descriptions"
+msgstr "Tampilkan semua deskripsi"
+
+#: crisis_room/templates/organization_crisis_room.html
+msgid "Hide all descriptions"
+msgstr "Sembunyikan semua deskripsi"
+
+#: crisis_room/templates/organization_crisis_room.html
+#: crisis_room/templates/partials/delete_dashboard_modal.html
+msgid "Delete dashboard"
+msgstr "Hapus dasbor"
+
+#: crisis_room/templates/organization_crisis_room.html
+msgid ""
+"There are no dashboards yet. Click on \"Add dashboard\" to create a new "
+"dashboard."
+msgstr "Belum ada dashboard. Klik \"Tambahkan dasbor\" untuk membuat dasbor baru."
+
+#: crisis_room/templates/organization_crisis_room_dashboard_items.html
+#: katalogus/templates/partials/objects_to_scan.html
+#: rocky/templates/forms/widgets/checkbox_group_table.html
+#: rocky/templates/oois/ooi_list.html
+msgid "Object list"
+msgstr "Daftar objek"
+
+#: crisis_room/templates/organization_crisis_room_dashboard_items.html
+msgid "Finding list"
+msgstr "Daftar temuan"
+
+#: crisis_room/templates/organization_crisis_room_dashboard_items.html
+#: crisis_room/templates/partials/new_dashboard_item_action_button.html
+msgid "Report section"
+msgstr "Bagian laporan"
+
+#: crisis_room/templates/organization_crisis_room_dashboard_items.html
+msgid "There are no dashboard items added yet."
+msgstr "Belum ada item dasbor yang ditambahkan."
+
+#: crisis_room/templates/organization_crisis_room_dashboard_items.html
+msgid ""
+"You can add dashboard items via the filters on the objects and findings page"
+" or you can add a report section."
+msgstr ""
+"Anda dapat menambahkan item dasbor melalui filter pada halaman objek dan "
+"temuan atau Anda dapat menambahkan bagian laporan."
+
+#: crisis_room/templates/organization_crisis_room_dashboard_items.html
+msgid "Add objects"
+msgstr "Tambahkan objek"
+
+#: crisis_room/templates/organization_crisis_room_dashboard_items.html
+msgid "Add findings"
+msgstr "Tambahkan temuan"
+
+#: crisis_room/templates/organization_crisis_room_dashboard_items.html
+msgid "Add report section"
+msgstr "Tambahkan bagian laporan"
+
+#: crisis_room/templates/organization_crisis_room_header.html
+#: crisis_room/templates/partials/new_dashboard_modal.html
+msgid "Add dashboard"
+msgstr "Tambahkan dasbor"
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+msgid "Findings per organization overview"
+msgstr "Temuan per ikhtisar organisasi"
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/partials/report_severity_totals_table.html
+#: tools/forms/finding_type.py
+msgid "Finding types"
+msgstr "Menemukan tipe"
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: reports/report_types/dns_report/report.html
+#: reports/report_types/vulnerability_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/partials/report_severity_totals_table.html
+#: rocky/templates/oois/ooi_detail_findings_overview.html
+#: rocky/templates/partials/ooi_report_findings_block_table.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid "Occurrences"
+msgstr "Kejadian"
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+msgid "Highest risk level"
+msgstr "Tingkat risiko tertinggi"
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+msgid "Critical finding types"
+msgstr "Jenis temuan kritis"
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: reports/report_types/dns_report/report.html
+#: reports/report_types/vulnerability_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/summary/selected_plugins.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/partials/ooi_report_findings_block_table.html
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
+#: rocky/templates/tasks/ooi_detail_task_list.html
+#: rocky/templates/tasks/plugin_detail_task_list.html
+msgid "Details"
+msgstr "Detail"
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: katalogus/templates/plugin_container_image.html
+#: reports/report_types/dns_report/report.html
+#: reports/report_types/vulnerability_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+#: reports/templates/summary/selected_plugins.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
+#: rocky/templates/tasks/ooi_detail_task_list.html
+#: rocky/templates/tasks/plugin_detail_task_list.html
+msgid "Close details"
+msgstr "Tutup detailnya"
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: katalogus/templates/plugin_container_image.html
+#: reports/report_types/dns_report/report.html
+#: reports/report_types/vulnerability_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+#: reports/templates/summary/selected_plugins.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
+#: rocky/templates/tasks/ooi_detail_task_list.html
+#: rocky/templates/tasks/plugin_detail_task_list.html
+msgid "Open details"
+msgstr "Buka detailnya"
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+msgid ""
+"This overview shows the total number of findings per severity that have been"
+" identified for this organization."
+msgstr ""
+"Ikhtisar ini menunjukkan jumlah total temuan per tingkat keparahan yang "
+"telah diidentifikasi untuk organisasi ini."
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: reports/report_types/findings_report/report.html
+msgid "Critical and high findings"
+msgstr "Temuan kritis dan tinggi"
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: reports/report_types/findings_report/report.html
+msgid ""
+"This table shows the top 25 critical and high findings that have been "
+"identified for this organization, grouped by finding types. A table with all"
+" the identified findings can be found in the Findings Report."
+msgstr ""
+"Tabel ini menunjukkan 25 temuan penting dan penting teratas yang telah "
+"diidentifikasi untuk organisasi ini, dikelompokkan berdasarkan jenis temuan."
+" Tabel berisi semua temuan yang teridentifikasi dapat ditemukan di Laporan "
+"Temuan."
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+msgid "No findings have been identified. Check report for more details."
+msgstr ""
+"Tidak ada temuan yang teridentifikasi. Periksa laporan untuk lebih jelasnya."
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+msgid "View findings report"
+msgstr "Lihat laporan temuan"
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Edit report recipe"
+msgstr "Edit resep laporan"
+
+#: crisis_room/templates/partials/dashboard_finding_list.html
+#, python-format
+msgid "Showing %(length)s findings"
+msgstr "Menampilkan %(length)s temuan"
+
+#: crisis_room/templates/partials/dashboard_finding_list.html
+msgid "Go to findings"
+msgstr "Buka temuan"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+msgid "Findings table "
+msgstr "Tabel temuan"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: crisis_room/templates/partials/dashboard_ooi_list_table.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/oois/ooi_list.html
+msgid "column headers with buttons are sortable"
+msgstr "tajuk kolom dengan tombol dapat diurutkan"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+#, python-format
+msgid "Show details for %(finding)s"
+msgstr "Tampilkan detail untuk %(finding)s"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/oois/ooi_page_tabs.html
+#: rocky/templates/partials/elements/ooi_tree_condensed_table.html
+#: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
+#: rocky/views/mixins.py
+msgid "Tree"
+msgstr "Pohon"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/oois/ooi_page_tabs.html
+#: rocky/templates/partials/elements/ooi_tree_condensed_table.html
+#: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
+#: rocky/views/mixins.py
+msgid "Graph"
+msgstr "Grafik"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: reports/report_types/dns_report/report.html
+#: rocky/templates/oois/ooi_detail_findings_list.html
+#: rocky/templates/oois/ooi_detail_findings_overview.html
+#: rocky/views/mixins.py
+msgid "Severity"
+msgstr "Kerasnya"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: reports/report_types/dns_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+#: rocky/views/mixins.py
+msgid "Finding"
+msgstr "Temuan"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/partials/ooi_report_findings_block_table.html
+msgid "Finding type"
+msgstr "Tipe penemuan"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+#, python-format
+msgid "Show details for %(finding_type)s"
+msgstr "Tampilkan detail untuk %(finding_type)s"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+msgid "OOI type"
+msgstr "OOI ketik"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+#, python-format
+msgid "Show %(ooi_type)s objects"
+msgstr "Tampilkan objek %(ooi_type)s"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/views/mixins.py
+msgid "Location"
+msgstr "Lokasi"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#, python-format
+msgid "Show details for %(ooi)s"
+msgstr "Tampilkan detail untuk %(ooi)s"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+msgid "Risk score"
+msgstr "Skor risiko"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: katalogus/templates/normalizer_detail.html
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: reports/report_types/dns_report/report.html
+#: reports/report_types/vulnerability_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/summary/report_asset_overview.html tools/forms/boefje.py
+#: tools/forms/finding_type.py rocky/templates/findings/finding_list.html
+#: rocky/templates/oois/ooi_detail.html
+#: rocky/templates/oois/ooi_detail_findings_list.html
+#: rocky/templates/scan.html
+msgid "Description"
+msgstr "Keterangan"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: reports/report_types/multi_organization_report/recommendations.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/partials/report_severity_totals_table.html
+#: rocky/templates/findings/finding_list.html
+msgid "Recommendation"
+msgstr "Rekomendasi"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: reports/report_types/vulnerability_report/report.py
+#: reports/templates/partials/report_findings_table.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/oois/ooi_detail_origins_inference.html
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid "Source"
+msgstr "Sumber"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: reports/templates/partials/report_findings_table.html
+#: rocky/templates/findings/finding_list.html
+msgid "Impact"
+msgstr "Dampak"
+
+#: crisis_room/templates/partials/dashboard_item_action_button.html
+msgid "Options for dashboard items"
+msgstr "Opsi untuk item dasbor"
+
+#: crisis_room/templates/partials/dashboard_item_action_button.html
+msgid "Show description"
+msgstr "Tampilkan deskripsi"
+
+#: crisis_room/templates/partials/dashboard_item_action_button.html
+msgid "Hide description"
+msgstr "Sembunyikan deskripsi"
+
+#: crisis_room/templates/partials/dashboard_item_action_button.html
+msgid "Position up"
+msgstr "Posisikan"
+
+#: crisis_room/templates/partials/dashboard_item_action_button.html
+msgid "Position down"
+msgstr "Posisikan ke bawah"
+
+#: crisis_room/templates/partials/dashboard_item_action_button.html
+msgid "Rerun report"
+msgstr "Jalankan kembali laporan"
+
+#: crisis_room/templates/partials/dashboard_item_action_button.html
+#: crisis_room/templates/partials/delete_dashboard_item_modal.html
+msgid "Delete item"
+msgstr "Hapus barang"
+
+#: crisis_room/templates/partials/dashboard_ooi_list.html
+#, python-format
+msgid "Showing %(length)s objects"
+msgstr "Menampilkan objek %(length)s"
+
+#: crisis_room/templates/partials/dashboard_ooi_list.html
+msgid "Go to objects"
+msgstr "Pergi ke objek"
+
+#: crisis_room/templates/partials/dashboard_ooi_list_table.html
+#: rocky/templates/oois/ooi_list.html
+msgid "Objects "
+msgstr "Objek"
+
+#: crisis_room/templates/partials/delete_dashboard_item_modal.html
+#, python-format
+msgid "Are you sure you want to delete '%(name)s' from this dashboard?"
+msgstr "Apakah Anda yakin ingin menghapus '%(name)s' dari dasbor ini?"
+
+#: crisis_room/templates/partials/delete_dashboard_item_modal.html
+#: crisis_room/templates/partials/delete_dashboard_modal.html
+#: katalogus/templates/plugin_settings_delete.html
+#: katalogus/views/plugin_settings_delete.py
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+#: rocky/templates/admin/delete_confirmation.html
+#: rocky/templates/oois/ooi_list.html
+#: rocky/templates/partials/delete_ooi_modal.html rocky/views/ooi_delete.py
+msgid "Delete"
+msgstr "Menghapus"
+
+#: crisis_room/templates/partials/delete_dashboard_modal.html
+#, python-format
+msgid ""
+"Are you sure you want to delete dashboard '%(dashboard)s'? All the items on "
+"the dashboard will be deleted as well."
+msgstr ""
+"Apakah Anda yakin ingin menghapus dasbor '%(dashboard)s'? Semua item di "
+"dasbor juga akan dihapus."
+
+#: crisis_room/templates/partials/new_dashboard_item_action_button.html
+msgid "Actions for adding dashboard items"
+msgstr "Tindakan untuk menambahkan item dasbor"
+
+#: crisis_room/templates/partials/new_dashboard_item_action_button.html
+msgid "Add item"
+msgstr "Tambahkan barang"
+
+#: crisis_room/templates/partials/new_dashboard_item_action_button.html
+#: crisis_room/templates/partials/report_dashboard_item_filter.html
+#: reports/templates/partials/report_ooi_list.html
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/summary/ooi_selection.html tools/forms/ooi.py
+#: tools/view_helpers.py rocky/templates/admin/delete_confirmation.html
+#: rocky/templates/admin/delete_selected_confirmation.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
+#: rocky/views/ooi_add.py rocky/views/ooi_list.py rocky/views/ooi_view.py
+#: rocky/views/upload_csv.py rocky/views/upload_raw.py
+msgid "Objects"
+msgstr "Objek"
+
+#: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
+msgid "Add dashboard item"
+msgstr "Tambahkan item dasbor"
+
+#: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
+msgid ""
+"To  add a <strong>report section</strong>, go to the history page and open a"
+" report. Then go to the section that you want to add to your dashboard and "
+"press the options button next to the section name to create a dashboard "
+"item."
+msgstr ""
+"Untuk menambahkan <strong>bagian laporan</strong>, buka halaman riwayat dan "
+"buka laporan. Lalu pergi ke bagian yang ingin Anda tambahkan ke dasbor Anda "
+"dan tekan tombol opsi di sebelah nama bagian untuk membuat item dasbor."
+
+#: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
+msgid "Go to report history"
+msgstr "Buka riwayat laporan"
+
+#: crisis_room/templates/partials/new_dashboard_item_modal.html
+#, python-format
+msgid ""
+"\n"
+"    Add %(item_type)s to dashboard\n"
+msgstr ""
+"\n"
+"Tambahkan %(item_type)s ke dasbor\n"
+
+#: crisis_room/templates/partials/new_dashboard_item_modal.html
+#, python-format
+msgid ""
+"Add these %(item_type)s with the selected filters to the dashboard of your "
+"choice."
+msgstr ""
+"Tambahkan %(item_type)s ini dengan filter yang dipilih ke dasbor pilihan "
+"Anda."
+
+#: crisis_room/templates/partials/new_dashboard_item_modal.html
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+#: katalogus/templates/partials/no_enabling_permission_message.html
+#: katalogus/templates/plugin_container_image.html
+#: rocky/templates/partials/edit_ooi_clearance_level_modal.html
+#: rocky/templates/partials/form/field_input_help_text.html
+#: rocky/templates/partials/notifications_block.html
+#: rocky/templates/two_factor/core/login.html
+msgid "explanation"
+msgstr "penjelasan"
+
+#: crisis_room/templates/partials/new_dashboard_item_modal.html
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+msgid "You do not have a custom dashboard yet"
+msgstr "Anda belum memiliki dasbor khusus"
+
+#: crisis_room/templates/partials/new_dashboard_item_modal.html
+#, python-format
+msgid ""
+"In order to add these %(item_type)s to a dashboard, you first need to create"
+" a dashboard. Please add a dashboard in the crisis room of your "
+"organization."
+msgstr ""
+"Untuk menambahkan %(item_type)s ini ke dasbor, Anda harus membuat dasbor "
+"terlebih dahulu. Silakan tambahkan dasbor di ruang krisis organisasi Anda."
+
+#: crisis_room/templates/partials/new_dashboard_item_modal.html
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/oois/ooi_list.html
+msgid "Add to dashboard"
+msgstr "Tambahkan ke dasbor"
+
+#: crisis_room/templates/partials/new_dashboard_item_modal.html
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+msgid "Go to crisis room"
+msgstr "Pergi ke ruang krisis"
+
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+msgid "Add report section to dashboard"
+msgstr "Tambahkan bagian laporan ke dasbor"
+
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+msgid ""
+"In order to add this report section to a dashboard, you first need to create"
+" a dashboard. Please create a dashboard in the crisis room of your "
+"organization."
+msgstr ""
+"Untuk menambahkan bagian laporan ini ke dasbor, Anda harus membuat dasbor "
+"terlebih dahulu. Silakan buat dashboard di ruang krisis organisasi Anda."
+
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+msgid "Report must be scheduled for dashboard items"
+msgstr "Laporan harus dijadwalkan untuk item dasbor"
+
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+msgid ""
+"In order for dashboard information to be updated on a regular basis instead "
+"of showing static data, the report should be scheduled. The frequency of the"
+" schedules recurrence determines how fresh the data on the dashboard will "
+"be."
+msgstr ""
+"Agar informasi dasbor diperbarui secara berkala alih-alih menampilkan data "
+"statis, laporan harus dijadwalkan. Frekuensi pengulangan jadwal menentukan "
+"seberapa segar data di dasbor."
+
+#: crisis_room/templates/partials/report_dashboard_item_filter.html
+msgid "Applied filters"
+msgstr "Filter yang diterapkan"
+
+#: crisis_room/templates/partials/report_dashboard_item_filter.html
+msgid "Object types"
+msgstr "Jenis objek"
+
+#: crisis_room/templates/partials/report_dashboard_item_filter.html
+#: katalogus/templates/change_clearance_level.html onboarding/forms.py
+#: reports/templates/partials/report_ooi_list.html
+#: reports/templates/summary/ooi_selection.html tools/forms/boefje.py
+#: tools/forms/ooi.py rocky/templates/oois/ooi_page_tabs.html
+#: rocky/templates/partials/explanations.html
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+#: rocky/views/mixins.py
+msgid "Clearance level"
+msgstr "Tingkat izin"
+
+#: crisis_room/templates/partials/report_dashboard_item_filter.html
+#: reports/templates/partials/report_ooi_list.html
+#: reports/templates/summary/ooi_selection.html tools/forms/ooi.py
+#: rocky/views/mixins.py
+msgid "Clearance type"
+msgstr "Jenis izin"
+
+#: crisis_room/templates/partials/report_dashboard_item_filter.html
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/modal_partials/rerun_modal.html
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Input objects"
+msgstr "Objek masukan"
+
+#: crisis_room/templates/partials/report_dashboard_item_filter.html
+msgid "Show all objects"
+msgstr "Tampilkan semua objek"
+
+#: crisis_room/templates/partials/report_dashboard_item_filter.html
+#: reports/templates/partials/report_types_selection.html
+msgid "No filters applied"
+msgstr "Tidak ada filter yang diterapkan"
+
+#: crisis_room/templates/partials/report_section_action_button.html
+msgid "Add section to dashboard"
+msgstr "Tambahkan bagian ke dasbor"
+
+#: katalogus/client.py
+msgid ""
+"The KATalogus has an unexpected error. Check the logs for further details."
+msgstr ""
+"KATalogus mengalami kesalahan yang tidak terduga. Periksa log untuk rincian "
+"lebih lanjut."
+
+#: katalogus/client.py
+#, python-format
+msgid "An HTTP %d error occurred. Check logs for more info."
+msgstr "Terjadi kesalahan HTTP %d. Periksa log untuk info lebih lanjut."
+
+#: katalogus/client.py
+msgid "An HTTP error occurred. Check logs for more info."
+msgstr "Terjadi kesalahan HTTP. Periksa log untuk info lebih lanjut."
+
+#: katalogus/client.py
+msgid "Boefje with this name already exists."
+msgstr "Boefje dengan nama ini sudah ada."
+
+#: katalogus/client.py
+msgid "Boefje with this ID already exists."
+msgstr "Boefje dengan ID ini sudah ada."
+
+#: katalogus/client.py
+msgid "Access to resource not allowed"
+msgstr "Akses ke sumber daya tidak diperbolehkan"
+
+#: katalogus/client.py
+msgid "User is not allowed to see plugin settings"
+msgstr "Pengguna tidak diperbolehkan melihat pengaturan plugin"
+
+#: katalogus/client.py
+msgid "User is not allowed to set plugin settings"
+msgstr "Pengguna tidak diperbolehkan mengatur pengaturan plugin"
+
+#: katalogus/client.py
+msgid "User is not allowed to delete plugin settings"
+msgstr "Pengguna tidak diperbolehkan menghapus pengaturan plugin"
+
+#: katalogus/client.py
+msgid "User is not allowed to view plugin settings"
+msgstr "Pengguna tidak diperbolehkan melihat pengaturan plugin"
+
+#: katalogus/client.py
+msgid "User is not allowed to access the other organization"
+msgstr "Pengguna tidak diperbolehkan mengakses organisasi lain"
+
+#: katalogus/client.py
+msgid "User is not allowed to enable plugins"
+msgstr "Pengguna tidak diperbolehkan mengaktifkan plugin"
+
+#: katalogus/client.py
+msgid "User is not allowed to disable plugins"
+msgstr "Pengguna tidak diperbolehkan menonaktifkan plugin"
+
+#: katalogus/client.py
+msgid "User is not allowed to create plugins"
+msgstr "Pengguna tidak diperbolehkan membuat plugin"
+
+#: katalogus/client.py
+msgid "User is not allowed to edit plugins"
+msgstr "Pengguna tidak diperbolehkan mengedit plugin"
+
+#: katalogus/forms/katalogus_filter.py
+msgid "Show all"
+msgstr "Tunjukkan semuanya"
+
+#: katalogus/forms/katalogus_filter.py
+#: katalogus/templates/partials/enable_disable_plugin.html
+#: katalogus/templates/partials/plugin_tile_modal.html
+#: katalogus/templates/plugin_container_image.html
+#: reports/report_types/dns_report/report.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Enabled"
+msgstr "Diaktifkan"
+
+#: katalogus/forms/katalogus_filter.py
+#: katalogus/templates/partials/enable_disable_plugin.html
+#: katalogus/templates/partials/plugin_tile_modal.html
+#: katalogus/templates/plugin_container_image.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+#: reports/templates/summary/selected_plugins.html
+msgid "Disabled"
+msgstr "Dengan disabilitas"
+
+#: katalogus/forms/katalogus_filter.py
+msgid "Enabled-Disabled"
+msgstr "Diaktifkan-Dinonaktifkan"
+
+#: katalogus/forms/katalogus_filter.py
+msgid "Disabled-Enabled"
+msgstr "Dinonaktifkan-Diaktifkan"
+
+#: katalogus/forms/katalogus_filter.py
+msgid "Filter options"
+msgstr "Opsi penyaring"
+
+#: katalogus/forms/katalogus_filter.py
+msgid "Sorting options"
+msgstr "Opsi penyortiran"
+
+#: katalogus/forms/plugin_settings.py
+msgid "This field is required."
+msgstr "Bidang ini wajib diisi."
+
+#: katalogus/templates/about_plugins.html
+#: katalogus/templates/partials/plugins_navigation.html
+msgid "About plugins"
+msgstr "Tentang plugin"
+
+#: katalogus/templates/about_plugins.html katalogus/templates/katalogus.html
+msgid ""
+"Plugins gather data, objects and insight. Each plugin has its own focus area"
+" and strengths and may be able to work with other plugins to gain even more "
+"insights."
+msgstr ""
+"Plugin mengumpulkan data, objek, dan wawasan. Setiap plugin memiliki area "
+"fokus dan kelebihannya masing-masing dan mungkin dapat bekerja sama dengan "
+"plugin lain untuk mendapatkan lebih banyak wawasan."
+
+#: katalogus/templates/about_plugins.html katalogus/templates/boefjes.html
+msgid ""
+"Boefjes are used to scan for objects. They detect vulnerabilities, security "
+"issues, and give insight. Each boefje is a separate scan that can run on a "
+"selection of objects."
+msgstr ""
+"Boefjes digunakan untuk memindai objek. Mereka mendeteksi kerentanan, "
+"masalah keamanan, dan memberikan wawasan. Setiap boefje adalah pemindaian "
+"terpisah yang dapat dijalankan pada objek tertentu."
+
+#: katalogus/templates/about_plugins.html katalogus/templates/normalizers.html
+msgid ""
+"Normalizers analyze the information and turn it into objects for the data "
+"model in Octopoes."
+msgstr ""
+"Normalizers menganalisis informasi dan mengubahnya menjadi objek untuk model"
+" data di Octopoes."
+
+#: katalogus/templates/about_plugins.html
+msgid ""
+"Bits are business rules that look for insight within the current dataset and"
+" search for specific insight and draw conclusions."
+msgstr ""
+"Bit adalah aturan bisnis yang mencari wawasan dalam kumpulan data saat ini "
+"dan mencari wawasan spesifik serta menarik kesimpulan."
+
+#: katalogus/templates/boefje_detail.html
+#: katalogus/templates/partials/plugin_tile_modal.html
+#: katalogus/templates/plugin_container_image.html
+msgid "Scan level"
+msgstr "Tingkat pemindaian"
+
+#: katalogus/templates/boefje_detail.html
+#: katalogus/templates/normalizer_detail.html
+msgid "Consumes"
+msgstr "Mengkonsumsi"
+
+#: katalogus/templates/boefje_detail.html
+#, python-format
+msgid "%(plugin_name)s is able to scan the following object types:"
+msgstr "%(plugin_name)s mampu memindai jenis objek berikut:"
+
+#: katalogus/templates/boefje_detail.html
+#: katalogus/templates/normalizer_detail.html
+#, python-format
+msgid "%(plugin_name)s does not need any input objects."
+msgstr "%(plugin_name)s tidak memerlukan objek input apa pun."
+
+#: katalogus/templates/boefje_detail.html
+#: katalogus/templates/normalizer_detail.html
+#: katalogus/templates/partials/plugin_tile_modal.html
+msgid "Produces"
+msgstr "Menghasilkan"
+
+#: katalogus/templates/boefje_detail.html
+#: katalogus/templates/normalizer_detail.html
+#: katalogus/templates/partials/plugin_tile_modal.html
+#, python-format
+msgid "%(plugin_name)s can produce the following output:"
+msgstr "%(plugin_name)s dapat menghasilkan keluaran sebagai berikut:"
+
+#: katalogus/templates/boefje_detail.html
+#, python-format
+msgid "%(plugin_name)s doesn't produce any output mime types."
+msgstr "%(plugin_name)s tidak menghasilkan tipe pantomim keluaran apa pun."
+
+#: katalogus/templates/boefje_setup.html
+msgid "Boefje variant setup"
+msgstr "Boefje penyiapan varian"
+
+#: katalogus/templates/boefje_setup.html
+#: rocky/templates/organizations/organization_member_list.html
+#: rocky/templates/organizations/organization_settings.html
+#: rocky/views/ooi_edit.py rocky/views/organization_edit.py
+msgid "Edit"
+msgstr "Sunting"
+
+#: katalogus/templates/boefje_setup.html
+msgid "Boefje setup"
+msgstr "Boefje penyiapan"
+
+#: katalogus/templates/boefje_setup.html
+msgid ""
+"You can create a new Boefje. If you want more information on this, you can "
+"check out the <a "
+"href=\"https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html\">documentation</a>."
+msgstr ""
+"Anda dapat membuat Boefje baru. Jika Anda ingin informasi lebih lanjut "
+"mengenai hal ini, Anda dapat melihat <a "
+"href=\"https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html\">dokumentasi</a>."
+
+#: katalogus/templates/boefje_setup.html
+#: rocky/templates/partials/edit_ooi_clearance_level_modal.html
+msgid "Save changes"
+msgstr "Simpan perubahan"
+
+#: katalogus/templates/boefje_setup.html
+msgid "Discard changes"
+msgstr "Buang perubahan"
+
+#: katalogus/templates/boefje_setup.html
+msgid "Create variant"
+msgstr "Buat varian"
+
+#: katalogus/templates/boefje_setup.html
+msgid "Discard variant"
+msgstr "Buang varian"
+
+#: katalogus/templates/boefje_setup.html
+msgid "Create new Boefje"
+msgstr "Buat Boefje baru"
+
+#: katalogus/templates/boefje_setup.html
+msgid "Discard new Boefje"
+msgstr "Buang Boefje baru"
+
+#: katalogus/templates/boefjes.html
+msgid "Add Boefje"
+msgstr "Tambahkan Boefje"
+
+#: katalogus/templates/boefjes.html katalogus/templates/katalogus.html
+#: katalogus/templates/normalizers.html
+msgid "available"
+msgstr "tersedia"
+
+#: katalogus/templates/change_clearance_level.html
+#: katalogus/templates/partials/objects_to_scan.html
+#: reports/templates/partials/report_setup_scan.html
+msgid "scan level warning"
+msgstr "peringatan tingkat pemindaian"
+
+#: katalogus/templates/change_clearance_level.html
+#, python-format
+msgid ""
+"%(plugin_name)s will only scan objects with a corresponding clearance level "
+"of <strong>L%(scan_level)s</strong> or higher."
+msgstr ""
+"%(plugin_name)s hanya akan memindai objek dengan tingkat izin yang sesuai "
+"<strong>L%(scan_level)s</strong> atau lebih tinggi."
+
+#: katalogus/templates/change_clearance_level.html
+msgid "Scan object"
+msgstr "Pindai objek"
+
+#: katalogus/templates/change_clearance_level.html
+#, python-format
+msgid ""
+"The following objects are not yet cleared for level %(scan_level)s, please "
+"be advised that by continuing you will declare a level %(scan_level)s on "
+"these objects."
+msgstr ""
+"Objek berikut belum dibersihkan untuk level %(scan_level)s, harap "
+"diperhatikan bahwa dengan melanjutkan Anda akan mendeklarasikan level "
+"%(scan_level)s pada objek ini."
+
+#: katalogus/templates/change_clearance_level.html
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: reports/templates/summary/report_asset_overview.html
+msgid "Selected objects"
+msgstr "Objek yang dipilih"
+
+#: katalogus/templates/change_clearance_level.html
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/summary/ooi_selection.html rocky/views/mixins.py
+msgid "Object"
+msgstr "Obyek"
+
+#: katalogus/templates/change_clearance_level.html
+msgid "Are you sure you want to scan anyways?"
+msgstr "Apakah Anda yakin ingin tetap memindai?"
+
+#: katalogus/templates/change_clearance_level.html
+#: rocky/templates/oois/ooi_detail.html
+msgid "Scan"
+msgstr "Pindai"
+
+#: katalogus/templates/clone_settings.html
+#: katalogus/templates/confirmation_clone_settings.html
+msgid "Clone settings"
+msgstr "Pengaturan klon"
+
+#: katalogus/templates/clone_settings.html
+#, python-format
+msgid ""
+"Use the form below to clone the settings from "
+"<strong>%(current_organization)s</strong> to the selected organization. This"
+" includes both the KAT-alogus settings as well as enabled and disabled "
+"plugins."
+msgstr ""
+"Gunakan formulir di bawah ini untuk mengkloning pengaturan dari "
+"<strong>%(current_organization)s</strong> ke organisasi yang dipilih. Ini "
+"mencakup pengaturan KAT-alogus serta plugin yang diaktifkan dan "
+"dinonaktifkan."
+
+#: katalogus/templates/confirmation_clone_settings.html
+msgid "Clone"
+msgstr "Klon"
+
+#: katalogus/templates/katalogus.html
+msgid "All plugins"
+msgstr "Semua plugin"
+
+#: katalogus/templates/katalogus_settings.html
+msgid "KAT-alogus settings"
+msgstr "KAT-pengaturan alogus"
+
+#: katalogus/templates/katalogus_settings.html
+msgid ""
+"There are currently no settings defined. Add settings at the plugin detail "
+"page."
+msgstr ""
+"Saat ini belum ada pengaturan yang ditentukan. Tambahkan pengaturan di "
+"halaman detail plugin."
+
+#: katalogus/templates/katalogus_settings.html
+#: rocky/templates/two_factor/core/otp_required.html
+msgid "Go back"
+msgstr "Kembali"
+
+#: katalogus/templates/katalogus_settings.html
+msgid "This is an overview of the latest settings of all plugins."
+msgstr "Ini adalah ikhtisar pengaturan terbaru semua plugin."
+
+#: katalogus/templates/katalogus_settings.html
+msgid "Latest plugin settings"
+msgstr "Pengaturan plugin terbaru"
+
+#: katalogus/templates/katalogus_settings.html
+#: rocky/templates/tasks/ooi_detail_task_list.html
+msgid "Plugin"
+msgstr "Pengaya"
+
+#: katalogus/templates/katalogus_settings.html
+#: katalogus/templates/plugin_settings_list.html
+#: rocky/templates/oois/ooi_delete.html
+msgid "Value"
+msgstr "Nilai"
+
+#: katalogus/templates/normalizer_detail.html
+#, python-format
+msgid "%(plugin_name)s is able to process the following mime types:"
+msgstr "%(plugin_name)s mampu memproses tipe mime berikut:"
+
+#: katalogus/templates/partials/boefje_tile.html
+msgid "This object type is required"
+msgstr "Jenis objek ini diperlukan"
+
+#: katalogus/templates/partials/boefje_tile.html
+msgid "Scan level:"
+msgstr "Tingkat pemindaian:"
+
+#: katalogus/templates/partials/boefje_tile.html
+msgid "Publisher:"
+msgstr "Penerbit:"
+
+#: katalogus/templates/partials/boefje_tile.html
+#: katalogus/templates/partials/plugin_tile.html
+#: katalogus/templates/partials/plugin_tile_modal.html
+msgid "See details"
+msgstr "Lihat detailnya"
+
+#: katalogus/templates/partials/enable_disable_plugin.html
+msgid "Enable"
+msgstr "Memungkinkan"
+
+#: katalogus/templates/partials/enable_disable_plugin.html
+#: rocky/templates/two_factor/profile/disable.html
+msgid "Disable"
+msgstr "Cacat"
+
+#: katalogus/templates/partials/katalogus_filter.html
+#: rocky/templates/findings/findings_filter.html
+#: rocky/templates/partials/ooi_list_filters.html
+#: rocky/templates/partials/organization_member_list_filters.html
+#: rocky/templates/tasks/partials/task_filter.html
+msgid "Hide filters"
+msgstr "Sembunyikan filter"
+
+#: katalogus/templates/partials/katalogus_filter.html
+#: rocky/templates/findings/findings_filter.html
+#: rocky/templates/partials/ooi_list_filters.html
+#: rocky/templates/partials/organization_member_list_filters.html
+#: rocky/templates/tasks/partials/task_filter.html
+msgid "Show filters"
+msgstr "Tampilkan filter"
+
+#: katalogus/templates/partials/katalogus_filter.html
+#: rocky/templates/findings/findings_filter.html
+#: rocky/templates/partials/ooi_list_filters.html
+#: rocky/templates/partials/organization_member_list_filters.html
+#: rocky/templates/tasks/partials/task_filter.html
+msgid "applied"
+msgstr "terapan"
+
+#: katalogus/templates/partials/katalogus_filter.html
+msgid "Filter plugins"
+msgstr "Filter plugin"
+
+#: katalogus/templates/partials/katalogus_filter.html
+msgid "Clear filter"
+msgstr "Hapus penyaring"
+
+#: katalogus/templates/partials/katalogus_header.html
+#: katalogus/views/change_clearance_level.py katalogus/views/katalogus.py
+#: katalogus/views/katalogus_settings.py katalogus/views/plugin_detail.py
+#: katalogus/views/plugin_settings_add.py
+#: katalogus/views/plugin_settings_delete.py
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
+msgid "KAT-alogus"
+msgstr "KAT-alogus"
+
+#: katalogus/templates/partials/katalogus_header.html
+msgid "An overview of all available plugins."
+msgstr "Ikhtisar semua plugin yang tersedia."
+
+#: katalogus/templates/partials/katalogus_header.html
+#: katalogus/templates/plugin_settings_list.html
+#: katalogus/views/katalogus_settings.py tools/view_helpers.py
+#: rocky/templates/header.html
+#: rocky/templates/organizations/organization_list.html
+#: rocky/templates/organizations/organization_settings.html
+msgid "Settings"
+msgstr "Pengaturan"
+
+#: katalogus/templates/partials/katalogus_toolbar.html
+msgid "Gridview"
+msgstr "tampilan grid"
+
+#: katalogus/templates/partials/katalogus_toolbar.html
+msgid "Tableview"
+msgstr "Tampilan tabel"
+
+#: katalogus/templates/partials/modal_report_types.html
+msgid "Required for"
+msgstr "Diperlukan untuk"
+
+#: katalogus/templates/partials/modal_report_types.html
+msgid "report types"
+msgstr "jenis laporan"
+
+#: katalogus/templates/partials/modal_report_types.html
+msgid "Report types for "
+msgstr "Jenis laporan untuk"
+
+#: katalogus/templates/partials/no_enabling_permission_message.html
+msgid "No permission to enable/disable plugins"
+msgstr "Tidak ada izin untuk mengaktifkan/menonaktifkan plugin"
+
+#: katalogus/templates/partials/no_enabling_permission_message.html
+msgid "Contact your administrator to request permission."
+msgstr "Hubungi administrator Anda untuk meminta izin."
+
+#: katalogus/templates/partials/objects_to_scan.html
+#, python-format
+msgid ""
+"This Boefje will only scan objects with a corresponding clearance level of "
+"<strong>L%(scan_level)s</strong> or higher. There is no indemnification for "
+"this Boefje to scan an OOI with a lower clearance level than "
+"<strong>L%(scan_level)s</strong>. Use the filter to show OOI's with a lower "
+"clearance level."
+msgstr ""
+"Boefje ini hanya akan memindai objek dengan tingkat izin yang sesuai "
+"<strong>L%(scan_level)s</strong> atau lebih tinggi. Tidak ada ganti rugi "
+"untuk Boefje ini untuk memindai OOI dengan tingkat izin lebih rendah dari "
+"<strong>L%(scan_level)s</strong>. Gunakan filter untuk menampilkan OOI "
+"dengan tingkat izin lebih rendah."
+
+#: katalogus/templates/partials/objects_to_scan.html
+msgid "Warning scan level:"
+msgstr "Tingkat pemindaian peringatan:"
+
+#: katalogus/templates/partials/objects_to_scan.html
+msgid ""
+"Scanning OOI's with a lower clearance level will result in OpenKAT "
+"increasing the clearance level on that OOI, not only for this scan but from "
+"now on out, until it manually gets set to something else again. This means "
+"that all other enabled Boefjes will use this higher clearance level aswel."
+msgstr ""
+"Memindai OOI dengan tingkat izin yang lebih rendah akan mengakibatkan "
+"OpenKAT meningkatkan tingkat izin pada OOI tersebut, tidak hanya untuk "
+"pemindaian ini tetapi mulai sekarang, hingga secara manual disetel ke yang "
+"lain lagi. Ini berarti bahwa semua Boefjes lainnya yang diaktifkan akan "
+"menggunakan tingkat izin yang lebih tinggi ini juga."
+
+#: katalogus/templates/partials/objects_to_scan.html
+#, python-format
+msgid ""
+"You currently don't have any objects that meet the scan level of %(name)s. "
+"Add objects with a complying clearance level, or alter the clearance level "
+"of existing objects."
+msgstr ""
+"Saat ini Anda tidak memiliki objek apa pun yang memenuhi tingkat pemindaian "
+"%(name)s. Tambahkan objek dengan tingkat jarak bebas yang sesuai, atau ubah "
+"tingkat jarak bebas objek yang ada."
+
+#: katalogus/templates/partials/objects_to_scan.html
+#, python-format
+msgid ""
+"You currently don't have scannable objects for %(name)s. Add objects to use "
+"this Boefje. This Boefje is able to scan objects of the following types:"
+msgstr ""
+"Saat ini Anda tidak memiliki objek yang dapat dipindai untuk %(name)s. "
+"Tambahkan objek untuk menggunakan Boefje ini. Boefje ini mampu memindai "
+"objek jenis berikut:"
+
+#: katalogus/templates/partials/plugin_settings_required.html
+msgid "The form could not be initialized."
+msgstr "Formulir tidak dapat diinisialisasi."
+
+#: katalogus/templates/partials/plugin_settings_required.html
+msgid "Required settings"
+msgstr "Pengaturan yang diperlukan"
+
+#: katalogus/templates/partials/plugin_settings_required.html
+#: rocky/templates/partials/ooi_list_toolbar.html
+msgid "Add"
+msgstr "Menambahkan"
+
+#: katalogus/templates/partials/plugin_tile.html
+msgid "Required for:"
+msgstr "Diperlukan untuk:"
+
+#: katalogus/templates/partials/plugin_tile_modal.html
+msgid "Boefje details"
+msgstr "Boefje detailnya"
+
+#: katalogus/templates/partials/plugin_tile_modal.html reports/forms.py
+#: reports/templates/report_overview/report_history_table.html
+msgid "Report types"
+msgstr "Jenis laporan"
+
+#: katalogus/templates/partials/plugin_tile_modal.html
+msgid "This boefje is required by the following report types."
+msgstr "Boefje ini diperlukan oleh jenis laporan berikut."
+
+#: katalogus/templates/partials/plugin_tile_modal.html
+msgid "Go to boefje detail page"
+msgstr "Buka halaman detail boefje"
+
+#: katalogus/templates/partials/plugins.html
+msgid "Plugins overview:"
+msgstr "Ikhtisar plugin:"
+
+#: katalogus/templates/partials/plugins.html
+#: reports/templates/summary/selected_plugins.html
+msgid "Plugin name"
+msgstr "Nama plugin"
+
+#: katalogus/templates/partials/plugins.html
+#: reports/templates/summary/selected_plugins.html
+msgid "Plugin type"
+msgstr "Jenis plugin"
+
+#: katalogus/templates/partials/plugins.html
+#: reports/templates/summary/selected_plugins.html
+msgid "Plugin description"
+msgstr "Deskripsi plugin"
+
+#: katalogus/templates/partials/plugins.html
+#: reports/templates/partials/report_header.html
+#: reports/templates/report_overview/report_history_table.html
+#: rocky/templates/organizations/organization_list.html
+#: rocky/templates/organizations/organization_settings.html
+msgid "Actions"
+msgstr "Tindakan"
+
+#: katalogus/templates/partials/plugins.html
+msgid "Detail page"
+msgstr "Halaman detail"
+
+#: katalogus/templates/partials/plugins_navigation.html
+#: reports/templates/report_overview/report_overview_navigation.html
+msgid "Plugins Navigation"
+msgstr "Navigasi Plugin"
+
+#: katalogus/templates/partials/plugins_navigation.html
+#: rocky/templates/scan.html rocky/templates/tasks/boefjes.html
+#: rocky/templates/tasks/partials/tab_navigation.html rocky/views/tasks.py
+msgid "Boefjes"
+msgstr "Boefjes"
+
+#: katalogus/templates/partials/plugins_navigation.html
+#: rocky/templates/tasks/normalizers.html
+#: rocky/templates/tasks/partials/tab_navigation.html rocky/views/tasks.py
+msgid "Normalizers"
+msgstr "Normalizers"
+
+#: katalogus/templates/partials/plugins_navigation.html
+#: tools/forms/scheduler.py
+msgid "All"
+msgstr "Semua"
+
+#: katalogus/templates/plugin_container_image.html tools/forms/boefje.py
+msgid "Container image"
+msgstr "Gambar kontainer"
+
+#: katalogus/templates/plugin_container_image.html
+msgid "The container image for this Boefje is:"
+msgstr "Gambar kontainer untuk Boefje ini adalah:"
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Variants"
+msgstr "Varian"
+
+#: katalogus/templates/plugin_container_image.html
+msgid ""
+"Boefje variants that use the same container image. For more information "
+"about Boefje variants you can read the documentation."
+msgstr ""
+"Boefje varian yang menggunakan gambar container yang sama. Untuk informasi "
+"lebih lanjut tentang varian Boefje Anda dapat membaca dokumentasi."
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Add variant"
+msgstr "Tambahkan varian"
+
+#: katalogus/templates/plugin_container_image.html
+#: rocky/templates/partials/notifications_block.html
+msgid "confirmation"
+msgstr "konfirmasi"
+
+#: katalogus/templates/plugin_container_image.html
+#, python-format
+msgid "Variant %(plugin.name)s created."
+msgstr "Varian %(plugin.name)s dibuat."
+
+#: katalogus/templates/plugin_container_image.html
+msgid "The Boefje variant is successfully created and can now be used."
+msgstr "Varian Boefje berhasil dibuat dan kini dapat digunakan."
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Overview of variants"
+msgstr "Ikhtisar varian"
+
+#: katalogus/templates/plugin_container_image.html
+#: reports/report_types/tls_report/report.html
+#: reports/templates/partials/plugin_overview_table.html
+#: rocky/templates/organizations/organization_member_list.html
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
+#: rocky/templates/tasks/ooi_detail_task_list.html
+#: rocky/templates/tasks/plugin_detail_task_list.html
+#: rocky/templates/tasks/reports.html
+msgid "Status"
+msgstr "Status"
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Age"
+msgstr "Usia"
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Scan interval"
+msgstr "Interval pemindaian"
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Run on"
+msgstr "Jalankan"
+
+#: katalogus/templates/plugin_container_image.html
+msgid "current"
+msgstr "saat ini"
+
+#: katalogus/templates/plugin_container_image.html
+#: reports/report_types/dns_report/report.html
+msgid "minutes"
+msgstr "menit"
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Default system scan frequency"
+msgstr "Frekuensi pemindaian sistem default"
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Boefje ID"
+msgstr "Boefje ID"
+
+#: katalogus/templates/plugin_container_image.html
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/modal_partials/rerun_modal.html
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/report_overview/subreports_table.html
+#: rocky/templates/tasks/reports.html
+msgid "Creation date"
+msgstr "Tanggal pembuatan"
+
+#: katalogus/templates/plugin_container_image.html tools/forms/boefje.py
+msgid "Arguments"
+msgstr "Argumen"
+
+#: katalogus/templates/plugin_container_image.html
+msgid "The following arguments are used for this Boefje variant:"
+msgstr "Argumen berikut digunakan untuk varian Boefje ini:"
+
+#: katalogus/templates/plugin_container_image.html
+msgid "There are no arguments used for this Boefje variant."
+msgstr "Tidak ada argumen yang digunakan untuk varian Boefje ini."
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Edit variant"
+msgstr "Sunting varian"
+
+#: katalogus/templates/plugin_container_image.html
+msgid "This Boefje has no variants yet."
+msgstr "Boefje ini belum memiliki varian."
+
+#: katalogus/templates/plugin_container_image.html
+msgid ""
+"You can make a variant and change the arguments and JSON Schema to customize"
+" it to fit your needs."
+msgstr ""
+"Anda dapat membuat varian dan mengubah argumen dan Skema JSON untuk "
+"menyesuaikannya agar sesuai dengan kebutuhan Anda."
+
+#: katalogus/templates/plugin_settings_add.html
+msgid "Add setting"
+msgid_plural "Add settings"
+msgstr[0] "Tambahkan pengaturan"
+
+#: katalogus/templates/plugin_settings_add.html
+msgid "Setting"
+msgid_plural "Settings"
+msgstr[0] "Pengaturan"
+
+#: katalogus/templates/plugin_settings_add.html
+msgid "Add setting and enable boefje"
+msgid_plural "Add settings and enable boefje"
+msgstr[0] "Tambahkan pengaturan dan aktifkan boefje"
+
+#: katalogus/templates/plugin_settings_delete.html
+msgid "Delete settings"
+msgstr "Hapus pengaturan"
+
+#: katalogus/templates/plugin_settings_delete.html
+#, python-format
+msgid ""
+"Are you sure you want to delete all settings for the plugin %(plugin_name)s?"
+msgstr ""
+"Apakah Anda yakin ingin menghapus semua pengaturan untuk plugin "
+"%(plugin_name)s?"
+
+#: katalogus/templates/plugin_settings_list.html
+msgid ""
+"In the table below the settings for this specific Boefje can be seen. Set or"
+" change the value of the variables by editing the settings."
+msgstr ""
+"Pada tabel di bawah pengaturan untuk Boefje spesifik ini dapat dilihat. "
+"Tetapkan atau ubah nilai variabel dengan mengedit pengaturan."
+
+#: katalogus/templates/plugin_settings_list.html
+msgid "Configure Settings"
+msgstr "Konfigurasikan Pengaturan"
+
+#: katalogus/templates/plugin_settings_list.html
+msgid "Overview of settings"
+msgstr "Ikhtisar pengaturan"
+
+#: katalogus/templates/plugin_settings_list.html
+msgid "Variable"
+msgstr "Variabel"
+
+#: katalogus/views/change_clearance_level.py
+msgid "Session has terminated, please select objects again."
+msgstr "Sesi telah berakhir, silakan pilih objek lagi."
+
+#: katalogus/views/change_clearance_level.py
+msgid "Change clearance level"
+msgstr "Ubah tingkat izin"
+
+#: katalogus/views/katalogus_settings.py
+msgid "Settings from {} to {} successfully cloned."
+msgstr "Setelan dari {} hingga {} berhasil dikloning."
+
+#: katalogus/views/katalogus_settings.py
+#: katalogus/views/plugin_settings_list.py
+msgid "Failed getting settings for boefje {}"
+msgstr "Gagal mendapatkan setelan untuk boefje {}"
+
+#: katalogus/views/mixins.py
+msgid ""
+"Getting information for plugin {} failed. Please check the KATalogus logs."
+msgstr ""
+"Gagal mendapatkan informasi untuk plugin {}. Silakan periksa log KATalogus."
+
+#: katalogus/views/plugin_detail.py
+msgid ""
+"Some selected OOIs needs an increase of clearance level to perform scans. "
+"You do not have the permission to change clearance level."
+msgstr ""
+"Beberapa OOIs yang dipilih memerlukan peningkatan tingkat izin untuk "
+"melakukan pemindaian. Anda tidak memiliki izin untuk mengubah tingkat izin."
+
+#: katalogus/views/plugin_enable_disable.py
+msgid "{} '{}' disabled."
+msgstr "{} '{}' dengan disabilitas."
+
+#: katalogus/views/plugin_enable_disable.py
+msgid "{} '{}' enabled."
+msgstr "{} '{}' diaktifkan."
+
+#: katalogus/views/plugin_enable_disable.py
+msgid ""
+"You have not acknowledged your clearance level. Go to your profile page to "
+"acknowledge your clearance level."
+msgstr ""
+"Anda belum mengakui tingkat izin Anda. Buka halaman profil Anda untuk "
+"mengetahui tingkat izin Anda."
+
+#: katalogus/views/plugin_enable_disable.py
+msgid ""
+"Your clearance level is not set. Go to your profile page to see your "
+"clearance or contact the administrator to set a clearance level."
+msgstr ""
+"Tingkat izin Anda belum disetel. Buka halaman profil Anda untuk melihat izin"
+" Anda atau hubungi administrator untuk menetapkan tingkat izin."
+
+#: katalogus/views/plugin_enable_disable.py
+msgid ""
+"Your clearance level is L{}. Contact your administrator to get a higher "
+"clearance level."
+msgstr ""
+"Tingkat izin Anda adalah L{}. Hubungi administrator Anda untuk mendapatkan "
+"tingkat izin yang lebih tinggi."
+
+#: katalogus/views/plugin_enable_disable.py
+msgid "To enable {} you need at least a clearance level of L{}. "
+msgstr "Untuk mengaktifkan {} Anda memerlukan setidaknya tingkat izin L{}."
+
+#: katalogus/views/plugin_settings_add.py
+msgid "Trying to add settings to boefje without schema"
+msgstr "Mencoba menambahkan pengaturan ke boefje tanpa skema"
+
+#: katalogus/views/plugin_settings_add.py
+msgid "No changes to the settings added: no form data present"
+msgstr ""
+"Tidak ada perubahan pada pengaturan yang ditambahkan: tidak ada data "
+"formulir"
+
+#: katalogus/views/plugin_settings_add.py
+msgid "Added settings for '{}'"
+msgstr "Menambahkan pengaturan untuk '{}'"
+
+#: katalogus/views/plugin_settings_add.py
+msgid "Failed adding settings"
+msgstr "Gagal menambahkan pengaturan"
+
+#: katalogus/views/plugin_settings_add.py
+msgid "Enabling {} failed"
+msgstr "Gagal mengaktifkan {}"
+
+#: katalogus/views/plugin_settings_add.py
+msgid "Boefje '{}' enabled."
+msgstr "Boefje '{}' diaktifkan."
+
+#: katalogus/views/plugin_settings_add.py
+msgid "Add settings"
+msgstr "Tambahkan pengaturan"
+
+#: katalogus/views/plugin_settings_delete.py
+msgid "Settings for plugin {} successfully deleted."
+msgstr "Setelan untuk plugin {} berhasil dihapus."
+
+#: katalogus/views/plugin_settings_delete.py
+msgid "Plugin {} has no settings."
+msgstr "Plugin {} tidak memiliki pengaturan."
+
+#: katalogus/views/plugin_settings_delete.py
+msgid ""
+"Failed deleting Settings for plugin {}. Check the Katalogus logs for more "
+"info."
+msgstr ""
+"Gagal menghapus Pengaturan untuk plugin {}. Periksa log Katalogus untuk info"
+" lebih lanjut."
+
+#: onboarding/forms.py
+msgid ""
+"The clearance level determines how aggressive the object can be scanned by "
+"plugins. A higher clearance level means more aggressive scans are allowed."
+msgstr ""
+"Tingkat izin menentukan seberapa agresif suatu objek dapat dipindai oleh "
+"plugin. Tingkat izin yang lebih tinggi berarti pemindaian yang lebih agresif"
+" diperbolehkan."
+
+#: onboarding/forms.py tools/forms/ooi.py
+msgid "explanation-clearance-level"
+msgstr "tingkat penjelasan-izin"
+
+#: onboarding/forms.py
+msgid "Please enter a valid URL starting with 'http://' or 'https://'."
+msgstr ""
+"Silakan masukkan URL yang valid dimulai dengan 'http://' atau 'https://'."
+
+#: onboarding/templates/partials/onboarding_header.html
+msgid "Onboarding"
+msgstr "Orientasi"
+
+#: onboarding/templates/partials/step_1_introduction_text.html
+msgid "Welcome to OpenKAT!"
+msgstr "Selamat datang di OpenKAT!"
+
+#: onboarding/templates/partials/step_1_introduction_text.html
+msgid ""
+"Welcome to the onboarding of OpenKAT. We will walk you through some steps to"
+" set everything up."
+msgstr ""
+"Selamat datang di orientasi OpenKAT. Kami akan memandu Anda melalui beberapa"
+" langkah untuk menyiapkan semuanya."
+
+#: onboarding/templates/partials/step_1_introduction_text.html
+msgid ""
+"At the end of this onboarding you have added your first object, created your"
+" first DNS report and learned about some basic concepts used within OpenKAT."
+msgstr ""
+"Di akhir orientasi ini, Anda telah menambahkan objek pertama, membuat "
+"laporan DNS pertama, dan mempelajari beberapa konsep dasar yang digunakan "
+"dalam OpenKAT."
+
+#: onboarding/templates/partials/step_1_introduction_text.html
+msgid "The full documentation for OpenKAT can be found at:"
+msgstr "Dokumentasi lengkap untuk OpenKAT dapat ditemukan di:"
+
+#: onboarding/templates/partials/step_2_organization_text.html
+#: rocky/templates/organizations/organization_add.html
+msgid "Organization setup"
+msgstr "Pengaturan organisasi"
+
+#: onboarding/templates/partials/step_2_organization_text.html
+msgid ""
+"Please enter the following organization details. The organization name can "
+"be changed later in the interface. The organization code cannot be changed "
+"as this is used by the database."
+msgstr ""
+"Silakan masukkan detail organisasi berikut. Nama organisasi dapat diubah "
+"nanti di antarmuka. Kode organisasi tidak dapat diubah karena digunakan oleh"
+" database."
+
+#: onboarding/templates/step_10_report.html
+#: reports/report_types/concatenated_report/report.py
+msgid "Report"
+msgstr "Laporan"
+
+#: onboarding/templates/step_10_report.html
+msgid "Boefjes are scanning"
+msgstr "Boefjes sedang memindai"
+
+#: onboarding/templates/step_10_report.html
+msgid ""
+"The enabled Boefjes are running in the background to gather the data for "
+"your DNS Report. This may take a few minutes."
+msgstr ""
+"Boefjes yang diaktifkan sedang berjalan di latar belakang untuk mengumpulkan"
+" data untuk Laporan DNS Anda. Ini mungkin memakan waktu beberapa menit."
+
+#: onboarding/templates/step_10_report.html
+msgid ""
+"In the meantime you can explore OpenKAT and view your DNS Report on the "
+"Reports page once it has been generated."
+msgstr ""
+"Sementara itu, Anda dapat menjelajahi OpenKAT dan melihat Laporan DNS Anda "
+"di laman Laporan setelah dibuat."
+
+#: onboarding/templates/step_10_report.html
+msgid "Continue to OpenKAT"
+msgstr "Lanjutkan ke OpenKAT"
+
+#: onboarding/templates/step_1_introduction_registration.html
+#: onboarding/templates/step_1a_introduction.html
+msgid "Let's get started"
+msgstr "Mari kita mulai"
+
+#: onboarding/templates/step_2a_organization_setup.html
+#: onboarding/templates/step_2b_organization_update.html
+#: rocky/templates/organizations/organization_add.html
+#: rocky/templates/organizations/organization_settings.html
+#: rocky/templates/partials/organization_properties_table.html
+msgid "Organization details"
+msgstr "Detail organisasi"
+
+#: onboarding/templates/step_2a_organization_setup.html
+#: rocky/templates/forms/json_schema_form.html
+#: rocky/templates/organizations/organization_add.html
+#: rocky/templates/organizations/organization_member_add.html
+#: rocky/templates/organizations/organization_member_add_account_type.html
+#: rocky/templates/partials/elements/ooi_detail_settings.html
+#: rocky/templates/partials/elements/ooi_report_settings.html
+#: rocky/templates/partials/form/indemnification_add_form.html
+#: rocky/templates/two_factor/_wizard_actions.html
+msgid "Submit"
+msgstr "Kirim"
+
+#: onboarding/templates/step_2b_organization_update.html
+msgid "Submit changes"
+msgstr "Kirim perubahan"
+
+#: onboarding/templates/step_2b_organization_update.html
+#: onboarding/templates/step_3_indemnification_setup.html
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+#: onboarding/templates/step_7_clearance_level_introduction.html
+msgid "Continue"
+msgstr "Melanjutkan"
+
+#: onboarding/templates/step_3_indemnification_setup.html
+msgid "Indemnification setup"
+msgstr "Pengaturan ganti rugi"
+
+#: onboarding/templates/step_3_indemnification_setup.html
+msgid "Indemnification on the organization is already present."
+msgstr "Ganti rugi terhadap organisasi sudah ada."
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+msgid "User clearance level"
+msgstr "Tingkat izin pengguna"
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+msgid ""
+"The user clearance level specifies the maximum scan level for security scans"
+" and the maximum clearance level you can assign to objects (e.g. a URL)."
+msgstr ""
+"Tingkat izin pengguna menentukan tingkat pemindaian maksimum untuk "
+"pemindaian keamanan dan tingkat izin maksimum yang dapat Anda tetapkan ke "
+"objek (misalnya URL)."
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+msgid ""
+"The administrator assigns a maximum user clearance level to each user. This "
+"will make sure that only trusted users can start more aggressive scans."
+msgstr ""
+"Administrator menetapkan tingkat izin pengguna maksimum untuk setiap "
+"pengguna. Ini akan memastikan bahwa hanya pengguna tepercaya yang dapat "
+"memulai pemindaian lebih agresif."
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+msgid ""
+"A user must accept a clearance level, before they perform actions in "
+"OpenKAT. Here you may accept the maximum trusted clearance level, as "
+"assigned by your administrator. On your user settings page you can choose to"
+" lower your accepted clearance level after completing the onboarding."
+msgstr ""
+"Pengguna harus menerima tingkat izin, sebelum mereka melakukan tindakan di "
+"OpenKAT. Di sini Anda dapat menerima tingkat izin tepercaya maksimum, "
+"seperti yang ditetapkan oleh administrator Anda. Di halaman pengaturan "
+"pengguna, Anda dapat memilih untuk menurunkan tingkat izin yang diterima "
+"setelah menyelesaikan orientasi."
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+msgid "What is my clearance level?"
+msgstr "Berapa tingkat izin saya?"
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+#, python-format
+msgid ""
+"Unfortunately you cannot continue the onboarding. </br> Your administrator "
+"has trusted you with a clearance level of <strong>L%(tcl)s</strong>. </br> "
+"You need at least a clearance level of "
+"<strong>L%(dns_report_least_clearance_level)s</strong> to scan "
+"<strong>%(ooi)s</strong> </br> Contact your administrator to receive a "
+"higher clearance."
+msgstr ""
+"Sayangnya Anda tidak dapat melanjutkan orientasi. </br> Administrator Anda "
+"telah mempercayai Anda dengan tingkat izin <strong>L%(tcl)s</strong>. </br> "
+"Anda memerlukan setidaknya tingkat izin "
+"<strong>L%(dns_report_least_clearance_level)s</strong> untuk memindai "
+"<strong>%(ooi)s</strong> </br> Hubungi administrator Anda untuk menerima "
+"izin yang lebih tinggi."
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+#: onboarding/templates/step_5_add_scan_ooi.html
+#: onboarding/templates/step_6_set_clearance_level.html
+#: onboarding/templates/step_7_clearance_level_introduction.html
+#: onboarding/templates/step_8_setup_scan_select_plugins.html
+#: onboarding/templates/step_9_choose_report_type.html
+#: rocky/templates/partials/form/boefje_tiles_form.html
+msgid "Skip onboarding"
+msgstr "Lewati orientasi"
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+#, python-format
+msgid ""
+"Your administrator has trusted you with a clearance level of "
+"<strong>L%(tcl)s</strong>. </br> You must first accept this clearance level "
+"to continue."
+msgstr ""
+"Administrator Anda telah mempercayai Anda dengan tingkat izin "
+"<strong>L%(tcl)s</strong>. </br> Anda harus terlebih dahulu menerima tingkat"
+" izin ini untuk melanjutkan."
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+#, python-format
+msgid ""
+"Your administrator has <strong>trusted</strong> you with a clearance level "
+"of <strong>L%(tcl)s</strong>."
+msgstr ""
+"Administrator Anda <strong>tepercaya</strong> Anda dengan tingkat izin "
+"<strong>L%(tcl)s</strong>."
+
+#: onboarding/templates/step_5_add_scan_ooi.html
+msgid "Add an object"
+msgstr "Tambahkan objek"
+
+#: onboarding/templates/step_5_add_scan_ooi.html
+msgid ""
+"OpenKAT uses various kinds of objects, like IP addresses, hostnames and "
+"URLs. In the onboarding we will add an URL object, such as our vulnerable "
+"OpenKAT website: https://mispo.es."
+msgstr ""
+"OpenKAT menggunakan berbagai jenis objek, seperti alamat IP, nama host, dan "
+"URLs. Dalam orientasi kita akan menambahkan objek URL, seperti situs web "
+"OpenKAT kita yang rentan: https://mispo.es."
+
+#: onboarding/templates/step_5_add_scan_ooi.html
+#: rocky/templates/partials/ooi_detail_related_object.html
+msgid "Related objects"
+msgstr "Objek terkait"
+
+#: onboarding/templates/step_5_add_scan_ooi.html
+msgid ""
+"Most objects have dependencies on the existence of related objects. For "
+"example a URL needs to be connected to a network, hostname, fqdn (fully "
+"qualified domain name) and IP address. When possible OpenKAT automatically "
+"collects and adds these related objects by running scans. Objects can also "
+"be manually added."
+msgstr ""
+"Kebanyakan objek memiliki ketergantungan pada keberadaan objek terkait. "
+"Misalnya URL harus terhubung ke jaringan, nama host, fqdn (nama domain yang "
+"sepenuhnya memenuhi syarat) dan alamat IP. Jika memungkinkan OpenKAT secara "
+"otomatis mengumpulkan dan menambahkan objek terkait ini dengan menjalankan "
+"pemindaian. Objek juga dapat ditambahkan secara manual."
+
+#: onboarding/templates/step_5_add_scan_ooi.html
+msgid "Create object"
+msgstr "Buat objek"
+
+#: onboarding/templates/step_6_set_clearance_level.html
+msgid "Set object clearance level"
+msgstr "Tetapkan tingkat izin objek"
+
+#: onboarding/templates/step_6_set_clearance_level.html
+msgid ""
+"After creating a new object you can set a clearance level for this object. A"
+" clearance level determines how aggressive the object can be scanned. A "
+"higher clearance level, means that more aggressive scans are allowed. "
+"Clearance levels can always be adjusted later on."
+msgstr ""
+"Setelah membuat objek baru, Anda dapat mengatur tingkat izin untuk objek "
+"ini. Tingkat izin menentukan seberapa agresif objek dapat dipindai. Tingkat "
+"izin yang lebih tinggi berarti pemindaian yang lebih agresif diperbolehkan. "
+"Tingkat izin selalu dapat disesuaikan nanti."
+
+#: onboarding/templates/step_6_set_clearance_level.html
+#, python-format
+msgid ""
+"For the onboarding we use a clearance level of "
+"L%(dns_report_least_clearance_level)s, meaning only informational scans are "
+"allowed."
+msgstr ""
+"Untuk orientasi kami menggunakan tingkat izin "
+"L%(dns_report_least_clearance_level)s, yang berarti hanya pemindaian "
+"informasi yang diperbolehkan."
+
+#: onboarding/templates/step_6_set_clearance_level.html
+msgid "Set clearance level"
+msgstr "Tetapkan tingkat izin"
+
+#: onboarding/templates/step_7_clearance_level_introduction.html
+msgid "Plugin introduction"
+msgstr "Pengenalan plugin"
+
+#: onboarding/templates/step_7_clearance_level_introduction.html
+msgid ""
+"OpenKAT uses plugins to scan your objects. Each plugin has a scan level to "
+"specify how aggressive the scan is. Plugins can only scan those objects with"
+" a clearance level that is equal to, or higher than the scan level of the "
+"plugin. Plugin scan level are indicated by the number of cat paws."
+msgstr ""
+"OpenKAT menggunakan plugin untuk memindai objek Anda. Setiap plugin memiliki"
+" tingkat pemindaian untuk menentukan seberapa agresif pemindaian tersebut. "
+"Plugin hanya dapat memindai objek dengan tingkat izin yang sama atau lebih "
+"tinggi dari tingkat pemindaian plugin. Tingkat pemindaian plugin ditunjukkan"
+" dengan jumlah kaki kucing."
+
+#: onboarding/templates/step_7_clearance_level_introduction.html
+msgid ""
+"The plugin <strong>DNS Zone</strong> has a scan level of 1, meaning that it "
+"performs non-intrusive scans which look for publicly available information. "
+"It scans objects with a clearance level of 1 or higher."
+msgstr ""
+"Plugin <strong>DNS Zone</strong> memiliki tingkat pemindaian 1, artinya ia "
+"melakukan pemindaian non-intrusif yang mencari informasi yang tersedia untuk"
+" umum. Ini memindai objek dengan tingkat izin 1 atau lebih tinggi."
+
+#: onboarding/templates/step_7_clearance_level_introduction.html
+msgid ""
+"The plugin <strong>Fierce</strong> has a scan level of 3, meaning that it "
+"more aggressive and could potentially break things. It scans objects with a "
+"clearance level of 3 or higher."
+msgstr ""
+"Plugin <strong>Fierce</strong> memiliki tingkat pemindaian 3, artinya lebih "
+"agresif dan berpotensi merusak. Ini memindai objek dengan tingkat izin 3 "
+"atau lebih tinggi."
+
+#: onboarding/templates/step_8_setup_scan_select_plugins.html
+msgid "Enabling plugins and start scanning"
+msgstr "Mengaktifkan plugin dan mulai memindai"
+
+#: onboarding/templates/step_8_setup_scan_select_plugins.html
+msgid ""
+"OpenKAT uses plugins to scan, check and analyze. There are three types of "
+"plugins."
+msgstr ""
+"OpenKAT menggunakan plugin untuk memindai, memeriksa, dan menganalisis. Ada "
+"tiga jenis plugin."
+
+#: onboarding/templates/step_8_setup_scan_select_plugins.html
+msgid ""
+"The first plugin are <b>Boefjes</b>, which scan objects for data. These are "
+"security tools like nmap, LeakIX and WPscan. </p>"
+msgstr ""
+"Plugin pertama adalah <b>Boefjes</b>, yang memindai objek untuk mencari "
+"data. Ini adalah alat keamanan seperti nmap, LeakIX dan WPscan. </p>"
+
+#: onboarding/templates/step_8_setup_scan_select_plugins.html
+msgid ""
+"The other two plugins are <b>Normalizers</b> and <b>Bits</b>, which are used"
+" to process the output of Boefjes. They can create findings and related "
+"objects. Bits are also used to create organization specific findings, based "
+"on policy requirements. </p>"
+msgstr ""
+"Dua plugin lainnya adalah <b>Normalizers</b> dan <b>Bits</b>, yang digunakan"
+" untuk memproses keluaran Boefjes. Mereka dapat membuat temuan dan objek "
+"terkait. Bit juga digunakan untuk membuat temuan spesifik organisasi, "
+"berdasarkan persyaratan kebijakan. </p>"
+
+#: onboarding/templates/step_8_setup_scan_select_plugins.html
+msgid ""
+"For the onboarding we will enable the Boefjes shown below. Once enabled "
+"these Boefjes gather publicly available information on suitable objects with"
+" a clearance level of 1 or higher. Normalizers and Bits are enabled by "
+"default."
+msgstr ""
+"Untuk orientasi kami akan mengaktifkan Boefjes yang ditunjukkan di bawah. "
+"Setelah diaktifkan, Boefjes ini mengumpulkan informasi yang tersedia untuk "
+"umum tentang objek yang sesuai dengan tingkat izin 1 atau lebih tinggi. "
+"Normalizers dan Bits diaktifkan secara default."
+
+#: onboarding/templates/step_8_setup_scan_select_plugins.html
+msgid "Enable and continue"
+msgstr "Aktifkan dan lanjutkan"
+
+#: onboarding/templates/step_9_choose_report_type.html
+msgid "Generate a report"
+msgstr "Buat laporan"
+
+#: onboarding/templates/step_9_choose_report_type.html
+msgid ""
+"Reports can be used to gain more insights in your organizations assets. You "
+"can generate different types of reports in OpenKAT. Each report may require "
+"one or more plugins that provide the input for the report."
+msgstr ""
+"Laporan dapat digunakan untuk mendapatkan lebih banyak wawasan tentang aset "
+"organisasi Anda. Anda dapat membuat berbagai jenis laporan di OpenKAT. "
+"Setiap laporan mungkin memerlukan satu atau lebih plugin yang memberikan "
+"masukan untuk laporan tersebut."
+
+#: onboarding/templates/step_9_choose_report_type.html
+msgid ""
+"For the onboarding we will generate a DNS report for your added URL. In the "
+"previous step you enabled the required plugins for this report."
+msgstr ""
+"Untuk orientasi kami akan membuat laporan DNS untuk URL Anda yang "
+"ditambahkan. Pada langkah sebelumnya Anda mengaktifkan plugin yang "
+"diperlukan untuk laporan ini."
+
+#: onboarding/templates/step_9_choose_report_type.html
+msgid "Generate DNS Report"
+msgstr "Hasilkan DNS Laporan"
+
+#: onboarding/view_helpers.py
+msgid "1: Welcome"
+msgstr "1: Selamat datang"
+
+#: onboarding/view_helpers.py
+msgid "2: Organization setup"
+msgstr "2: Pengaturan organisasi"
+
+#: onboarding/view_helpers.py
+msgid "3: Add object"
+msgstr "3: Tambahkan objek"
+
+#: onboarding/view_helpers.py
+msgid "4: Plugins"
+msgstr "4: Plugin"
+
+#: onboarding/view_helpers.py
+msgid "5: Generating report"
+msgstr "5: Menghasilkan laporan"
+
+#: onboarding/views.py
+#, python-brace-format
+msgid "{org_name} successfully created."
+msgstr "{org_name} berhasil dibuat."
+
+#: onboarding/views.py
+#, python-brace-format
+msgid "{org_name} successfully updated."
+msgstr "{org_name} berhasil diperbarui."
+
+#: onboarding/views.py
+msgid "Creating an object"
+msgstr "Membuat sebuah objek"
+
+#: onboarding/views.py
+msgid "Fetch the parent DNS zone of a hostname"
+msgstr "Ambil zona DNS induk dari nama host"
+
+#: onboarding/views.py
+msgid "Finds subdomains by brute force"
+msgstr "Menemukan subdomain dengan kekerasan"
+
+#: onboarding/views.py
+msgid "Please select a plugin to proceed."
+msgstr "Silakan pilih plugin untuk melanjutkan."
+
+#: onboarding/views.py
+msgid "Please select all required plugins to proceed."
+msgstr "Silakan pilih semua plugin yang diperlukan untuk melanjutkan."
+
+#: onboarding/views.py reports/views/aggregate_report.py
+#: reports/views/generate_report.py
+msgid "An error occurred while enabling {}. The plugin is not available."
+msgstr "Terjadi kesalahan saat mengaktifkan {}. Pluginnya tidak tersedia."
+
+#: onboarding/views.py
+msgid "Plugins successfully enabled."
+msgstr "Plugin berhasil diaktifkan."
+
+#: onboarding/views.py
+msgid "Web URL not found."
+msgstr "Web URL tidak ditemukan."
+
+#: onboarding/views.py
+msgid ""
+"Your report is scheduled for generation in about 3 minutes, as we are "
+"waiting for Boefjes to complete. In the meantime get familiar with OpenKAT "
+"and visit the Reports History tab later."
+msgstr ""
+"Laporan Anda dijadwalkan untuk dibuat dalam waktu sekitar 3 menit, karena "
+"kami menunggu Boefjes selesai. Sementara itu, kenali OpenKAT dan kunjungi "
+"tab Riwayat Laporan nanti."
+
+#: reports/forms.py tools/forms/ooi_form.py
+msgid "Filter by OOI types"
+msgstr "Filter menurut jenis OOI"
+
+#: reports/forms.py
+msgid "Today"
+msgstr "Hari ini"
+
+#: reports/forms.py
+msgid "Different date"
+msgstr "Tanggal berbeda"
+
+#: reports/forms.py
+msgid "No, just once"
+msgstr "Tidak, sekali saja"
+
+#: reports/forms.py
+msgid "Yes, repeat"
+msgstr "Ya, ulangi"
+
+#: reports/forms.py
+msgid "Start date"
+msgstr "Tanggal mulai"
+
+#: reports/forms.py
+msgid "Start time (UTC)"
+msgstr "Waktu mulai (UTC)"
+
+#: reports/forms.py
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Recurrence"
+msgstr "Kambuh"
+
+#: reports/forms.py
+msgid "No recurrence, just once"
+msgstr "Tidak terulang kembali, cukup sekali saja"
+
+#: reports/forms.py
+msgid "Daily"
+msgstr "Sehari-hari"
+
+#: reports/forms.py
+msgid "Weekly"
+msgstr "Mingguan"
+
+#: reports/forms.py
+msgid "Monthly"
+msgstr "Bulanan"
+
+#: reports/forms.py
+msgid "Yearly"
+msgstr "Tahunan"
+
+#: reports/forms.py
+msgid "day"
+msgstr "hari"
+
+#: reports/forms.py
+msgid "week"
+msgstr "pekan"
+
+#: reports/forms.py
+msgid "month"
+msgstr "bulan"
+
+#: reports/forms.py
+msgid "year"
+msgstr "tahun"
+
+#: reports/forms.py
+msgid "Never"
+msgstr "Tidak pernah"
+
+#: reports/forms.py
+msgid "On"
+msgstr "Pada"
+
+#: reports/forms.py
+msgid "After"
+msgstr "Setelah"
+
+#: reports/forms.py
+msgid "Report name format"
+msgstr "Format nama laporan"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: reports/report_types/multi_organization_report/appendix.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Appendix"
+msgstr "Lampiran"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Currently filtered on"
+msgstr "Saat ini sedang difilter"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: reports/templates/partials/report_sidemenu.html
+#: reports/templates/summary/report_asset_overview.html
+msgid "Selected Report Types"
+msgstr "Jenis Laporan yang Dipilih"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Selected report types"
+msgstr "Jenis laporan yang dipilih"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: reports/templates/partials/plugin_overview_table.html
+#: reports/templates/report_overview/modal_partials/rename_modal.html
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+#: reports/templates/report_overview/subreports_table.html
+#: reports/templates/summary/report_asset_overview.html
+msgid "Report type"
+msgstr "Jenis laporan"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Service Versions and Health"
+msgstr "Versi Layanan dan Kesehatan"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Service, version and health"
+msgstr "Layanan, versi, dan kesehatan"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: reports/templates/summary/service_health.html rocky/templates/footer.html
+#: rocky/templates/health.html
+msgid "Service"
+msgstr "Melayani"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: reports/templates/summary/service_health.html rocky/templates/health.html
+msgid "Version"
+msgstr "Versi"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: rocky/templates/footer.html rocky/views/health.py
+msgid "Health"
+msgstr "Kesehatan"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: rocky/templates/health.html
+msgid "Healthy"
+msgstr "Sehat"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Unhealthy"
+msgstr "Tidak sehat"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Used Config objects"
+msgstr "Objek Config yang digunakan"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Used config objects"
+msgstr "Objek konfigurasi yang digunakan"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Primary Key"
+msgstr "Kunci Utama"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Bit ID"
+msgstr "ID sedikit"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Config"
+msgstr "Konfigurasi"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "No config objects found."
+msgstr "Tidak ada objek konfigurasi yang ditemukan."
+
+#: reports/report_types/aggregate_organisation_report/asset_overview.html
+#: reports/report_types/multi_organization_report/asset_overview.html
+#: reports/templates/partials/generate_report_sidemenu.html
+#: reports/templates/partials/report_sidemenu.html
+#: reports/templates/summary/report_asset_overview.html
+msgid "Asset overview"
+msgstr "Ikhtisar aset"
+
+#: reports/report_types/aggregate_organisation_report/asset_overview.html
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid ""
+"An overview of the manually released scanned assets. Assets in "
+"<strong>bold</strong> are taken as a starting point, assets that are not in "
+"bold were found by OpenKAT itself."
+msgstr ""
+"Ikhtisar aset pindaian yang dirilis secara manual. Aset yang dicetak "
+"<strong>tebal</strong> diambil sebagai titik awal, aset yang tidak dicetak "
+"tebal ditemukan oleh OpenKAT itu sendiri."
+
+#: reports/report_types/aggregate_organisation_report/basic_security.html
+#: reports/report_types/aggregate_organisation_report/report.html
+msgid "Overview of the basic security status"
+msgstr "Ikhtisar status keamanan dasar"
+
+#: reports/report_types/aggregate_organisation_report/basic_security.html
+msgid ""
+"This table provides an overview of the basic security status of the known "
+"assets. Basic security in order. In principle, all values in this table "
+"should be checked off."
+msgstr ""
+"Tabel ini memberikan ikhtisar status keamanan dasar dari aset yang "
+"diketahui. Keamanan dasar teratur. Pada prinsipnya, semua nilai dalam tabel "
+"ini harus dicentang."
+
+#: reports/report_types/aggregate_organisation_report/basic_security.html
+msgid "Basic security status"
+msgstr "Status keamanan dasar"
+
+#: reports/report_types/aggregate_organisation_report/basic_security.html
+#: reports/report_types/ipv6_report/report.html
+#: reports/report_types/multi_organization_report/ipv6.html
+#: reports/report_types/systems_report/report.html
+msgid "System type"
+msgstr "Tipe sistem"
+
+#: reports/report_types/aggregate_organisation_report/basic_security.html
+#: reports/report_types/aggregate_organisation_report/report.html
+#: reports/report_types/multi_organization_report/basic_security_details.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Safe connections"
+msgstr "Koneksi aman"
+
+#: reports/report_types/aggregate_organisation_report/basic_security.html
+msgid "System Specific"
+msgstr "Spesifik Sistem"
+
+#: reports/report_types/aggregate_organisation_report/basic_security.html
+msgid "RPKI"
+msgstr "RPKI"
+
+#: reports/report_types/aggregate_organisation_report/basic_security.html
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/rpki_report/report.html
+#: reports/report_types/safe_connections_report/report.html
+msgid "server"
+msgstr "server"
+
+#: reports/report_types/aggregate_organisation_report/findings.html
+#: reports/report_types/aggregate_organisation_report/report.html
+msgid ""
+"This chapter contains information about the findings that have been "
+"identified for this organization."
+msgstr ""
+"Bab ini berisi informasi tentang temuan yang telah diidentifikasi untuk "
+"organisasi ini."
+
+#: reports/report_types/aggregate_organisation_report/recommendations.html
+#: reports/report_types/multi_organization_report/recommendations.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Recommendations"
+msgstr "Rekomendasi"
+
+#: reports/report_types/aggregate_organisation_report/recommendations.html
+#, python-format
+msgid "There is <i>%(total_findings)s</i> vulnerability"
+msgid_plural "There are <i>%(total_findings)s</i> vulnerabilities"
+msgstr[0] "Terdapat <i>%(total_findings)s</i> kerentanan"
+
+#: reports/report_types/aggregate_organisation_report/recommendations.html
+#, python-format
+msgid "found on <i>%(total_systems)s</i> system."
+msgid_plural "found on <i>%(total_systems)s</i> systems."
+msgstr[0] "ditemukan pada sistem <i>%(total_systems)s</i>."
+
+#: reports/report_types/aggregate_organisation_report/recommendations.html
+#: reports/report_types/multi_organization_report/recommendations.html
+msgid "There are no recommendations."
+msgstr "Tidak ada rekomendasi."
+
+#: reports/report_types/aggregate_organisation_report/report.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Basic security"
+msgstr "Keamanan dasar"
+
+#: reports/report_types/aggregate_organisation_report/report.html
+msgid ""
+"In this chapter, first a table of compliance checks is displayed, followed "
+"by a detailed examination of compliance issues for each component."
+msgstr ""
+"Dalam bab ini, pertama-tama tabel pemeriksaan kepatuhan ditampilkan, diikuti"
+" dengan pemeriksaan mendetail mengenai masalah kepatuhan untuk setiap "
+"komponen."
+
+#: reports/report_types/aggregate_organisation_report/report.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "System specific"
+msgstr "Khusus sistem"
+
+#: reports/report_types/aggregate_organisation_report/report.html
+#: reports/report_types/multi_organization_report/basic_security_details.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Resource Public Key Infrastructure"
+msgstr "Infrastruktur Kunci Publik Sumber Daya"
+
+#: reports/report_types/aggregate_organisation_report/report.html
+#: reports/report_types/aggregate_organisation_report/vulnerabilities.html
+#: reports/report_types/multi_organization_report/vulnerabilities.html
+#: reports/report_types/vulnerability_report/report.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Vulnerabilities"
+msgstr "Kerentanan"
+
+#: reports/report_types/aggregate_organisation_report/report.html
+#: reports/report_types/aggregate_organisation_report/vulnerabilities.html
+msgid "Vulnerabilities found are grouped per system."
+msgstr "Kerentanan yang ditemukan dikelompokkan per sistem."
+
+#: reports/report_types/aggregate_organisation_report/report.py
+msgid "Aggregate Organisation Report"
+msgstr "Laporan Organisasi Agregat"
+
+#: reports/report_types/aggregate_organisation_report/rpki.html
+#: reports/report_types/multi_organization_report/basic_security_details.html
+msgid ""
+"This section contains basic security information about resource public key "
+"infrastructure. If your web server employs RPKI for its IP addresses and "
+"associated nameservers, then it enhances visitor protection against "
+"misconfigurations and malicious route intercepts through verified route "
+"announcements, ensuring reliable server access and secure internet traffic."
+msgstr ""
+"Bagian ini berisi informasi keamanan dasar tentang infrastruktur kunci "
+"publik sumber daya. Jika server web Anda menggunakan RPKI untuk alamat IP "
+"dan server nama terkait, maka server web tersebut akan meningkatkan "
+"perlindungan pengunjung terhadap kesalahan konfigurasi dan penyadapan rute "
+"berbahaya melalui pengumuman rute terverifikasi, memastikan akses server "
+"yang andal dan lalu lintas internet yang aman."
+
+#: reports/report_types/aggregate_organisation_report/safe_connections.html
+#: reports/report_types/multi_organization_report/basic_security_details.html
+msgid ""
+"In this chapter we check if the connections of all the IP ports of the "
+"system are safe. Safe connections are important to prevent unauthorised "
+"access and data breaches. Strong ciphers are crucial because they ensure "
+"strong encryption which protects the data from interception during "
+"communiction."
+msgstr ""
+"Dalam bab ini kita memeriksa apakah koneksi semua port IP pada sistem aman. "
+"Koneksi yang aman penting untuk mencegah akses tidak sah dan pelanggaran "
+"data. Sandi yang kuat sangat penting karena menjamin enkripsi yang kuat yang"
+" melindungi data dari intersepsi selama komunikasi."
+
+#: reports/report_types/aggregate_organisation_report/summary.html
+#: reports/report_types/multi_organization_report/summary.html
+#: rocky/views/ooi_tree.py
+msgid "Summary"
+msgstr "Ringkasan"
+
+#: reports/report_types/aggregate_organisation_report/summary.html
+msgid "Critical Vulnerabilities"
+msgstr "Kerentanan Kritis"
+
+#: reports/report_types/aggregate_organisation_report/summary.html
+msgid "IPs scanned"
+msgstr "IPs dipindai"
+
+#: reports/report_types/aggregate_organisation_report/summary.html
+msgid "Hostnames scanned"
+msgstr "Nama host dipindai"
+
+#: reports/report_types/aggregate_organisation_report/summary.html
+msgid "Terms in report"
+msgstr "Istilah dalam laporan"
+
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/rpki_report/report.html
+#: reports/report_types/safe_connections_report/report.html
+#, python-format
+msgid ""
+"This table shows which checks were performed. Following that, the compliance"
+" issues, if any, are shown for each %(type)s Server."
+msgstr ""
+"Tabel ini menunjukkan pemeriksaan mana yang dilakukan. Setelah itu, masalah "
+"kepatuhan, jika ada, ditampilkan untuk setiap Server %(type)s."
+
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+msgid "Check overview"
+msgstr "Periksa ikhtisar"
+
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/mail_report/report.html
+#: reports/report_types/multi_organization_report/basic_security_details.html
+#: reports/report_types/name_server_report/report.html
+#: reports/report_types/rpki_report/report.html
+#: reports/report_types/safe_connections_report/report.html
+#: reports/report_types/web_system_report/report.html
+msgid "Check"
+msgstr "Memeriksa"
+
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/mail_report/report.html
+#: reports/report_types/name_server_report/report.html
+#: reports/report_types/rpki_report/report.html
+#: reports/report_types/safe_connections_report/report.html
+#: reports/report_types/web_system_report/report.html
+msgid "Compliance"
+msgstr "Kepatuhan"
+
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/rpki_report/report.html
+msgid "IPs are compliant"
+msgstr "IPs mematuhi"
+
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/safe_connections_report/report.html
+#: reports/report_types/vulnerability_report/report.html
+msgid "Host:"
+msgstr "Tuan rumah:"
+
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/mail_report/report.html
+#: reports/report_types/name_server_report/report.html
+#: reports/report_types/rpki_report/report.html
+#: reports/report_types/safe_connections_report/report.html
+#: reports/report_types/web_system_report/report.html
+msgid "Compliance issue"
+msgstr "Masalah kepatuhan"
+
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/mail_report/report.html
+#: reports/report_types/name_server_report/report.html
+#: reports/report_types/rpki_report/report.html
+#: reports/report_types/safe_connections_report/report.html
+#: reports/report_types/vulnerability_report/report.html
+#: reports/report_types/web_system_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/partials/report_severity_totals_table.html
+#: rocky/templates/partials/ooi_report_findings_block_table.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid "Risk level"
+msgstr "Tingkat risiko"
+
+#: reports/report_types/aggregate_organisation_report/system_specific_overview.html
+#: reports/report_types/multi_organization_report/basic_security_details.html
+msgid ""
+"This is where checks are done that are specific to system types. Different "
+"security and compliance issues come into play for different systems. They "
+"are listed here under each other."
+msgstr ""
+"Di sinilah pemeriksaan dilakukan khusus untuk tipe sistem. Masalah keamanan "
+"dan kepatuhan yang berbeda-beda juga terjadi pada sistem yang berbeda. "
+"Mereka terdaftar di sini di bawah satu sama lain."
+
+#: reports/report_types/aggregate_organisation_report/term_overview.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Term Overview"
+msgstr "Ikhtisar Istilah"
+
+#: reports/report_types/aggregate_organisation_report/term_overview.html
+msgid "For definitions of terms used in this chapter, see the glossary below."
+msgstr ""
+"Untuk definisi istilah-istilah yang digunakan dalam bab ini, lihat glosarium"
+" di bawah."
+
+#: reports/report_types/aggregate_organisation_report/term_overview.html
+msgid ""
+"Web servers and domains are examples of digital assets within this "
+"framework. Web servers are essential for hosting and serving websites or web"
+" applications, while domains represent the online addresses used to access "
+"these resources. Other examples of assets in the IT realm include databases,"
+" user accounts, software applications, and networking infrastructure. Asset "
+"management is a critical aspect of cybersecurity, involving the "
+"identification, classification, and protection of these assets to safeguard "
+"against threats and ensure the overall security and functionality of an "
+"organization's IT environment."
+msgstr ""
+"Server web dan domain adalah contoh aset digital dalam kerangka ini. Server "
+"web sangat penting untuk menghosting dan melayani situs web atau aplikasi "
+"web, sementara domain mewakili alamat online yang digunakan untuk mengakses "
+"sumber daya ini. Contoh aset lain di bidang TI mencakup database, akun "
+"pengguna, aplikasi perangkat lunak, dan infrastruktur jaringan. Manajemen "
+"aset adalah aspek penting dari keamanan siber, yang melibatkan identifikasi,"
+" klasifikasi, dan perlindungan aset-aset ini untuk melindungi dari ancaman "
+"dan memastikan keamanan dan fungsionalitas keseluruhan lingkungan TI "
+"organisasi."
+
+#: reports/report_types/aggregate_organisation_report/term_overview.html
+msgid ""
+"Multiple hostnames that resolve to one IP address where at least one of the "
+"hostnames or the IP address has a declared scan level that is at least L1. "
+"Type systems are web servers, mail servers and name servers (DNS)."
+msgstr ""
+"Beberapa nama host yang memutuskan ke satu alamat IP yang mana setidaknya "
+"salah satu nama host atau alamat IP memiliki tingkat pemindaian yang "
+"dinyatakan setidaknya L1. Jenis sistemnya adalah server web, server email, "
+"dan server nama (DNS)."
+
+#: reports/report_types/aggregate_organisation_report/term_overview.html
+msgid ""
+"A fundamental component of the client-server model. A web server uses "
+"protocols like HTTP or HTTPS to facilitate communication between clients and"
+" the server."
+msgstr ""
+"Komponen mendasar dari model klien-server. Server web menggunakan protokol "
+"seperti HTTP atau HTTPS untuk memfasilitasi komunikasi antara klien dan "
+"server."
+
+#: reports/report_types/aggregate_organisation_report/term_overview.html
+msgid ""
+"A mail server is a specialized software application or hardware device that "
+"facilitates the sending, receiving, and storage of emails within a computer "
+"network. Operating on the Simple Mail Transfer Protocol (SMTP) for outgoing "
+"messages and either Internet Message Access Protocol (IMAP) or Post Office "
+"Protocol (POP) for incoming messages, a mail server manages email "
+"communication by routing messages between users and storing them until they "
+"are retrieved. The server ensures the efficient and secure transfer of "
+"emails, handling tasks such as authentication, spam filtering, and message "
+"storage."
+msgstr ""
+"Server email adalah aplikasi perangkat lunak atau perangkat keras khusus "
+"yang memfasilitasi pengiriman, penerimaan, dan penyimpanan email dalam "
+"jaringan komputer. Beroperasi pada Simple Mail Transfer Protocol (SMTP) "
+"untuk pesan keluar dan Internet Message Access Protocol (IMAP) atau Post "
+"Office Protocol (POP) untuk pesan masuk, server email mengelola komunikasi "
+"email dengan merutekan pesan antar pengguna dan menyimpannya hingga pesan "
+"tersebut diambil. Server memastikan transfer email yang efisien dan aman, "
+"menangani tugas-tugas seperti otentikasi, pemfilteran spam, dan penyimpanan "
+"pesan."
+
+#: reports/report_types/aggregate_organisation_report/term_overview.html
+msgid ""
+"A nameserver, or Domain Name System (DNS) server, is a critical component of"
+" the internet infrastructure responsible for translating human-readable "
+"domain names into IP addresses, enabling the seamless navigation of the web."
+" When a user enters a domain name in a web browser, the nameserver is "
+"queried to obtain the corresponding IP address of the server hosting the "
+"associated website or service."
+msgstr ""
+"Server nama, atau server Sistem Nama Domain (DNS), adalah komponen penting "
+"infrastruktur internet yang bertanggung jawab untuk menerjemahkan nama "
+"domain yang dapat dibaca manusia menjadi alamat IP, sehingga memungkinkan "
+"navigasi web yang lancar. Saat pengguna memasukkan nama domain di browser "
+"web, server nama diminta untuk mendapatkan alamat IP yang sesuai dari server"
+" yang menghosting situs web atau layanan terkait."
+
+#: reports/report_types/aggregate_organisation_report/term_overview.html
+msgid ""
+"A DICOM server, which stands for Digital Imaging and Communications in "
+"Medicine, is a specialized server designed for the storage, retrieval, and "
+"exchange of medical images and related information in the healthcare "
+"industry. DICOM is a widely adopted standard that ensures interoperability "
+"and consistency in the communication of medical images and associated data "
+"among different devices and systems, such as medical imaging equipment, "
+"picture archiving and communication systems (PACS), and radiology "
+"information systems (RIS). DICOM servers store and manage patient-specific "
+"medical images, like X-rays, CT scans, and MRIs, utilizing a standardized "
+"format."
+msgstr ""
+"Server DICOM, yang merupakan singkatan dari Digital Imaging and "
+"Communications in Medicine, adalah server khusus yang dirancang untuk "
+"penyimpanan, pengambilan, dan pertukaran gambar medis dan informasi terkait "
+"dalam industri perawatan kesehatan. DICOM adalah standar yang diadopsi "
+"secara luas yang memastikan interoperabilitas dan konsistensi dalam "
+"komunikasi gambar medis dan data terkait di antara berbagai perangkat dan "
+"sistem, seperti peralatan pencitraan medis, pengarsipan gambar dan sistem "
+"komunikasi (PACS), dan sistem informasi radiologi (RIS). Server DICOM "
+"menyimpan dan mengelola gambar medis khusus pasien, seperti sinar-X, CT "
+"scan, dan MRI, menggunakan format standar."
+
+#: reports/report_types/aggregate_organisation_report/vulnerabilities.html
+#: reports/report_types/multi_organization_report/vulnerabilities.html
+msgid "No CVEs have been found."
+msgstr "Tidak ada CVE yang ditemukan."
+
+#: reports/report_types/dns_report/report.html
+msgid "Records found"
+msgstr "Catatan ditemukan"
+
+#: reports/report_types/dns_report/report.html
+msgid ""
+"The DNS report gives an overview of the DNS records that were found for the "
+"DNSZone. Additionally the security measures table shows whether or not DNS "
+"relating security measures are enabled."
+msgstr ""
+"Laporan DNS memberikan gambaran umum tentang catatan DNS yang ditemukan "
+"untuk DNSZone. Selain itu, tabel tindakan keamanan menunjukkan apakah DNS "
+"tindakan keamanan terkait diaktifkan atau tidak."
+
+#: reports/report_types/dns_report/report.html
+msgid ""
+"<strong>Disclaimer:</strong> Not all DNSRecords are parsed in OpenKAT. DNS "
+"record types that are parsed and could be displayed in the table are:"
+msgstr ""
+"<strong>Penafian:</strong> Tidak semua DNSRecords diuraikan dalam OpenKAT. "
+"DNS tipe record yang diurai dan dapat ditampilkan dalam tabel adalah:"
+
+#: reports/report_types/dns_report/report.html
+msgid "All existing DNS record types can be found here:"
+msgstr "Semua tipe data DNS yang ada dapat ditemukan di sini:"
+
+#: reports/report_types/dns_report/report.html
+msgid "Record"
+msgstr "Catatan"
+
+#: reports/report_types/dns_report/report.html
+msgid "TTL"
+msgstr "TTL"
+
+#: reports/report_types/dns_report/report.html
+msgid "Data"
+msgstr "Data"
+
+#: reports/report_types/dns_report/report.html
+msgid "No records have been found."
+msgstr "Tidak ada catatan yang ditemukan."
+
+#: reports/report_types/dns_report/report.html
+msgid "Security measures"
+msgstr "Langkah-langkah keamanan"
+
+#: reports/report_types/dns_report/report.html
+msgid ""
+"The security measures table below shows which DNS relating security measures"
+" are enabled based on the contents of the DNS records."
+msgstr ""
+"Tabel tindakan keamanan di bawah ini menunjukkan DNS tindakan keamanan "
+"terkait mana yang diaktifkan berdasarkan konten data DNS."
+
+#: reports/report_types/dns_report/report.html
+#: reports/templates/partials/report_ooi_list.html
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/modal_partials/rerun_modal.html
+#: reports/templates/summary/ooi_selection.html tools/forms/ooi.py
+#: rocky/templates/partials/elements/ooi_tree_condensed_table.html
+#: rocky/templates/partials/explanations.html
+#: rocky/templates/partials/ooi_detail_related_object.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+#: rocky/views/mixins.py
+msgid "Type"
+msgstr "Jenis"
+
+#: reports/report_types/dns_report/report.html
+msgid "Yes"
+msgstr "Ya"
+
+#: reports/report_types/dns_report/report.html
+msgid "No"
+msgstr "TIDAK"
+
+#: reports/report_types/dns_report/report.html
+#: reports/templates/partials/report_findings_table.html
+msgid "Other findings found"
+msgstr "Temuan lain ditemukan"
+
+#: reports/report_types/dns_report/report.html
+msgid "Findings information"
+msgstr "Informasi temuan"
+
+#: reports/report_types/dns_report/report.py
+msgid "DNS Report"
+msgstr "DNS Laporkan"
+
+#: reports/report_types/dns_report/report.py
+msgid ""
+"DNS reports focus on domain name system configuration and potential "
+"weaknesses."
+msgstr ""
+"Laporan DNS berfokus pada konfigurasi sistem nama domain dan potensi "
+"kelemahannya."
+
+#: reports/report_types/findings_report/report.html
+msgid ""
+"The Findings Report contains information about the findings that have been "
+"identified for the selected asset and organization."
+msgstr ""
+"Laporan Temuan berisi informasi tentang temuan yang telah diidentifikasi "
+"untuk aset dan organisasi yang dipilih."
+
+#: reports/report_types/findings_report/report.py
+msgid "Findings Report"
+msgstr "Laporan Temuan"
+
+#: reports/report_types/findings_report/report.py
+msgid "Shows all the finding types and their occurrences."
+msgstr "Menampilkan semua tipe temuan dan kemunculannya."
+
+#: reports/report_types/ipv6_report/report.html
+msgid ""
+"The IPv6 report provides an overview of the current IPv6 status of the "
+"identified system. The table below shows whether the domain is reachable "
+"over IPv6 or not. A green compliance check is shown if this is the case. A "
+"grey compliance cross is shown if no IPv6 address was detected."
+msgstr ""
+"Laporan IPv6 memberikan ikhtisar status IPv6 saat ini dari sistem yang "
+"teridentifikasi. Tabel di bawah menunjukkan apakah domain dapat dijangkau "
+"melalui IPv6 atau tidak. Pemeriksaan kepatuhan berwarna hijau akan "
+"ditampilkan jika hal ini terjadi. Tanda silang kepatuhan berwarna abu-abu "
+"ditampilkan jika tidak ada alamat IPv6 yang terdeteksi."
+
+#: reports/report_types/ipv6_report/report.html
+msgid "IPv6 overview"
+msgstr "IPv6 ikhtisar"
+
+#: reports/report_types/ipv6_report/report.html
+#: reports/report_types/systems_report/report.html
+msgid "Domain"
+msgstr "Domain"
+
+#: reports/report_types/ipv6_report/report.py
+msgid "IPv6 Report"
+msgstr "IPv6 Laporkan"
+
+#: reports/report_types/ipv6_report/report.py
+msgid "Check whether hostnames point to IPv6 addresses."
+msgstr "Periksa apakah nama host mengarah ke alamat IPv6."
+
+#: reports/report_types/mail_report/report.html
+msgid ""
+"The Mail Report provides an overview of the compliance checks associated "
+"with email servers. The current compliance checks the presence of SPF, DKIM "
+"and DMARC records. The table below shows for each of these checks how many "
+"of the identified mail servers are compliant, and if applicable a compliance"
+" issue description and risk level. The risk level may be different for your "
+"specific environment."
+msgstr ""
+"Laporan Email memberikan ikhtisar pemeriksaan kepatuhan yang terkait dengan "
+"server email. Kepatuhan saat ini memeriksa keberadaan catatan SPF, DKIM dan "
+"DMARC. Tabel di bawah ini menunjukkan untuk masing-masing pemeriksaan ini "
+"berapa banyak server email yang teridentifikasi yang mematuhi kebijakan, dan"
+" jika berlaku, deskripsi masalah kepatuhan dan tingkat risiko. Tingkat "
+"risiko mungkin berbeda untuk lingkungan spesifik Anda."
+
+#: reports/report_types/mail_report/report.html
+msgid "Mailserver compliance"
+msgstr "Kepatuhan server surat"
+
+#: reports/report_types/mail_report/report.html
+msgid "mailservers compliant"
+msgstr "sesuai dengan server email"
+
+#: reports/report_types/mail_report/report.html
+msgid "No mailservers have been found on this system."
+msgstr "Tidak ada server email yang ditemukan pada sistem ini."
+
+#: reports/report_types/mail_report/report.py
+msgid "Mail Report"
+msgstr "Laporan Surat"
+
+#: reports/report_types/mail_report/report.py
+msgid ""
+"System specific Mail Report that focusses on IP addresses and hostnames."
+msgstr ""
+"Laporan Email khusus sistem yang berfokus pada alamat dan nama host IP."
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid "Overview of included assets"
+msgstr "Ikhtisar aset yang disertakan"
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid "Asset"
+msgstr "Aset"
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+#: reports/report_types/multi_organization_report/basic_security_details.html
+msgid "Amount"
+msgstr "Jumlah"
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid "IP addresses"
+msgstr "IP alamat"
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid "Domain names"
+msgstr "Nama domain"
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid "Assets with most critical vulnerabilities"
+msgstr "Aset dengan kerentanan paling kritis"
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid "Vulnerability"
+msgstr "Kerentanan"
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid "Organisation"
+msgstr "Organisasi"
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid "No vulnerabilities found."
+msgstr "Tidak ada kerentanan yang ditemukan."
+
+#: reports/report_types/multi_organization_report/basic_security_details.html
+msgid "Overview of safe connections"
+msgstr "Ikhtisar koneksi aman"
+
+#: reports/report_types/multi_organization_report/basic_security_details.html
+#: reports/report_types/safe_connections_report/report.html
+msgid "Only Safe Ciphers"
+msgstr "Hanya Sandi Aman"
+
+#: reports/report_types/multi_organization_report/basic_security_details.html
+#: reports/report_types/safe_connections_report/report.html
+msgid "services are compliant"
+msgstr "layanan sudah sesuai"
+
+#: reports/report_types/multi_organization_report/basic_security_details.html
+msgid "System specific checks"
+msgstr "Pemeriksaan khusus sistem"
+
+#: reports/report_types/multi_organization_report/ipv6.html
+msgid "IPv6"
+msgstr "IPv6"
+
+#: reports/report_types/multi_organization_report/ipv6.html
+msgid ""
+"IPv6 includes improvements in security features compared to IPv4. While IPv4"
+" can implement security measures, IPv6 was designed with security in mind, "
+"and its adoption can contribute to a more secure internet."
+msgstr ""
+"IPv6 mencakup peningkatan fitur keamanan dibandingkan dengan IPv4. Meskipun "
+"IPv4 dapat menerapkan langkah-langkah keamanan, IPv6 dirancang dengan "
+"mempertimbangkan keamanan, dan penerapannya dapat berkontribusi pada "
+"internet yang lebih aman."
+
+#: reports/report_types/multi_organization_report/ipv6.html
+msgid "In total "
+msgstr "Total"
+
+#: reports/report_types/multi_organization_report/ipv6.html
+msgid " out of "
+msgstr "dari"
+
+#: reports/report_types/multi_organization_report/ipv6.html
+msgid " systems have an IPv6 connection."
+msgstr "sistem memiliki koneksi IPv6."
+
+#: reports/report_types/multi_organization_report/ipv6.html
+msgid "Overview of IP version compliance"
+msgstr "Ikhtisar kepatuhan versi IP"
+
+#: reports/report_types/multi_organization_report/open_ports.html
+msgid ""
+"See an overview of open ports found over all systems and the services these "
+"systems provide."
+msgstr ""
+"Lihat ikhtisar port terbuka yang ditemukan di semua sistem dan layanan yang "
+"disediakan sistem ini."
+
+#: reports/report_types/multi_organization_report/open_ports.html
+msgid "Overview of detected open ports"
+msgstr "Ikhtisar port terbuka yang terdeteksi"
+
+#: reports/report_types/multi_organization_report/open_ports.html
+#: reports/report_types/open_ports_report/report.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Open ports"
+msgstr "Buka port"
+
+#: reports/report_types/multi_organization_report/open_ports.html
+msgid "Occurrences (IP addresses)"
+msgstr "Kemunculan (IP alamat)"
+
+#: reports/report_types/multi_organization_report/open_ports.html
+#: reports/templates/summary/service_health.html
+msgid "Services"
+msgstr "Layanan"
+
+#: reports/report_types/multi_organization_report/open_ports.html
+msgid "No open ports found."
+msgstr "Tidak ditemukan port terbuka."
+
+#: reports/report_types/multi_organization_report/recommendations.html
+msgid "Overview of recommendations"
+msgstr "Ikhtisar rekomendasi"
+
+#: reports/report_types/multi_organization_report/recommendations.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid "Occurrence"
+msgstr "Kejadian"
+
+#: reports/report_types/multi_organization_report/report.html
+msgid "No findings have been identified yet."
+msgstr "Belum ada temuan yang teridentifikasi."
+
+#: reports/report_types/multi_organization_report/report.py
+msgid "Multi Organization Report"
+msgstr "Laporan Multi Organisasi"
+
+#: reports/report_types/multi_organization_report/summary.html
+msgid "Best scoring security check"
+msgstr "Pemeriksaan keamanan dengan skor terbaik"
+
+#: reports/report_types/multi_organization_report/summary.html
+msgid "Worst scoring security check"
+msgstr "Pemeriksaan keamanan dengan skor terburuk"
+
+#: reports/report_types/multi_organization_report/vulnerabilities.html
+msgid ""
+"Vulnerabilities found are grouped per system. Here, we only consider CVE "
+"vulnerabilities."
+msgstr ""
+"Kerentanan yang ditemukan dikelompokkan per sistem. Di sini, kami hanya "
+"mempertimbangkan kerentanan CVE."
+
+#: reports/report_types/multi_organization_report/vulnerabilities.html
+msgid "Vulnerabilities grouped per system"
+msgstr "Kerentanan dikelompokkan per sistem"
+
+#: reports/report_types/multi_organization_report/vulnerabilities.html
+msgid "total"
+msgstr "total"
+
+#: reports/report_types/name_server_report/report.html
+msgid ""
+"The Name Server Report provides an overview of the compliance checks that "
+"were performed against the identified Domain Name Servers (DNS). The "
+"compliance checks verify the presence and validity of DNSSEC and whether no "
+"unnecessary ports were identified to be open. The table below gives an "
+"overview of the available checks including whether the system passed the "
+"performed checks. The risk level and reasoning as to why an issue was "
+"identified are shown too. The risk level may be different for your specific "
+"environment."
+msgstr ""
+"Laporan Server Nama memberikan gambaran umum tentang pemeriksaan kepatuhan "
+"yang dilakukan terhadap Server Nama Domain yang teridentifikasi (DNS). "
+"Pemeriksaan kepatuhan memverifikasi keberadaan dan validitas DNSSEC dan "
+"apakah tidak ada port yang tidak diperlukan yang diidentifikasi sebagai "
+"terbuka. Tabel di bawah ini memberikan ikhtisar pemeriksaan yang tersedia "
+"termasuk apakah sistem lulus pemeriksaan yang dilakukan. Tingkat risiko dan "
+"alasan mengapa suatu masalah teridentifikasi juga ditampilkan. Tingkat "
+"risiko mungkin berbeda untuk lingkungan spesifik Anda."
+
+#: reports/report_types/name_server_report/report.html
+msgid "Name server compliance"
+msgstr "Kepatuhan server nama"
+
+#: reports/report_types/name_server_report/report.html
+msgid "DNSSEC Present"
+msgstr "DNSSEC Hadir"
+
+#: reports/report_types/name_server_report/report.html
+msgid "name servers compliant"
+msgstr "sesuai dengan server nama"
+
+#: reports/report_types/name_server_report/report.html
+msgid "Valid DNSSEC"
+msgstr "Berlaku DNSSEC"
+
+#: reports/report_types/name_server_report/report.html
+#: reports/report_types/web_system_report/report.html
+msgid "No unnecessary ports open"
+msgstr "Tidak ada port yang tidak diperlukan yang terbuka"
+
+#: reports/report_types/name_server_report/report.html
+msgid "No nameservers have been found on this system."
+msgstr "Tidak ada server nama yang ditemukan pada sistem ini."
+
+#: reports/report_types/name_server_report/report.py
+msgid "Name Server Report"
+msgstr "Laporan Server Nama"
+
+#: reports/report_types/name_server_report/report.py
+msgid "Name Server Report checks name servers on basic security standards."
+msgstr ""
+"Laporan Server Nama memeriksa server nama berdasarkan standar keamanan "
+"dasar."
+
+#: reports/report_types/open_ports_report/report.html
+msgid ""
+"The Open Ports Report provides an overview of the open ports identified on a"
+" system. The ports that are marked as <b>bold</b> were identified by direct "
+"scans performed by OpenKAT (such as nmap). Ports that are not marked in bold"
+" were identified through external services and/or scans (such as Shodan). "
+"Scans with the same hostnames, ports and IPs are merged."
+msgstr ""
+"Laporan Port Terbuka memberikan gambaran umum tentang port terbuka yang "
+"diidentifikasi pada suatu sistem. Port yang ditandai sebagai <b>bold</b> "
+"diidentifikasi dengan pemindaian langsung yang dilakukan oleh OpenKAT "
+"(seperti nmap). Port yang tidak ditandai dengan huruf tebal diidentifikasi "
+"melalui layanan eksternal dan/atau pemindaian (seperti Shodan). Pemindaian "
+"dengan nama host, port, dan IPs yang sama digabungkan."
+
+#: reports/report_types/open_ports_report/report.html
+msgid "Overview of open ports found for the scanned assets"
+msgstr "Ikhtisar port terbuka yang ditemukan untuk aset yang dipindai"
+
+#: reports/report_types/open_ports_report/report.html
+#: reports/report_types/systems_report/report.html
+msgid "IP address"
+msgstr "IP alamat"
+
+#: reports/report_types/open_ports_report/report.html
+msgid "Hostnames"
+msgstr "Nama host"
+
+#: reports/report_types/open_ports_report/report.html
+msgid "Direct scan"
+msgstr "Pemindaian langsung"
+
+#: reports/report_types/open_ports_report/report.py
+msgid "Open Ports Report"
+msgstr "Buka Laporan Pelabuhan"
+
+#: reports/report_types/open_ports_report/report.py
+msgid "Find open ports of IP addresses"
+msgstr "Temukan port terbuka dari alamat IP"
+
+#: reports/report_types/rpki_report/report.html
+msgid ""
+"This section contains basic security information about Resource Public Key "
+"Infrastructure (RPKI). If your web server employs RPKI for its IP addresses "
+"and associated nameservers, then it enhances visitor protection against "
+"misconfigurations and malicious route intercepts through verified route "
+"announcements, ensuring reliable server access and secure internet traffic."
+msgstr ""
+"Bagian ini berisi informasi keamanan dasar tentang Infrastruktur Kunci "
+"Publik Sumber Daya (RPKI). Jika server web Anda menggunakan RPKI untuk "
+"alamat IP dan server nama terkait, maka server web tersebut akan "
+"meningkatkan perlindungan pengunjung terhadap kesalahan konfigurasi dan "
+"penyadapan rute berbahaya melalui pengumuman rute terverifikasi, memastikan "
+"akses server yang andal dan lalu lintas internet yang aman."
+
+#: reports/report_types/rpki_report/report.html
+msgid ""
+"The RPKI Report shows if an RPKI route announcement was available for the "
+"system and if this announcement is not expired."
+msgstr ""
+"Laporan RPKI menunjukkan apakah pengumuman rute RPKI tersedia untuk sistem "
+"dan apakah pengumuman ini belum kedaluwarsa."
+
+#: reports/report_types/rpki_report/report.html
+msgid "RPKI compliance"
+msgstr "RPKI kepatuhan"
+
+#: reports/report_types/rpki_report/report.html
+msgid "RPKI Available"
+msgstr "RPKI Tersedia"
+
+#: reports/report_types/rpki_report/report.html
+msgid "RPKI valid"
+msgstr "RPKI valid"
+
+#: reports/report_types/rpki_report/report.html
+msgid "RPKI record is not valid."
+msgstr "RPKI catatan tidak valid."
+
+#: reports/report_types/rpki_report/report.html
+msgid "RPKI record does not exist."
+msgstr "RPKI catatan tidak ada."
+
+#: reports/report_types/rpki_report/report.html
+#: reports/report_types/safe_connections_report/report.html
+msgid "No IPs have been found on this system."
+msgstr "Tidak ada IPs yang ditemukan di sistem ini."
+
+#: reports/report_types/rpki_report/report.py
+msgid "RPKI Report"
+msgstr "RPKI Laporkan"
+
+#: reports/report_types/rpki_report/report.py
+msgid ""
+"Shows whether the IP is covered by a valid RPKI ROA. For a hostname it shows"
+" the IP addresses and whether they are covered by a valid RPKI ROA."
+msgstr ""
+"Menunjukkan apakah IP tercakup dalam RPKI ROA yang valid. Untuk nama host, "
+"ini menunjukkan alamat IP dan apakah alamat tersebut tercakup dalam RPKI ROA"
+" yang valid."
+
+#: reports/report_types/safe_connections_report/report.html
+msgid ""
+"The Safe Connections report provides an overview of the performed checks "
+"with regard to encrypted communication channels such as HTTPS. The table "
+"below gives an overview of the available checks including whether the system"
+" passed the performed checks. The risk level and reasoning as to why an "
+"issue was identified are shown too. The risk level may be different for your"
+" specific environment."
+msgstr ""
+"Laporan Koneksi Aman memberikan ikhtisar pemeriksaan yang dilakukan "
+"sehubungan dengan saluran komunikasi terenkripsi seperti HTTPS. Tabel di "
+"bawah ini memberikan ikhtisar pemeriksaan yang tersedia termasuk apakah "
+"sistem lulus pemeriksaan yang dilakukan. Tingkat risiko dan alasan mengapa "
+"suatu masalah teridentifikasi juga ditampilkan. Tingkat risiko mungkin "
+"berbeda untuk lingkungan spesifik Anda."
+
+#: reports/report_types/safe_connections_report/report.html
+msgid "Safe connections compliance"
+msgstr "Kepatuhan koneksi yang aman"
+
+#: reports/report_types/safe_connections_report/report.py
+msgid "Safe Connections Report"
+msgstr "Laporan Koneksi Aman"
+
+#: reports/report_types/safe_connections_report/report.py
+msgid "Shows whether the IPService contains safe ciphers."
+msgstr "Menunjukkan apakah IPService berisi sandi yang aman."
+
+#: reports/report_types/systems_report/report.html
+msgid ""
+"The System Report provides an overview of the system types (types of similar"
+" services) that were identified for each system. The following system types "
+"can be identified: DNS servers, Web servers, Mail servers and those "
+"classified as 'Other' servers. Each hostname and/or IP address is given one "
+"or more system types depending on the identified ports and services. The "
+"table below gives an overview of these results."
+msgstr ""
+"Laporan Sistem memberikan gambaran umum tentang jenis sistem (jenis layanan "
+"serupa) yang diidentifikasi untuk setiap sistem. Jenis sistem berikut dapat "
+"diidentifikasi: server DNS, server Web, server Mail dan yang "
+"diklasifikasikan sebagai server 'Lainnya'. Setiap nama host dan/atau alamat "
+"IP diberikan satu atau lebih tipe sistem tergantung pada port dan layanan "
+"yang diidentifikasi. Tabel di bawah ini memberikan ikhtisar hasil tersebut."
+
+#: reports/report_types/systems_report/report.html
+msgid "Selected assets"
+msgstr "Aset yang dipilih"
+
+#: reports/report_types/systems_report/report.html
+msgid "No system types have been identified on this system."
+msgstr "Tidak ada tipe sistem yang diidentifikasi pada sistem ini."
+
+#: reports/report_types/systems_report/report.py
+msgid "System Report"
+msgstr "Laporan Sistem"
+
+#: reports/report_types/systems_report/report.py
+msgid "Combine IP addresses, hostnames and services into systems."
+msgstr "Gabungkan alamat IP, nama host, dan layanan ke dalam sistem."
+
+#: reports/report_types/tls_report/report.html
+msgid ""
+"The TLS Report shows which TLS protocols and ciphers were identified on the "
+"host for the provided port."
+msgstr ""
+"Laporan TLS menunjukkan protokol dan sandi TLS mana yang diidentifikasi pada"
+" host untuk port yang disediakan."
+
+#: reports/report_types/tls_report/report.html
+msgid ""
+"The table below provides an overview of the identified TLS protocols and "
+"ciphers, including a status suggestion."
+msgstr ""
+"Tabel di bawah memberikan ikhtisar protokol dan sandi TLS yang "
+"teridentifikasi, termasuk saran status."
+
+#: reports/report_types/tls_report/report.html
+msgid "Ciphers"
+msgstr "sandi"
+
+#: reports/report_types/tls_report/report.html
+msgid "Protocol"
+msgstr "Protokol"
+
+#: reports/report_types/tls_report/report.html
+msgid "Encryption Algorithm"
+msgstr "Algoritma Enkripsi"
+
+#: reports/report_types/tls_report/report.html
+msgid "Bits"
+msgstr "sedikit"
+
+#: reports/report_types/tls_report/report.html
+msgid "Key Size"
+msgstr "Ukuran Kunci"
+
+#: reports/report_types/tls_report/report.html
+#: rocky/templates/organizations/organization_list.html
+#: rocky/templates/organizations/organization_settings.html
+msgid "Code"
+msgstr "Kode"
+
+#: reports/report_types/tls_report/report.html
+msgid "Phase out"
+msgstr "Keluarkan secara bertahap"
+
+#: reports/report_types/tls_report/report.html
+msgid "Good"
+msgstr "Bagus"
+
+#: reports/report_types/tls_report/report.html
+msgid ""
+"No ciphers were found for this combination of IP address, port and service."
+msgstr ""
+"Tidak ada sandi yang ditemukan untuk kombinasi alamat, port, dan layanan IP "
+"ini."
+
+#: reports/report_types/tls_report/report.html
+msgid ""
+"The list below gives an overview of the findings based on the identified TLS"
+" protocols and ciphers. This includes the reasoning why the cipher or "
+"protocol is marked as a finding."
+msgstr ""
+"Daftar di bawah ini memberikan ikhtisar temuan berdasarkan protokol dan "
+"sandi TLS yang teridentifikasi. Hal ini mencakup alasan mengapa sandi atau "
+"protokol ditandai sebagai temuan."
+
+#: reports/report_types/tls_report/report.py
+msgid "TLS Report"
+msgstr "TLS Laporkan"
+
+#: reports/report_types/tls_report/report.py
+msgid ""
+"TLS Report assesses the security of data encryption and transmission "
+"protocols."
+msgstr "TLS Laporan menilai keamanan enkripsi data dan protokol transmisi."
+
+#: reports/report_types/vulnerability_report/report.html
+msgid "No vulnerabilities have been found on this system."
+msgstr "Tidak ada kerentanan yang ditemukan pada sistem ini."
+
+#: reports/report_types/vulnerability_report/report.html
+msgid ""
+"The Vulnerability Report provides an overview of all identified CVE "
+"vulnerabilities that were identified on the selected systems. For each CVE "
+"the table shows the CVE scoring, the number of occurrences, and the CVE "
+"details."
+msgstr ""
+"Laporan Kerentanan memberikan gambaran umum tentang semua kerentanan CVE "
+"yang teridentifikasi pada sistem yang dipilih. Untuk setiap CVE tabel "
+"menunjukkan skor CVE, jumlah kemunculan, dan detail CVE."
+
+#: reports/report_types/vulnerability_report/report.html
+msgid "vulnerabilities on this system"
+msgstr "kerentanan pada sistem ini"
+
+#: reports/report_types/vulnerability_report/report.html
+msgid "Advice"
+msgstr "Nasihat"
+
+#: reports/report_types/vulnerability_report/report.py
+msgid "Vulnerability Report"
+msgstr "Laporan Kerentanan"
+
+#: reports/report_types/vulnerability_report/report.py
+msgid "Vulnerabilities found are grouped for each system."
+msgstr "Kerentanan yang ditemukan dikelompokkan untuk setiap sistem."
+
+#: reports/report_types/vulnerability_report/report.py
+msgid "First seen"
+msgstr "Pertama kali terlihat"
+
+#: reports/report_types/vulnerability_report/report.py
+msgid "Last seen"
+msgstr "Terakhir terlihat"
+
+#: reports/report_types/vulnerability_report/report.py
+msgid "Evidence"
+msgstr "Bukti"
+
+#: reports/report_types/web_system_report/report.html
+msgid ""
+"The Web System Report provides an overview of various web server checks that"
+" were performed against the scanned system(s). For each performed check the "
+"table below shows whether or not the server is compliant with the checks. A "
+"description of why this compliant check failed is also shown, including an "
+"general risk level. The risk level may be different for your specific "
+"environment."
+msgstr ""
+"Laporan Sistem Web memberikan gambaran umum tentang berbagai pemeriksaan "
+"server web yang dilakukan terhadap sistem yang dipindai. Untuk setiap "
+"pemeriksaan yang dilakukan, tabel di bawah ini menunjukkan apakah server "
+"mematuhi pemeriksaan tersebut atau tidak. Deskripsi mengapa pemeriksaan "
+"kepatuhan ini gagal juga ditampilkan, termasuk tingkat risiko umum. Tingkat "
+"risiko mungkin berbeda untuk lingkungan spesifik Anda."
+
+#: reports/report_types/web_system_report/report.html
+msgid "Web system compliance"
+msgstr "Kepatuhan sistem web"
+
+#: reports/report_types/web_system_report/report.html
+msgid "CSP Present"
+msgstr "CSP Hadir"
+
+#: reports/report_types/web_system_report/report.html
+msgid "webservers compliant"
+msgstr "sesuai dengan server web"
+
+#: reports/report_types/web_system_report/report.html
+msgid "Secure CSP Header"
+msgstr "Amankan CSP Header"
+
+#: reports/report_types/web_system_report/report.html
+msgid "Redirects HTTP to HTTPS"
+msgstr "Mengalihkan HTTP ke HTTPS"
+
+#: reports/report_types/web_system_report/report.html
+msgid "Offers HTTPS"
+msgstr "Penawaran HTTPS"
+
+#: reports/report_types/web_system_report/report.html
+msgid "Has a Security.txt"
+msgstr "Memiliki Keamanan.txt"
+
+#: reports/report_types/web_system_report/report.html
+msgid "Has a certificate"
+msgstr "Memiliki sertifikat"
+
+#: reports/report_types/web_system_report/report.html
+msgid "Certificate is valid"
+msgstr "Sertifikat valid"
+
+#: reports/report_types/web_system_report/report.html
+msgid "Certificate is not expiring soon"
+msgstr "Sertifikat tidak akan segera habis masa berlakunya"
+
+#: reports/report_types/web_system_report/report.html
+msgid "No webservers have been found on this system."
+msgstr "Tidak ada server web yang ditemukan pada sistem ini."
+
+#: reports/report_types/web_system_report/report.py
+msgid "Web System Report"
+msgstr "Laporan Sistem Web"
+
+#: reports/report_types/web_system_report/report.py
+msgid "Web System Reports check web systems on basic security standards."
+msgstr ""
+"Laporan Sistem Web memeriksa sistem web berdasarkan standar keamanan dasar."
+
+#: reports/templates/partials/export_report_settings.html
+msgid "Report schedule"
+msgstr "Jadwal laporan"
+
+#: reports/templates/partials/export_report_settings.html
+msgid ""
+"When scheduling your report, you have two options. You can either choose to "
+"generate it just once now, or set it to run automatically at regular "
+"intervals, like daily, weekly, or monthly. If you need the report just for a"
+" single occasion, select the one-time option."
+msgstr ""
+"Saat menjadwalkan laporan, Anda memiliki dua opsi. Anda dapat memilih untuk "
+"membuatnya sekali saja sekarang, atau mengaturnya agar berjalan secara "
+"otomatis secara berkala, seperti harian, mingguan, atau bulanan. Jika Anda "
+"memerlukan laporan hanya untuk satu kali kejadian, pilih opsi satu kali."
+
+#: reports/templates/partials/export_report_settings.html
+#: reports/templates/report_overview/report_history_table.html
+msgid "Report name"
+msgstr "Nama laporan"
+
+#: reports/templates/partials/export_report_settings.html
+#, python-format, python-brace-format
+msgid ""
+"When generating reports, it is possible to give the report a name. The name "
+"can be static or dynamic. The default format for a report is '${report_type}"
+" for ${oois_count} objects'. These placeholders automatically adapt based on"
+" the report details. This format could for example return 'Aggregate Report "
+"for 15 objects'. Another placeholder that can be used is '${ooi}', which "
+"will show the name of the object when there is only one object. You can also"
+" customize the name by adding prefixes, suffixes, or other formats like "
+"'%%W' for the week number, using options from <a "
+"href=\"https://strftime.org/\" target=\"_blank\" rel=\"noopener\">Python "
+"strftime code</a>."
+msgstr ""
+"Saat membuat laporan, dimungkinkan untuk memberi nama pada laporan tersebut."
+" Namanya bisa statis atau dinamis. Format default untuk laporan adalah "
+"'${report_type} untuk objek ${oois_count}'. Placeholder ini secara otomatis "
+"beradaptasi berdasarkan rincian laporan. Format ini misalnya dapat "
+"mengembalikan 'Laporan Agregat untuk 15 objek'. Placeholder lain yang bisa "
+"digunakan adalah '${ooi}', yang akan menampilkan nama objek ketika hanya ada"
+" satu objek. Anda juga dapat menyesuaikan nama dengan menambahkan awalan, "
+"akhiran, atau format lain seperti '%%W' untuk nomor minggu, menggunakan opsi"
+" dari <a href=\"https://strftime.org/\" target=\"_blank\" "
+"rel=\"noopener\">Kode strftime Python</a>."
+
+#: reports/templates/partials/export_report_settings.html
+#: reports/templates/partials/generate_report_header.html
+#: reports/templates/partials/new_report_action_button.html
+#: reports/views/generate_report.py
+msgid "Generate report"
+msgstr "Hasilkan laporan"
+
+#: reports/templates/partials/generate_report_header.html
+msgid "To generate an aggregate report, complete the following steps."
+msgstr ""
+"Untuk menghasilkan laporan agregat, selesaikan langkah-langkah berikut."
+
+#: reports/templates/partials/generate_report_header.html
+msgid "To generate a multi report, complete the following steps."
+msgstr "Untuk menghasilkan multilaporan, selesaikan langkah-langkah berikut."
+
+#: reports/templates/partials/generate_report_header.html
+msgid "To generate separate report(s), complete the following steps."
+msgstr ""
+"Untuk menghasilkan laporan terpisah, selesaikan langkah-langkah berikut."
+
+#: reports/templates/partials/generate_report_sidemenu.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Table of contents"
+msgstr "Daftar isi"
+
+#: reports/templates/partials/new_report_action_button.html
+msgid "Actions for creating a new report"
+msgstr "Tindakan untuk membuat laporan baru"
+
+#: reports/templates/partials/new_report_action_button.html
+msgid "Separate report(s)"
+msgstr "Laporan terpisah"
+
+#: reports/templates/partials/new_report_action_button.html
+#: reports/views/aggregate_report.py
+msgid "Aggregate report"
+msgstr "Laporan agregat"
+
+#: reports/templates/partials/new_report_action_button.html
+#: reports/views/multi_report.py
+msgid "Multi report"
+msgstr "Banyak laporan"
+
+#: reports/templates/partials/plugin_overview_table.html
+#: reports/templates/partials/report_sidemenu.html
+#: rocky/templates/oois/ooi_page_tabs.html
+msgid "Overview"
+msgstr "Ringkasan"
+
+#: reports/templates/partials/plugin_overview_table.html
+msgid "Plugin overview table"
+msgstr "Tabel ikhtisar plugin"
+
+#: reports/templates/partials/plugin_overview_table.html
+#: reports/templates/partials/report_setup_scan.html
+msgid "Required plugins"
+msgstr "Plugin yang diperlukan"
+
+#: reports/templates/partials/plugin_overview_table.html
+#: reports/templates/partials/report_setup_scan.html
+msgid "Suggested plugins"
+msgstr "Plugin yang disarankan"
+
+#: reports/templates/partials/plugin_overview_table.html
+msgid "Action required"
+msgstr "Diperlukan tindakan"
+
+#: reports/templates/partials/plugin_overview_table.html
+msgid "Ready"
+msgstr "Siap"
+
+#: reports/templates/partials/report_findings_table.html
+msgid ""
+"This table provides an overview of the identified findings on the scanned "
+"systems. For each finding type it shows the risk level, the number of "
+"occurrences and the first known occurrence of the finding. The risk level "
+"may be different for your specific environment. The details can be seen when"
+" expanding a row. A description, the source, impact and recommendation of "
+"the finding can be found here. It also shows in which findings the finding "
+"type occurred."
+msgstr ""
+"Tabel ini memberikan gambaran umum tentang temuan yang diidentifikasi pada "
+"sistem yang dipindai. Untuk setiap jenis temuan, ditampilkan tingkat risiko,"
+" jumlah kejadian, dan kejadian temuan pertama yang diketahui. Tingkat risiko"
+" mungkin berbeda untuk lingkungan spesifik Anda. Detailnya dapat dilihat "
+"saat memperluas baris. Uraian, sumber, dampak dan rekomendasi temuan dapat "
+"dilihat di sini. Hal ini juga menunjukkan pada temuan mana jenis temuan "
+"tersebut terjadi."
+
+#: reports/templates/partials/report_findings_table.html
+msgid "First known occurrence"
+msgstr "Kejadian pertama yang diketahui"
+
+#: reports/templates/partials/report_findings_table.html
+msgid "Open in report"
+msgstr "Buka di laporan"
+
+#: reports/templates/partials/report_findings_table.html
+msgid ""
+"No critical and high findings have been identified for this organization."
+msgstr ""
+"Tidak ada temuan penting dan penting yang diidentifikasi untuk organisasi "
+"ini."
+
+#: reports/templates/partials/report_findings_table.html
+msgid "No findings have been identified for this organization."
+msgstr "Tidak ada temuan yang diidentifikasi untuk organisasi ini."
+
+#: reports/templates/partials/report_header.html
+msgid "Download as PDF"
+msgstr "Unduh sebagai PDF"
+
+#: reports/templates/partials/report_header.html
+#: rocky/templates/partials/ooi_list_toolbar.html
+msgid "Download as JSON"
+msgstr "Unduh sebagai JSON"
+
+#: reports/templates/partials/report_header.html
+msgid "Open asset reports"
+msgstr "Buka laporan aset"
+
+#: reports/templates/partials/report_header.html
+msgid "This is the OpenKAT report for organization"
+msgstr "Ini adalah laporan OpenKAT untuk organisasi"
+
+#: reports/templates/partials/report_header.html
+msgid ""
+"All selected report types for the selected objects are displayed one below "
+"the other."
+msgstr ""
+"Semua jenis laporan yang dipilih untuk objek yang dipilih ditampilkan satu "
+"di bawah yang lain."
+
+#: reports/templates/partials/report_header.html
+msgid "Created with data from:"
+msgstr "Dibuat dengan data dari:"
+
+#: reports/templates/partials/report_header.html
+msgid "Created on:"
+msgstr "Dibuat pada:"
+
+#: reports/templates/partials/report_header.html
+msgid "Created from recipe:"
+msgstr "Dibuat dari resep:"
+
+#: reports/templates/partials/report_header.html
+msgid "Recipe created by:"
+msgstr "Resep dibuat oleh:"
+
+#: reports/templates/partials/report_header.html
+#, python-format
+msgid "This sector contains %(length)s scanned organizations."
+msgstr "Sektor ini berisi %(length)s organisasi yang dipindai."
+
+#: reports/templates/partials/report_header.html
+msgid "Of these organizations"
+msgstr "Dari organisasi-organisasi ini"
+
+#: reports/templates/partials/report_header.html
+msgid "organizations have tag"
+msgstr "organisasi memiliki tag"
+
+#: reports/templates/partials/report_header.html
+msgid "The basic security scores are around "
+msgstr "Skor keamanan dasar sudah ada"
+
+#: reports/templates/partials/report_header.html
+#, python-format
+msgid "A total of %(total)s critical vulnerabilities have been identified."
+msgstr "Total %(total)s kerentanan kritis telah diidentifikasi."
+
+#: reports/templates/partials/report_introduction.html
+msgid "Introduction"
+msgstr "Perkenalan"
+
+#: reports/templates/partials/report_introduction.html
+msgid ""
+"This report gives an overview of the current state of security for your "
+"organisation for the selected date. The summary section provides an overview"
+" of the selected systems (objects), plugins and reports. This is followed "
+"with the findings for each report."
+msgstr ""
+"Laporan ini memberikan gambaran umum tentang kondisi keamanan organisasi "
+"Anda saat ini pada tanggal yang dipilih. Bagian ringkasan memberikan "
+"gambaran umum tentang sistem (objek), plugin, dan laporan yang dipilih. Hal "
+"ini diikuti dengan temuan untuk setiap laporan."
+
+#: reports/templates/partials/report_names_form.html
+msgid "Report names:"
+msgstr "Nama laporan:"
+
+#: reports/templates/partials/report_names_form.html
+#: rocky/templates/forms/widgets/checkbox_group_table.html
+#: rocky/templates/oois/ooi_detail_add_related_object.html
+#: rocky/templates/partials/edit_ooi_clearance_level_modal.html
+#: rocky/templates/partials/form/field_input.html
+#: rocky/templates/partials/form/field_input_checkbox.html
+#: rocky/templates/partials/form/field_input_multiselect.html
+#: rocky/templates/partials/form/field_input_radio.html
+msgid "Required"
+msgstr "Diperlukan"
+
+#: reports/templates/partials/report_names_form.html
+msgid "Add reference date"
+msgstr "Tambahkan tanggal referensi"
+
+#: reports/templates/partials/report_names_form.html
+#: reports/templates/report_overview/modal_partials/rename_modal.html
+msgid "Reset"
+msgstr "Mengatur ulang"
+
+#: reports/templates/partials/report_names_form.html
+msgid "No reference date"
+msgstr "Tidak ada tanggal referensi"
+
+#: reports/templates/partials/report_names_form.html
+msgid "Day"
+msgstr "Hari"
+
+#: reports/templates/partials/report_names_form.html
+msgid "Week"
+msgstr "Pekan"
+
+#: reports/templates/partials/report_names_form.html
+msgid "Month"
+msgstr "Bulan"
+
+#: reports/templates/partials/report_names_form.html
+msgid "Year"
+msgstr "Tahun"
+
+#: reports/templates/partials/report_ooi_list.html
+msgid "Object selection"
+msgstr "Pemilihan objek"
+
+#: reports/templates/partials/report_ooi_list.html
+msgid ""
+"Select which objects you want to include in your report. You can either "
+"continue with a live set or you can select the objects manually from the "
+"table below."
+msgstr ""
+"Pilih objek mana yang ingin Anda sertakan dalam laporan Anda. Anda dapat "
+"melanjutkan dengan set langsung atau memilih objek secara manual dari tabel "
+"di bawah."
+
+#: reports/templates/partials/report_ooi_list.html
+msgid ""
+"A live set is a set of objects based on the applied filters. Any object that"
+" matches this applied filter (now or in the future) will be used as input "
+"for the scheduled report. If your live set filter (e.g. 'hostnames' with 'L2"
+" clearance' that are 'declared') shows 2 hostnames that match the filter "
+"today, the scheduled report will run for those 2 hostnames. If you add 3 "
+"more hostnames tomorrow (with the same filter criteria), your next scheduled"
+" report will contain 5 hostnames. Your live set will update as you go."
+msgstr ""
+"Kumpulan langsung adalah kumpulan objek berdasarkan filter yang diterapkan. "
+"Objek apa pun yang cocok dengan filter yang diterapkan ini (sekarang atau di"
+" masa mendatang) akan digunakan sebagai masukan untuk laporan terjadwal. "
+"Jika filter set langsung Anda (misalnya 'nama host' dengan 'izin L2' yang "
+"'dideklarasikan') menunjukkan 2 nama host yang cocok dengan filter hari ini,"
+" laporan terjadwal akan dijalankan untuk 2 nama host tersebut. Jika Anda "
+"menambahkan 3 nama host lagi besok (dengan kriteria filter yang sama), "
+"laporan terjadwal Anda berikutnya akan berisi 5 nama host. Set siaran "
+"langsung Anda akan diperbarui seiring berjalannya waktu."
+
+#: reports/templates/partials/report_ooi_list.html
+msgid ""
+"Based on the current dataset, your selected filters result in the following "
+"objects."
+msgstr ""
+"Berdasarkan kumpulan data saat ini, filter yang Anda pilih menghasilkan "
+"objek berikut."
+
+#: reports/templates/partials/report_ooi_list.html
+msgid "objects selected"
+msgstr "objek yang dipilih"
+
+#: reports/templates/partials/report_ooi_list.html
+msgid "Deselect all objects"
+msgstr "Batalkan pilihan semua objek"
+
+#: reports/templates/partials/report_ooi_list.html
+#: rocky/templates/oois/ooi_list.html
+#, python-format
+msgid "Showing %(length)s of %(total)s objects"
+msgstr "Menampilkan %(length)s dari %(total)s objek"
+
+#: reports/templates/partials/report_ooi_list.html
+#, python-format
+msgid "Select all %(total_oois)s object"
+msgid_plural "Select all %(total_oois)s objects"
+msgstr[0] "Pilih semua objek %(total_oois)s"
+
+#: reports/templates/partials/report_ooi_list.html
+msgid "Object name"
+msgstr "Nama objek"
+
+#: reports/templates/partials/report_ooi_list.html
+msgid "Report(s) may be empty due to no objects in the selected filters."
+msgstr "Laporan mungkin kosong karena tidak ada objek di filter yang dipilih."
+
+#: reports/templates/partials/report_ooi_list.html
+msgid ""
+"Reports matching the selected filters will be empty at this moment in time. "
+"Future reports may contain data. It is still possible to generate the "
+"(potentially empty) report."
+msgstr ""
+"Laporan yang cocok dengan filter yang dipilih akan kosong pada saat ini. "
+"Laporan mendatang mungkin berisi data. Laporan (yang berpotensi kosong) "
+"masih dapat dibuat."
+
+#: reports/templates/partials/report_ooi_list.html
+msgid "Continue with live set"
+msgstr "Lanjutkan dengan set langsung"
+
+#: reports/templates/partials/report_ooi_list.html
+#: reports/templates/partials/report_types_selection.html
+msgid "Continue with selection"
+msgstr "Lanjutkan dengan seleksi"
+
+#: reports/templates/partials/report_setup_scan.html
+#: reports/views/aggregate_report.py reports/views/generate_report.py
+#: reports/views/multi_report.py
+msgid "Configuration"
+msgstr "Konfigurasi"
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Set up the required plugins for this report."
+msgstr "Siapkan plugin yang diperlukan untuk laporan ini."
+
+#: reports/templates/partials/report_setup_scan.html
+#: reports/templates/summary/selected_plugins.html
+msgid "Plugins"
+msgstr "Plugin"
+
+#: reports/templates/partials/report_setup_scan.html
+msgid ""
+"KAT will be able to generate a full report when all the required and "
+"suggested boefjes are enabled."
+msgstr ""
+"KAT akan dapat menghasilkan laporan lengkap ketika semua boefje yang "
+"diperlukan dan disarankan diaktifkan."
+
+#: reports/templates/partials/report_setup_scan.html
+msgid ""
+"If you choose not to enable a plugin, the data that plugin would collect or "
+"produce will be left out of the report which will then be generated based on"
+" the available data collected by the enabled plugins."
+msgstr ""
+"Jika Anda memilih untuk tidak mengaktifkan plugin, data yang dikumpulkan "
+"atau dihasilkan oleh plugin tersebut akan dikeluarkan dari laporan yang "
+"kemudian akan dibuat berdasarkan data yang tersedia yang dikumpulkan oleh "
+"plugin yang diaktifkan."
+
+#: reports/templates/partials/report_setup_scan.html
+msgid ""
+"Some plugins are mandatory as they are crucial for a report type. Reports "
+"that don't have their requirements met will be skipped."
+msgstr ""
+"Beberapa plugin bersifat wajib karena sangat penting untuk jenis laporan. "
+"Laporan yang persyaratannya tidak terpenuhi akan dilewati."
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Warning! Before you proceed read the following points:"
+msgstr "Peringatan! Sebelum Anda melanjutkan, bacalah poin-poin berikut:"
+
+#: reports/templates/partials/report_setup_scan.html
+msgid ""
+"OpenKAT is designed to scan all known objects on a regular basis using the "
+"enabled plugins and set clearance levels. This means that scans will run "
+"automatically. Be patient; plugins may take some time before they have "
+"collected all their data. Enabling them just before report generation will "
+"likely result in inaccurate reports, as plugins have not finished collecting"
+" data."
+msgstr ""
+"OpenKAT dirancang untuk memindai semua objek yang dikenal secara teratur "
+"menggunakan plugin yang diaktifkan dan mengatur tingkat izin. Artinya "
+"pemindaian akan berjalan secara otomatis. Bersabarlah; plugin mungkin "
+"memerlukan waktu beberapa saat sebelum mengumpulkan semua datanya. "
+"Mengaktifkannya tepat sebelum pembuatan laporan kemungkinan besar akan "
+"menghasilkan laporan yang tidak akurat, karena plugin belum selesai "
+"mengumpulkan data."
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Good job! All required plugins are enabled."
+msgstr "Kerja bagus! Semua plugin yang diperlukan diaktifkan."
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "This report type requires the following plugins to be enabled:"
+msgstr "Jenis laporan ini memerlukan plugin berikut untuk diaktifkan:"
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Toggle all required plugins"
+msgstr "Alihkan semua plugin yang diperlukan"
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Show enabled plugins"
+msgstr "Tampilkan plugin yang diaktifkan"
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "There are no required plugins."
+msgstr "Tidak ada plugin yang diperlukan."
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Good job! All suggested plugins are enabled."
+msgstr "Kerja bagus! Semua plugin yang disarankan diaktifkan."
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "The following plugins are optional to generate the report:"
+msgstr "Plugin berikut bersifat opsional untuk menghasilkan laporan:"
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Toggle all optional plugins"
+msgstr "Alihkan semua plugin opsional"
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Hide suggested plugins"
+msgstr "Sembunyikan plugin yang disarankan"
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Show more suggested plugins"
+msgstr "Tampilkan lebih banyak plugin yang disarankan"
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "There are no optional plugins."
+msgstr "Tidak ada plugin opsional."
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Enable selected plugins and continue"
+msgstr "Aktifkan plugin yang dipilih dan lanjutkan"
+
+#: reports/templates/partials/report_severity_totals_table.html
+msgid ""
+"\n"
+"            This overview shows the total number of findings per\n"
+"            severity that have been identified for this organization.\n"
+"        "
+msgstr ""
+"\n"
+"Ikhtisar ini menunjukkan jumlah total temuan per\n"
+"            tingkat keparahan yang telah diidentifikasi untuk organisasi ini."
+
+#: reports/templates/partials/report_severity_totals_table.html
+msgid "Total per severity overview"
+msgstr "Ikhtisar total per tingkat keparahan"
+
+#: reports/templates/partials/report_severity_totals_table.html
+msgid "Critical"
+msgstr "Kritis"
+
+#: reports/templates/partials/report_severity_totals_table.html
+msgid "High"
+msgstr "Tinggi"
+
+#: reports/templates/partials/report_severity_totals_table.html
+msgid "Medium"
+msgstr "Sedang"
+
+#: reports/templates/partials/report_severity_totals_table.html
+msgid "Low"
+msgstr "Rendah"
+
+#: reports/templates/partials/report_severity_totals_table.html
+#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+msgid "Pending"
+msgstr "Tertunda"
+
+#: reports/templates/partials/report_severity_totals_table.html
+msgid "Unknown"
+msgstr "Tidak dikenal"
+
+#: reports/templates/partials/report_severity_totals_table.html
+msgid "Total"
+msgstr "Total"
+
+#: reports/templates/partials/report_sidemenu.html
+msgid "Selected Objects"
+msgstr "Objek yang Dipilih"
+
+#: reports/templates/partials/report_sidemenu.html
+msgid "Selected Plugins"
+msgstr "Plugin yang Dipilih"
+
+#: reports/templates/partials/report_sidemenu.html
+msgid "Used Config Objects"
+msgstr "Objek Konfigurasi yang Digunakan"
+
+#: reports/templates/partials/report_types_selection.html
+msgid "Choose report types"
+msgstr "Pilih jenis laporan"
+
+#: reports/templates/partials/report_types_selection.html
+msgid ""
+"Various types of reports, such as DNS reports and TLS reports, are essential"
+" for identifying vulnerabilities in different aspects of a system's "
+"security. DNS reports focus on domain name system configuration and "
+"potential weaknesses, while TLS reports assess the security of data "
+"encryption and transmission protocols, helping organizations pinpoint areas "
+"where security improvements are needed."
+msgstr ""
+"Berbagai jenis laporan, seperti laporan DNS dan laporan TLS, sangat penting "
+"untuk mengidentifikasi kerentanan dalam berbagai aspek keamanan sistem. "
+"Laporan DNS fokus pada konfigurasi sistem nama domain dan potensi "
+"kelemahannya, sedangkan laporan TLS menilai keamanan enkripsi data dan "
+"protokol transmisi, membantu organisasi menentukan area mana yang memerlukan"
+" peningkatan keamanan."
+
+#: reports/templates/partials/report_types_selection.html
+#, python-format
+msgid "Selected object (%(total_oois)s)"
+msgid_plural "Selected objects (%(total_oois)s)"
+msgstr[0] "Objek yang dipilih (%(total_oois)s)"
+
+#: reports/templates/partials/report_types_selection.html
+#, python-format
+msgid ""
+"You have selected a live set in the previous step. Based on the current "
+"dataset, this live set results in %(total_oois)s objects."
+msgstr ""
+"Anda telah memilih set live pada langkah sebelumnya. Berdasarkan kumpulan "
+"data saat ini, kumpulan langsung ini menghasilkan objek %(total_oois)s."
+
+#: reports/templates/partials/report_types_selection.html
+msgid "Applied filters:"
+msgstr "Filter yang diterapkan:"
+
+#: reports/templates/partials/report_types_selection.html
+#, python-format
+msgid "You have selected %(total_oois)s object in the previous step."
+msgid_plural "You have selected %(total_oois)s objects in the previous step."
+msgstr[0] "Anda telah memilih objek %(total_oois)s pada langkah sebelumnya."
+
+#: reports/templates/partials/report_types_selection.html
+msgid "Change selection"
+msgstr "Ubah pilihan"
+
+#: reports/templates/partials/report_types_selection.html
+msgid "Available report types"
+msgstr "Jenis laporan yang tersedia"
+
+#: reports/templates/partials/report_types_selection.html
+msgid "All report types that are available for your selection."
+msgstr "Semua jenis laporan yang tersedia untuk pilihan Anda."
+
+#: reports/templates/partials/report_types_selection.html
+msgid "Toggle all report types"
+msgstr "Alihkan semua jenis laporan"
+
+#: reports/templates/partials/return_button.html
+#, python-format
+msgid "%(btn_text)s"
+msgstr "%(btn_text)s"
+
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/modal_partials/share_modal.html
+msgid "Delete the following report(s):"
+msgstr "Hapus laporan berikut:"
+
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/modal_partials/share_modal.html
+msgid ""
+"Deleted reports are removed in the view from the moment of deletion. The "
+"report can still be accessed on timestamps before the deletion. Only the "
+"report is removed from the view, not the data it is based on."
+msgstr ""
+"Laporan yang dihapus akan dihapus dalam tampilan sejak saat penghapusan. "
+"Laporan masih dapat diakses berdasarkan stempel waktu sebelum penghapusan. "
+"Hanya laporan yang dihapus dari tampilan, bukan data yang menjadi dasarnya."
+
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/modal_partials/share_modal.html
+msgid ""
+"It is still possible to generate a new report for same date. If the report "
+"is part of a combined report, it will remain available in the combined "
+"report."
+msgstr ""
+"Masih dimungkinkan untuk membuat laporan baru untuk tanggal yang sama. Jika "
+"laporan tersebut merupakan bagian dari laporan gabungan, laporan tersebut "
+"akan tetap tersedia dalam laporan gabungan."
+
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/modal_partials/rerun_modal.html
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+#: reports/templates/report_overview/subreports_table.html
+msgid "Reference date"
+msgstr "Tanggal referensi"
+
+#: reports/templates/report_overview/modal_partials/enable_disable_schedule_modal.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Disable schedule"
+msgstr "Nonaktifkan jadwal"
+
+#: reports/templates/report_overview/modal_partials/enable_disable_schedule_modal.html
+#, python-format
+msgid ""
+"Are you sure you want to disable the schedule for "
+"<strong>%(report_name)s</strong>? The recipe will still exist and the "
+"schedule can be enabled later on."
+msgstr ""
+"Apakah Anda yakin ingin menonaktifkan jadwal untuk "
+"<strong>%(report_name)s</strong>? Resepnya akan tetap ada dan jadwalnya bisa"
+" diaktifkan nanti."
+
+#: reports/templates/report_overview/modal_partials/rename_modal.html
+msgid "Rename the following report(s):"
+msgstr "Ganti nama laporan berikut:"
+
+#: reports/templates/report_overview/modal_partials/rename_modal.html
+#: reports/templates/report_overview/report_history_table.html
+msgid "Rename"
+msgstr "Ganti nama"
+
+#: reports/templates/report_overview/modal_partials/rerun_modal.html
+msgid "Rerun the following report(s):"
+msgstr "Jalankan kembali laporan berikut:"
+
+#: reports/templates/report_overview/modal_partials/rerun_modal.html
+msgid ""
+"By submitting you're generating the selected reports again, using the "
+"current data."
+msgstr ""
+"Dengan mengirimkannya, Anda membuat kembali laporan yang dipilih, "
+"menggunakan data saat ini."
+
+#: reports/templates/report_overview/modal_partials/rerun_modal.html
+#: reports/templates/report_overview/report_history_table.html
+msgid "Rerun"
+msgstr "Memutarkan lagi"
+
+#: reports/templates/report_overview/report_history.html
+msgid "Reports history"
+msgstr "Melaporkan sejarah"
+
+#: reports/templates/report_overview/report_history.html
+msgid ""
+"On this page you can see all the reports that have been generated in the "
+"past. To create a new report, click the 'Generate Report' button."
+msgstr ""
+"Di halaman ini Anda dapat melihat semua laporan yang telah dibuat "
+"sebelumnya. Untuk membuat laporan baru, klik tombol 'Buat Laporan'."
+
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/report_overview/subreports.html
+#, python-format
+msgid "Showing %(length)s of %(total)s reports"
+msgstr "Menampilkan %(length)s dari %(total)s laporan"
+
+#: reports/templates/report_overview/report_history_table.html
+#: rocky/templates/tasks/reports.html
+msgid "Reports:"
+msgstr "Laporan:"
+
+#: reports/templates/report_overview/report_history_table.html
+msgid "Shows parent report details"
+msgstr "Menampilkan detail laporan orang tua"
+
+#: reports/templates/report_overview/report_history_table.html
+msgid "Close asset report object details"
+msgstr "Tutup detail objek laporan aset"
+
+#: reports/templates/report_overview/report_history_table.html
+msgid "Open asset report object details"
+msgstr "Buka detail objek laporan aset"
+
+#: reports/templates/report_overview/report_history_table.html
+msgid "Asset reports details"
+msgstr "Detail laporan aset"
+
+#: reports/templates/report_overview/report_history_table.html
+#, python-format
+msgid ""
+"This report consists of %(counter)s asset report with the following report "
+"type and object:"
+msgid_plural ""
+"This report consists of %(counter)s asset reports with the following report "
+"types and objects:"
+msgstr[0] ""
+"Laporan ini terdiri dari %(counter)s laporan aset dengan jenis dan objek "
+"laporan sebagai berikut:"
+
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/report_overview/subreports_header.html
+#: reports/templates/report_overview/subreports_table.html
+#: reports/views/report_overview.py
+msgid "Asset reports"
+msgstr "Laporan aset"
+
+#: reports/templates/report_overview/report_history_table.html
+msgid "Shows asset report details"
+msgstr "Menampilkan detail laporan aset"
+
+#: reports/templates/report_overview/report_history_table.html
+msgid "View all asset reports"
+msgstr "Lihat semua laporan aset"
+
+#: reports/templates/report_overview/report_history_table.html
+msgid "No reports have been generated yet."
+msgstr "Belum ada laporan yang dibuat."
+
+#: reports/templates/report_overview/report_overview_header.html
+#: reports/views/base.py rocky/templates/header.html
+#: rocky/templates/tasks/partials/tab_navigation.html
+#: rocky/templates/tasks/reports.html rocky/views/tasks.py
+msgid "Reports"
+msgstr "Laporan"
+
+#: reports/templates/report_overview/report_overview_header.html
+msgid "An overview of reports that are scheduled or have been generated."
+msgstr "Ikhtisar laporan yang dijadwalkan atau telah dihasilkan."
+
+#: reports/templates/report_overview/report_overview_navigation.html
+msgid "Scheduled"
+msgstr "Dijadwalkan"
+
+#: reports/templates/report_overview/report_overview_navigation.html
+msgid "History"
+msgstr "Sejarah"
+
+#: reports/templates/report_overview/scheduled_reports.html
+msgid "Scheduled reports"
+msgstr "Laporan terjadwal"
+
+#: reports/templates/report_overview/scheduled_reports.html
+msgid ""
+"On this page you can see all the reports that are or have been scheduled. To"
+" schedule a report, select a start date and recurrence while generating a "
+"report."
+msgstr ""
+"Pada halaman ini Anda dapat melihat semua laporan yang sedang atau telah "
+"dijadwalkan. Untuk menjadwalkan laporan, pilih tanggal mulai dan pengulangan"
+" saat membuat laporan."
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+#, python-format
+msgid "Showing %(length)s of %(total)s schedules"
+msgstr "Menampilkan %(length)s dari %(total)s jadwal"
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Scheduled reports:"
+msgstr "Laporan terjadwal:"
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Scheduled for"
+msgstr "Dijadwalkan untuk"
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Schedule status"
+msgstr "Status jadwal"
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Once"
+msgstr "Sekali"
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Recent reports"
+msgstr "Laporan terbaru"
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Scheduled Reports:"
+msgstr "Laporan Terjadwal:"
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Show report details"
+msgstr "Tampilkan detail laporan"
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "objects"
+msgstr "objek"
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Enable schedule"
+msgstr "Aktifkan jadwal"
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "No scheduled reports have been generated yet."
+msgstr "Belum ada laporan terjadwal yang dibuat."
+
+#: reports/templates/report_overview/subreports_header.html
+msgid "Back to Reports History"
+msgstr "Kembali ke Riwayat Laporan"
+
+#: reports/templates/report_overview/subreports_header.html
+msgid "An overview of all underlying reports of"
+msgstr "Ikhtisar semua laporan yang mendasari"
+
+#: reports/templates/report_overview/subreports_header.html
+#: reports/templates/report_overview/subreports_table.html
+msgid "Shows report details"
+msgstr "Menampilkan detail laporan"
+
+#: reports/templates/report_overview/subreports_table.html
+#: rocky/templates/tasks/boefjes.html
+#: rocky/templates/tasks/plugin_detail_task_list.html
+msgid "Input Object"
+msgstr "Objek Masukan"
+
+#: reports/templates/report_schedules/delete_recipe_modal.html
+msgid "Delete report recipe"
+msgstr "Hapus resep laporan"
+
+#: reports/templates/report_schedules/delete_recipe_modal.html
+#, python-format
+msgid "Are you sure you want to delete report recipe \"%(name)s\"?"
+msgstr "Apakah Anda yakin ingin menghapus resep laporan \"%(name)s\"?"
+
+#: reports/templates/report_schedules/delete_recipe_modal.html
+msgid ""
+"Deleting this report recipe means it will be permanently deleted. It will "
+"not be possible anymore to see or enable the schedule. You will find "
+"previously generated reports in the report history tab."
+msgstr ""
+"Menghapus resep laporan ini berarti akan dihapus secara permanen. Tidak "
+"mungkin lagi melihat atau mengaktifkan jadwal. Anda akan menemukan laporan "
+"yang dibuat sebelumnya di tab riwayat laporan."
+
+#: reports/templates/summary/report_asset_overview.html
+msgid ""
+"The objects listed in the table below were used to generate this report. For"
+" each object in the table it additionally shows the clearance level and "
+"whether or not the object was added by a user ('Declared') or indirectly "
+"identified through another service or system ('Inherited')."
+msgstr ""
+"Objek yang tercantum dalam tabel di bawah digunakan untuk menghasilkan "
+"laporan ini. Untuk setiap objek dalam tabel, tabel ini juga menunjukkan "
+"tingkat izin dan apakah objek tersebut ditambahkan oleh pengguna "
+"('Deklarasikan') atau diidentifikasi secara tidak langsung melalui layanan "
+"atau sistem lain ('Diwarisi')."
+
+#: reports/templates/summary/report_asset_overview.html
+msgid "No objects found."
+msgstr "Tidak ada objek yang ditemukan."
+
+#: reports/templates/summary/report_asset_overview.html
+msgid ""
+"The table below shows which reports were chosen to generate this report, "
+"including a report description."
+msgstr ""
+"Tabel di bawah menunjukkan laporan mana yang dipilih untuk menghasilkan "
+"laporan ini, termasuk deskripsi laporan."
+
+#: reports/templates/summary/report_asset_overview.html
+msgid "No report types found."
+msgstr "Tidak ada jenis laporan yang ditemukan."
+
+#: reports/templates/summary/selected_plugins.html
+msgid ""
+"The table below shows all required or optional plugins for the selected "
+"reports."
+msgstr ""
+"Tabel di bawah menunjukkan semua plugin wajib atau opsional untuk laporan "
+"yang dipilih."
+
+#: reports/templates/summary/selected_plugins.html
+msgid "Required and optional plugins"
+msgstr "Plugin wajib dan opsional"
+
+#: reports/templates/summary/selected_plugins.html
+msgid "Plugin enabled"
+msgstr "Plugin diaktifkan"
+
+#: reports/templates/summary/selected_plugins.html
+msgid "Plugin options"
+msgstr "Opsi plugin"
+
+#: reports/templates/summary/selected_plugins.html
+msgid "Plugin scan level"
+msgstr "Tingkat pemindaian plugin"
+
+#: reports/templates/summary/selected_plugins.html
+msgid "Enabled."
+msgstr "Diaktifkan."
+
+#: reports/templates/summary/selected_plugins.html
+msgid "required"
+msgstr "diperlukan"
+
+#: reports/templates/summary/selected_plugins.html
+msgid "optional"
+msgstr "opsional"
+
+#: reports/templates/summary/selected_plugins.html
+msgid "Plugin extra info"
+msgstr "Plugin info tambahan"
+
+#: reports/templates/summary/selected_plugins.html
+msgid ""
+"There are no required or optional plugins needed for the selected report "
+"types."
+msgstr ""
+"Tidak ada plugin wajib atau opsional yang diperlukan untuk jenis laporan "
+"yang dipilih."
+
+#: reports/views/aggregate_report.py reports/views/generate_report.py
+#: reports/views/multi_report.py
+msgid "Select objects"
+msgstr "Pilih objek"
+
+#: reports/views/aggregate_report.py reports/views/generate_report.py
+#: reports/views/multi_report.py
+msgid "Select report types"
+msgstr "Pilih jenis laporan"
+
+#: reports/views/aggregate_report.py reports/views/generate_report.py
+#: reports/views/multi_report.py
+msgid "Export setup"
+msgstr "Ekspor pengaturan"
+
+#: reports/views/aggregate_report.py reports/views/generate_report.py
+msgid "Save report"
+msgstr "Simpan laporan"
+
+#: reports/views/aggregate_report.py reports/views/generate_report.py
+msgid "You do not have the required permissions to enable plugins."
+msgstr "Anda tidak memiliki izin yang diperlukan untuk mengaktifkan plugin."
+
+#: reports/views/base.py
+msgid "Select at least one OOI to proceed."
+msgstr "Pilih setidaknya satu OOI untuk melanjutkan."
+
+#: reports/views/base.py
+msgid "Select at least one report type to proceed."
+msgstr "Pilih setidaknya satu jenis laporan untuk melanjutkan."
+
+#: reports/views/mixins.py
+msgid ""
+"No data could be found for %(report_types). Object(s) did not exist on "
+"%(date)s."
+msgstr ""
+"Tidak ada data yang dapat ditemukan untuk %(report_types). Objek tidak ada "
+"pada %(date)s."
+
+#: reports/views/multi_report.py
+msgid "View report"
+msgstr "Lihat laporan"
+
+#: reports/views/report_overview.py
+msgid "Not enough permissions"
+msgstr "Izin tidak cukup"
+
+#: reports/views/report_overview.py
+msgid "Recipe '{}' deleted successfully"
+msgstr "Resep '{}' berhasil dihapus"
+
+#: reports/views/report_overview.py
+msgid "Recipe not found."
+msgstr "Resep tidak ditemukan."
+
+#: reports/views/report_overview.py
+msgid "No schedule or recipe selected"
+msgstr "Tidak ada jadwal atau resep yang dipilih"
+
+#: reports/views/report_overview.py
+msgid ""
+"Schedule disabled successfully. '{}' will not be generated automatically "
+"until the schedule is enabled again."
+msgstr ""
+"Jadwal berhasil dinonaktifkan. '{}' tidak akan dihasilkan secara otomatis "
+"hingga jadwal diaktifkan kembali."
+
+#: reports/views/report_overview.py
+msgid ""
+"Schedule enabled successfully. '{}' will be generated according to schedule."
+msgstr "Jadwal berhasil diaktifkan. '{}' akan dihasilkan sesuai jadwal."
+
+#: reports/views/report_overview.py
+msgid "An unexpected error occurred, please check logs for more info."
+msgstr ""
+"Terjadi kesalahan yang tidak terduga, silakan periksa log untuk info lebih "
+"lanjut."
+
+#: reports/views/report_overview.py
+msgid "Other OOI type selected than Report"
+msgstr "Jenis OOI lain yang dipilih selain Laporan"
+
+#: reports/views/report_overview.py
+msgid "Deletion successful."
+msgstr "Penghapusan berhasil."
+
+#: reports/views/report_overview.py
+msgid ""
+"Multi organization reports cannot be rescheduled. It consists of imported "
+"data from different organizations and is not based on newly generated data."
+msgstr ""
+"Laporan multi organisasi tidak dapat dijadwal ulang. Ini terdiri dari data "
+"yang diimpor dari organisasi berbeda dan tidak didasarkan pada data baru."
+
+#: reports/views/report_overview.py
+msgid ""
+"Rerun successful. It may take a moment before the new report has been "
+"generated."
+msgstr ""
+"Jalankan ulang berhasil. Mungkin diperlukan waktu beberapa saat sebelum "
+"laporan baru dibuat."
+
+#: reports/views/report_overview.py
+#, python-format
+msgid ""
+"Couldn't rerun %s, since the recipe for this report has been disabled or "
+"deleted."
+msgstr ""
+"Tidak dapat menjalankan kembali %s, karena resep untuk laporan ini telah "
+"dinonaktifkan atau dihapus."
+
+#: reports/views/report_overview.py
+msgid "Renaming failed. Empty report name found."
+msgstr "Penggantian nama gagal. Nama laporan kosong ditemukan."
+
+#: reports/views/report_overview.py
+msgid "Report names and reports does not match."
+msgstr "Nama laporan dan laporan tidak cocok."
+
+#: reports/views/report_overview.py
+msgid "Reports successfully renamed."
+msgstr "Laporan berhasil diganti namanya."
+
+#: reports/views/report_overview.py
+msgid "Report {} could not be renamed."
+msgstr "Laporan {} tidak bisa diganti namanya."
+
+#: reports/views/view_helpers.py
+msgid "1: Select objects"
+msgstr "1: Pilih objek"
+
+#: reports/views/view_helpers.py
+msgid "2: Choose report types"
+msgstr "2: Pilih jenis laporan"
+
+#: reports/views/view_helpers.py
+msgid "3: Configuration"
+msgstr "3: Konfigurasi"
+
+#: reports/views/view_helpers.py
+msgid "4: Export setup"
+msgstr "4: Ekspor pengaturan"
+
+#: reports/views/view_helpers.py
+msgid "3: Export setup"
+msgstr "3: Ekspor pengaturan"
+
+#: tools/forms/base.py
+msgid "Date"
+msgstr "Tanggal"
+
+#: tools/forms/boefje.py
+msgid "For example: -sTU --top-ports 1000"
+msgstr "Misalnya: -sTU --top-ports 1000"
+
+#: tools/forms/boefje.py
+msgid "JSON Schema"
+msgstr "JSON Skema"
+
+#: tools/forms/boefje.py
+msgid "Input object type"
+msgstr "Jenis objek masukan"
+
+#: tools/forms/boefje.py
+msgid "Output mime types"
+msgstr "Jenis pantomim keluaran"
+
+#: tools/forms/boefje.py
+msgid "Scan type"
+msgstr "Jenis pemindaian"
+
+#: tools/forms/boefje.py
+msgid "Interval amount"
+msgstr "Jumlah interval"
+
+#: tools/forms/boefje.py
+msgid ""
+"Specify the scanning interval for this Boefje. The default is 24 hours. For "
+"example: 5 minutes will let the Boefje scan every 5 minutes."
+msgstr ""
+"Tentukan interval pemindaian untuk Boefje ini. Standarnya adalah 24 jam. "
+"Misalnya: 5 menit akan membiarkan Boefje memindai setiap 5 menit."
+
+#: tools/forms/boefje.py
+msgid "Interval frequency"
+msgstr "Frekuensi interval"
+
+#: tools/forms/boefje.py
+msgid "Object creation/change"
+msgstr "Pembuatan/perubahan objek"
+
+#: tools/forms/boefje.py
+msgid ""
+"Choose weather the Boefje should run after creating and/or changing an "
+"object. "
+msgstr ""
+"Pilih cuaca yang Boefje harus dijalankan setelah membuat dan/atau mengubah "
+"objek."
+
+#: tools/forms/finding_type.py
+msgid "KAT-ID"
+msgstr "KAT-ID"
+
+#: tools/forms/finding_type.py
+msgid "Unique ID within OpenKAT, for this type"
+msgstr "ID unik dalam OpenKAT, untuk jenis ini"
+
+#: tools/forms/finding_type.py
+msgid "Title"
+msgstr "Judul"
+
+#: tools/forms/finding_type.py
+msgid "Give the finding type a fitting title"
+msgstr "Berikan judul yang sesuai pada tipe temuan"
+
+#: tools/forms/finding_type.py
+msgid "Describe the finding type"
+msgstr "Jelaskan jenis temuannya"
+
+#: tools/forms/finding_type.py
+msgid "Risk"
+msgstr "Mempertaruhkan"
+
+#: tools/forms/finding_type.py
+msgid "Solution"
+msgstr "Larutan"
+
+#: tools/forms/finding_type.py
+msgid "How can this be solved?"
+msgstr "Bagaimana hal ini dapat diatasi?"
+
+#: tools/forms/finding_type.py
+msgid "Describe how this type of finding can be solved"
+msgstr "Jelaskan bagaimana temuan semacam ini dapat diselesaikan"
+
+#: tools/forms/finding_type.py
+msgid "References"
+msgstr "Referensi"
+
+#: tools/forms/finding_type.py
+msgid "Please give some references on the solution"
+msgstr "Tolong berikan beberapa referensi tentang solusinya"
+
+#: tools/forms/finding_type.py
+msgid "Please give sources and references on the suggested solution"
+msgstr "Tolong berikan sumber dan referensi tentang solusi yang disarankan"
+
+#: tools/forms/finding_type.py
+msgid "Impact description"
+msgstr "Deskripsi dampak"
+
+#: tools/forms/finding_type.py
+msgid "Describe the solutions impact"
+msgstr "Jelaskan dampak solusinya"
+
+#: tools/forms/finding_type.py
+msgid "Solution chance"
+msgstr "Peluang solusi"
+
+#: tools/forms/finding_type.py
+msgid "Solution impact"
+msgstr "Dampak solusi"
+
+#: tools/forms/finding_type.py
+msgid "Solution effort"
+msgstr "Upaya solusi"
+
+#: tools/forms/finding_type.py
+msgid "ID should start with "
+msgstr "ID harus dimulai dengan"
+
+#: tools/forms/finding_type.py
+msgid "Finding type already exists"
+msgstr "Tipe temuan sudah ada"
+
+#: tools/forms/finding_type.py
+msgid "Click to select one of the available options"
+msgstr "Klik untuk memilih salah satu opsi yang tersedia"
+
+#: tools/forms/finding_type.py
+#: rocky/templates/partials/finding_occurrence_definition_list.html
+msgid "Proof"
+msgstr "Bukti"
+
+#: tools/forms/finding_type.py
+msgid "Provide evidence of your finding"
+msgstr "Berikan bukti temuan Anda"
+
+#: tools/forms/finding_type.py
+msgid "Describe your finding"
+msgstr "Jelaskan temuan Anda"
+
+#: tools/forms/finding_type.py
+msgid "Reproduce finding"
+msgstr "Reproduksi temuan"
+
+#: tools/forms/finding_type.py
+msgid "Please explain how to reproduce your finding"
+msgstr "Tolong jelaskan bagaimana mereproduksi temuan Anda"
+
+#: tools/forms/finding_type.py tools/forms/upload_raw.py
+msgid "Date/Time (UTC)"
+msgstr "Tanggal/Waktu (UTC)"
+
+#: tools/forms/finding_type.py tools/forms/upload_raw.py
+msgid "Doc! I'm from the future, I'm here to take you back!"
+msgstr "Dokter! Aku dari masa depan, aku di sini untuk membawamu kembali!"
+
+#: tools/forms/finding_type.py
+msgid "OOI doesn't exist"
+msgstr "OOI tidak ada"
+
+#: tools/forms/findings.py
+msgid "Show non-muted findings"
+msgstr "Tampilkan temuan yang tidak dibungkam"
+
+#: tools/forms/findings.py
+msgid "Show muted findings"
+msgstr "Tampilkan temuan yang diredam"
+
+#: tools/forms/findings.py
+msgid "Show muted and non-muted findings"
+msgstr "Tampilkan temuan yang diredam dan tidak diredam"
+
+#: tools/forms/findings.py
+msgid "Filter by severity"
+msgstr "Filter berdasarkan tingkat keparahan"
+
+#: tools/forms/findings.py
+msgid "Filter by muted findings"
+msgstr "Filter berdasarkan temuan yang diredam"
+
+#: tools/forms/findings.py tools/forms/ooi_form.py tools/forms/scheduler.py
+msgid "Search"
+msgstr "Mencari"
+
+#: tools/forms/findings.py
+msgid "Object ID contains (case sensitive)"
+msgstr "ID objek berisi (peka huruf besar/kecil)"
+
+#: tools/forms/ooi.py
+msgid "Filter types"
+msgstr "Jenis penyaring"
+
+#: tools/forms/ooi.py
+msgid "Clearance Level"
+msgstr "Tingkat Izin"
+
+#: tools/forms/ooi.py
+msgid "Next scan"
+msgstr "Pemindaian selanjutnya"
+
+#: tools/forms/ooi.py
+msgid "Show objects that don't meet the Boefjes scan level."
+msgstr "Tampilkan objek yang tidak memenuhi tingkat pemindaian Boefjes."
+
+#: tools/forms/ooi.py
+msgid "Show Boefjes that exceed the objects clearance level."
+msgstr "Tampilkan Boefjes yang melebihi tingkat izin objek."
+
+#: tools/forms/ooi.py
+msgid ""
+"All the boefjes with a scan level below or equal to the clearance level will"
+" be allowed to scan this object."
+msgstr ""
+"Semua boefje dengan tingkat pemindaian di bawah atau sama dengan tingkat "
+"izin akan diizinkan untuk memindai objek ini."
+
+#: tools/forms/ooi.py
+msgid "Expires by (UTC)"
+msgstr "Berakhir pada (UTC)"
+
+#: tools/forms/ooi_form.py
+msgid "option"
+msgstr "pilihan"
+
+#: tools/forms/ooi_form.py
+#, python-brace-format
+msgid "Optionally choose a {option_label}"
+msgstr "Secara opsional pilih {option_label}"
+
+#: tools/forms/ooi_form.py
+#, python-brace-format
+msgid "Please choose a {option_label}"
+msgstr "Silakan pilih {option_label}"
+
+#: tools/forms/ooi_form.py
+msgid "Filter by clearance level"
+msgstr "Filter berdasarkan tingkat izin"
+
+#: tools/forms/ooi_form.py
+msgid "Filter by clearance type"
+msgstr "Filter berdasarkan jenis izin"
+
+#: tools/forms/scheduler.py
+msgid "From"
+msgstr "Dari"
+
+#: tools/forms/scheduler.py
+msgid "To"
+msgstr "Ke"
+
+#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+msgid "Cancelled"
+msgstr "Dibatalkan"
+
+#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+msgid "Completed"
+msgstr "Selesai"
+
+#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+msgid "Dispatched"
+msgstr "Dikirim"
+
+#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+msgid "Failed"
+msgstr "Gagal"
+
+#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+msgid "Queued"
+msgstr "Mengantri"
+
+#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+msgid "Running"
+msgstr "Berlari"
+
+#: tools/forms/scheduler.py
+msgid "Search by object name"
+msgstr "Cari berdasarkan nama objek"
+
+#: tools/forms/scheduler.py
+msgid "The selected date is in the future. Please select a different date."
+msgstr ""
+"Tanggal yang dipilih adalah di masa depan. Silakan pilih tanggal lain."
+
+#: tools/forms/settings.py
+msgid "--- Show all ----"
+msgstr "--- Tampilkan semua ----"
+
+#: tools/forms/settings.py
+msgid "recommendation"
+msgstr "rekomendasi"
+
+#: tools/forms/settings.py
+msgid "low"
+msgstr "rendah"
+
+#: tools/forms/settings.py
+msgid "medium"
+msgstr "sedang"
+
+#: tools/forms/settings.py
+msgid "high"
+msgstr "tinggi"
+
+#: tools/forms/settings.py
+msgid "very high"
+msgstr "sangat tinggi"
+
+#: tools/forms/settings.py
+msgid "critical"
+msgstr "kritis"
+
+#: tools/forms/settings.py
+msgid "quickfix"
+msgstr "perbaikan cepat"
+
+#: tools/forms/settings.py
+msgid "Declared"
+msgstr "Dinyatakan"
+
+#: tools/forms/settings.py
+msgid "Inherited"
+msgstr "Diwarisi"
+
+#: tools/forms/settings.py
+msgid "Empty"
+msgstr "Kosong"
+
+#: tools/forms/settings.py
+msgid "Add one finding type ID per line."
+msgstr "Tambahkan satu ID jenis temuan per baris."
+
+#: tools/forms/settings.py
+msgid "Add the date and time of your finding (UTC)"
+msgstr "Tambahkan tanggal dan waktu temuan Anda (UTC)"
+
+#: tools/forms/settings.py
+msgid "Add the date and time of when the raw file was generated (UTC)"
+msgstr "Tambahkan tanggal dan waktu pembuatan file mentah (UTC)"
+
+#: tools/forms/settings.py
+msgid ""
+"OpenKAT stores a time indication with every observation, so it is possible "
+"to see the status of your network through time. Select a datetime to change "
+"the view to represent that moment in time."
+msgstr ""
+"OpenKAT menyimpan indikasi waktu pada setiap pengamatan, sehingga status "
+"jaringan Anda dapat dilihat sepanjang waktu. Pilih tanggal waktu untuk "
+"mengubah tampilan guna mewakili momen waktu tersebut."
+
+#: tools/forms/settings.py
+msgid ""
+"<p>The name of the Docker image. For example: "
+"<i>'ghcr.io/minvws/openkat/nmap'</i>. In OpenKAT, all Boefjes with the same "
+"container image will be seen as 'variants' and will be shown together on the"
+" Boefje detail page. </p> "
+msgstr ""
+"<p>Nama gambar Docker. Misalnya: <i>'ghcr.io/minvws/openkat/nmap'</i>. Di "
+"OpenKAT, semua Boefjes dengan gambar container yang sama akan dilihat "
+"sebagai 'varian' dan akan ditampilkan bersama di halaman detail Boefje. </p>"
+
+#: tools/forms/settings.py
+msgid ""
+"A description of the Boefje explaining in short what it can do. This will "
+"both be displayed inside the KAT-alogus and on the Boefje details page."
+msgstr ""
+"Deskripsi Boefje menjelaskan secara singkat apa yang dapat dilakukannya. Ini"
+" akan ditampilkan di dalam KAT-alogus dan di halaman detail Boefje."
+
+#: tools/forms/settings.py
+msgid ""
+"Select the object type(s) that your Boefje consumes. To select multiple "
+"objects, press and hold the 'ctrl'/'command' key and then click the items "
+"you want to select. "
+msgstr ""
+"Pilih jenis objek yang digunakan Boefje Anda. Untuk memilih beberapa objek, "
+"tekan dan tahan tombol 'ctrl'/'command' lalu klik item yang ingin Anda "
+"pilih."
+
+#: tools/forms/settings.py
+msgid ""
+"<p>If any other settings are needed for your Boefje, add these as a JSON "
+"Schema, otherwise, leave the field empty or 'null'.</p> <p> This JSON is "
+"used as the basis for a form for the user. When the user enables this Boefje"
+" they can get the option to give extra information. For example, it can "
+"contain an API key that the script requires.</p> <p>More information about "
+"what the schema.json file looks like can be found <a "
+"href='https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html'>"
+" here</a>.</p> "
+msgstr ""
+"<p>Jika ada pengaturan lain yang diperlukan untuk Boefje Anda, tambahkan ini"
+" sebagai Skema JSON, jika tidak, biarkan bidang kosong atau 'null'.</p> <p> "
+"JSON ini digunakan sebagai dasar formulir untuk pengguna. Ketika pengguna "
+"mengaktifkan Boefje ini, mereka bisa mendapatkan opsi untuk memberikan "
+"informasi tambahan. Misalnya, dapat berisi kunci API yang diperlukan "
+"skrip.</p> <p>Informasi selengkapnya tentang tampilan file skema.json dapat "
+"ditemukan <a "
+"href='https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html'>"
+" di sini</a>.</p>"
+
+#: tools/forms/settings.py
+msgid ""
+"<p>Add a set of mime types that are produced by this Boefje, separated by "
+"commas. For example: <i>'text/html'</i>, <i>'image/jpeg'</i> or "
+"<i>'boefje/{boefje-id}'</i></p> <p>These output mime types will be shown on "
+"the Boefje detail page as information for other users. </p> "
+msgstr ""
+"<p>Tambahkan sekumpulan tipe mime yang dihasilkan oleh Boefje ini, "
+"dipisahkan dengan koma. Misalnya: <i>'text/html'</i>, <i>'image/jpeg'</i> "
+"atau <i>'boefje/{boefje-id}'</i></p> <p>Jenis pantomim keluaran ini akan "
+"ditampilkan pada halaman detail Boefje sebagai informasi bagi pengguna lain."
+" </p>"
+
+#: tools/forms/settings.py
+msgid ""
+"<p>Select a clearance level for your Boefje. For more information about the "
+"different clearance levels please check the <a "
+"href='https://docs.openkat.nl/manual/usermanual.html#scan-levels-clearance-"
+"indemnities'> documentation</a>.</p> "
+msgstr ""
+"<p>Pilih tingkat izin untuk Boefje Anda. Untuk informasi lebih lanjut "
+"tentang tingkat izin yang berbeda, silakan periksa <a "
+"href='https://docs.openkat.nl/manual/usermanual.html#scan-levels-clearance-"
+"indemnities'> dokumentasi</a>.</p>"
+
+#: tools/forms/settings.py
+msgid ""
+"Choose when this Boefje will scan objects. It can run on a given interval or"
+" it can run every time an object has been created or changed. "
+msgstr ""
+"Pilih kapan Boefje ini akan memindai objek. Itu bisa berjalan pada interval "
+"tertentu atau bisa berjalan setiap kali suatu objek dibuat atau diubah."
+
+#: tools/forms/settings.py
+msgid "Depth of the tree."
+msgstr "Kedalaman pohon."
+
+#: tools/forms/upload_csv.py
+msgid "Only CSV file supported"
+msgstr "Hanya file CSV yang didukung"
+
+#: tools/forms/upload_csv.py
+msgid "File could not be decoded"
+msgstr "File tidak dapat didekodekan"
+
+#: tools/forms/upload_csv.py
+msgid "No file selected"
+msgstr "Tidak ada berkas yang dipilih"
+
+#: tools/forms/upload_csv.py
+msgid "The uploaded file is empty."
+msgstr "File yang diunggah kosong."
+
+#: tools/forms/upload_csv.py
+msgid "The number of columns do not meet the requirements."
+msgstr "Jumlah kolom tidak memenuhi persyaratan."
+
+#: tools/forms/upload_csv.py
+msgid "OOI Type in CSV does not meet the criteria."
+msgstr "OOI Ketik CSV tidak memenuhi kriteria."
+
+#: tools/forms/upload_csv.py
+msgid "An error has occurred during the parsing of the csv file:"
+msgstr "Terjadi kesalahan saat menguraikan file csv:"
+
+#: tools/forms/upload_csv.py
+msgid "Upload CSV file"
+msgstr "Unggah berkas CSV"
+
+#: tools/forms/upload_csv.py
+msgid "Only accepts CSV file."
+msgstr "Hanya menerima file CSV."
+
+#: tools/forms/upload_oois.py rocky/templates/partials/explanations.html
+msgid "Object Type"
+msgstr "Jenis Objek"
+
+#: tools/forms/upload_oois.py
+msgid "Choose a type of which objects are added."
+msgstr "Pilih jenis objek yang ditambahkan."
+
+#: tools/forms/upload_raw.py
+msgid "Mime types"
+msgstr "Tipe pantomim"
+
+#: tools/forms/upload_raw.py
+msgid ""
+"<p>Add a set of mime types, separated by commas, for "
+"example:</p><p><i>\"text/html, image/jpeg\"</i> or <i>\"boefje/dns-"
+"records\"</i>.</p><p>Mime types are used to match the correct normalizer to "
+"a raw file. When the mime type \"boefje/dns-records\" is added, the "
+"normalizer expects the raw file to contain dns scan information.</p>"
+msgstr ""
+"<p>Tambahkan kumpulan tipe mime, dipisahkan dengan koma, "
+"misalnya:</p><p><i>\"text/html, image/jpeg\"</i> atau <i>\"boefje/dns-"
+"records\"</i>.</p><p>Jenis pantomim digunakan untuk mencocokkan normalizer "
+"yang benar dengan file mentah. Ketika tipe mime \"boefje/dns-records\" "
+"ditambahkan, normalizer mengharapkan file mentah berisi informasi pemindaian"
+" dns.</p>"
+
+#: tools/forms/upload_raw.py rocky/templates/partials/ooi_list_toolbar.html
+#: rocky/templates/upload_raw.html
+msgid "Upload raw file"
+msgstr "Unggah file mentah"
+
+#: tools/forms/upload_raw.py
+msgid "Input or Scan OOI"
+msgstr "Masukkan atau Pindai OOI"
+
+#: tools/forms/upload_raw.py
+msgid "Click to select one of the available options, or type one yourself"
+msgstr "Klik untuk memilih salah satu opsi yang tersedia, atau ketik sendiri"
+
+#: tools/forms/upload_raw.py
+msgid "OOI doesn't exist, try another valid time"
+msgstr "OOI tidak ada, coba waktu valid lainnya"
+
+#: tools/models.py
+msgid ""
+"A short code containing only lower-case unicode letters, numbers, hyphens or"
+" underscores that will be used in URLs and paths."
+msgstr ""
+"Kode pendek yang hanya berisi huruf kecil unicode, angka, tanda hubung, atau"
+" garis bawah yang akan digunakan di URLs dan jalur."
+
+#: tools/models.py
+msgid ""
+"This organization code is reserved by OpenKAT and cannot be used. Choose "
+"another organization code."
+msgstr ""
+"Kode organisasi ini dicadangkan oleh OpenKAT dan tidak dapat digunakan. "
+"Pilih kode organisasi lain."
+
+#: tools/models.py
+msgid "new"
+msgstr "baru"
+
+#: tools/templatetags/ooi_extra.py
+msgid "Unknown user"
+msgstr "Pengguna tidak dikenal"
+
+#: tools/view_helpers.py rocky/templates/header.html
+#: rocky/templates/organizations/organization_member_list.html
+#: rocky/views/organization_member_edit.py
+msgid "Members"
+msgstr "Anggota"
+
+#: rocky/forms.py
+msgid "Current status"
+msgstr "Status saat ini"
+
+#: rocky/forms.py rocky/templates/organizations/organization_member_list.html
+msgid "Active"
+msgstr "Aktif"
+
+#: rocky/forms.py rocky/templates/organizations/organization_member_list.html
+msgid "New"
+msgstr "Baru"
+
+#: rocky/forms.py
+msgid "Account status"
+msgstr "Status akun"
+
+#: rocky/forms.py
+msgid "Not blocked"
+msgstr "Tidak diblokir"
+
+#: rocky/messaging.py
+msgid ""
+"You have trusted this member with a clearance level of L{}. This member "
+"needs at least a clearance level of L{} in order to do a proper onboarding. "
+"Edit this member and change the clearance level if necessary."
+msgstr ""
+"Anda telah memercayai anggota ini dengan tingkat izin L{}. Anggota ini "
+"memerlukan setidaknya tingkat izin L{} agar dapat melakukan orientasi dengan"
+" benar. Edit anggota ini dan ubah tingkat izin jika perlu."
+
+#: rocky/paginator.py
+msgid "That page number is not an integer"
+msgstr "Nomor halaman itu bukan bilangan bulat"
+
+#: rocky/paginator.py
+msgid "That page number is less than 1"
+msgstr "Nomor halaman itu kurang dari 1"
+
+#: rocky/paginator.py
+msgid "That page contains no results"
+msgstr "Halaman itu tidak berisi hasil"
+
+#: rocky/scheduler.py
+msgid ""
+"The Scheduler has an unexpected error. Check the Scheduler logs for further "
+"details."
+msgstr ""
+"Penjadwal mengalami kesalahan yang tidak terduga. Periksa log Penjadwal "
+"untuk rincian lebih lanjut."
+
+#: rocky/scheduler.py
+msgid "Could not connect to Scheduler. Service is possibly down."
+msgstr "Tidak dapat terhubung ke Penjadwal. Layanan mungkin sedang down."
+
+#: rocky/scheduler.py
+msgid "Your request could not be validated."
+msgstr "Permintaan Anda tidak dapat divalidasi."
+
+#: rocky/scheduler.py
+msgid "Task could not be found."
+msgstr "Tugas tidak dapat ditemukan."
+
+#: rocky/scheduler.py
+msgid ""
+"Scheduler is receiving too many requests. Increase SCHEDULER_PQ_MAXSIZE or "
+"wait for task to finish."
+msgstr ""
+"Penjadwal menerima terlalu banyak permintaan. Tingkatkan "
+"SCHEDULER_PQ_MAXSIZE atau tunggu hingga tugas selesai."
+
+#: rocky/scheduler.py
+msgid "Bad request. Your request could not be interpreted by the Scheduler."
+msgstr ""
+"Permintaan buruk. Permintaan Anda tidak dapat ditafsirkan oleh Penjadwal."
+
+#: rocky/scheduler.py
+msgid "The Scheduler has received a conflict. Your task is already in queue."
+msgstr "Penjadwal telah menerima konflik. Tugas Anda sudah ada dalam antrean."
+
+#: rocky/scheduler.py
+msgid "A HTTPError occurred. See Scheduler logs for more info."
+msgstr "Terjadi HTTPError. Lihat Log penjadwal untuk informasi lebih lanjut."
+
+#: rocky/scheduler.py
+msgid "Schedule list: "
+msgstr "Daftar jadwal:"
+
+#: rocky/scheduler.py
+msgid "Task list: "
+msgstr "Daftar tugas:"
+
+#: rocky/settings.py
+msgid "Blue light"
+msgstr "Cahaya biru"
+
+#: rocky/settings.py
+msgid "Blue medium"
+msgstr "Sedang biru"
+
+#: rocky/settings.py
+msgid "Blue dark"
+msgstr "Biru gelap"
+
+#: rocky/settings.py
+msgid "Green light"
+msgstr "Lampu hijau"
+
+#: rocky/settings.py
+msgid "Green medium"
+msgstr "Media hijau"
+
+#: rocky/settings.py
+msgid "Green dark"
+msgstr "Hijau gelap"
+
+#: rocky/settings.py
+msgid "Yellow light"
+msgstr "Lampu kuning"
+
+#: rocky/settings.py
+msgid "Yellow medium"
+msgstr "media kuning"
+
+#: rocky/settings.py
+msgid "Yellow dark"
+msgstr "Kuning gelap"
+
+#: rocky/settings.py
+msgid "Orange light"
+msgstr "Cahaya oranye"
+
+#: rocky/settings.py
+msgid "Orange medium"
+msgstr "Oranye sedang"
+
+#: rocky/settings.py
+msgid "Orange dark"
+msgstr "Oranye gelap"
+
+#: rocky/settings.py
+msgid "Red light"
+msgstr "Lampu merah"
+
+#: rocky/settings.py
+msgid "Red medium"
+msgstr "media merah"
+
+#: rocky/settings.py
+msgid "Red dark"
+msgstr "Merah gelap"
+
+#: rocky/settings.py
+msgid "Violet light"
+msgstr "Cahaya ungu"
+
+#: rocky/settings.py
+msgid "Violet medium"
+msgstr "sedang ungu"
+
+#: rocky/settings.py
+msgid "Violet dark"
+msgstr "Ungu gelap"
+
+#: rocky/settings.py
+msgid "Plain"
+msgstr "Polos"
+
+#: rocky/settings.py
+msgid "Solid"
+msgstr "Padat"
+
+#: rocky/settings.py
+msgid "Dashed"
+msgstr "Putus-putus"
+
+#: rocky/settings.py
+msgid "Dotted"
+msgstr "Burik"
+
+#: rocky/templates/403.html
+msgid "Error code 403: Unauthorized"
+msgstr "Kode kesalahan 403: Tidak sah"
+
+#: rocky/templates/403.html
+msgid "Your account is not authorized to access this page or organization."
+msgstr ""
+"Akun Anda tidak berwenang untuk mengakses halaman atau organisasi ini."
+
+#: rocky/templates/403.html
+msgid "Please contact your system administrator."
+msgstr "Silakan hubungi administrator sistem Anda."
+
+#: rocky/templates/403.html rocky/templates/404.html
+msgid "You may want to go back to the"
+msgstr "Anda mungkin ingin kembali ke"
+
+#: rocky/templates/403.html rocky/templates/404.html
+msgid "Crisis Room"
+msgstr "Ruang Krisis"
+
+#: rocky/templates/404.html
+msgid "Error code 404: Page not found"
+msgstr "Kode kesalahan 404: Halaman tidak ditemukan"
+
+#: rocky/templates/404.html
+msgid ""
+"The page you wanted to see or the file you wanted to view was not found."
+msgstr ""
+"Halaman yang ingin Anda lihat atau file yang ingin Anda lihat tidak "
+"ditemukan."
+
+#: rocky/templates/admin/base.html
+msgid "Skip to main content"
+msgstr "Lompat ke konten utama"
+
+#: rocky/templates/admin/base.html
+msgid "Welcome,"
+msgstr "Selamat datang,"
+
+#: rocky/templates/admin/base.html
+msgid "View site"
+msgstr "Lihat situs"
+
+#: rocky/templates/admin/base.html
+msgid "Documentation"
+msgstr "Dokumentasi"
+
+#: rocky/templates/admin/base.html
+msgid "Change password"
+msgstr "Ubah kata sandi"
+
+#: rocky/templates/admin/base.html
+msgid "Log out"
+msgstr "Keluar"
+
+#: rocky/templates/admin/base.html rocky/templates/header.html
+msgid "Breadcrumbs"
+msgstr "Tepung roti"
+
+#: rocky/templates/admin/base.html rocky/templates/admin/change_form.html
+#: rocky/templates/admin/change_list.html
+#: rocky/templates/admin/delete_confirmation.html
+#: rocky/templates/admin/delete_selected_confirmation.html
+msgid "Home"
+msgstr "Rumah"
+
+#: rocky/templates/admin/change_form.html
+#, python-format
+msgid "Add %(name)s"
+msgstr "Tambahkan %(name)s"
+
+#: rocky/templates/admin/change_form.html
+#: rocky/templates/admin/change_list.html
+msgid "Please correct the error below."
+msgid_plural "Please correct the errors below."
+msgstr[0] "Harap perbaiki kesalahan di bawah ini."
+
+#: rocky/templates/admin/change_list.html
+msgid "Filter"
+msgstr "Menyaring"
+
+#: rocky/templates/admin/change_list.html
+msgid "Hide counts"
+msgstr "Sembunyikan jumlah"
+
+#: rocky/templates/admin/change_list.html
+msgid "Show counts"
+msgstr "Tampilkan penting"
+
+#: rocky/templates/admin/change_list.html
+msgid "Clear all filters"
+msgstr "Hapus semua filter"
+
+#: rocky/templates/admin/delete_confirmation.html
+#, python-format
+msgid ""
+"Deleting the %(object_name)s '%(escaped_object)s' would result in deleting "
+"related objects, but your account doesn't have permission to delete the "
+"following types of objects"
+msgstr ""
+"Menghapus %(object_name)s '%(escaped_object)s' akan mengakibatkan "
+"penghapusan objek terkait, namun akun Anda tidak memiliki izin untuk "
+"menghapus jenis objek berikut"
+
+#: rocky/templates/admin/delete_confirmation.html
+#, python-format
+msgid ""
+"Deleting the %(object_name)s '%(escaped_object)s' would require deleting the"
+" following protected related objects"
+msgstr ""
+"Menghapus %(object_name)s '%(escaped_object)s' akan memerlukan penghapusan "
+"objek terkait yang dilindungi berikut ini"
+
+#: rocky/templates/admin/delete_confirmation.html
+#, python-format
+msgid ""
+"Are you sure you want to delete the %(object_name)s \"%(escaped_object)s\"? "
+"All of the following related items will be deleted"
+msgstr ""
+"Apakah Anda yakin ingin menghapus %(object_name)s \"%(escaped_object)s\"? "
+"Semua item terkait berikut akan dihapus"
+
+#: rocky/templates/admin/delete_confirmation.html
+#: rocky/templates/admin/delete_selected_confirmation.html
+msgid "Yes, I’m sure"
+msgstr "Ya saya yakin"
+
+#: rocky/templates/admin/delete_confirmation.html
+#: rocky/templates/admin/delete_selected_confirmation.html
+msgid "No, take me back"
+msgstr "Tidak, bawa aku kembali"
+
+#: rocky/templates/admin/delete_selected_confirmation.html
+msgid "Delete multiple objects"
+msgstr "Hapus beberapa objek"
+
+#: rocky/templates/admin/delete_selected_confirmation.html
+#, python-format
+msgid ""
+"Deleting the selected %(objects_name)s would result in deleting related "
+"objects, but your account doesn't have permission to delete the following "
+"types of objects"
+msgstr ""
+"Menghapus %(objects_name)s yang dipilih akan mengakibatkan penghapusan objek"
+" terkait, namun akun Anda tidak memiliki izin untuk menghapus jenis objek "
+"berikut"
+
+#: rocky/templates/admin/delete_selected_confirmation.html
+#, python-format
+msgid ""
+"Deleting the selected %(objects_name)s would require deleting the following "
+"protected related objects"
+msgstr ""
+"Menghapus %(objects_name)s yang dipilih akan memerlukan penghapusan objek "
+"terkait yang dilindungi berikut ini"
+
+#: rocky/templates/admin/delete_selected_confirmation.html
+#, python-format
+msgid ""
+"Are you sure you want to delete the selected %(objects_name)s? All of the "
+"following objects and their related items will be deleted"
+msgstr ""
+"Apakah Anda yakin ingin menghapus %(objects_name)s yang dipilih? Semua objek"
+" berikut dan item terkaitnya akan dihapus"
+
+#: rocky/templates/admin/popup_response.html
+msgid "Popup closing…"
+msgstr "Penutupan pop-up…"
+
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
+msgid "Close menu"
+msgstr "Tutup menunya"
+
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
+msgid "Main navigation"
+msgstr "Navigasi utama"
+
+#: rocky/templates/dashboard_client.html
+msgid "Indemnifications"
+msgstr "Ganti Rugi"
+
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html
+#: rocky/templates/partials/secondary-menu.html
+msgid "Logout"
+msgstr "Keluar"
+
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html
+msgid "Welcome"
+msgstr "Selamat datang"
+
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html
+msgid "User overview"
+msgstr "Ikhtisar pengguna"
+
+#: rocky/templates/dashboard_redteam.html
+#: rocky/templates/partials/notifications_block.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid "warning"
+msgstr "peringatan"
+
+#: rocky/templates/dashboard_redteam.html
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+#: rocky/templates/partials/notifications_block.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid "Warning:"
+msgstr "Peringatan:"
+
+#: rocky/templates/dashboard_redteam.html
+msgid "Organization code missing"
+msgstr "Kode organisasi tidak ada"
+
+#: rocky/templates/finding_type_add.html
+#: rocky/templates/partials/findings_list_toolbar.html
+#: rocky/views/finding_type_add.py
+msgid "Add finding type"
+msgstr "Tambahkan jenis temuan"
+
+#: rocky/templates/finding_type_add.html
+msgid "Finding Type"
+msgstr "Tipe Temuan"
+
+#: rocky/templates/findings/finding_add.html
+#: rocky/templates/oois/ooi_detail_findings_list.html
+#: rocky/templates/oois/ooi_findings.html
+#: rocky/templates/partials/findings_list_toolbar.html
+#: rocky/views/finding_add.py
+msgid "Add finding"
+msgstr "Tambahkan temuan"
+
+#: rocky/templates/findings/finding_list.html
+msgid "Findings "
+msgstr "Temuan"
+
+#: rocky/templates/findings/finding_list.html
+#, python-format
+msgid ""
+"An overview of all findings OpenKAT found for organization "
+"<strong>%(organization_name)s</strong>. Each finding relates to an object. "
+"Click a finding for additional information."
+msgstr ""
+"Ikhtisar semua temuan OpenKAT yang ditemukan untuk organisasi "
+"<strong>%(organization_name)s</strong>. Setiap temuan berhubungan dengan "
+"suatu objek. Klik temuan untuk informasi tambahan."
+
+#: rocky/templates/findings/finding_list.html
+#, python-format
+msgid "Showing %(length)s of %(total)s findings"
+msgstr "Menampilkan %(length)s dari %(total)s temuan"
+
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/partials/mute_findings_modal.html
+msgid "Mute findings"
+msgstr "Temuan bisu"
+
+#: rocky/templates/findings/finding_list.html
+msgid "Unmute findings"
+msgstr "Suarakan temuan"
+
+#: rocky/templates/findings/findings_filter.html
+#: rocky/templates/partials/elements/ooi_list_settings_form.html
+#: rocky/templates/tasks/partials/task_filter.html
+msgid "Set filters"
+msgstr "Setel filter"
+
+#: rocky/templates/findings/findings_filter.html
+#: rocky/templates/partials/elements/ooi_list_settings_form.html
+#: rocky/templates/tasks/partials/task_filter.html
+msgid "Clear filters"
+msgstr "Hapus filter"
+
+#: rocky/templates/footer.html rocky/views/privacy_statement.py
+msgid "Privacy Statement"
+msgstr "Pernyataan Privasi"
+
+#: rocky/templates/forms/json_schema_form.html
+msgid "Fill out this form to answer the Question (again):"
+msgstr "Isi formulir ini untuk menjawab Pertanyaan (sekali lagi):"
+
+#: rocky/templates/graph-d3.html
+msgid ""
+"Click a circle to collapse / expand the tree, click the text to view the "
+"tree from that OOI and hover over the text to see details."
+msgstr ""
+"Klik lingkaran untuk menciutkan/memperluas pohon, klik teks untuk melihat "
+"pohon dari OOI tersebut dan arahkan kursor ke teks untuk melihat detailnya."
+
+#: rocky/templates/graph-d3.html
+msgid "Tree graph"
+msgstr "Grafik pohon"
+
+#: rocky/templates/header.html
+msgid "Menu"
+msgstr "Menu"
+
+#: rocky/templates/header.html
+msgid "OpenKAT logo, go to the homepage of OpenKAT"
+msgstr "logo OpenKAT, buka beranda OpenKAT"
+
+#: rocky/templates/header.html rocky/templates/tasks/ooi_detail_task_list.html
+#: rocky/templates/tasks/partials/tasks_overview_header.html
+#: rocky/templates/tasks/plugin_detail_task_list.html
+#: rocky/views/task_detail.py rocky/views/tasks.py
+msgid "Tasks"
+msgstr "Tugas"
+
+#: rocky/templates/health.html
+msgid "Health Checks"
+msgstr "Pemeriksaan Kesehatan"
+
+#: rocky/templates/health.html
+msgid "Health checks"
+msgstr "Pemeriksaan kesehatan"
+
+#: rocky/templates/health.html
+msgid "Additional"
+msgstr "Tambahan"
+
+#: rocky/templates/indemnification_present.html
+msgid "Indemnification"
+msgstr "Ganti Rugi"
+
+#: rocky/templates/indemnification_present.html
+msgid ""
+"Indemnification on the organization present. You may now add objects and "
+"start scans."
+msgstr ""
+"Ganti rugi pada organisasi yang hadir. Anda sekarang dapat menambahkan objek"
+" dan memulai pemindaian."
+
+#: rocky/templates/indemnification_present.html
+msgid "Go to Objects"
+msgstr "Pergi ke Objek"
+
+#: rocky/templates/indemnification_present.html
+msgid "Go to"
+msgstr "Pergi ke"
+
+#: rocky/templates/landing_page.html
+msgid "Welcome to OpenKAT"
+msgstr "Selamat datang di OpenKAT"
+
+#: rocky/templates/landing_page.html
+msgid "Kwetsbaarheden Analyse Tool"
+msgstr "Alat Analisis Kwetsbaarheden"
+
+#: rocky/templates/landing_page.html
+msgid "What is OpenKAT?"
+msgstr "Apa itu OpenKAT?"
+
+#: rocky/templates/landing_page.html
+msgid ""
+"OpenKAT is a vulnerability analysis tool. An Open Source-project developed "
+"by the Ministry of Health, Welfare and Sport to make your and our world "
+"safer."
+msgstr ""
+"OpenKAT adalah alat analisis kerentanan. Sebuah proyek Sumber Terbuka yang "
+"dikembangkan oleh Kementerian Kesehatan, Kesejahteraan dan Olahraga untuk "
+"membuat dunia Anda dan kita lebih aman."
+
+#: rocky/templates/landing_page.html
+msgid "OpenKAT sees"
+msgstr "OpenKAT melihat"
+
+#: rocky/templates/landing_page.html
+msgid ""
+"Dozens of tools are integrated in OpenKAT to view the world (digital and "
+"analog)."
+msgstr ""
+"Puluhan alat terintegrasi di OpenKAT untuk melihat dunia (digital dan "
+"analog)."
+
+#: rocky/templates/landing_page.html
+msgid "Our motto is therefore: I see, I see, what you do not see."
+msgstr ""
+"Oleh karena itu, semboyan kami adalah: Saya melihat, saya melihat, apa yang "
+"tidak Anda lihat."
+
+#: rocky/templates/landing_page.html
+msgid "OpenKAT knows"
+msgstr "OpenKAT tahu"
+
+#: rocky/templates/landing_page.html
+msgid ""
+"OpenKAT does not forget (just like that), and can be queried without "
+"scanning again. Also about a historical situation."
+msgstr ""
+"OpenKAT tidak lupa (begitu saja), dan dapat ditanyakan tanpa memindai lagi. "
+"Juga tentang situasi sejarah."
+
+#: rocky/templates/landing_page.html
+msgid "OpenKAT is secure"
+msgstr "OpenKAT aman"
+
+#: rocky/templates/landing_page.html
+msgid ""
+"Forensically secured storage of evidence is one of the basic ingredients of "
+"OpenKAT."
+msgstr ""
+"Penyimpanan bukti yang diamankan secara forensik adalah salah satu bahan "
+"dasar OpenKAT."
+
+#: rocky/templates/landing_page.html
+msgid "OpenKAT is sweet"
+msgstr "OpenKAT manis"
+
+#: rocky/templates/landing_page.html
+msgid ""
+"OpenKAT thinks about privacy, and stores what is necessary, within the rules"
+" of your organization and the law."
+msgstr ""
+"OpenKAT memikirkan privasi, dan menyimpan apa yang diperlukan, sesuai aturan"
+" organisasi Anda dan hukum."
+
+#: rocky/templates/landing_page.html
+msgid "A wide playing field"
+msgstr "Lapangan bermain yang luas"
+
+#: rocky/templates/landing_page.html
+msgid ""
+"OpenKAT makes a copy of the actual reality by means of the integrated tools."
+" Within this copy you can search for answers to countless security and "
+"policy questions. Expected and unexpected changes in the world are made "
+"visible, and where necessary reported or made known directly to the right "
+"people."
+msgstr ""
+"OpenKAT membuat salinan realitas aktual melalui alat yang terintegrasi. "
+"Dalam salinan ini Anda dapat mencari jawaban atas pertanyaan keamanan dan "
+"kebijakan yang tak terhitung jumlahnya. Perubahan yang diharapkan dan tidak "
+"terduga di dunia dibuat terlihat, dan bila perlu dilaporkan atau "
+"diberitahukan secara langsung kepada orang yang tepat."
+
+#: rocky/templates/legal/privacy_statement.html
+msgid "OpenKAT Privacy Statement"
+msgstr "OpenKAT Pernyataan Privasi"
+
+#: rocky/templates/legal/privacy_statement.html
+msgid ""
+"OpenKAT is dedicated to protecting the confidentiality and privacy of "
+"information entrusted to it. As part of this fundamental obligation, OpenKAT"
+" is committed to the appropriate protection and use of personal information "
+"(sometimes referred to as \"personal data\", \"personally identifiable "
+"information\" or \"PII\") that has been collected online."
+msgstr ""
+"OpenKAT didedikasikan untuk melindungi kerahasiaan dan privasi informasi "
+"yang dipercayakan kepadanya. Sebagai bagian dari kewajiban mendasar ini, "
+"OpenKAT berkomitmen terhadap perlindungan dan penggunaan informasi pribadi "
+"yang sesuai (terkadang disebut sebagai \"data pribadi\", \"informasi "
+"identitas pribadi\" atau \"PII\") yang telah dikumpulkan secara online."
+
+#: rocky/templates/oois/error.html
+msgid "Object List"
+msgstr "Daftar Objek"
+
+#: rocky/templates/oois/error.html
+msgid "An error occurred. Please contact a system administrator."
+msgstr "Terjadi kesalahan. Silakan hubungi administrator sistem."
+
+#: rocky/templates/oois/ooi_add.html
+#, python-format
+msgid "Add a %(display_type)s"
+msgstr "Tambahkan %(display_type)s"
+
+#: rocky/templates/oois/ooi_add.html
+msgid ""
+"Here you can add the asset of the client. Findings can be added to these in "
+"the findings page."
+msgstr ""
+"Di sini Anda dapat menambahkan aset klien. Temuan dapat ditambahkan ke "
+"dalamnya di halaman temuan."
+
+#: rocky/templates/oois/ooi_add.html
+#, python-format
+msgid "Add %(display_type)s"
+msgstr "Tambahkan %(display_type)s"
+
+#: rocky/templates/oois/ooi_add_type_select.html
+#: rocky/templates/oois/ooi_detail_add_related_object.html
+#: rocky/templates/partials/elements/ooi_add_type_select_form.html
+#: rocky/templates/partials/ooi_list_toolbar.html rocky/views/ooi_add.py
+msgid "Add object"
+msgstr "Tambahkan objek"
+
+#: rocky/templates/oois/ooi_add_type_select.html
+msgid "Select the type of object you want to create."
+msgstr "Pilih jenis objek yang ingin Anda buat."
+
+#: rocky/templates/oois/ooi_delete.html
+#, python-format
+msgid "Delete %(primary_key)s"
+msgstr "Hapus %(primary_key)s"
+
+#: rocky/templates/oois/ooi_delete.html
+msgid "Are you sure?"
+msgstr "Apa kamu yakin?"
+
+#: rocky/templates/oois/ooi_delete.html
+#, python-format
+msgid "Here you can delete the %(display_type)s."
+msgstr "Di sini Anda dapat menghapus %(display_type)s."
+
+#: rocky/templates/oois/ooi_delete.html
+msgid "To be deleted object(s)"
+msgstr "Objek yang akan dihapus"
+
+#: rocky/templates/oois/ooi_delete.html
+#: rocky/templates/partials/elements/ooi_tree_condensed_table.html
+msgid "Key"
+msgstr "Kunci"
+
+#: rocky/templates/oois/ooi_delete.html
+#: rocky/templates/partials/ooi_detail_toolbar.html
+#, python-format
+msgid "Delete %(display_type)s"
+msgstr "Hapus %(display_type)s"
+
+#: rocky/templates/oois/ooi_delete.html
+msgid "Deletion not possible for types: KATFindingType and CVEFindingType"
+msgstr ""
+"Penghapusan tidak dimungkinkan untuk tipe: KATFindingType dan CVEFindingType"
+
+#: rocky/templates/oois/ooi_detail.html
+msgid "using boefjes"
+msgstr "menggunakan boefjes"
+
+#: rocky/templates/oois/ooi_detail.html
+#: rocky/templates/organizations/organization_settings.html
+msgid "indemnification warning"
+msgstr "peringatan ganti rugi"
+
+#: rocky/templates/oois/ooi_detail.html
+#, python-format
+msgid ""
+"<strong>Warning:</strong> There is no indemnification for this organization."
+" Go to the <a href=\"%(organization_settings)s\">organization settings "
+"page</a> to add one."
+msgstr ""
+"<strong>Peringatan:</strong> Tidak ada ganti rugi untuk organisasi ini. Buka"
+" <a href=\"%(organization_settings)s\">laman setelan organisasi</a> untuk "
+"menambahkannya."
+
+#: rocky/templates/oois/ooi_detail.html
+msgid "Permission warning"
+msgstr "Peringatan izin"
+
+#: rocky/templates/oois/ooi_detail.html
+msgid ""
+"<strong>Warning:</strong> You don't have the proper permission at the "
+"organizational level to scan objects. Contact your administrator."
+msgstr ""
+"<strong>Peringatan:</strong> Anda tidak memiliki izin yang sesuai di tingkat"
+" organisasi untuk memindai objek. Hubungi administrator Anda."
+
+#: rocky/templates/oois/ooi_detail.html
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Scan warning"
+msgstr "Peringatan pemindaian"
+
+#: rocky/templates/oois/ooi_detail.html
+#, python-format
+msgid ""
+"<strong>Warning:</strong> You are not allowed to scan this OOI. Your maximum"
+" clearance level is %(member_clearance_level)s and this OOI has level "
+"%(boefje_scan_level)s. Go to your <a href=\"%(account_details)s\">account "
+"details</a> to manage your clearance level."
+msgstr ""
+"<strong>Peringatan:</strong> Anda tidak diperbolehkan memindai OOI ini. "
+"Level izin maksimum Anda adalah %(member_clearance_level)s dan OOI ini "
+"memiliki level %(boefje_scan_level)s. Buka <a "
+"href=\"%(account_details)s\">detail akun</a> Anda untuk mengelola tingkat "
+"izin Anda."
+
+#: rocky/templates/oois/ooi_detail.html rocky/templates/scan.html
+msgid "Boefjes overview"
+msgstr "Boefjes ikhtisar"
+
+#: rocky/templates/oois/ooi_detail.html
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+#: rocky/templates/scan.html rocky/templates/tasks/boefjes.html
+#: rocky/templates/tasks/normalizers.html
+msgid "Boefje"
+msgstr "Boefje"
+
+#: rocky/templates/oois/ooi_detail.html rocky/templates/scan.html
+msgid "Scan profile"
+msgstr "Pindai profil"
+
+#: rocky/templates/oois/ooi_detail.html
+msgid "Unable to start scan. See the warning for more details."
+msgstr ""
+"Tidak dapat memulai pemindaian. Lihat peringatan untuk lebih jelasnya."
+
+#: rocky/templates/oois/ooi_detail.html
+msgid "Start scan"
+msgstr "Mulai pemindaian"
+
+#: rocky/templates/oois/ooi_detail.html
+msgid "There are no boefjes enabled to scan an OOI of type"
+msgstr "Tidak ada boefjes yang diaktifkan untuk memindai tipe OOI"
+
+#: rocky/templates/oois/ooi_detail.html
+msgid "See"
+msgstr "Melihat"
+
+#: rocky/templates/oois/ooi_detail.html
+msgid "to find and enable boefjes that can scan within the current level."
+msgstr ""
+"untuk menemukan dan mengaktifkan boefjes yang dapat memindai dalam level "
+"saat ini."
+
+#: rocky/templates/oois/ooi_detail_add_related_object.html
+#: rocky/templates/partials/ooi_detail_related_object.html
+msgid "Add related object"
+msgstr "Tambahkan objek terkait"
+
+#: rocky/templates/oois/ooi_detail_add_related_object.html
+#: rocky/templates/oois/ooi_detail_object.html
+msgid "Object details"
+msgstr "Detail objek"
+
+#: rocky/templates/oois/ooi_detail_add_related_object.html
+#: rocky/templates/partials/elements/ooi_add_type_select_form.html
+msgid "Object type"
+msgstr "Jenis objek"
+
+#: rocky/templates/oois/ooi_detail_add_related_object.html
+#: rocky/templates/partials/elements/ooi_add_type_select_form.html
+msgid "Choose an object type to add"
+msgstr "Pilih jenis objek untuk ditambahkan"
+
+#: rocky/templates/oois/ooi_detail_add_related_object.html
+#: rocky/templates/partials/elements/ooi_add_type_select_form.html
+msgid "Select an object type to add."
+msgstr "Pilih jenis objek untuk ditambahkan."
+
+#: rocky/templates/oois/ooi_detail_findings_list.html
+msgid "Overview of findings for"
+msgstr "Ikhtisar temuan untuk"
+
+#: rocky/templates/oois/ooi_detail_findings_list.html
+msgid "Score"
+msgstr "Skor"
+
+#: rocky/templates/oois/ooi_detail_findings_list.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid "Finding details"
+msgstr "Menemukan detail"
+
+#: rocky/templates/oois/ooi_detail_findings_overview.html
+msgid "Overview of the number of findings and their severity found on"
+msgstr "Ikhtisar jumlah temuan dan tingkat keparahannya yang ditemukan"
+
+#: rocky/templates/oois/ooi_detail_findings_overview.html
+msgid ""
+"Findings can occur multiple times. To give better insight the following "
+"table shows the number of unique findings found as well as the number of "
+"occurrences."
+msgstr ""
+"Temuan dapat terjadi berkali-kali. Untuk memberikan pemahaman yang lebih "
+"baik, tabel berikut menunjukkan jumlah temuan unik yang ditemukan serta "
+"jumlah kejadiannya."
+
+#: rocky/templates/oois/ooi_detail_findings_overview.html
+msgid "See finding details"
+msgstr "Lihat detail temuan"
+
+#: rocky/templates/oois/ooi_detail_findings_overview.html
+msgid "Total findings"
+msgstr "Jumlah temuan"
+
+#: rocky/templates/oois/ooi_detail_object.html
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Inactive"
+msgstr "Tidak aktif"
+
+#: rocky/templates/oois/ooi_detail_origins_declarations.html
+msgid "Declarations"
+msgstr "Deklarasi"
+
+#: rocky/templates/oois/ooi_detail_origins_inference.html
+msgid "Inferred by"
+msgstr "Disimpulkan oleh"
+
+#: rocky/templates/oois/ooi_detail_origins_inference.html
+msgid "Bit"
+msgstr "Sedikit"
+
+#: rocky/templates/oois/ooi_detail_origins_inference.html
+msgid "Parameters"
+msgstr "Parameter"
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+msgid "Last observed by"
+msgstr "Terakhir diamati oleh"
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+msgid "Task ID"
+msgstr "ID Tugas"
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+msgid "When"
+msgstr "Kapan"
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+#: rocky/templates/tasks/normalizers.html
+msgid "Normalizer"
+msgstr "Normalizer"
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+msgid "This scan was manually created."
+msgstr "Pemindaian ini dibuat secara manual."
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+msgid "The boefje has since been deleted or disabled."
+msgstr "Boefje telah dihapus atau dinonaktifkan."
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+msgid "No Raw file could be found, this might point to an error in OpenKAT"
+msgstr ""
+"Tidak ada file mentah yang ditemukan, ini mungkin menunjukkan kesalahan di "
+"OpenKAT"
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Warning"
+msgstr "Peringatan"
+
+#: rocky/templates/oois/ooi_edit.html
+#, python-format
+msgid "Edit %(type)s: %(ooi_human_readable)s"
+msgstr "Sunting %(type)s: %(ooi_human_readable)s"
+
+#: rocky/templates/oois/ooi_edit.html
+msgid "Primary key fields cannot be edited."
+msgstr "Bidang kunci utama tidak dapat diedit."
+
+#: rocky/templates/oois/ooi_edit.html
+#, python-format
+msgid "Save %(display_type)s"
+msgstr "Simpan %(display_type)s"
+
+#: rocky/templates/oois/ooi_findings.html
+msgid "Currently no findings have been identified for OOI"
+msgstr "Saat ini tidak ada temuan yang teridentifikasi untuk OOI"
+
+#: rocky/templates/oois/ooi_list.html
+#, python-format
+msgid ""
+"An overview of objects found for organization "
+"<strong>%(organization_name)s</strong>. Objects can be added manually or by "
+"running Boefjes. Click an object for additional information."
+msgstr ""
+"Ikhtisar objek yang ditemukan untuk organisasi "
+"<strong>%(organization_name)s</strong>. Objek dapat ditambahkan secara "
+"manual atau dengan menjalankan Boefjes. Klik objek untuk informasi tambahan."
+
+#: rocky/templates/oois/ooi_list.html
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Edit clearance level"
+msgstr "Edit tingkat izin"
+
+#: rocky/templates/oois/ooi_mute_finding.html
+msgid "Mute finding:"
+msgstr "Temuan bisu:"
+
+#: rocky/templates/oois/ooi_mute_finding.html
+msgid "Give a reason below why you want to mute this finding."
+msgstr "Berikan alasan di bawah mengapa Anda ingin membungkam temuan ini."
+
+#: rocky/templates/oois/ooi_mute_finding.html
+#: rocky/templates/partials/mute_findings_modal.html
+#: rocky/templates/partials/ooi_detail_toolbar.html
+msgid "Mute finding"
+msgstr "Temuan bisu"
+
+#: rocky/templates/oois/ooi_mute_finding.html
+msgid "Mute"
+msgstr "Bisu"
+
+#: rocky/templates/oois/ooi_page_tabs.html
+msgid "List of views for OOI"
+msgstr "Daftar tampilan untuk OOI"
+
+#: rocky/templates/oois/ooi_past_due_warning.html
+msgid "This object is past due"
+msgstr "Obyek ini sudah lewat jatuh tempo"
+
+#: rocky/templates/oois/ooi_past_due_warning.html
+msgid "This object is past due and has been deleted"
+msgstr "Objek ini telah lewat jatuh tempo dan telah dihapus"
+
+#: rocky/templates/oois/ooi_past_due_warning.html
+msgid ""
+"This object is past due. You are viewing the object state in a past state."
+msgstr ""
+"Obyek ini sudah lewat jatuh tempo. Anda melihat keadaan objek dalam keadaan "
+"lampau."
+
+#: rocky/templates/oois/ooi_past_due_warning.html
+msgid ""
+"You will not be able to add Findings or other OOI's to past due objects."
+msgstr ""
+"Anda tidak akan dapat menambahkan Temuan atau OOI lainnya ke objek yang "
+"telah lewat jatuh tempo."
+
+#: rocky/templates/oois/ooi_past_due_warning.html
+#: rocky/templates/partials/hyperlink_ooi_id.html
+#, python-format
+msgid "Show details for %(name)s"
+msgstr "Tampilkan detail untuk %(name)s"
+
+#: rocky/templates/oois/ooi_past_due_warning.html
+msgid "View the current state"
+msgstr "Lihat keadaan saat ini"
+
+#: rocky/templates/oois/ooi_past_due_warning.html
+msgid ""
+"You will not be able to add Findings or other OOI's, this object has been "
+"deleted and is no longer available."
+msgstr ""
+"Anda tidak akan dapat menambahkan Temuan atau OOI lainnya, objek ini telah "
+"dihapus dan tidak tersedia lagi."
+
+#: rocky/templates/oois/ooi_summary.html
+msgid "Summary for"
+msgstr "Ringkasan untuk"
+
+#: rocky/templates/oois/ooi_summary.html
+msgid "Below you can see findings that were found for"
+msgstr "Di bawah ini Anda dapat melihat temuan yang ditemukan"
+
+#: rocky/templates/oois/ooi_summary.html
+msgid "and direct  children of this"
+msgstr "dan mengarahkan anak-anak tentang hal ini"
+
+#: rocky/templates/oois/ooi_summary.html
+msgid "This"
+msgstr "Ini"
+
+#: rocky/templates/oois/ooi_summary.html
+msgid "tree view"
+msgstr "pemandangan pohon"
+
+#: rocky/templates/oois/ooi_summary.html
+msgid "of the"
+msgstr "dari"
+
+#: rocky/templates/oois/ooi_summary.html
+msgid "shows the same objects."
+msgstr "menunjukkan objek yang sama."
+
+#: rocky/templates/organizations/organization_add.html
+msgid ""
+"Please enter the following organization details. These details can be edited"
+" within the organization page within OpenKAT when necessary."
+msgstr ""
+"Silakan masukkan detail organisasi berikut. Detail ini dapat diedit dalam "
+"halaman organisasi dalam OpenKAT bila diperlukan."
+
+#: rocky/templates/organizations/organization_edit.html
+msgid "Edit organization"
+msgstr "Sunting organisasi"
+
+#: rocky/templates/organizations/organization_edit.html
+msgid "Save organization"
+msgstr "Simpan organisasi"
+
+#: rocky/templates/organizations/organization_list.html
+msgid "An overview of all organizations you are a member of."
+msgstr "Ikhtisar semua organisasi tempat Anda menjadi anggotanya."
+
+#: rocky/templates/organizations/organization_list.html
+msgid "Add new organization"
+msgstr "Tambahkan organisasi baru"
+
+#: rocky/templates/organizations/organization_list.html
+#, python-format
+msgid ""
+"\n"
+"                            Showing %(total)s organizations\n"
+"                        "
+msgstr ""
+"\n"
+"Menampilkan %(total)s organisasi"
+
+#: rocky/templates/organizations/organization_list.html
+msgid "Organization overview:"
+msgstr "Ikhtisar organisasi:"
+
+#: rocky/templates/organizations/organization_list.html
+#: rocky/templates/organizations/organization_settings.html
+msgid "Tags"
+msgstr "Tag"
+
+#: rocky/templates/organizations/organization_list.html
+msgid "There were no organizations found for your user account"
+msgstr "Tidak ada organisasi yang ditemukan untuk akun pengguna Anda"
+
+#: rocky/templates/organizations/organization_list.html
+msgid "Actions to perform for all of your organizations."
+msgstr "Tindakan yang harus dilakukan untuk semua organisasi Anda."
+
+#: rocky/templates/organizations/organization_list.html
+#: rocky/templates/organizations/organization_settings.html
+msgid "Rerun all bits"
+msgstr "Jalankan kembali semua bit"
+
+#: rocky/templates/organizations/organization_member_add.html
+msgid "Change account type"
+msgstr "Ubah jenis akun"
+
+#: rocky/templates/organizations/organization_member_add_header.html
+#: rocky/views/organization_member_add.py
+msgid "Add member"
+msgstr "Tambahkan anggota"
+
+#: rocky/templates/organizations/organization_member_add_header.html
+#, python-format
+msgid ""
+"Creating a new member of organization <strong>%(organization)s</strong>. For"
+" detailed information about the different account types, check the <a "
+"href=\"https://docs.openkat.nl/basics/users-and-organisations.html#users\" "
+"target=\"_blank\" rel=\"noopener\">documentation</a>."
+msgstr ""
+"Membuat anggota baru organisasi <strong>%(organization)s</strong>. Untuk "
+"informasi detail tentang berbagai jenis akun, lihat <a "
+"href=\"https://docs.openkat.nl/basics/users-and-organisations.html#users\" "
+"target=\"_blank\" rel=\"noopener\">dokumentasi</a>."
+
+#: rocky/templates/organizations/organization_member_edit.html
+#: rocky/views/organization_member_edit.py
+msgid "Edit member"
+msgstr "Sunting anggota"
+
+#: rocky/templates/organizations/organization_member_edit.html
+msgid "Save member"
+msgstr "Simpan anggota"
+
+#: rocky/templates/organizations/organization_member_list.html
+#, python-format
+msgid "An overview of members of <strong>%(organization_name)s</strong>."
+msgstr "Ikhtisar anggota <strong>%(organization_name)s</strong>."
+
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Add member(s)"
+msgstr "Tambahkan anggota"
+
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Manually"
+msgstr "Secara manual"
+
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Upload a CSV"
+msgstr "Unggah CSV"
+
+#: rocky/templates/organizations/organization_member_list.html
+#, python-format
+msgid ""
+"\n"
+"                        Showing %(total)s members\n"
+"                    "
+msgstr ""
+"\n"
+"Menampilkan %(total)s anggota"
+
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Member overview:"
+msgstr "Ikhtisar anggota:"
+
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Role"
+msgstr "Peran"
+
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Assigned clearance level"
+msgstr "Tingkat izin yang ditetapkan"
+
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Super user"
+msgstr "Pengguna super"
+
+#: rocky/templates/organizations/organization_member_upload.html
+#: rocky/views/organization_member_add.py
+msgid "Add members"
+msgstr "Tambahkan anggota"
+
+#: rocky/templates/organizations/organization_member_upload.html
+#, python-format
+msgid ""
+"To upload multiple members at once, you can upload a CSV file or you can <a "
+"href=\"%(download_url)s\">download the template</a>."
+msgstr ""
+"Untuk mengupload beberapa anggota sekaligus, Anda dapat mengupload file CSV "
+"atau Anda dapat <a href=\"%(download_url)s\">mengunduh template</a>."
+
+#: rocky/templates/organizations/organization_member_upload.html
+msgid ""
+"To create a custom CSV file, make sure it meets the following criteria:"
+msgstr ""
+"Untuk membuat file CSV khusus, pastikan file tersebut memenuhi kriteria "
+"berikut:"
+
+#: rocky/templates/organizations/organization_member_upload.html
+msgid "Upload"
+msgstr "Mengunggah"
+
+#: rocky/templates/organizations/organization_settings.html
+#, python-format
+msgid ""
+"An overview of general information and settings for "
+"<strong>%(organization_name)s</strong>."
+msgstr ""
+"Ikhtisar informasi umum dan pengaturan untuk "
+"<strong>%(organization_name)s</strong>."
+
+#: rocky/templates/organizations/organization_settings.html
+msgid ""
+"<strong>Warning:</strong> Indemnification is not set for this organization."
+msgstr ""
+"<strong>Peringatan:</strong> Ganti rugi tidak ditetapkan untuk organisasi "
+"ini."
+
+#: rocky/templates/organizations/organization_settings.html
+#: rocky/views/indemnification_add.py
+msgid "Add indemnification"
+msgstr "Tambahkan ganti rugi"
+
+#: rocky/templates/partials/current_config.html
+msgid "Current configuration"
+msgstr "Konfigurasi saat ini"
+
+#: rocky/templates/partials/delete_ooi_modal.html
+msgid "Delete objects"
+msgstr "Hapus objek"
+
+#: rocky/templates/partials/delete_ooi_modal.html
+msgid ""
+"Are you sure you want to delete all the selected objects? The history of the"
+" deleted objects will still be available."
+msgstr ""
+"Apakah Anda yakin ingin menghapus semua objek yang dipilih? Riwayat objek "
+"yang dihapus akan tetap tersedia."
+
+#: rocky/templates/partials/edit_ooi_clearance_level_modal.html
+msgid "Edit clearance level settings"
+msgstr "Edit pengaturan tingkat izin"
+
+#: rocky/templates/partials/edit_ooi_clearance_level_modal.html
+msgid "You are editing clearance level of all the selected objects."
+msgstr "Anda sedang mengedit tingkat izin semua objek yang dipilih."
+
+#: rocky/templates/partials/edit_ooi_clearance_level_modal.html
+msgid "Switching between declare and inherit"
+msgstr "Beralih antara mendeklarasikan dan mewarisi"
+
+#: rocky/templates/partials/edit_ooi_clearance_level_modal.html
+msgid ""
+"Clearance levels can be automatically inherited or you can manually declare "
+"the clearance level for an object. Switching to inherit clearance level will"
+" also recalculate the clearance levels of objects that inherit from these "
+"clearance levels."
+msgstr ""
+"Tingkat izin dapat diwariskan secara otomatis atau Anda dapat "
+"mendeklarasikan tingkat izin suatu objek secara manual. Beralih ke tingkat "
+"izin warisan juga akan menghitung ulang tingkat izin objek yang mewarisi "
+"tingkat izin tersebut."
+
+#: rocky/templates/partials/elements/ooi_detail_settings.html
+msgid "Observed at"
+msgstr "Diamati di"
+
+#: rocky/templates/partials/elements/ooi_detail_settings.html
+#: rocky/templates/partials/elements/ooi_report_settings.html
+msgid "Show settings"
+msgstr "Tampilkan pengaturan"
+
+#: rocky/templates/partials/elements/ooi_detail_settings.html
+#: rocky/templates/partials/elements/ooi_report_settings.html
+msgid "Hide settings"
+msgstr "Sembunyikan pengaturan"
+
+#: rocky/templates/partials/elements/ooi_list_settings_form.html
+msgid "Toggle all OOI types"
+msgstr "Alihkan semua jenis OOI"
+
+#: rocky/templates/partials/elements/ooi_tree_condensed_table.html
+msgid "Children"
+msgstr "Anak-anak"
+
+#: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
+#, python-format
+msgid "Show details for %(object_id)s, with %(child_count)s children."
+msgstr "Tampilkan detail untuk %(object_id)s, dengan %(child_count)s turunan."
+
+#: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
+#, python-format
+msgid ""
+"Show tree for %(object_id)s with only children of type %(object_ooi_type)s"
+msgstr ""
+"Tampilkan pohon untuk %(object_id)s dengan hanya anak bertipe "
+"%(object_ooi_type)s"
+
+#: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
+#, python-format
+msgid "Unfold %(object_id)s with %(child_count)s children"
+msgstr "Buka %(object_id)s dengan anak %(child_count)s"
+
+#: rocky/templates/partials/elements/ooi_tree_table.html
+msgid "go to:"
+msgstr "pergi ke:"
+
+#: rocky/templates/partials/elements/ooi_tree_table.html
+msgid "Go to detailpage"
+msgstr "Buka halaman detail"
+
+#: rocky/templates/partials/elements/ooi_tree_table.html
+msgid "detail"
+msgstr "detail"
+
+#: rocky/templates/partials/elements/ooi_tree_table.html
+msgid "Go to tree view"
+msgstr "Pergi ke tampilan pohon"
+
+#: rocky/templates/partials/elements/ooi_tree_table.html
+msgid "tree"
+msgstr "pohon"
+
+#: rocky/templates/partials/elements/ooi_tree_table.html
+msgid "Go to graph view"
+msgstr "Pergi ke tampilan grafik"
+
+#: rocky/templates/partials/elements/ooi_tree_table.html
+msgid "graph"
+msgstr "grafik"
+
+#: rocky/templates/partials/explanations.html
+msgid "Clearance level inheritance"
+msgstr "Warisan tingkat izin"
+
+#: rocky/templates/partials/explanations.html
+msgid "OOI"
+msgstr "OOI"
+
+#: rocky/templates/partials/explanations.html
+msgid "This OOI"
+msgstr "Ini OOI"
+
+#: rocky/templates/partials/explanations.html
+msgid "Origin"
+msgstr "Asal"
+
+#: rocky/templates/partials/explanations.html
+msgid "declared"
+msgstr "dideklarasikan"
+
+#: rocky/templates/partials/explanations.html
+msgid "inherited from ↓"
+msgstr "diwarisi dari ↓"
+
+#: rocky/templates/partials/explanations.html
+msgid "Show clearance level inheritance"
+msgstr "Tampilkan warisan tingkat izin"
+
+#: rocky/templates/partials/finding_occurrence_definition_list.html
+msgid "Reproduction"
+msgstr "Reproduksi"
+
+#: rocky/templates/partials/form/checkbox_group_table_form.html
+msgid "Please enable plugin to start scanning."
+msgstr "Harap aktifkan plugin untuk mulai memindai."
+
+#: rocky/templates/partials/form/field_input.html
+msgid "Not set"
+msgstr "Tidak disetel"
+
+#: rocky/templates/partials/form/field_input.html
+msgid "Forgot email"
+msgstr "Lupa email"
+
+#: rocky/templates/partials/form/field_input.html
+msgid "Forgot password"
+msgstr "Lupa kata sandi"
+
+#: rocky/templates/partials/form/field_input_errors.html
+#: rocky/templates/partials/notifications_block.html
+msgid "error"
+msgstr "kesalahan"
+
+#: rocky/templates/partials/form/field_input_errors.html
+#: rocky/templates/partials/form/form_errors.html
+#: rocky/templates/partials/notifications_block.html
+msgid "Error:"
+msgstr "Kesalahan:"
+
+#: rocky/templates/partials/form/field_input_help_text.html
+msgid "Open explanation"
+msgstr "Penjelasan terbuka"
+
+#: rocky/templates/partials/form/field_input_help_text.html
+msgid "Close explanation"
+msgstr "Penjelasan dekat"
+
+#: rocky/templates/partials/form/field_input_help_text.html
+#: rocky/templates/partials/notifications_block.html
+#: rocky/templates/two_factor/core/login.html
+msgid "Explanation:"
+msgstr "Penjelasan:"
+
+#: rocky/templates/partials/form/indemnification_add_form.html
+msgid ""
+"Performing security scans against assets is generally only allowed if you "
+"have permission to scan those assets. Certain scans might also have a "
+"negative impact on (your) assets. Therefore it is important to know and be "
+"aware of the impact of security scans."
+msgstr ""
+"Melakukan pemindaian keamanan terhadap aset umumnya hanya diperbolehkan jika"
+" Anda memiliki izin untuk memindai aset tersebut. Pemindaian tertentu "
+"mungkin juga berdampak negatif pada aset (Anda). Oleh karena itu penting "
+"untuk mengetahui dan mewaspadai dampak pemindaian keamanan."
+
+#: rocky/templates/partials/form/indemnification_add_form.html
+msgid ""
+"An organization indemnification is required before you can use OpenKAT. With"
+" the indemnification you declare that you, as a person, can be held "
+"accountable."
+msgstr ""
+"Diperlukan ganti rugi organisasi sebelum Anda dapat menggunakan OpenKAT. "
+"Dengan ganti rugi tersebut Anda menyatakan bahwa Anda, sebagai pribadi, "
+"dapat dimintai pertanggungjawaban."
+
+#: rocky/templates/partials/form/indemnification_add_form.html
+msgid "Set an indemnification"
+msgstr "Tetapkan ganti rugi"
+
+#: rocky/templates/partials/hyperlink_ooi_type.html
+#, python-format
+msgid "Only show objects of type %(type)s"
+msgstr "Hanya tampilkan objek bertipe %(type)s"
+
+#: rocky/templates/partials/list_filters.html
+msgid "Hide filter options"
+msgstr "Sembunyikan opsi filter"
+
+#: rocky/templates/partials/list_filters.html
+msgid "Show filter options"
+msgstr "Tampilkan opsi filter"
+
+#: rocky/templates/partials/list_paginator.html
+msgid "List pagination"
+msgstr "Daftar paginasi"
+
+#: rocky/templates/partials/list_paginator.html
+msgid "Previous Page"
+msgstr "Halaman Sebelumnya"
+
+#: rocky/templates/partials/list_paginator.html
+msgid "Previous"
+msgstr "Sebelumnya"
+
+#: rocky/templates/partials/list_paginator.html
+msgid "Five Pages Back"
+msgstr "Lima Halaman Kembali"
+
+#: rocky/templates/partials/list_paginator.html
+#: rocky/templates/partials/pagination.html
+msgid "Page"
+msgstr "Halaman"
+
+#: rocky/templates/partials/list_paginator.html
+msgid "Current"
+msgstr "Saat ini"
+
+#: rocky/templates/partials/list_paginator.html
+msgid "Five Pages Forward"
+msgstr "Lima Halaman Maju"
+
+#: rocky/templates/partials/list_paginator.html
+msgid "Next Page"
+msgstr "Halaman Berikutnya"
+
+#: rocky/templates/partials/list_paginator.html
+msgid "Next"
+msgstr "Berikutnya"
+
+#: rocky/templates/partials/mute_findings_modal.html
+msgid "You are muting the selected findings."
+msgstr "Anda menonaktifkan temuan yang dipilih."
+
+#: rocky/templates/partials/mute_findings_modal.html
+msgid "Reason:"
+msgstr "Alasan:"
+
+#: rocky/templates/partials/mute_findings_modal.html
+msgid "Expires by (UTC):"
+msgstr "Berakhir pada (UTC):"
+
+#: rocky/templates/partials/notifications_block.html
+msgid "Confirmation:"
+msgstr "Konfirmasi:"
+
+#: rocky/templates/partials/ooi_detail_related_object.html
+msgid "No related object known for"
+msgstr "Tidak ada objek terkait yang diketahui"
+
+#: rocky/templates/partials/ooi_detail_toolbar.html
+msgid "Generate Report"
+msgstr "Hasilkan Laporan"
+
+#: rocky/templates/partials/ooi_detail_toolbar.html
+#, python-format
+msgid "Edit %(display_type)s"
+msgstr "Sunting %(display_type)s"
+
+#: rocky/templates/partials/ooi_head.html
+msgid "Data from:"
+msgstr "Data dari:"
+
+#: rocky/templates/partials/ooi_head.html
+msgid "(Now)"
+msgstr "(Sekarang)"
+
+#: rocky/templates/partials/ooi_list_toolbar.html
+msgid "Scan for objects"
+msgstr "Pindai objek"
+
+#: rocky/templates/partials/ooi_list_toolbar.html
+#: rocky/templates/upload_csv.html rocky/views/upload_csv.py
+msgid "Upload CSV"
+msgstr "Unggah CSV"
+
+#: rocky/templates/partials/ooi_list_toolbar.html
+msgid "Export"
+msgstr "Ekspor"
+
+#: rocky/templates/partials/ooi_list_toolbar.html
+msgid "Download as CSV"
+msgstr "Unduh sebagai CSV"
+
+#: rocky/templates/partials/ooi_report_findings_block.html
+#, python-format
+msgid "%(total)s findings on %(name)s"
+msgstr "%(total)s temuan pada %(name)s"
+
+#: rocky/templates/partials/ooi_report_findings_block_table.html
+#, python-format
+msgid "Findings for %(type)s %(name)s on %(observed_at)s:"
+msgstr "Temuan untuk %(type)s %(name)s pada %(observed_at)s:"
+
+#: rocky/templates/partials/ooi_report_findings_block_table.html
+msgid "Open finding details"
+msgstr "Buka detail temuan"
+
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+#, python-format
+msgid "Details of %(object_id)s"
+msgstr "Detail %(object_id)s"
+
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid ""
+"The severity of this findingtype has not (yet) been determined by the data "
+"source. This situation requires manual investigation of the severity."
+msgstr ""
+"Tingkat keparahan jenis temuan ini belum (belum) ditentukan oleh sumber "
+"data. Situasi ini memerlukan penyelidikan manual mengenai tingkat "
+"keparahannya."
+
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid "Total occurrences"
+msgstr "Jumlah kejadian"
+
+#: rocky/templates/partials/ooi_tree_toolbar_bottom.html
+msgid "Tree - dense view"
+msgstr "Pohon - pemandangan lebat"
+
+#: rocky/templates/partials/ooi_tree_toolbar_bottom.html
+msgid "Tree - table view"
+msgstr "Tampilan pohon - tabel"
+
+#: rocky/templates/partials/organization_member_list_filters.html
+msgid "Update List"
+msgstr "Daftar Pembaruan"
+
+#: rocky/templates/partials/organization_properties_table.html
+msgid "Organization name"
+msgstr "Nama organisasi"
+
+#: rocky/templates/partials/organization_properties_table.html
+msgid "Organization code"
+msgstr "Kode organisasi"
+
+#: rocky/templates/partials/organizations_menu_dropdown.html
+msgid "Select organization"
+msgstr "Pilih organisasi"
+
+#: rocky/templates/partials/organizations_menu_dropdown.html
+msgid "All organizations"
+msgstr "Semua organisasi"
+
+#: rocky/templates/partials/page-meta.html
+msgid "Logged in as:"
+msgstr "Masuk sebagai:"
+
+#: rocky/templates/partials/pagination.html
+msgid "of"
+msgstr "dari"
+
+#: rocky/templates/partials/pagination.html
+msgid "first"
+msgstr "Pertama"
+
+#: rocky/templates/partials/pagination.html
+msgid "previous"
+msgstr "sebelumnya"
+
+#: rocky/templates/partials/pagination.html
+msgid "next"
+msgstr "Berikutnya"
+
+#: rocky/templates/partials/pagination.html
+msgid "last"
+msgstr "terakhir"
+
+#: rocky/templates/partials/secondary-menu.html
+msgid "User navigation"
+msgstr "Navigasi pengguna"
+
+#: rocky/templates/partials/secondary-menu.html
+msgid "Close user navigation"
+msgstr "Tutup navigasi pengguna"
+
+#: rocky/templates/partials/secondary-menu.html
+msgid "My organizations"
+msgstr "Organisasi saya"
+
+#: rocky/templates/partials/secondary-menu.html
+msgid "Profile"
+msgstr "Profil"
+
+#: rocky/templates/partials/skip-to-content.html
+msgid "Go to content"
+msgstr "Buka konten"
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid ""
+"The clearance level determines the level of boefje scans allowed on this "
+"object. An object inherits its clearance level from neighbouring objects. "
+"This means that the clearance level might stay the same, increase or "
+"decrease, depending on other declared clearance levels."
+msgstr ""
+"Tingkat izin menentukan tingkat pemindaian boefje yang diperbolehkan pada "
+"objek ini. Suatu objek mewarisi tingkat izinnya dari objek tetangganya. "
+"Artinya, tingkat izin mungkin tetap sama, bertambah atau berkurang, "
+"bergantung pada tingkat izin lain yang dinyatakan."
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Empty clearance level explanation"
+msgstr "Penjelasan tingkat izin kosong"
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Empty:"
+msgstr "Kosong:"
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid ""
+"This object has a clearance level of \"empty\". This means that this object "
+"has no clearance level."
+msgstr ""
+"Benda ini mempunyai tingkat kelonggaran “kosong”. Artinya objek tersebut "
+"tidak memiliki tingkat izin."
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Indemnification warning"
+msgstr "Peringatan ganti rugi"
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Indemnification is not set for this organization."
+msgstr "Ganti rugi tidak ditetapkan untuk organisasi ini."
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Go to the"
+msgstr "Pergi ke"
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "organization settings page"
+msgstr "halaman pengaturan organisasi"
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "to add one."
+msgstr "untuk menambahkan satu."
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Set clearance level warning"
+msgstr "Atur peringatan tingkat izin"
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid ""
+"You don't have permissions to set the clearance level. Contact your "
+"administrator."
+msgstr ""
+"Anda tidak memiliki izin untuk menyetel tingkat izin. Hubungi administrator "
+"Anda."
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+#, python-format
+msgid ""
+"You are not allowed to set the clearance level of this OOI. Your maximum "
+"clearance level is %(member_clearance_level)s and this OOI has level "
+"%(boefje_scan_level)s."
+msgstr ""
+"Anda tidak diperbolehkan mengatur tingkat izin OOI ini. Level izin maksimum "
+"Anda adalah %(member_clearance_level)s dan OOI ini memiliki level "
+"%(boefje_scan_level)s."
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Go to your"
+msgstr "Pergi ke Anda"
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "account details"
+msgstr "detail akun"
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "to manage your clearance level."
+msgstr "untuk mengelola tingkat izin Anda."
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Current clearance level"
+msgstr "Tingkat izin saat ini"
+
+#: rocky/templates/tasks/boefje_task_detail.html
+msgid ""
+"An overview of the boefje task, the input OOI and the RAW data it generated."
+msgstr "Ikhtisar tugas boefje, input OOI dan data RAW yang dihasilkannya."
+
+#: rocky/templates/tasks/boefje_task_detail.html
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Download meta and raw data"
+msgstr "Unduh meta dan data mentah"
+
+#: rocky/templates/tasks/boefje_task_detail.html
+msgid "Download meta data"
+msgstr "Unduh data meta"
+
+#: rocky/templates/tasks/boefje_task_detail.html
+msgid "Input object"
+msgstr "Objek masukan"
+
+#: rocky/templates/tasks/boefjes.html
+msgid "There are no tasks for boefjes."
+msgstr "Tidak ada tugas untuk boefjes."
+
+#: rocky/templates/tasks/boefjes.html
+msgid "List of tasks for boefjes."
+msgstr "Daftar tugas untuk boefjes."
+
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/reports.html
+msgid "Organization Code"
+msgstr "Kode Organisasi"
+
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
+#: rocky/templates/tasks/ooi_detail_task_list.html
+#: rocky/templates/tasks/plugin_detail_task_list.html
+msgid "Created date"
+msgstr "Tanggal dibuat"
+
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
+#: rocky/templates/tasks/reports.html
+msgid "Modified date"
+msgstr "Tanggal diubah"
+
+#: rocky/templates/tasks/normalizers.html
+msgid "There are no tasks for normalizers."
+msgstr "Tidak ada tugas untuk normalizer."
+
+#: rocky/templates/tasks/normalizers.html
+msgid "List of tasks for normalizers."
+msgstr "Daftar tugas untuk normalizer."
+
+#: rocky/templates/tasks/normalizers.html
+msgid "Boefje input OOI"
+msgstr "Boefje masukan OOI"
+
+#: rocky/templates/tasks/normalizers.html
+msgid "Manually added"
+msgstr "Ditambahkan secara manual"
+
+#: rocky/templates/tasks/ooi_detail_task_list.html
+msgid "There have been no tasks."
+msgstr "Belum ada tugas."
+
+#: rocky/templates/tasks/partials/stats.html
+msgid "Task statistics - Last 24 hours"
+msgstr "Statistik tugas - 24 jam terakhir"
+
+#: rocky/templates/tasks/partials/stats.html
+msgid "All times in UTC, blocks of 1 hour."
+msgstr "Semua waktu dalam UTC, blok 1 jam."
+
+#: rocky/templates/tasks/partials/stats.html
+msgid "Timeslot"
+msgstr "slot waktu"
+
+#: rocky/templates/tasks/partials/stats.html
+msgid "Could not load stats, Scheduler error."
+msgstr "Tidak dapat memuat statistik, kesalahan Penjadwal."
+
+#: rocky/templates/tasks/partials/tab_navigation.html
+msgid "List of tasks"
+msgstr "Daftar tugas"
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Loading..."
+msgstr "Memuat..."
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Yielded objects"
+msgstr "Benda yang dihasilkan"
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Yielded raw files"
+msgstr "Menghasilkan file mentah"
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Reschedule"
+msgstr "Menjadwalkan ulang"
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Download task data"
+msgstr "Unduh data tugas"
+
+#: rocky/templates/tasks/partials/tasks_overview_header.html
+#, python-format
+msgid ""
+"An overview of the tasks for <strong>%(organization)s</strong>. Tasks are "
+"divided in Boefjes, Normalizers and Reports. Boefjes scan objects and "
+"Normalizers dispatch on the output mime-type. Additionally, there is a "
+"Report tasks. This task aggregates and presents findings from both Boefjes "
+"and Normalizers."
+msgstr ""
+"Ikhtisar tugas untuk <strong>%(organization)s</strong>. Tugas dibagi menjadi"
+" Boefjes, Normalizers dan Laporan. Boefjes memindai objek dan Normalizers "
+"mengirimkan pada tipe pantomim keluaran. Selain itu, ada tugas Laporan. "
+"Tugas ini mengumpulkan dan menyajikan temuan dari Boefjes dan Normalizers."
+
+#: rocky/templates/tasks/plugin_detail_task_list.html
+msgid "There are no tasks for"
+msgstr "Tidak ada tugas untuk"
+
+#: rocky/templates/tasks/plugin_detail_task_list.html
+msgid "List of tasks for"
+msgstr "Daftar tugas untuk"
+
+#: rocky/templates/tasks/reports.html
+msgid "There are no tasks for reports."
+msgstr "Tidak ada tugas untuk laporan."
+
+#: rocky/templates/tasks/reports.html
+msgid "List of tasks for reports."
+msgstr "Daftar tugas untuk laporan."
+
+#: rocky/templates/tasks/reports.html
+msgid "Recipe ID"
+msgstr "ID Resep"
+
+#: rocky/templates/two_factor/_wizard_actions.html
+msgid "Log in"
+msgstr "Masuk"
+
+#: rocky/templates/two_factor/_wizard_actions.html
+msgid "Authenticate"
+msgstr "Otentikasi"
+
+#: rocky/templates/two_factor/core/backup_tokens.html
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Backup Tokens"
+msgstr "Token Cadangan"
+
+#: rocky/templates/two_factor/core/backup_tokens.html
+msgid ""
+"Backup tokens can be used when your primary and backup phone numbers aren't "
+"available. The backup tokens below can be used for login verification. If "
+"you've used up all your backup tokens, you can generate a new set of backup "
+"tokens. Only the backup tokens shown below will be valid."
+msgstr ""
+"Token cadangan dapat digunakan ketika nomor telepon utama dan cadangan Anda "
+"tidak tersedia. Token cadangan di bawah ini dapat digunakan untuk verifikasi"
+" login. Jika Anda telah menggunakan semua token cadangan, Anda dapat membuat"
+" kumpulan token cadangan baru. Hanya token cadangan yang ditunjukkan di "
+"bawah ini yang valid."
+
+#: rocky/templates/two_factor/core/backup_tokens.html
+msgid "Print these tokens and keep them somewhere safe."
+msgstr "Cetak token ini dan simpan di tempat yang aman."
+
+#: rocky/templates/two_factor/core/backup_tokens.html
+msgid "You don't have any backup codes yet."
+msgstr "Anda belum memiliki kode cadangan apa pun."
+
+#: rocky/templates/two_factor/core/backup_tokens.html
+msgid "Generate Tokens"
+msgstr "Hasilkan Token"
+
+#: rocky/templates/two_factor/core/backup_tokens.html
+#: rocky/templates/two_factor/core/setup_complete.html
+msgid "Back to Account Security"
+msgstr "Kembali ke Keamanan Akun"
+
+#: rocky/templates/two_factor/core/login.html
+msgid "You are logged in."
+msgstr "Anda sudah masuk."
+
+#: rocky/templates/two_factor/core/login.html
+msgid "Two factor authentication is enabled for your account."
+msgstr "Otentikasi dua faktor diaktifkan untuk akun Anda."
+
+#: rocky/templates/two_factor/core/login.html
+msgid ""
+"Two factor authentication is not enabled for your account. Enable it to "
+"continue."
+msgstr ""
+"Otentikasi dua faktor tidak diaktifkan untuk akun Anda. Aktifkan untuk "
+"melanjutkan."
+
+#: rocky/templates/two_factor/core/login.html
+msgid "Setup two factor authentication"
+msgstr "Siapkan otentikasi dua faktor"
+
+#: rocky/templates/two_factor/core/login.html
+msgid "Credentials"
+msgstr "Kredensial"
+
+#: rocky/templates/two_factor/core/login.html
+msgid ""
+"Use this form for entering backup tokens for logging in. These tokens have "
+"been generated for you to print and keep safe. Please enter one of these "
+"backup tokens to login to your account."
+msgstr ""
+"Gunakan formulir ini untuk memasukkan token cadangan untuk masuk. Token ini "
+"telah dibuat untuk Anda cetak dan simpan dengan aman. Silakan masukkan salah"
+" satu token cadangan ini untuk login ke akun Anda."
+
+#: rocky/templates/two_factor/core/login.html
+msgid "As a last resort, you can use a backup token:"
+msgstr "Sebagai upaya terakhir, Anda dapat menggunakan token cadangan:"
+
+#: rocky/templates/two_factor/core/login.html
+msgid "Use Backup Token"
+msgstr "Gunakan Token Cadangan"
+
+#: rocky/templates/two_factor/core/otp_required.html
+msgid "Permission Denied"
+msgstr "Izin Ditolak"
+
+#: rocky/templates/two_factor/core/otp_required.html
+msgid ""
+"The page you requested, enforces users to verify using two-factor "
+"authentication for security reasons. You need to enable these security "
+"features in order to access this page."
+msgstr ""
+"Halaman yang Anda minta, memaksa pengguna untuk memverifikasi menggunakan "
+"otentikasi dua faktor untuk alasan keamanan. Anda perlu mengaktifkan fitur "
+"keamanan ini untuk mengakses halaman ini."
+
+#: rocky/templates/two_factor/core/otp_required.html
+#: rocky/templates/two_factor/profile/profile.html
+msgid ""
+"Two-factor authentication is not enabled for your account. Enable two-factor"
+" authentication for enhanced account security."
+msgstr ""
+"Otentikasi dua faktor tidak diaktifkan untuk akun Anda. Aktifkan autentikasi"
+" dua faktor untuk meningkatkan keamanan akun."
+
+#: rocky/templates/two_factor/core/otp_required.html
+#: rocky/templates/two_factor/core/setup.html
+#: rocky/templates/two_factor/core/setup_complete.html
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Enable Two-Factor Authentication"
+msgstr "Aktifkan Otentikasi Dua Faktor"
+
+#: rocky/templates/two_factor/core/phone_register.html
+msgid "Add Backup Phone"
+msgstr "Tambahkan Telepon Cadangan"
+
+#: rocky/templates/two_factor/core/phone_register.html
+msgid ""
+"You'll be adding a backup phone number to your account. This number will be "
+"used if your primary method of registration is not available."
+msgstr ""
+"Anda akan menambahkan nomor telepon cadangan ke akun Anda. Nomor ini akan "
+"digunakan jika metode pendaftaran utama Anda tidak tersedia."
+
+#: rocky/templates/two_factor/core/phone_register.html
+msgid ""
+"We've sent a token to your phone number. Please enter the token you've "
+"received."
+msgstr ""
+"Kami telah mengirimkan token ke nomor telepon Anda. Silakan masukkan token "
+"yang Anda terima."
+
+#: rocky/templates/two_factor/core/setup.html
+msgid ""
+"To start using a token generator, please use your smartphone to scan the QR "
+"code below or use the setup key. For example, use GoogleAuthenticator. Then,"
+" enter the token generated by the app."
+msgstr ""
+"Untuk mulai menggunakan pembuat token, silakan gunakan ponsel cerdas Anda "
+"untuk memindai kode QR di bawah atau gunakan kunci pengaturan. Misalnya, "
+"gunakan GoogleAuthenticator. Lalu, masukkan token yang dihasilkan oleh "
+"aplikasi."
+
+#: rocky/templates/two_factor/core/setup.html
+msgid "QR code"
+msgstr "kode QR"
+
+#: rocky/templates/two_factor/core/setup.html
+msgid "Setup key"
+msgstr "Kunci pengaturan"
+
+#: rocky/templates/two_factor/core/setup.html
+msgid ""
+"The secret key is a 32 characters representation of the QR code. There are 2"
+" options to setup the two factor authtentication. You can scan the QR code "
+"above or you can insert this key using the secret key option of the "
+"authenticator app."
+msgstr ""
+"Kunci rahasianya adalah representasi 32 karakter dari kode QR. Ada 2 opsi "
+"untuk mengatur otentikasi dua faktor. Anda dapat memindai kode QR di atas "
+"atau Anda dapat memasukkan kunci ini menggunakan opsi kunci rahasia pada "
+"aplikasi autentikator."
+
+#: rocky/templates/two_factor/core/setup_complete.html
+msgid ""
+"Congratulations, you've successfully enabled two-factor authentication."
+msgstr "Selamat, Anda berhasil mengaktifkan autentikasi dua faktor."
+
+#: rocky/templates/two_factor/core/setup_complete.html
+msgid "Start using OpenKAT"
+msgstr "Mulai gunakan OpenKAT"
+
+#: rocky/templates/two_factor/core/setup_complete.html
+msgid ""
+"However, it might happen that you don't have access to your primary token "
+"device. To enable account recovery, add a phone number."
+msgstr ""
+"Namun, mungkin saja Anda tidak memiliki akses ke perangkat token utama Anda."
+" Untuk mengaktifkan pemulihan akun, tambahkan nomor telepon."
+
+#: rocky/templates/two_factor/core/setup_complete.html
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Add Phone Number"
+msgstr "Tambahkan Nomor Telepon"
+
+#: rocky/templates/two_factor/profile/disable.html
+msgid "Disable Two-factor Authentication"
+msgstr "Nonaktifkan Otentikasi Dua Faktor"
+
+#: rocky/templates/two_factor/profile/disable.html
+msgid ""
+"You are about to disable two-factor authentication. This weakens your "
+"account security, are you sure?"
+msgstr ""
+"Anda akan menonaktifkan autentikasi dua faktor. Ini melemahkan keamanan akun"
+" Anda, apakah Anda yakin?"
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Account Security"
+msgstr "Keamanan Akun"
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Tokens will be generated by your token generator."
+msgstr "Token akan dihasilkan oleh generator token Anda."
+
+#: rocky/templates/two_factor/profile/profile.html
+#, python-format
+msgid "Primary method: %(primary)s"
+msgstr "Metode utama: %(primary)s"
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Tokens will be generated by your YubiKey."
+msgstr "Token akan dihasilkan oleh YubiKey Anda."
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Backup Phone Numbers"
+msgstr "Nomor Telepon Cadangan"
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid ""
+"If your primary method is not available, we are able to send backup tokens "
+"to the phone numbers listed below."
+msgstr ""
+"Jika metode utama Anda tidak tersedia, kami dapat mengirimkan token cadangan"
+" ke nomor telepon yang tercantum di bawah."
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Unregister"
+msgstr "Batalkan pendaftaran"
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid ""
+"If you don't have any device with you, you can access your account using "
+"backup tokens."
+msgstr ""
+"Jika Anda tidak membawa perangkat apa pun, Anda dapat mengakses akun Anda "
+"menggunakan token cadangan."
+
+#: rocky/templates/two_factor/profile/profile.html
+#, python-format
+msgid "You have only one backup token remaining."
+msgid_plural "You have %(counter)s backup tokens remaining."
+msgstr[0] "Anda memiliki %(counter)s token cadangan yang tersisa."
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Show Codes"
+msgstr "Tampilkan Kode"
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Disable Two-Factor Authentication"
+msgstr "Nonaktifkan Otentikasi Dua Faktor"
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid ""
+"However we strongly discourage you to do so, you can also disable two-factor"
+" authentication for your account."
+msgstr ""
+"Namun kami sangat tidak menyarankan Anda melakukannya, Anda juga dapat "
+"menonaktifkan otentikasi dua faktor untuk akun Anda."
+
+#: rocky/templates/two_factor/twilio/sms_message.html
+#, python-format
+msgid "Your OTP token is %(token)s"
+msgstr "Token OTP Anda adalah %(token)s"
+
+#: rocky/templates/upload_csv.html
+msgid "Automate the creation of multiple objects by uploading a CSV file."
+msgstr "Otomatiskan pembuatan beberapa objek dengan mengunggah file CSV."
+
+#: rocky/templates/upload_csv.html
+msgid "These are the criteria for CSV upload:"
+msgstr "Berikut kriteria unggahan CSV:"
+
+#: rocky/templates/upload_raw.html
+msgid "Automate the creation of multiple objects by uploading a raw file."
+msgstr "Otomatiskan pembuatan banyak objek dengan mengunggah file mentah."
+
+#: rocky/templates/upload_raw.html
+msgid ""
+"An input OOI can be selected for the normalizer to attach newly yielded OOIs"
+" to. If no input OOI was used for the raw file, a placeholder ExternalScan "
+"OOI can be used. ExternalScan OOIs can be created from the objects page. "
+"When a new version of the raw file is generated, the same ExternalScan OOI "
+"should be chosen to ensure that old results are overwritten."
+msgstr ""
+"Input OOI dapat dipilih agar normalizer dapat melampirkan OOIs yang baru "
+"dihasilkan. Jika tidak ada input OOI yang digunakan untuk file mentah, "
+"placeholder ExternalScan OOI dapat digunakan. ExternalScan OOIs dapat dibuat"
+" dari halaman objek. Ketika versi baru dari file mentah dibuat, ExternalScan"
+" OOI yang sama harus dipilih untuk memastikan bahwa hasil lama ditimpa."
+
+#: rocky/templates/upload_raw.html rocky/views/upload_raw.py
+msgid "Upload raw"
+msgstr "Unggah mentah"
+
+#: rocky/views/bytes_raw.py
+msgid "Getting raw data failed."
+msgstr "Gagal mendapatkan data mentah."
+
+#: rocky/views/bytes_raw.py
+msgid "The task does not have any raw data."
+msgstr "Tugas tersebut tidak memiliki data mentah apa pun."
+
+#: rocky/views/finding_list.py rocky/views/ooi_list.py
+msgid "Unknown action."
+msgstr "Tindakan tidak diketahui."
+
+#: rocky/views/health.py
+msgid "Beautified"
+msgstr "Dipercantik"
+
+#: rocky/views/indemnification_add.py
+msgid "Indemnification successfully set."
+msgstr "Ganti rugi berhasil ditetapkan."
+
+#: rocky/views/mixins.py
+msgid "The selected date is in the future."
+msgstr "Tanggal yang dipilih adalah di masa depan."
+
+#: rocky/views/mixins.py
+msgid "Can not parse date, falling back to show current date."
+msgstr "Tidak dapat mengurai tanggal, kembali menampilkan tanggal saat ini."
+
+#: rocky/views/mixins.py
+#, python-format
+msgid "Could not load origins for OOI: %s from octopoes"
+msgstr "Tidak dapat memuat asal untuk OOI: %s dari gurita"
+
+#: rocky/views/mixins.py
+msgid "Could not load normalizer metas from bytes"
+msgstr "Tidak dapat memuat meta normalizer dari byte"
+
+#: rocky/views/mixins.py
+#, python-format
+msgid "Could not load boefje %s from katalogus"
+msgstr "Tidak dapat memuat boefje %s dari katalogus"
+
+#: rocky/views/mixins.py
+msgid "You do not have the permission to add items to a dashboard."
+msgstr "Anda tidak memiliki izin untuk menambahkan item ke dasbor."
+
+#: rocky/views/mixins.py
+msgid "Dashboard item has been added."
+msgstr "Item dasbor telah ditambahkan."
+
+#: rocky/views/ooi_add.py
+#, python-format
+msgid "Add %(ooi_type)s"
+msgstr "Tambahkan %(ooi_type)s"
+
+#: rocky/views/ooi_detail.py
+msgid ""
+"Cannot set clearance level. It must be provided and must be a valid number."
+msgstr ""
+"Tidak dapat mengatur tingkat izin. Itu harus disediakan dan harus berupa "
+"nomor yang valid."
+
+#: rocky/views/ooi_detail.py
+msgid "Only Question OOIs can be answered."
+msgstr "Hanya Pertanyaan OOIs yang dapat dijawab."
+
+#: rocky/views/ooi_detail.py
+msgid "Question has been answered."
+msgstr "Pertanyaan telah terjawab."
+
+#: rocky/views/ooi_detail_related_object.py
+msgid " (as "
+msgstr "(sebagai"
+
+#: rocky/views/ooi_findings.py
+msgid "Object findings"
+msgstr "Temuan objek"
+
+#: rocky/views/ooi_list.py
+msgid "No OOIs selected."
+msgstr "Tidak ada OOIs yang dipilih."
+
+#: rocky/views/ooi_list.py
+#, python-format
+msgid ""
+"Could not raise clearance levels to L%s. Indemnification not present at "
+"organization %s."
+msgstr ""
+"Tidak dapat menaikkan level izin ke L%s. Ganti rugi tidak ada di organisasi "
+"%s."
+
+#: rocky/views/ooi_list.py
+#, python-format
+msgid ""
+"Could not raise clearance level to L%s. You were trusted a clearance level "
+"of L%s. Contact your administrator to receive a higher clearance."
+msgstr ""
+"Tidak dapat menaikkan level izin ke L%s. Anda dipercaya dengan tingkat izin "
+"L%s. Hubungi administrator Anda untuk menerima izin yang lebih tinggi."
+
+#: rocky/views/ooi_list.py
+#, python-format
+msgid ""
+"Could not raise clearance level to L%s. You acknowledged a clearance level "
+"of L%s. Please accept the clearance level below to proceed."
+msgstr ""
+"Tidak dapat menaikkan level izin ke L%s. Anda mengakui tingkat izin L%s. "
+"Harap terima tingkat izin di bawah ini untuk melanjutkan."
+
+#: rocky/views/ooi_list.py
+msgid "An error occurred while saving clearance levels."
+msgstr "Terjadi kesalahan saat menyimpan level izin."
+
+#: rocky/views/ooi_list.py
+msgid "One of the OOI's doesn't exist"
+msgstr "Salah satu OOI tidak ada"
+
+#: rocky/views/ooi_list.py
+#, python-format
+msgid "Successfully set scan profile to %s for %d OOIs."
+msgstr "Berhasil mengatur profil pemindaian ke %s untuk %d OOIs."
+
+#: rocky/views/ooi_list.py
+msgid "An error occurred while setting clearance levels to inherit."
+msgstr "Terjadi kesalahan saat menyetel tingkat izin untuk diwarisi."
+
+#: rocky/views/ooi_list.py
+msgid ""
+"An error occurred while setting clearance levels to inherit: one of the OOIs"
+" doesn't exist."
+msgstr ""
+"Terjadi kesalahan saat menyetel tingkat izin untuk diwarisi: salah satu dari"
+" OOIs tidak ada."
+
+#: rocky/views/ooi_list.py
+#, python-format
+msgid "Successfully set %d OOI(s) clearance level to inherit."
+msgstr "Berhasil menetapkan tingkat izin %d OOI(s) untuk diwarisi."
+
+#: rocky/views/ooi_list.py
+msgid "An error occurred while deleting oois."
+msgstr "Terjadi kesalahan saat menghapus oois."
+
+#: rocky/views/ooi_list.py
+msgid "An error occurred while deleting OOIs: one of the OOIs doesn't exist."
+msgstr ""
+"Terjadi kesalahan saat menghapus OOIs: salah satu dari OOIs tidak ada."
+
+#: rocky/views/ooi_list.py
+#, python-format
+msgid ""
+"Successfully deleted %d ooi(s). Note: Bits can recreate objects "
+"automatically."
+msgstr ""
+"Berhasil menghapus %d ooi. Catatan: Bit dapat membuat ulang objek secara "
+"otomatis."
+
+#: rocky/views/ooi_mute.py
+msgid "Please select at least one finding."
+msgstr "Silakan pilih setidaknya satu temuan."
+
+#: rocky/views/ooi_mute.py
+msgid "Finding(s) successfully unmuted."
+msgstr "Temuan berhasil dibunyikan."
+
+#: rocky/views/ooi_mute.py
+msgid "Finding(s) successfully muted."
+msgstr "Temuan berhasil dibungkam."
+
+#: rocky/views/ooi_tree.py
+msgid "Tree Visualisation"
+msgstr "Visualisasi Pohon"
+
+#: rocky/views/ooi_tree.py
+msgid "Graph Visualisation"
+msgstr "Visualisasi Grafik"
+
+#: rocky/views/ooi_view.py
+msgid "Observed_at: "
+msgstr "Diamati_di:"
+
+#: rocky/views/ooi_view.py
+msgid "OOI types: "
+msgstr "OOI jenis:"
+
+#: rocky/views/ooi_view.py
+msgid "Clearance level: "
+msgstr "Tingkat izin:"
+
+#: rocky/views/ooi_view.py
+msgid "Clearance type: "
+msgstr "Jenis izin:"
+
+#: rocky/views/ooi_view.py
+msgid "Searching for: "
+msgstr "Mencari:"
+
+#: rocky/views/organization_add.py
+msgid "Setup"
+msgstr "Pengaturan"
+
+#: rocky/views/organization_add.py
+msgid "Organization added successfully."
+msgstr "Organisasi berhasil ditambahkan."
+
+#: rocky/views/organization_add.py
+msgid "You are not allowed to add organizations."
+msgstr "Anda tidak diperbolehkan menambahkan organisasi."
+
+#: rocky/views/organization_edit.py
+#, python-format
+msgid "Organization %s successfully updated."
+msgstr "Organisasi %s berhasil diperbarui."
+
+#: rocky/views/organization_member_add.py
+msgid "Add column titles, followed by each object on a new line."
+msgstr "Tambahkan judul kolom, diikuti setiap objek pada baris baru."
+
+#: rocky/views/organization_member_add.py
+msgid "The columns are: "
+msgstr "Kolomnya adalah:"
+
+#: rocky/views/organization_member_add.py
+msgid "Clearance levels should be between -1 and 4."
+msgstr "Tingkat izin harus antara -1 dan 4."
+
+#: rocky/views/organization_member_add.py
+msgid "Account type can be one of: "
+msgstr "Jenis akun dapat berupa salah satu dari:"
+
+#: rocky/views/organization_member_add.py
+msgid "Member added successfully."
+msgstr "Anggota berhasil ditambahkan."
+
+#: rocky/views/organization_member_add.py
+msgid "The csv file is missing required columns"
+msgstr "File csv tidak memiliki kolom wajib"
+
+#: rocky/views/organization_member_add.py
+#, python-brace-format
+msgid "Invalid account type: '{account_type}'"
+msgstr "Jenis akun tidak valid: '{account_type}'"
+
+#: rocky/views/organization_member_add.py
+#, python-brace-format
+msgid "Invalid data for: '{email}'"
+msgstr "Data tidak valid untuk: '{email}'"
+
+#: rocky/views/organization_member_add.py
+#, python-brace-format
+msgid "Invalid email address: '{email}'"
+msgstr "Alamat email tidak valid: '{email}'"
+
+#: rocky/views/organization_member_add.py
+msgid "Successfully processed users from csv."
+msgstr "Berhasil memproses pengguna dari csv."
+
+#: rocky/views/organization_member_add.py
+msgid "Error parsing the csv file. Please verify its contents."
+msgstr "Terjadi kesalahan saat menguraikan file csv. Harap verifikasi isinya."
+
+#: rocky/views/organization_member_edit.py
+#, python-format
+msgid "Member %s successfully updated."
+msgstr "Anggota %s berhasil diperbarui."
+
+#: rocky/views/organization_member_edit.py
+#, python-format
+msgid ""
+"The updated trusted clearance level of L%s is lower then the member's "
+"acknowledged clearance level of L%s. This member only has clearance for "
+"level L%s. For this reason the acknowledged clearance level has been set at "
+"the same level as trusted clearance level."
+msgstr ""
+"Tingkat izin tepercaya yang diperbarui sebesar L%s lebih rendah dari tingkat"
+" izin yang diakui anggota sebesar L%s. Anggota ini hanya memiliki izin untuk"
+" level L%s. Oleh karena itu, tingkat izin yang diakui telah ditetapkan pada "
+"tingkat yang sama dengan tingkat izin tepercaya."
+
+#: rocky/views/organization_member_edit.py
+msgid ""
+"You have trusted this member with a higher trusted level than member "
+"acknowledged. Member must first accept this level to use it."
+msgstr ""
+"Anda telah mempercayai anggota ini dengan tingkat kepercayaan yang lebih "
+"tinggi daripada yang diakui anggota. Anggota harus terlebih dahulu menerima "
+"level ini untuk menggunakannya."
+
+#: rocky/views/organization_member_list.py
+#, python-format
+msgid "Blocked member %s successfully."
+msgstr "Anggota %s berhasil diblokir."
+
+#: rocky/views/organization_member_list.py
+#, python-format
+msgid "Unblocked member %s successfully."
+msgstr "Anggota %s berhasil dibuka blokirnya."
+
+#: rocky/views/organization_settings.py
+#, python-brace-format
+msgid "Recalculated {number_of_bits} bits. Duration: {duration}"
+msgstr "Menghitung ulang {number_of_bits} bit. Durasi: {duration}"
+
+#: rocky/views/page_actions.py
+msgid "Could not process your request, action required."
+msgstr "Tidak dapat memproses permintaan Anda, diperlukan tindakan."
+
+#: rocky/views/scan_profile.py
+msgid ""
+"Cannot set clearance level. The clearance type must be inherited or "
+"declared."
+msgstr ""
+"Tidak dapat mengatur tingkat izin. Jenis izin harus diwariskan atau "
+"diumumkan."
+
+#: rocky/views/scans.py
+msgid "Scans"
+msgstr "Pemindaian"
+
+#: rocky/views/scheduler.py
+msgid "Your report has been scheduled."
+msgstr "Laporan Anda telah dijadwalkan."
+
+#: rocky/views/scheduler.py
+msgid ""
+"Your task is scheduled and will soon be started in the background. Results "
+"will be added to the object list when they are in. It may take some time, a "
+"refresh of the page may be needed to show the results."
+msgstr ""
+"Tugas Anda telah dijadwalkan dan akan segera dimulai di latar belakang. "
+"Hasil akan ditambahkan ke daftar objek saat sudah masuk. Mungkin memerlukan "
+"waktu, mungkin diperlukan penyegaran halaman untuk menampilkan hasilnya."
+
+#: rocky/views/tasks.py
+#, python-brace-format
+msgid "Fetching tasks failed: no connection with scheduler: {error}"
+msgstr "Gagal mengambil tugas: tidak ada koneksi dengan penjadwal: {error}"
+
+#: rocky/views/tasks.py
+msgid "All Tasks"
+msgstr "Semua Tugas"
+
+#: rocky/views/upload_csv.py
+msgid "Add column titles. Followed by each object on a new line."
+msgstr "Tambahkan judul kolom. Diikuti oleh setiap objek pada baris baru."
+
+#: rocky/views/upload_csv.py
+msgid ""
+"For URL object type, a column 'raw' with URL values is required, starting "
+"with http:// or https://, optionally a second column 'network' is supported "
+msgstr ""
+"Untuk tipe objek URL, kolom 'mentah' dengan nilai URL diperlukan, dimulai "
+"dengan http:// atau https://, opsional, kolom kedua 'jaringan' didukung"
+
+#: rocky/views/upload_csv.py
+msgid ""
+"For Hostname object type, a column with 'name' values is required, "
+"optionally a second column 'network' is supported "
+msgstr ""
+"Untuk tipe objek Hostname, kolom dengan nilai 'nama' diperlukan, secara "
+"opsional kolom kedua 'jaringan' didukung"
+
+#: rocky/views/upload_csv.py
+msgid ""
+"For IPAddressV4 and IPAddressV6 object types, a column of 'address' is "
+"required, optionally a second column 'network' is supported "
+msgstr ""
+"Untuk tipe objek IPAddressV4 dan IPAddressV6, kolom 'alamat' diperlukan, "
+"secara opsional kolom 'jaringan' kedua didukung"
+
+#: rocky/views/upload_csv.py
+msgid ""
+"Clearance levels can be controlled by a column 'clearance' taking numerical "
+"values 0, 1, 2, 3, and 4 for the corresponding clearance level (other values"
+" are ignored) "
+msgstr ""
+"Tingkat izin dapat dikontrol dengan kolom 'izin' yang mengambil nilai "
+"numerik 0, 1, 2, 3, dan 4 untuk tingkat izin yang sesuai (nilai lainnya "
+"diabaikan)"
+
+#: rocky/views/upload_csv.py
+msgid "Object(s) could not be created for row number(s): "
+msgstr "Objek tidak dapat dibuat untuk nomor baris:"
+
+#: rocky/views/upload_csv.py
+msgid "Object(s) successfully added."
+msgstr "Objek berhasil ditambahkan."
+
+#: rocky/views/upload_raw.py
+#, python-format
+msgid "Raw file could not be uploaded to Bytes: status code %d"
+msgstr "File mentah tidak dapat diunggah ke Bytes: kode status %d"
+
+#: rocky/views/upload_raw.py
+#, python-format
+msgid "Raw file could not be uploaded to Bytes: %s"
+msgstr "File mentah tidak dapat diunggah ke Bytes: %s"
+
+#: rocky/views/upload_raw.py
+msgid "Raw file successfully added."
+msgstr "File mentah berhasil ditambahkan."
+
+#, fuzzy
+#~ msgid "Findings @ "
+#~ msgstr "Diskubrimentu"
+
+#~ msgid "Clearance level has been set"
+#~ msgstr "Nivel di autorisashon a ser poni"
+
+#~ msgid "Add URL"
+#~ msgstr "Añadi URL"
+
+#~ msgid ""
+#~ "Boefjes that has a scan level below or equal to the clearance level, is "
+#~ "permitted to scan an object."
+#~ msgstr ""
+#~ "Boefjes ku tin un nivél di skan mas abou of parew ku e nivél di "
+#~ "autorisashon, tin pèrmit pa skan un opheto."
+
+#~ msgid "Delete object(s)"
+#~ msgstr "Kita opheto(nan)"
+
+#~ msgid "Set clearance level to inherit"
+#~ msgstr "Pone nivél di autorisashon na heredá"
+
+#~ msgid "Set clearance level for:"
+#~ msgstr "Pone nivél di autorisashon pa:"
+
+#~ msgid "Setting the scan level from \\"
+#~ msgstr "Ajustando e nivel di skan for di \\"
+
+#~ msgid "You are about to set the clearance level from \\"
+#~ msgstr "Bo ta na e punto di pone e nivél di autorisashon for di \\"
+
+#~ msgid "Yes, set to inherit"
+#~ msgstr "Si, poné na heredá"
+
+#, python-format
+#~ msgid "Successfully set scan profile to %s for %d oois."
+#~ msgstr "Ku exito a pone profil di skén pa %s pa %d oois."
+
+#, python-format
+#~ msgid "Successfully set %d ooi(s) clearance level to inherit."
+#~ msgstr "Éksito den ajustá %d OOI(s) nivel di autorisashon pa heredá."
+
+#~ msgid "An error occurred while deleting oois: one of the OOIs doesn't exist."
+#~ msgstr ""
+#~ "Un error a sosodé durante e eliminashon di OOI nan: un di e OOI nan no ta "
+#~ "eksistí."
+
+#, python-brace-format
+#~ msgid "Can not reset scan level. Scan level of {ooi_name} not declared"
+#~ msgstr "No por resèt nivél di skan. Nivél di skan òf {ooi_name} no ta deklará"
+
+#~ msgid "The Email must be set"
+#~ msgstr "E email adrès mester wordu yena"
+
+#~ msgid "E-mail address"
+#~ msgstr "Email adrès"
+
+#~ msgid ""
+#~ "Dozens of tools are integrated in OpenKAT to view the world (digital and "
+#~ "analog). <br> Our motto is therefore: I see, I see, what you do not see."
+#~ msgstr ""
+#~ "Dosen di hermentnan ta integrá den OpenKAT pa mira e mundu (digital i "
+#~ "anoloog). <br>Nos lema ta: Mi ta mira, mi ta mira loke bo no ta mira."
+
+#~ msgid "E-mail"
+#~ msgstr "E-korreo"
+
+#, python-brace-format
+#~ msgid "A unique code of {code_length} characters."
+#~ msgstr "Un codigo uniko di {code_length} letras."
+
+#~ msgid ""
+#~ "I declare that OpenKAT may scan the assets of my organization and that I "
+#~ "have permission to scan these assets. I am aware of the implications a scan "
+#~ "with a higher scan level brings on my systems."
+#~ msgstr ""
+#~ "Mi ta deklara ku OpenKAT por skan e propiedatnan di mi organisashon i ku mi "
+#~ "tin pèrmit pa skan e propiedatnan aki. Mi ta konsiente di e implikashonnan "
+#~ "un skan ku nivel di skan haltu tin riba mi sistemanan."
+
+#~ msgid ""
+#~ "I declare that I am authorized to give this indemnification within my "
+#~ "organization. I have the experience and knowledge to know what the "
+#~ "consequences might be and can be held responsible for them."
+#~ msgstr ""
+#~ "Mi ta deklará ku mi tin autorisashon pa duna e indemnisashon aki den mi "
+#~ "organisashon. Mi tin e eksperensia i konosementu pa sa e konsekensianan i mi"
+#~ " por ta responsabel pa nan."
+
+#~ msgid "Register"
+#~ msgstr "Registrá"
+
+#~ msgid "Create a new account for your organization"
+#~ msgstr "Krea un account nobo pa bo organisashon"
+
+#~ msgid ""
+#~ "All user  accounts are part of an organization. So if you’re new and your "
+#~ "company is also new to OpenKAT you can register here to create a OpenKAT "
+#~ "account for your company including an admin account for you. If you like a "
+#~ "user account that is connected to an already existing organization within "
+#~ "OpenKAT you can ask the admin to create an account for you."
+#~ msgstr ""
+#~ "Tur account ta parti di un organisashon. Kèmèn si bo ta nobo i bo kompania "
+#~ "tambe ta nobo na OpenKAT bo por registrá akinan pa krea un OpenKAT account "
+#~ "pa bo kompania inkluéndo un admin account pa bo. Si bo ke un account ku ta "
+#~ "konekta ku un organisashon ku ta èksisti kaba na KAT bo por puntra e admin "
+#~ "pa krea un account pa bo."
+
+#~ msgid "How does OpenKAT work"
+#~ msgstr "Kon OpenKAT ta functiona?"
+
+#~ msgid ""
+#~ "OpenKAT is able to give insight into security risks on your online objects. "
+#~ "For example, your websites, mailservers or online data. OpenKAT uses scans "
+#~ "to find and assess the area's that might be at risk and reports these back "
+#~ "to you. As a user you decide which insight you would like and OpenKAT guides"
+#~ " you to through the process. During this introduction you will be guided "
+#~ "through the steps to create a report."
+#~ msgstr ""
+#~ "OpenKAT tin e posibilidàt di duna informashon mas detaya den riésgonan di "
+#~ "siguridát di bo online ophetonan. Por ehempel, bo websites, mailservers òf "
+#~ "online data. OpenKAT ta úza scans pa enkontra i asertà areanan ku por kore "
+#~ "riésgo i rapòrta esaki bèk na abo. Komo kliente bo ta skohè ki informashon "
+#~ "bo ke i OpenKAT ta guiá'bu dor di e proceso Durante e introdukshon aki bo lo"
+#~ " wòrdu guiá dor di e stapnan pa traha un rapòrt."
+
+#~ msgid "OpenKAT setup"
+#~ msgstr "OpenKAT setup"
+
+#~ msgid ""
+#~ "Please enter the following organization details. These details can be edited"
+#~ " within the organization page within OpenKAT when necessary. Adding a new "
+#~ "organization requires a new database."
+#~ msgstr ""
+#~ "Por fabor pone e detayenan di e siguiente organisashon. E detayenan aki por "
+#~ "wordu editá den e página di organisashon den OpenKAT si ta nesesario. Agregá"
+#~ " un organisashon nobo ta requeri un base di datos nobo."
+
+#~ msgid "Account setup"
+#~ msgstr "Account setup"
+
+#~ msgid "Organization setup with separate accounts:"
+#~ msgstr "Konfigurá organisashon ku accountnan separá:"
+
+#~ msgid ""
+#~ "Within OpenKAT it is possible to create separate user accounts with the "
+#~ "specific roles. Each with their own functionalities and permissions. This is"
+#~ " useful when multiple people will be working with the same OpenKAT-setup. "
+#~ "You can choose to create the separate accounts during this introduction or "
+#~ "when you’re ready from the OpenKAT users page."
+#~ msgstr ""
+#~ "Den OpenKAT ta posibel pa krea accountnan separá ku e ròlnan specìfiko kada "
+#~ "un ku nan mes functionalidat ì pèrmitnan. Esaki ta útil ora mayoria hende ke"
+#~ " traha ku e mesun OpenKAT-setup. Bo por skohé pa krea e accountnan separá "
+#~ "durante e introdukshon aki of ora bo ta kla."
+
+#~ msgid "Single account setup:"
+#~ msgstr "Setup account pa mi mes:"
+
+#~ msgid ""
+#~ "Alternatively it is also an option to run OpenKAT from a single user "
+#~ "account. Which is useful when you are the only user in the account. You will"
+#~ " be able to access the functionality of the different roles from your "
+#~ "account. You can always add additional user accounts If you’re team expands "
+#~ "in the future."
+#~ msgstr ""
+#~ "Alternativamente tambe ta un opshón pa huza OpenKAT for di un solo account. "
+#~ "Ku ta útil si bo ta e úniko usadó di e account. Bo lo por tin e posibilidát "
+#~ "pa tin accesso na functionalidatnan di e diferente ròlnan for di bo account."
+#~ " Abo por semper añadi accountnan adishonál si bo tìm expandé den futuro."
+
+#~ msgid "Create separate accounts"
+#~ msgstr "Krea accountnan separá"
+
+#~ msgid "Continue with this account, onboard me!"
+#~ msgstr "Sigi ku e account aki, abòrdami!"
+
+#~ msgid "Users"
+#~ msgstr "Usarionan"
+
+#~ msgid ""
+#~ "Within OpenKAT there are three types of user accounts. Each has its own "
+#~ "functions."
+#~ msgstr ""
+#~ "Den OpenKAT tin trés diferente tipo di user accounts. Kada ún tin su mes "
+#~ "funkshón."
+
+#~ msgid "Admin"
+#~ msgstr "Admin"
+
+#~ msgid ""
+#~ "Each organization must have an admin. The admin can create and manage user "
+#~ "accounts as well as organization details."
+#~ msgstr ""
+#~ "Kada organisashon mester tin un admin. E admin por krea i manehá accountnan "
+#~ "pa usudonan i tambe detayes di organisashon."
+
+#~ msgid "Red teamer"
+#~ msgstr "Tìm kòrá"
+
+#~ msgid "A red teamer account can run scans and generate reports."
+#~ msgstr "Un account pa tìm kòrá por start scans òf generá rapòrtnan."
+
+#~ msgid "Client account"
+#~ msgstr "Account pa kliénte"
+
+#~ msgid "A client account can access reports."
+#~ msgstr "Un account pa kliénte por tin accesso na rapòrtnan."
+
+#~ msgid ""
+#~ "Each organization requires at least one admin and one red teamer account to "
+#~ "function. This introduction will guide you through the setup of both. After "
+#~ "that you can choose to add a client account as well."
+#~ msgstr ""
+#~ "Kada organisashon ta requerì sikiera ún admin ì ún tìm kòrá account pa "
+#~ "functioná. É introdukshon aki ta guiabu pa setup tur dós. Despues ku bo por "
+#~ "skohé pa añadi ún account pa kliénte tambe."
+
+#~ msgid "Let's add accounts"
+#~ msgstr "Laga nos añadi accounts"
+
+#~ msgid "Admin account setup"
+#~ msgstr "Account setup pa admin"
+
+#~ msgid "Admin details"
+#~ msgstr "Admin detayes"
+
+#~ msgid "Skip this step"
+#~ msgstr "Salta e stèp aki"
+
+#~ msgid "Go back to previous step"
+#~ msgstr "Bai bèk na e stèp anterior"
+
+#~ msgid "Red teamer account setup"
+#~ msgstr "Setup account pa tìm kòrà"
+
+#~ msgid "Red teamer details"
+#~ msgstr "Tìm kòrà detayes"
+
+#~ msgid "Client account setup (optional)"
+#~ msgstr "Setup account pa kliénte (opcionàl)"
+
+#~ msgid ""
+#~ "A client account can access reports. Adding a client account to the "
+#~ "organization is optional."
+#~ msgstr ""
+#~ "Un account pa kliénte por tin accesso na rapòrtnan. Añadi un account pa "
+#~ "kliénte na e organisashon ta optionàl."
+
+#~ msgid "User details"
+#~ msgstr "Usario detayes"
+
+#~ msgid "Finish organization setup"
+#~ msgstr "Finalisá setup organisashon"
+
+#~ msgid ""
+#~ "OpenKAT is the \"Kwetsbaarheden Analyse Tool\" (Vulnerabilities Analysis "
+#~ "Tool). An Open-Source-project developed by the Ministry of Health, Welfare "
+#~ "and Sport to make your and our world a safer place."
+#~ msgstr ""
+#~ "OpenKAT ta e \"Kwetsbaarheden Analyse Tool\" (tool pa hasi análisis di "
+#~ "bulerabilidat). Un proyekto Open Source desaroyá pa Ministerio di Salú "
+#~ "Públiko, Salú i Deporte pa hasi nos mundu un lugar mas sigur pa bo i nos."
+
+#~ msgid ""
+#~ "OpenKAT is able to give insight into security risks on your online objects. "
+#~ "For example, your websites, mailservers or online data."
+#~ msgstr ""
+#~ "OpenKAT tin e abilidát di duna revelashon di riésgonan di siguridát di bo "
+#~ "online ophetonan. Por ehèmpel, bo website nan, mailservers òf online data."
+
+#~ msgid ""
+#~ "OpenKAT uses plugins to find and assess the area's that might be at risk and"
+#~ " reports these back to you. Each plugin has its own skillset which could be "
+#~ "scanning, normalizing or analyzing data. As a user you decide which areas "
+#~ "you would like to monitor or scan and which insight you would like to "
+#~ "receive."
+#~ msgstr ""
+#~ "OpenKAT ta huza plugins pa deskubrì i evalúa e areanan ku por ta un riésgo i"
+#~ " rapòrta esaki bèk na bo. Kada plugin tin nan mes sèt di abilidát ku por ta "
+#~ "scan, nòrmalisá òf analisá data. Komo usario bo ta disidì kwa area bo tin "
+#~ "gana di monitoriá òf skan i tambe ki tipo di revelashon bo tin gana di "
+#~ "recibí."
+
+#~ msgid ""
+#~ "Within OpenKAT you can view the insights as well as all the data OpenKAT has"
+#~ " found. You can choose to browse through the data or view reports."
+#~ msgstr ""
+#~ "Den OpenKAT bo por mira e insights i tambe tur data ku KAT a deskubrì. Bo "
+#~ "por skohé pa buska den e data òf wak rapòrt nan."
+
+#~ msgid ""
+#~ "During this introduction you will be guided through the steps to create a "
+#~ "report."
+#~ msgstr ""
+#~ "Durante e introdukshon aki bo lo wordu guiá dor di e stap nan pa krea un "
+#~ "rapòrt."
+
+#~ msgid "OpenKAT introduction"
+#~ msgstr "OpenKAT introdukshon"
+
+#~ msgid "Choose a report - Introduction"
+#~ msgstr "Skohé un rapòrt - Introduskhon"
+
+#~ msgid ""
+#~ "Reports within OpenKAT contain an overview of the scanned objects, issues "
+#~ "found within them and known security risks that the object might be "
+#~ "vulnerable to. Each report gives a high overview of the state of the object "
+#~ "as well as detailed information on what OpenKAT found and possible "
+#~ "solutions."
+#~ msgstr ""
+#~ "Rapòrtnan den OpenKAT ta kontene un lista di ophetonan di skan, problemanan "
+#~ "haña serka nan i riesgo di siguridat nan ku e opheto por ta vulnerabel na "
+#~ "dje. Kada rapòrt ta duna un lista prioritá di e estado di e opheto i tambe "
+#~ "informashon detaya di tur loke KAT a enkontra i solushonanan posibel."
+
+#~ msgid ""
+#~ "OpenKAT can scan and analyze by using plugins. Each plugin has it's unique "
+#~ "skillset and will collect specific data or give specific insights. You "
+#~ "manage the plugins within your account which let's OpenKAT know which "
+#~ "plugins to run and on which objects or areas."
+#~ msgstr ""
+#~ "OpenKAT por skan i analisá dor di huza plugins. Kada plugin tin nan mas sèt "
+#~ "di skills uniko i lo kolekta data spesifiko of duna mas informashon "
+#~ "spesifiko. Bo ta maneha plugins den bo account ku ta laga OpenKAT sa kwa "
+#~ "plugins mester huza riba kwa opheto òf areanan."
+
+#~ msgid "Generating a report"
+#~ msgstr "Generándo un rapport"
+
+#~ msgid ""
+#~ "When you choose a report type OpenKAT will guide you through the setup. "
+#~ "OpenKAT will ask the necessary questions based on the input the report "
+#~ "needs, as well as asks for permission to run plugins that you haven’t "
+#~ "enabled yet but are needed to collect or analyze the data."
+#~ msgstr ""
+#~ "Ora bo selektá un tipo di informe, OpenKAT lo guia bo den e ajuste. OpenKAT "
+#~ "lo hasi e preguntanan necesario basá riba e entrada ku e informe ta "
+#~ "nesesitá, tambe lo pidi permiso pa eksekutá plug-innan ku ainda bo no a "
+#~ "habilidá, pero ku ta nesesario pa kolektá òf analisá e datonan."
+
+#~ msgid ""
+#~ "You can also choose to look at the collected data directly or generate your "
+#~ "own report by selecting and running plugins on objects of your choice. "
+#~ "OpenKAT will present the results."
+#~ msgstr ""
+#~ "Bo por tambe skohé pa mira e data kolekta direktamente òf genera bo mes "
+#~ "rapòrt dor di selekta i start plugins riba ophetonan si bo eskoho. OpenKAT "
+#~ "lo presentabu ku e resultadonan."
+
+#~ msgid "Permission"
+#~ msgstr "Permiso Nenga"
+
+#~ msgid ""
+#~ "Plugins can be provided by OpenKAT but they can also come from the "
+#~ "community. Before a plugin can run, you need to give it permission by "
+#~ "enabling it."
+#~ msgstr ""
+#~ "Plugins ta bin di OpenKAT pero nan tambe por bini dor di e komunidát. Promé "
+#~ "un plugin por wordu huza, bo mester dunele pèrmiso dor di activé"
+
+#~ msgid ""
+#~ "When you generate a report. OpenKAT will let you know which plugins it "
+#~ "requires or suggests so you can choose to enable them."
+#~ msgstr ""
+#~ "Ora bo genera un rapòrt. OpenKAT ta lagabu sa kwa plugins e mester òf "
+#~ "duna'bu sugerencias pa skohé kwa pa activá."
+
+#~ msgid "Let's choose a report"
+#~ msgstr "Ban skohé un rapòrt"
+
+#~ msgid "Choose a report - Type"
+#~ msgstr "Skohé un rapòrt - Tipo"
+
+#~ msgid ""
+#~ "When you start to generate this report. OpenKAT will guide you through the "
+#~ "necessary steps."
+#~ msgstr ""
+#~ "Ora bo kuminsa generá e rapòrt aki. OpenKAT lo guiá'bu dor di e stapnan "
+#~ "necesario."
+
+#~ msgid "Setup scan"
+#~ msgstr "Setup skan"
+
+#~ msgid "Let OpenKAT know what object to scan"
+#~ msgstr "Laga OpenKAT sa kwa opheto e tinku skan"
+
+#~ msgid ""
+#~ "Plugins scan and analyze objects. OpenKAT needs to know which object(s) you "
+#~ "would like to scan and analyze for the DNS-report. So it can tell you which "
+#~ "plugins are available for the chosen object."
+#~ msgstr ""
+#~ "Plug-innan skan i analisá objektonan. OpenKAT mester sa kua objèkto(s) bo "
+#~ "kier skan i analisá pa e informe DNS. Asina ku por bisa bo ku kuál plug-"
+#~ "innan ta disponibel pa e objèkto selektá."
+
+#~ msgid "Understanding objects"
+#~ msgstr "Kompronde ophetonan"
+
+#~ msgid "Creating, adding and editing objects"
+#~ msgstr "Kreando, añadiando i editá ophetonan"
+
+#~ msgid ""
+#~ "Within OpenKAT you can view, add and edit objects from the organization’s "
+#~ "object page."
+#~ msgstr ""
+#~ "Den OpenKAT bo por mira, añadi i editá ophetonan di e organisashon su page "
+#~ "di opheto."
+
+#~ msgid ""
+#~ "Let’s add an object to scan for the DNS-Report. For this introduction we "
+#~ "suggest adding a URL."
+#~ msgstr ""
+#~ "Ban añadi un opheto pa skan pa traha e DNS-rapòrt. Pa e introdukshon aki nos"
+#~ " ta sugerí añadi un URL."
+
+#~ msgid "Create your first object, a URL by filling out the form below."
+#~ msgstr "Krea bo promé opheto, un URL dor di yena e formulario abou."
+
+#~ msgid ""
+#~ "Additional details and examples can be found by pressing on the help button "
+#~ "next to the input field."
+#~ msgstr ""
+#~ "Detayesnan i ehempelnan adishonal bo por haña dor di primi e help botón "
+#~ "banda di e vèld."
+
+#~ msgid "Dependencies"
+#~ msgstr "Dependesianan"
+
+#~ msgid ""
+#~ "The additional objects that OpenKAT created will be added to your object "
+#~ "list as separate objects. If OpenKAT can’t add them automatically it will "
+#~ "guide you through the process of creating them manually."
+#~ msgstr ""
+#~ "E ophetonan adishonal ku OpenKAT á krea lo wordu agregá na e lista di opehto"
+#~ " komo ophetonan separá. Si OpenKAT no por agregá esakinan automatikamente e "
+#~ "ta guia'bu dor di e processo pa kreanan manualmente."
+
+#~ msgid ""
+#~ "Based on the url you provided OpenKAT added the necessary additional objects"
+#~ " to create a url object."
+#~ msgstr ""
+#~ "Basá riba e URL ku bo a duna, OpenKAT a agrega e ophetonan adishonal "
+#~ "necesario pa krea un opheto di URL."
+
+#~ msgid "URL"
+#~ msgstr "URL"
+
+#~ msgid "Path"
+#~ msgstr "Routa"
+
+#~ msgid "Hostname"
+#~ msgstr "Hostname"
+
+#~ msgid "scheme"
+#~ msgstr "programa"
+
+#~ msgid "Network"
+#~ msgstr "Nètwèrk"
+
+#~ msgid "Start scanning"
+#~ msgstr "Start skan"
+
+#~ msgid "OpenKAT Introduction"
+#~ msgstr "OpenKAT Introdukshon"
+
+#~ msgid "Setup scan - OOI clearance for"
+#~ msgstr "Sètup skan- OOI autorisashon pa"
+
+#~ msgid ""
+#~ "Some scans are lightweight while others might be a bit more aggressive with "
+#~ "their scanning. OpenKAT requires you to set a clearance level for each "
+#~ "object to prevent you from unintentionally running aggressive scans. For "
+#~ "example you might have the right to run any type of scan on your own server "
+#~ "but you probably don’t have the right to do so for objects owned by other "
+#~ "people of companies."
+#~ msgstr ""
+#~ "Algun skan ta ligero, i otro por ta un tiki mas agresivo den nan skaneo. "
+#~ "OpenKAT ta requeri bo pa ajustá un nivel di autorisashon pa kada opheto pa "
+#~ "evitá ku b'a sende skan agresivo sin intenshón. Por ehèmpel, bo por tin e "
+#~ "derechi pa skan kualkier tipo di opheto riba bo propio server, pero "
+#~ "probabelmente bo no tin e derechi pa hasi meskos ku ophetonan ku ta "
+#~ "pertenese na otro personanan of kompanianan."
+
+#~ msgid "How to know required clearance level"
+#~ msgstr "Kon pa sa nivél di autorisashon requerí"
+
+#~ msgid ""
+#~ "Each plugin that scans will have a scan intensity score. The intensity of "
+#~ "the scan must be equal to or below the clearance level you set for your "
+#~ "object. If the scan has an intensity level that is too high, OpenKAT will "
+#~ "notify you before running it. Visually clearance levels and intensity scores"
+#~ " are indicated with little cat paws."
+#~ msgstr ""
+#~ "Kada plug-in ku skan ta tin un puntu di intensidat di skaneo. E intensidat "
+#~ "di e skaneo mester ta igual òf mas abou ku e nivel di autorisashon ku bo a "
+#~ "ajustá pa bo opheto. Si e skaneo tin un nivel di intensidat ku ta hopi "
+#~ "haltu, OpenKAT lo notifiká bo promé di eksekutá e skaneo. Visualmente, "
+#~ "nivelnan di autorisashon i punto di intensidat ta indiká ku patanan di "
+#~ "pushi."
+
+#~ msgid ""
+#~ "This scan has a scan intensity score of 1, requiring a level 1 clearance "
+#~ "level to be run. This means that the scan does not touch the object itself, "
+#~ "but only searches for information about the object."
+#~ msgstr ""
+#~ "E skan tin un score di nivél di intensidat di 1, ku ta requerí nivél 1 di "
+#~ "autorisashon pa start. Esaki ta nifika ku e skan no ta mishi ku e opheto "
+#~ "riba su mes, pero solamente ta buska informashon tokante e opheto."
+
+#~ msgid ""
+#~ "An example of a more aggressive scan. Which has a scan intensity score of 3."
+#~ " Meaning it requires at least a level 3 clearance level to be set on your "
+#~ "object."
+#~ msgstr ""
+#~ "Un ehèmpel di un skaneo mas agresivo. Ku tin un puntu di intensidat di "
+#~ "skaneo di 3. Esaki ta nifiká ku mester tin por lo menos un nivel di "
+#~ "autorisashon di 3 pa wordu ajustá riba bo opheto."
+
+#~ msgid "Acknowledge clearance level"
+#~ msgstr "Rekonosé nivel di autorisashon"
+
+#~ msgid "Setup scan - Set clearance level for"
+#~ msgstr "Sètup skan- Pone nivel di autorisashon pa"
+
+#, python-format
+#~ msgid ""
+#~ "After creating a new object OpenKAT will ask you to set a clearance level. "
+#~ "On the object detail page you can always change the clearance level. For the"
+#~ " onboarding we will suggest to set the clearance level to "
+#~ "L%(dns_report_least_clearance_level)s."
+#~ msgstr ""
+#~ "Despues di krea un opheto nobo, OpenKAT lo puntra bo pa pone un nivel di "
+#~ "autorisashon. Na e página di detaye di e opheto, bo por kambia e nivel di "
+#~ "autorisashon semper. Pa e proceso di onboarding nos lo sugeri pa pone e "
+#~ "nivel di autorisashon na L%(dns_report_least_clearance_level)s."
+
+#~ msgid "Setup scan - Enable plugins"
+#~ msgstr "Configurá skan - Aktivá plugins"
+
+#~ msgid "Plugins introduction"
+#~ msgstr "Plugins su introduskhon"
+
+#~ msgid ""
+#~ "OpenKAT uses plugins to scan, check and analyze. Each plugin will bring a "
+#~ "specific skillset that will help to generate your report. There are three "
+#~ "types of plugins."
+#~ msgstr ""
+#~ "OpenKAT ta huza plugins pa scan, check i analisá. Kada plugin ta trese un "
+#~ "abilidát specifikó ku lo juda pa generá bo rapòrt. Tin tres tipo di plugins."
+
+#~ msgid ""
+#~ "Scan objects for data. Each boefje has a scan intensity score to prevent "
+#~ "invasive scanning on objects where you don’t have the clearance to do so."
+#~ msgstr ""
+#~ "Skèn ophetonan pa data. Kada boefje tin un intesidát score pa skan pa "
+#~ "prevení scannan invasivo riba opheto kaminda bo no tin autorisashon pa hasi "
+#~ "esaki."
+
+#~ msgid ""
+#~ "Check the data for specific objects and add these object to your object "
+#~ "list."
+#~ msgstr ""
+#~ "Chèk e data pa ophetonan specifikó i añadi e ophetonan aki na bo lista di "
+#~ "opheto."
+
+#~ msgid "Analyze the available data to come to insights and conclusions."
+#~ msgstr "Analisá e data disponibel pa yega na konklushonnan i perspectivanan."
+
+#~ msgid ""
+#~ "OpenKAT will be able to generate a full report when all the required and "
+#~ "suggested plugins are enabled. If you choose not to give a plugin permission"
+#~ " to run, the data that plugin would collect or produce will be left out of "
+#~ "the report which will then be generated based on the available data "
+#~ "collected by the enabled plugins. Below are the suggested and required "
+#~ "plugins for this report."
+#~ msgstr ""
+#~ "OpenKAT ta dispuesto pa generá un fúl rapòrt ora tur e plugins nan requerí i"
+#~ " sugerá ta aktivá. Si bo skohé pa no duna un plugin pèrmiso  pa start, e "
+#~ "data ku e plugin lo mester kolektá òf produsí lo wordu saka for di e rapòrt "
+#~ "ku lo generá a base di e data ku tin disponibel kolektá pa e plugins aktivo."
+#~ " Abou bo por mira e plugins nan ku ta requerí pa e rapòrt aki."
+
+#~ msgid "Let’s setup your scan by enabling the plugins of your choice below."
+#~ msgstr "Laga nos ban setup e skan dor di aktivá e plugins di bo eskoho abou."
+
+#~ msgid ""
+#~ "The enabled boefjes are collecting the data needed to generate the DNS-"
+#~ "report. This may take some time based on the type of scans and the number of"
+#~ " objects found. For the current scan we expect boefjes to take about 3 "
+#~ "minutes."
+#~ msgstr ""
+#~ "E Boefjes nan aktivá ta bezig ta kolektando e data necesario pa generá e "
+#~ "DNS-rapòrt. Esaki ta bai tuma tempu a base di e tipo di scannan i e kantidát"
+#~ " di ophetonan enkontrá."
+
+#~ msgid ""
+#~ "During this introduction we ask you to wait till the scan is ready. After "
+#~ "which you can view the report."
+#~ msgstr ""
+#~ "Durante e introdukshon aki nos ta pidibu pa warda te ora e skan kaba. "
+#~ "Despues bo por mira e rapòrt."
+
+#~ msgid ""
+#~ "After the onboarding, boefjes run in the background. This enables you to use"
+#~ " OpenKAT in the meantime without waiting for scans to finish. When you would"
+#~ " like to see the status of a scan you can open the \"tasks\" page."
+#~ msgstr ""
+#~ "Despues di e onboarding, boefjes nan ta sigi den background. Esaki ta pone "
+#~ "ku bo por uza OpenKAT mientras tantu sin mester warda te ora e skannan kaba."
+#~ " Kaminda bo lo por ke mira e status di un skan bo por habri e pagina di "
+#~ "\"tarea\". "
+
+#~ msgid "Open my DNS-report"
+#~ msgstr "Habri mi DNS-rapòrt"
+
+#~ msgid "1: Introduction"
+#~ msgstr "Introdukshon"
+
+#~ msgid "2: Choose a report"
+#~ msgstr "Skohé un rapòrt"
+
+#~ msgid "3: Setup scan"
+#~ msgstr "Setup scan"
+
+#~ msgid "4: Open report"
+#~ msgstr "Habri rapòrt"
+
+#~ msgid "3: Indemnification"
+#~ msgstr "3: Indemnizashon"
+
+#~ msgid "4: Account setup"
+#~ msgstr "4: Account setup"
+
+#~ msgid "OpenKAT Setup"
+#~ msgstr "OpenKAT Setup"
+
+#, python-brace-format
+#~ msgid "{name} successfully created."
+#~ msgstr "{name} a wòrdu krea ku èksito."
+
+#~ msgid "The name of the organisation"
+#~ msgstr "E nòmber di e organisashon"
+
+#~ msgid ""
+#~ "A slug containing only lower-case unicode letters, numbers, hyphens or "
+#~ "underscores that will be used in URLs and paths"
+#~ msgstr ""
+#~ "Un slug ta kontene solamente lower-case unicode letras, numbernan, hyphens "
+#~ "òf underscores ku lo wordu huza den URLs i paths"
+
+#~ msgid ""
+#~ "Before you're able to add assets to OpenKAT and to assign clearance levels, "
+#~ "you have to give indemnification on the organization and declare that you as"
+#~ " a person can be held accountable."
+#~ msgstr ""
+#~ "Prome ku bo por añadi propiedatnan na OpenKAT i pone nivelnan di "
+#~ "authorisashon, bo mester duna indemnizashon na e organisashon i deklara ku "
+#~ "abo komo persona por wordu pone responsabel."
+
+#~ msgid "Register an indemnification"
+#~ msgstr "Registrá un indemnizashon"
+
+#~ msgid "Add Finding"
+#~ msgstr "Añadí Diskubrimentu"
+
+#~ msgid "Mute Findings"
+#~ msgstr "Muta Diskubrimentu"
+
+#~ msgid "Mute Finding"
+#~ msgstr "Muta diskubrimentu"
+
+#~ msgid "Account Type"
+#~ msgstr "Tipo di account"
+
+#~ msgid "Every member of OpenKAT must be part of an account type."
+#~ msgstr "Kada miembro di OpenKAT mester ta parti di un tipo di kuenta."
+
+#~ msgid "Source OOI"
+#~ msgstr "Orígen OOI"
+
+#~ msgid "Manual creation"
+#~ msgstr "Kreashon manual"
+
+#~ msgid " member account setup"
+#~ msgstr " konfigurashon di kuenta di miembro"
+
+#~ msgid "Member details"
+#~ msgstr "Detayes di miembro"
+
+#~ msgid "Member account type setup"
+#~ msgstr "Konfigurashon di tipo di kuenta di miembro"
+
+#~ msgid "Choose an account type for this new member."
+#~ msgstr "Selekshoná un tipo di kuenta pa e miembro nobo aki."
+
+#~ msgid "Account type details"
+#~ msgstr "Detayenan di tipo di kuenta"
+
+#~ msgid "Upload a csv file with members for organisation"
+#~ msgstr "Subi un archivo csv ku miembronan pa e organisashon"
+
+#~ msgid "Download the template"
+#~ msgstr "Download e template"
+
+#~ msgid "or create a csv file with the following criteria"
+#~ msgstr "òf krea un archivo csv ku e kriterionan sigiente"
+
+#~ msgid "Shown status types"
+#~ msgstr "Muestra di tiponan di status"
+
+#~ msgid "Blocked status"
+#~ msgstr "Status blòkiá"
+
+#~ msgid "Type select"
+#~ msgstr "Selektá tipo"
+
+#~ msgid "Add Account Type"
+#~ msgstr "Añadi Tipo di account"
+
+#~ msgid "Add Member"
+#~ msgstr "Añadí miembro"
+
+#~ msgid ""
+#~ "An overview of the top 10 most severe findings OpenKAT found. Check the "
+#~ "detail section for additional severity information."
+#~ msgstr ""
+#~ "Un bista general di e 10 diskubrimentunan mas serio ku OpenKAT a haña. Chèk "
+#~ "den seccion di detaye pa informashon adishonal tokante severidat."
+
+#~ msgid "Top 10 most severe Findings"
+#~ msgstr "Top 10 di e diskubrimentunan mas serio."
+
+#~ msgid "Showing "
+#~ msgstr "Mustra "
+
+#~ msgid "findings"
+#~ msgstr "diskubrimentunan"
+
+#~ msgid "Finding type:"
+#~ msgstr "Tipo di diskubrimentu:"
+
+#~ msgid "OOI type:"
+#~ msgstr "Tipo di opheto"
+
+#~ msgid "Source OOI:"
+#~ msgstr "Orígen OOI:"
+
+#~ msgid "KAT-alogus Settings"
+#~ msgstr "KAT-alogus Settings"
+
+#~ msgid ""
+#~ "There are currently no settings defined. Add settings at plugin detail page."
+#~ msgstr ""
+#~ "Na e momentonan aki no tin settings pone. Añadi settings na e página detaya "
+#~ "di plugin."
+
+#, python-format
+#~ msgid ""
+#~ "These are the findings of a OpenKAT-analysis (%(observed_at)s). Click a "
+#~ "finding for more detailed information about the issue, its origin, severity "
+#~ "and possible solutions."
+#~ msgstr ""
+#~ "Esakinan ta e resultadonan di un OpenKAT-analysis riba %(observed_at)s. "
+#~ "Click un resultadopa mas informashon detayá tokante e problema, su orígen, "
+#~ "severidat i posibel solushonnan."
+
+#~ msgid "DNS Tree"
+#~ msgstr "DNS Mapa"
+
+#~ msgid "Total findings:"
+#~ msgstr "Totál diskubrimentu:"
+
+#~ msgid "An overview of"
+#~ msgstr "Resúmen di resultado"
+
+#~ msgid "object type"
+#~ msgstr "tipo di opheto"
+
+#~ msgid ""
+#~ "This shows general information and its related objects. It also gives the "
+#~ "possibility to add additional related objects, or to scan for them."
+#~ msgstr ""
+#~ "Esaki ta mustra informashon general i e ophetonan relashoná. Tambe ta brinda"
+#~ " e posibilidat pa agrega ophetonan relashoná adishonal, òf pa skan pa nan."
+
+#~ msgid "Unique"
+#~ msgstr "Úniko"
+
+#~ msgid "There are no tasks for boefjes"
+#~ msgstr "No tin tareanan pa boefjes"
+
+#~ msgid "List of tasks for boefjes"
+#~ msgstr "Lista di tareanan pa boefjes"
+
+#~ msgid "There are no tasks for normalizers"
+#~ msgstr "No tin tareanan pa normalizers"
+
+#~ msgid "List of tasks for normalizers"
+#~ msgstr "Lista di tareanan pa normalizers"
+
+#~ msgid "Your password must contain at least the following:"
+#~ msgstr "Bo password mester kontené por lo menos lo siguinte:"
+
+#~ msgid " special characters such as: "
+#~ msgstr " karakternan speshal manera: "
+
+#~ msgid ""
+#~ "Failed to get list of findings for organization {}, check server logs for "
+#~ "more details."
+#~ msgstr ""
+#~ "No por a optené lista di diskubrimentu pa e organisashon {}, kontrolá "
+#~ "registro di servidor pa detayenan mas."
+
+#~ msgid ""
+#~ "An overview of all (critical) findings OpenKAT found. Check the detail "
+#~ "section for additional severity information."
+#~ msgstr ""
+#~ "Un relato general di tur diskubrimentu (krítiko) ku OpenKAT a enkontrá. Chèk"
+#~ " e sekshon detayá pa informashon addishonal severo."
+
+#~ msgid "Total Findings"
+#~ msgstr "Diskubrimentu Totál"
+
+#~ msgid " Finding Details"
+#~ msgstr "Detayes di diskubrimentu"
+
+#~ msgid "Top critical organizations"
+#~ msgstr "Top organisashonnan krítiko"
+
+#~ msgid "Critical findings"
+#~ msgstr "Diskubrimentu Kritiko"
+
+#~ msgid "Critical Findings"
+#~ msgstr "Diskubrimentu Kritiko"
+
+#~ msgid "this field is required"
+#~ msgstr "E vèld aki ta obligatorio"
+
+#~ msgid "This field is required"
+#~ msgstr "E vèld aki ta obligatorio"
+
+#~ msgid ""
+#~ "\n"
+#~ "                            You don't have any clearance to scan objects.<br>\n"
+#~ "                            Get in contact with the admin to give you the necessary clearance level.\n"
+#~ "                        "
+#~ msgstr ""
+#~ "\n"
+#~ " Bo no tin ningun nivel di autorisashon pa skan ophetonan.<br>\n"
+#~ " Tuma kontakto ku e administradó pa duna bo e nivel di autorisashon nesesario.\n"
+#~ " "
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "        Use the form below to clone the settings from <i>%(current_organization)s</i> to the selected organization.\n"
+#~ "        This includes both the KAT-alogus settings as well as enabled and disabled plugins.\n"
+#~ "      "
+#~ msgstr ""
+#~ "\n"
+#~ " Uza e formulario abou pa kopia e konfigurashon di <i>%(current_organization)s</i> pa e organisashon selektá.\n"
+#~ " Esaki ta inkluí tanto e konfigurashonnan di KAT-alogus manera tambe e plug-innan aktivá i desaktivá.\n"
+#~ "      "
+
+#~ msgid ""
+#~ "\n"
+#~ "                            Plugin available\n"
+#~ "                        "
+#~ msgid_plural ""
+#~ "\n"
+#~ "                            Plugins available\n"
+#~ "                        "
+#~ msgstr[0] ""
+#~ "\n"
+#~ "                        Plug-in disponibel\n"
+#~ "                        "
+#~ msgstr[1] ""
+#~ "\n"
+#~ "                        Plug-ins disponibel\n"
+#~ "                      "
+
+#~ msgid ""
+#~ "\n"
+#~ "            Add setting\n"
+#~ "          "
+#~ msgid_plural ""
+#~ "\n"
+#~ "            Add settings\n"
+#~ "          "
+#~ msgstr[0] ""
+#~ "\n"
+#~ "            Añadi configurashon\n"
+#~ "          "
+#~ msgstr[1] ""
+#~ "\n"
+#~ "            Añadi configurashonnan\n"
+#~ "          "
+
+#~ msgid ""
+#~ "\n"
+#~ "            Setting\n"
+#~ "          "
+#~ msgid_plural ""
+#~ "\n"
+#~ "            Settings\n"
+#~ "          "
+#~ msgstr[0] ""
+#~ "\n"
+#~ "            Configurashon\n"
+#~ "          "
+#~ msgstr[1] ""
+#~ "\n"
+#~ "            Configurashonnan\n"
+#~ "          "
+
+#~ msgid ""
+#~ "\n"
+#~ "                  Add setting and enable boefje\n"
+#~ "                "
+#~ msgid_plural ""
+#~ "\n"
+#~ "                  Add settings and enable boefje\n"
+#~ "                "
+#~ msgstr[0] ""
+#~ "\n"
+#~ "                        Pone setting i sende boefje\n"
+#~ "                        "
+#~ msgstr[1] ""
+#~ "\n"
+#~ "                        Pone settings i sende boefje\n"
+#~ "                      "
+
+#~ msgid ""
+#~ "\n"
+#~ "                    OpenKAT has a permission system that allows administrators to\n"
+#~ "                    configure which users can set a certain clearance level. The will make sure\n"
+#~ "                    that only users that are trusted can start the more aggressive scans.\n"
+#~ "                "
+#~ msgstr ""
+#~ "\n"
+#~ "OpenKAT tin un sistema di permiso ku ta laga administratornan\n"
+#~ "configure kua usuarionan por pone un nivel di autorisashon determiná. Esaki lo segurá\n"
+#~ "ku solamente usuarionan ku ta konfiable por inisiá e skaneonan mas agresivo.\n"
+#~ " "
+
+#~ msgid ""
+#~ "\n"
+#~ "                    Before a member is granted the ability to set clearance levels on an object,\n"
+#~ "                    they must first acknowledge and accept the clearance level set by the administrators.\n"
+#~ "                    The maximum scanning level permitted for a member is aligned with the trusted clearance level.\n"
+#~ "                    By acknowledging the trusted clearance level, this member formally agrees to abide by\n"
+#~ "                    this permission and gains the capability to perform scans only up to this trusted clearance level.\n"
+#~ "                    This two-step process ensures that the member operates within authorized boundaries.\n"
+#~ "                "
+#~ msgstr ""
+#~ "\n"
+#~ "Promé ku un miembro ta otorgá e habilidat pa pone nivelnan di autorisashon riba un opheto,\n"
+#~ "promé nan mester reconosé i aseptá e nivel di autorisashon poni pa e administratornan.\n"
+#~ "E nivel máksimo di skaneo permití pa un miembro ta aliná ku e nivel di autorisashon konfiable.\n"
+#~ "Pa reconosé e nivel di autorisashon konfiable, e miembro aki formalmente ta akordá pa kumpli ku\n"
+#~ "e permiso aki i ta haña e kapasidat pa realizá skaneonan solamente te na e nivel di autorisashon konfiable aki.\n"
+#~ "E proheso di dos pason aki ta garantisá ku e miembro ta operá den fronteranan autorisá.\n"
+#~ " "
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "                                Unfortunately you cannot continue the onboarding. </br>\n"
+#~ "                                Your administrator has trusted you with a clearance level of <strong>L%(tcl)s</strong>.</br>\n"
+#~ "                                You need at least a clearance level of <strong>L%(dns_report_least_clearance_level)s</strong> to scan <strong>%(ooi)s</strong></br>\n"
+#~ "                                Contact your administrator to receive a higher clearance.\n"
+#~ "                            "
+#~ msgstr ""
+#~ "\n"
+#~ " Desafortunadamente bo no por sigui ku e proceso di onboarding. </br>\n"
+#~ " Bo administrator a konfia bo ku un nivel di autorisashon di <strong>L%(tcl)s</strong>.</br>\n"
+#~ " Bo mester tin almenos un nivel di autorisashon di <strong>L%(dns_report_least_clearance_level)s</strong> pa skaneá\n"
+#~ " <strong>%(ooi)s</strong></br>\n"
+#~ " Tuma kontakto ku bo administrator pa risibí un nivel di autorisashon mas haltu.\n"
+#~ " "
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "                            Your administrator has trusted you with a clearance level of <strong>L%(tcl)s</strong>.</br>\n"
+#~ "                            You must first accept this clearance level to continue.\n"
+#~ "                            "
+#~ msgstr ""
+#~ "\n"
+#~ " Bo administrator a konfia bo ku un nivel di autorisashon di <strong>L%(tcl)s</strong>.</br>\n"
+#~ " Promé bo mester aseptá e nivel di autorisashon aki pa por sigui.\n"
+#~ " "
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "                            Accept level L%(tcl)s clearance and responsibility\n"
+#~ "                        "
+#~ msgstr ""
+#~ "\n"
+#~ "Aseptá nivel di autorisashon L%(tcl)s i responsabilidat\n"
+#~ "                        "
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "                            Your administrator has <strong>trusted</strong> you with a clearance level of <strong>L%(tcl)s</strong>.</br>\n"
+#~ "                            You have also <strong>acknowledged</strong> to use this clearance level of <strong>L%(acl)s</strong>.\n"
+#~ "                            "
+#~ msgstr ""
+#~ "\n"
+#~ " Bo administrator a <strong>konfia</strong> bo ku un nivel di autorisashon di <strong>L%(tcl)s</strong>.</br>\n"
+#~ " Bo tambe a <strong>rekonosé</strong> pa usa e nivel di autorisashon aki di <strong>L%(acl)s</strong>.\n"
+#~ " "
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "                            <strong>Warning:</strong>\n"
+#~ "                            Indemnification is not set for this organization.\n"
+#~ "                            Go to the <a href=\"%(organization_settings)s\">organization settings page</a> to add one.\n"
+#~ "                        "
+#~ msgstr ""
+#~ "\n"
+#~ " <strong>Advertensia:</strong>\n"
+#~ " Indemnisashon no ta ajustá pa e organisashon aki.\n"
+#~ " Bishitá e <a href=\"%(organization_settings)s\">página di ajuste di organisashon</a> pa agregá un.\n"
+#~ "                        "
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "                    An overview of \"%(organization_name)s\" its members.\n"
+#~ "                "
+#~ msgstr ""
+#~ "\n"
+#~ " Un bista general di e miembronan di \"%(organization_name)s\".\n"
+#~ "                "
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "            An overview of \"%(organization_name)s\". This shows general information and its settings.\n"
+#~ "          "
+#~ msgstr ""
+#~ "\n"
+#~ " Un bista general di \"%(organization_name)s\". Esaki ta mustra informashon general i su ajustenan.\n"
+#~ "          "
+
+#~ msgid ""
+#~ "\n"
+#~ "              <strong>Warning:</strong>\n"
+#~ "              Indemnification is not set for this organization.\n"
+#~ "            "
+#~ msgstr ""
+#~ "\n"
+#~ " <strong>Advertensia:</strong>\n"
+#~ " Indemnisashon no ta ajustá pa e organisashon aki.\n"
+#~ "            "
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "              This means that this object will be scanned by Boefjes with scan level\n"
+#~ "              %(scan_level)s and lower. Setting the clearance level from “declared”\n"
+#~ "              to “inherit” means that this object will inherit its level from neighbouring\n"
+#~ "              objects. This means that the clearance level might stay the same, increase,\n"
+#~ "              or decrease depending on other declared clearance levels. Clearance levels\n"
+#~ "              of objects that inherit from this clearance level will also be recalculated.\n"
+#~ "            "
+#~ msgstr ""
+#~ "\n"
+#~ "              Esaki ta nifiká ku e opheto aki lo wordu di skan dor di Boefjes ku nivél di skan\n"
+#~ "              %(scan_level)s i mas abou. Pone e nivél di autorisashon for di deklará\n"
+#~ "              na “heredá” ta nifiká ku e opheto aki lo heredá su nivél for di ophetonan den bisindario.\n"
+#~ "              Esaki ta nifiká ku e nivél di autorisashon por keda meskos, subi,\n"
+#~ "              òf baha depende di e otro nivél di autorisashonnan. Nivél di autorisashonnan\n"
+#~ "              di ophetonan ku ta heredá for di e nivél di autorisashon tambe lo wordu rekalkulá.\n"
+#~ "            "
+
+#~ msgid ""
+#~ "\n"
+#~ "                This object has a clearance level of \"L0\". This means that this object will not be scanned by any Boefje until that\n"
+#~ "                Boefje is run manually for this object again. Objects with a clearance level higher than \"L0\" will be scanned automatically by Boefjes with\n"
+#~ "                corresponding scan levels.\n"
+#~ "            "
+#~ msgstr ""
+#~ "\n"
+#~ "                E opheto aki tin un nivel di authorisashon di \"L0\". Esaki ta nifika ku e opheto aki no por wòrdu di skan dor di ningun Boefje te ora\n"
+#~ "                e Boefje aki ta wordu di skan manualmente atrobe pe e opheto. Ophetonan ku un nivel di authorisashon mas haltu ku \"L0\" ta wòrdu di skan automatikamente dor di Boefjes ku\n"
+#~ "                nivelnan di skan korespondiente.\n"
+#~ "            "
+
+#~ msgid "Download PDF"
+#~ msgstr "Download PDF"
+
+#~ msgid "There are no boefjes available within the current clearance level of"
+#~ msgstr "No tin boefjes disponibel den e nivel di authorisashon di"
+
+#~ msgid "Or if you have the authorization, upgrade the clearance level of"
+#~ msgstr "Òf si bo tin authorisashon, subi e nivel di authorisason di"
+
+#~ msgid "Accounts"
+#~ msgstr "Habri detayes"
+
+#~ msgid "Currently there are no findings for OOI"
+#~ msgstr "Aktualmente no a diskubri nada pa OOI"
+
+#~ msgid "Select your language"
+#~ msgstr "Selekshoná bo idioma"
+
+#, python-format
+#~ msgid ""
+#~ "Current language is %(current_language)s. Choose your preferred language."
+#~ msgstr "Idioma aktual ta %(current_language)s. Escoge bo idioma preferí."
+
+#, python-format
+#~ msgid "Findings report for %(name)s"
+#~ msgstr "Rapport di resultadonan pa %(name)s"
+
+#, python-format
+#~ msgid ""
+#~ "These are the findings of a OpenKAT-analysis on %(observed_at)s. Click a "
+#~ "finding for more detailed information about the issue, its origin, severity "
+#~ "and possible solutions."
+#~ msgstr ""
+#~ "Esakinan ta e resultadonan di un OpenKAT-analysis riba %(observed_at)s. "
+#~ "Click un resultadopa mas informashon detayá tokante e problema, su orígen, "
+#~ "severidat i posibel solushonnan."
+
+#, python-format
+#~ msgid "A report for %(name)s wasn't found."
+#~ msgstr "Un rapport pa %(name)s no por a wordu haña."
+
+#, python-format
+#~ msgid ""
+#~ "Perhaps it never was, perhaps it just didn't exist on %(observed_at)s <br> "
+#~ "Try some other dates!"
+#~ msgstr ""
+#~ "Probablemente e no tabata, probablemente e nunka a eksistí riba "
+#~ "%(observed_at)s<br> Purba algun otro fechanan!"
+
+#~ msgid "You can't generate a report for an OOI on a date in the future."
+#~ msgstr "Bo no por generà un rapòrt pa un OOI ku un fecha den futuro."
+
+#~ msgid "Findings report"
+#~ msgstr "Rapòrt di diskubrimentu"
+
+#~ msgid "Generating report failed. See Keiko logs for more information."
+#~ msgstr ""
+#~ "Falamentu den generashon di rapòrt. Wak Keiko logs pa mas informashon."
+
+#~ msgid ""
+#~ "Timeout reached generating report. See Keiko logs for more information."
+#~ msgstr ""
+#~ "Tempo di espera a yega na su fin den generashon di rapòrt. Wak e Keiko logs "
+#~ "pa mas informashon."
+
+#~ msgid ""
+#~ "Boefjes gather factual information, such as by calling an external scanning "
+#~ "tool like nmap or using a database like shodan."
+#~ msgstr ""
+#~ "Boefjes ta reuni informashon faktuál, huzando tools manera nmap òf usando un"
+#~ " base di datos manera shodan."
+
+#~ msgid " Details"
+#~ msgstr "Detayes"
+
+#~ msgid "Action"
+#~ msgstr "Akshon"
+
+#~ msgid "Unset"
+#~ msgstr "Bashi"
+
+#~ msgid "Failed fetching settings for {}. Is the Katalogus up?"
+#~ msgstr "No por a enkontra e ajustamentunan pa {}. Katalogus ta disponibel?"
+
+#~ msgid "Before enabling, please set the required settings for '{}'."
+#~ msgstr "Promé ku aktivá, por fabor pone e ajustamentunan necesario pa '{}'."
+
+#~ msgid "Currently filtered on:"
+#~ msgstr "Aktuálmente filtrá riba:"
+
+#~ msgid "Object tree"
+#~ msgstr "Mapa di opheto"
+
+#~ msgid "Please select an OOI to start scan."
+#~ msgstr "Por fabor, selekshoná un OOI pa kuminsá skan."
+
+#~ msgid "Task queue is full, please try again later."
+#~ msgstr "Lista di trabou ta yen, por fabor purba atrobe mas laat."
+
+#~ msgid "Task is invalid."
+#~ msgstr "Tarea ta inbalido"
+
+#~ msgid "Task already queued."
+#~ msgstr "Tarea ta pone kla kaba."
+
+#~ msgid "Observed by"
+#~ msgstr "Obserbá pa"
+
+#~ msgid "Select status"
+#~ msgstr "Selektá status"
+
+#~ msgid "Success"
+#~ msgstr "Èxito"
+
+#~ msgid "No scans found for this object."
+#~ msgstr "Ningun skan enkontra pa e opheto."
+
+#~ msgid "all"
+#~ msgstr "tur"
+
+#~ msgid "Fetching tasks failed: no connection with scheduler"
+#~ msgstr "No por haña tarea: no tin konekshon ku scheduler"
+
+#~ msgid "Latest plugin settings:"
+#~ msgstr "Reciente plugin settings:"
+
+#~ msgid "Overview of settings:"
+#~ msgstr "Relato di settings:"
+
+#~ msgid "For this tutorial we suggest a DNS-report to get you started."
+#~ msgstr "Pa a tutoriál aki nos ta sugerí un DNS-rapòrt pa kuminsa ku ne."
+
+#~ msgid "DNS report"
+#~ msgstr "DNS Rapòrt"
+
+#~ msgid "User overview:"
+#~ msgstr "Resúmen di kliente:"
+
+#~ msgid "Boefjes overview:"
+#~ msgstr "Relato general di Boefjes:"
+
+#~ msgid ""
+#~ "Within OpenKAT you can view reports for each of your current objects. For "
+#~ "specific reports you can choose one of the available report types and "
+#~ "generate a report. Such as a pen-test, a DNS-report or a mail report to give"
+#~ " some examples."
+#~ msgstr ""
+#~ "Den OpenKAT bo por mira rapòrtnan pa kada un di bo ophetonan. Pa rapòrtnan "
+#~ "specifikó bo por skohé un di e tipo rapòrtnan obtenibel i generá un rapòrt. "
+#~ "Manera un pen-test, un DNS-rapòrt òf un mail rapòrt pa duna algun ehempel."
+
+#~ msgid ""
+#~ "A lot of things can be an object within the scope of OpenKAT. For example a "
+#~ "mailserver, an ip-address, a URL, a DNS record, a hostname or a network to "
+#~ "name a few.  While these objects can be related to each other they are all "
+#~ "objects within OpenKAT that can be scanned to gain valuable insight."
+#~ msgstr ""
+#~ "Hopi kos por ta un opheto den di e alkanse di OpenKAT. Por ehempel un "
+#~ "mailserver, un ip-adrès, un URL, un DNS record, un hostname òf un netwèrk pa"
+#~ " nombra un par. Mientras tantu e ophetonan aki por ta relatá na otro nan tur"
+#~ " ta ophetonan den di OpenKAT ku por wordu di skan pa haña informashon "
+#~ "balioso."
+
+#~ msgid ""
+#~ "Most objects have dependencies on the existence of other objects. For "
+#~ "example a URL needs to be connected to a network, hostname, fqdn (fully "
+#~ "qualified domain name) and ip-address. OpenKAT collects these additional "
+#~ "object automatically when possible. By running plugins to collect or extract"
+#~ " this data."
+#~ msgstr ""
+#~ "Mayoria ophetonan tin dependesianan riba e exsistencia di otro ophetonan. "
+#~ "Por ehempel un URL mester ta konektá ku un nètwèrk, hostname, fqdn (fúl "
+#~ "kwalifiká nòmber di domèin) i ip-adrès. OpenKAT ta kolektá e ophetonan "
+#~ "adishonal automatikamente si ta posibel. Dor di start plugins pa kolektá òf "
+#~ "extrahé data."
+
+#~ msgid "Risk score:"
+#~ msgstr "Puntuashon di riesgo:"
+
+#~ msgid "Permission to set OOI clearance levels "
+#~ msgstr "Pèrmit pa pone nivél di autorisashonnan pa OOI "
+
+#~ msgid "You have currently accepted clearance up to level "
+#~ msgstr "Bo aktualmente a aseptá e nivel di autorisashon te na nivel "
+
+#~ msgid ""
+#~ "If you don’t remember the email address connected to your account, contact: "
+#~ msgstr ""
+#~ "Si bo no ta kòrda e email adrès konektá ku bo account, tuma kontákto ku: "
+
+#~ msgid "Publisher"
+#~ msgstr "Editora"
+
+#~ msgid "You don't have permission to enable "
+#~ msgstr "Bo no tin permiso pa aktivá "
+
+#, fuzzy
+#~ msgid ""
+#~ "<span>Warning scan level:</span> Scanning OOI's with a lower clearance level"
+#~ " will result in OpenKAT increasing the clearance level on that OOI, not only"
+#~ " for this scan but from now on out, until it manually gets set to something "
+#~ "else again. This means that all other enabled Boefjes will use this higher "
+#~ "clearance level aswel."
+#~ msgstr ""
+#~ "\n"
+#~ "          <span>Advertensia nivel di skan:</span>\n"
+#~ "          Skèn OOI's ku nivel di authorisashon mas abou lo resulta ku OpenKAT mester subi e nivel di authorisashon pa e OOI,\n"
+#~ "          no solamente pa e skan aki for di awor i adelante, te ora manualmente e wordu pone na algu otro atrobe.\n"
+#~ "          Esaki ta nifika ku tur otro Boefjes aktivo lo huza e nivel di authorisashon  aki tambe.\n"
+#~ "        "
+
+#~ msgid "Reason"
+#~ msgstr "Motibu"
+
+#~ msgid "Overview of findings for "
+#~ msgstr "Reprodusí búskeda"
+
+#~ msgid "Error"
+#~ msgstr "Error"
+
+#~ msgid "Explanation"
+#~ msgstr "Deklarashon"
+
+#~ msgid "Here, an indemnification can be given on behalf of your organization"
+#~ msgstr "Akinan, un indemnizashon por wordu duna p’e organisashon"
+
+#~ msgid "Confirmation"
+#~ msgstr "Indemnizashon"
+
+#~ msgid "No related objects added to "
+#~ msgstr "Ningún ophetonan relatá añadi na"
+
+#~ msgid "Use the button below to add a related object. "
+#~ msgstr "Huza e botón abou pa añadi un opheto relatá. "
+
+#~ msgid "Logged in as"
+#~ msgstr "Logged in komo"
+
+#, python-format
+#~ msgid ""
+#~ "Could not raise clearance level of %s to L%s.                             "
+#~ "Indemnification not present at organization %s."
+#~ msgstr ""
+#~ "No por subi e nivel di autorisashon di %s pa L%s. Indemnisashon no ta "
+#~ "presente na organisashon %s."
+
+#~ msgid "DNS Zone"
+#~ msgstr "Zona DNS"
+
+#~ msgid ""
+#~ "OpenKAT added the following required object to your object list to complete "
+#~ "your request: {}"
+#~ msgstr ""
+#~ "OpenKAT a añadi e siguinte opheton na bo lista di ophetonan pa kompleta bo "
+#~ "petishon: {}"
+
+#, python-format
+#~ msgid ""
+#~ "Could not raise clearance level of %s to L%s.                 "
+#~ "Indemnification not present at organization %s."
+#~ msgstr ""
+#~ "No por a subi e nivel di autorisashon di %s pa L%s. Indemnisashon no ta "
+#~ "presente pa organisashon %s."
+
+#~ msgid ""
+#~ "Not all required boefjes are selected. Please select all required boefjes."
+#~ msgstr ""
+#~ "No tur boefjes necesario ta selektá. Por fabor selektá tur boefjes "
+#~ "necesario."
+
+#, python-format
+#~ msgid ""
+#~ "Could not raise clearance level of %s to L%s.                         "
+#~ "Indemnification not present at organization %s."
+#~ msgstr ""
+#~ "No por a subi e nivel di autorisashon di %s pa L%s. Indemnisashon no ta "
+#~ "presente pa organisashon %s."
+
+#, python-format
+#~ msgid ""
+#~ "Could not raise clearance level of %s to L%s. You acknowledged a clearance "
+#~ "level of L%s. Please accept the clearance level below to proceed."
+#~ msgstr ""
+#~ "No por a subi e nivel di autorisashon di %s pa L%s. Bo a rekonosé un nivel "
+#~ "di autorisashon di L%s. Por fabor, akseptá e nivel di autorisashon mas abou "
+#~ "pa por sigui."
+
+#~ msgid "Choose a valid level"
+#~ msgstr "Skohé un nivél balido"
+
+#, python-format
+#~ msgid "Raw file could not be uploaded to Bytes: status code %s"
+#~ msgstr "No por a subi e arkivo na Bytes: status code %s"
+
+#~ msgid "Failure mode"
+#~ msgstr "Failure mode"
+
+#~ msgid "Frequency Level"
+#~ msgstr "Nivél di frequensidat"
+
+#~ msgid "Detectability Level"
+#~ msgstr "Nivél di detectabilidat"
+
+#~ msgid "Effect(s)"
+#~ msgstr "Efekto"
+
+#~ msgid "Describe in one sentence what type of failure mode you are creating."
+#~ msgstr "Deskribi den un sentencia ki tipo di failure mode bo ta kreando."
+
+#~ msgid "Describe the failure mode in details."
+#~ msgstr "Reprodusí búskeda"
+
+#~ msgid ""
+#~ "From 1 to 5, how often does this failure mode occurs. 1: Almost unthinkable "
+#~ "and 5: occurs daily."
+#~ msgstr ""
+#~ "Di 1 te 5, kwantu biaha e failure mode aki ta occurí. 1: Kasi imposibeli 5: "
+#~ "occurí diariamente."
+
+#~ msgid ""
+#~ "Is this failure mode easy detectable? Give it a score from 1 to 5. 1: always"
+#~ " detectable and 5: almost undetectable."
+#~ msgstr ""
+#~ "E failure mode aki por wordu detektá fasil? Duné un score for di 1 te 5. 1: "
+#~ "semper detektábel i 5: kasi imposibel."
+
+#~ msgid "Describe the type of failure mode"
+#~ msgstr "Deskribi e tipo di failure mode"
+
+#~ msgid "explanation-failure-mode"
+#~ msgstr "splikashon-failure-mode"
+
+#~ msgid "Describe in more detail what the failure mode is about."
+#~ msgstr "Deskribi mas detayá kiko e failure mode aki ta."
+
+#~ msgid "explanation-description"
+#~ msgstr "splikashon-diskripshon"
+
+#~ msgid "explanation-frequency-level"
+#~ msgstr "splikashon-nivel-di-freqeuncia"
+
+#~ msgid "explanation-detectability_level"
+#~ msgstr "splikashon-nivel-detektebilidat"
+
+#~ msgid "You must at least set a failure mode."
+#~ msgstr "Bo mester por lo menos pone un failure mode."
+
+#~ msgid "Choose a frequency level."
+#~ msgstr "Nivél di frequensidat"
+
+#~ msgid "Choose a detectability level."
+#~ msgstr "Nivél di detectabilidat"
+
+#~ msgid "Choose at least one effect."
+#~ msgstr "Skohé por lo menos ùn efekto"
+
+#~ msgid "Affected Department"
+#~ msgstr "Departamentu afektá"
+
+#~ msgid "Affected Objects"
+#~ msgstr "Ophetonan afektá"
+
+#~ msgid "Choose a failure mode which applies to "
+#~ msgstr "Skohé un failure mode ku ta aplika na "
+
+#~ msgid "When this failure mode occurs, which department is affected?"
+#~ msgstr "Ora a failure mode aki occurí, kwa departamentu ta afekta?"
+
+#~ msgid "Which objects does this failure mode affect when it occurs?"
+#~ msgstr "Kwa opheto e failure mode aki ta afekta ora e occurí?"
+
+#~ msgid "explanation-affected-ooi-type"
+#~ msgstr "splikashon-tipo-di-ooi-afekta"
+
+#~ msgid "Effect"
+#~ msgstr "Efekto"
+
+#~ msgid "Severity Level"
+#~ msgstr "Nivél di severedat"
+
+#~ msgid "Name a possible effect of any type of failure mode that can occur."
+#~ msgstr "Duna un ehempel di un posibel efekto di e failre mode aki."
+
+#~ msgid ""
+#~ "Describe the severity of this effect ex. 1: not severe and 5: catastrophic"
+#~ msgstr ""
+#~ "Diskribi e seviridat di e efekto aki, por ehempel 1: no severo i 5: "
+#~ "katastrófiko"
+
+#~ msgid "Describe a possible effect for FMEA"
+#~ msgstr "Deskibri un posibel efekto pa FMEA"
+
+#~ msgid "explanation-effect"
+#~ msgstr "splikashon-efekto"
+
+#~ msgid "explanation-severity-level"
+#~ msgstr "splikashon-nivel-severo"
+
+#~ msgid "The effect is required."
+#~ msgstr "E vak aki ta obligatorio"
+
+#~ msgid "This effect already exists."
+#~ msgstr "E organisashon aki ta eksistí kaba"
+
+#~ msgid "Choose a severity level."
+#~ msgstr "Nivel di rísiko"
+
+#~ msgid "Finances"
+#~ msgstr "Finansiasnan"
+
+#~ msgid "Marketing"
+#~ msgstr "Marketing"
+
+#~ msgid "Human Resources"
+#~ msgstr "Human Resources"
+
+#~ msgid "Research & Development"
+#~ msgstr "Research & Development"
+
+#~ msgid "Administration"
+#~ msgstr "Indemnizashon"
+
+#~ msgid "Level 1: Not Severe"
+#~ msgstr "Nivèl 1: No Severo"
+
+#~ msgid "Level 2: Harmful"
+#~ msgstr "Nivel 2: Dañoso"
+
+#~ msgid "Level 3: Severe"
+#~ msgstr "Nivel 3: Severo"
+
+#~ msgid "Level 4: Very Harmful"
+#~ msgstr "Nivel 4: Hopi Dañoso"
+
+#~ msgid "Level 5: Catastrophic"
+#~ msgstr "Nivel 5: Katastrófiko"
+
+#~ msgid ""
+#~ "Level 1: Very Rare. Incident (almost) never occurs, almost unthinkable."
+#~ msgstr ""
+#~ "Nivel 1: Hopi Straño. Insidente (kasi) nunka ta okuri, kasi inpensabel."
+
+#~ msgid "Level 2: Rare. Incidents occur less than once a year (3-5)."
+#~ msgstr "Nivel 2: Straño. Insidente ta okuri menos ku un biaha pa aña (3-5)."
+
+#~ msgid "Level 3: Occurs. Incidents occur several times a year."
+#~ msgstr "Nivel 3: Ta okuri, Insidente ta okuri par di biaha pa aña."
+
+#~ msgid "Level 4: Regularly. Incidents occur weekly."
+#~ msgstr "Nivel 4: Regularmente. Insidente ta pasa tur siman."
+
+#~ msgid "Level 5: Frequent. Incidents occur daily."
+#~ msgstr "Nivel 5: Frquente. Incidente ta pasa tur dia."
+
+#~ msgid ""
+#~ "Level 1: Always Detectable. Incident (almost) never occurs, almost "
+#~ "unthinkable."
+#~ msgstr ""
+#~ "Nivel 1: Semper Detektabel. Insidente (kasi) nunka ta okuri, kasi imposibel."
+
+#~ msgid ""
+#~ "Level 2: Usually Detectable. Incidents occur less than once a year (3-5)."
+#~ msgstr ""
+#~ "Nivel 2: Normalmente Dektetabel. Insidente ta okuri menos ku un biaha pa aña"
+#~ " (3-5)."
+
+#~ msgid "Level 3: Detectable. Failure mode is detectable with effort."
+#~ msgstr "Nivel 3: Detektabel. Faillure mode ta detektabel ku eksfuerzo."
+
+#~ msgid "Level 4: Poorly Detectable. Detecting the failure mode is difficult."
+#~ msgstr "Nivel 4: Malu Detectabel. Detektá e failure mode ta difícil."
+
+#~ msgid ""
+#~ "Level 5: Almost Undetectable. Failure mode detection is very difficult or "
+#~ "nearly impossible."
+#~ msgstr ""
+#~ "Nivel 5: Pobremente Detektabel. Faillure mode detekshon ta hopi difisil òf "
+#~ "kasi imposibel."
+
+#~ msgid "Failure modes"
+#~ msgstr "Failure modes"
+
+#~ msgid "Failure Mode Affected Objects"
+#~ msgstr "Failure Mode Ophetonan afektá"
+
+#~ msgid "FMEA Departments Heatmap:"
+#~ msgstr "Departamento di FMEA Heatmap:"
+
+#~ msgid "No data to build heatmap"
+#~ msgstr "Ningun data pa kontruí heatmap "
+
+#~ msgid "Failure mode affected object table:"
+#~ msgstr "Failure mode tabèl di opheto afektá "
+
+#~ msgid "Affected Object"
+#~ msgstr "Ophetonan afektá"
+
+#~ msgid "Failure mode affected objects cannot be found."
+#~ msgstr "No por decodifica e archivo"
+
+#~ msgid "Define which objects are affected for a failure mode"
+#~ msgstr "Defini kwa ophetonan ta afekta pa un failure mode"
+
+#~ msgid "Failure mode affected objects"
+#~ msgstr "No por decódifica e archivo"
+
+#~ msgid "Save"
+#~ msgstr "Warda"
+
+#~ msgid "No failure mode yet defined."
+#~ msgstr "Ningun failure mode ahinda defini"
+
+#~ msgid "To add affected objects to a failure mode, first create one."
+#~ msgstr "Pa agregá ophetonan afektá na un failure mode, krea un prome."
+
+#~ msgid "Create failure mode"
+#~ msgstr "Krea failure mode"
+
+#~ msgid "Failure mode affected objects table:"
+#~ msgstr "Failure mode tabèl di ophetonan afekta:"
+
+#~ msgid "No failure mode affected objects yet defined."
+#~ msgstr "Ningun failure mode ophetonan afekta ahinda defini."
+
+#~ msgid "Create failure mode Affected Objects"
+#~ msgstr "Reprodusí búskeda"
+
+#~ msgid "Departments failure modes"
+#~ msgstr "Failure modes departamentonan"
+
+#~ msgid "Failure modes and affected departments table:"
+#~ msgstr "Failure modes i tabèl di departamentonan afekta:"
+
+#~ msgid "Failure Mode"
+#~ msgstr "Failure Mode"
+
+#~ msgid "Affected Departments"
+#~ msgstr "Departementonan Afektá"
+
+#~ msgid "Nothing found."
+#~ msgstr "Nada enkontra."
+
+#~ msgid "Failure mode properties"
+#~ msgstr "No por decodifica e archivo"
+
+#~ msgid "Properties"
+#~ msgstr "Karakteristikanan"
+
+#~ msgid "Risk class"
+#~ msgstr "Nivel di rísiko"
+
+#~ msgid "Frequency level"
+#~ msgstr "Nivel di frequensidat"
+
+#~ msgid "Detectability level"
+#~ msgstr "Nivel di detektabilidat"
+
+#~ msgid ""
+#~ "\n"
+#~ "                        Effect and severity level\n"
+#~ "                        "
+#~ msgid_plural ""
+#~ "\n"
+#~ "                        Effects and severity levels\n"
+#~ "                      "
+#~ msgstr[0] ""
+#~ "\n"
+#~ "                        Nivel di efekto i severidat\n"
+#~ "                        "
+#~ msgstr[1] ""
+#~ "\n"
+#~ "                        Nivel di efektonan i severidatnan\n"
+#~ "                      "
+
+#~ msgid "Failure mode effect"
+#~ msgstr "No por decodifica e archivo"
+
+#~ msgid "Failure mode effect properties"
+#~ msgstr "No por decodifica e archivo"
+
+#~ msgid "FMEA effect and severity"
+#~ msgstr "FMEA efekto i seviridat"
+
+#~ msgid "FMEA effect"
+#~ msgstr "FMEA efekto"
+
+#~ msgid "Failure mode effects table:"
+#~ msgstr "Tabèl di Efektonan di Modo di Falla"
+
+#~ msgid "Severity level"
+#~ msgstr "Nivel di rísiko"
+
+#~ msgid "No failure mode effect yet defined."
+#~ msgstr "No por decodifica e archivo"
+
+#~ msgid "Create a failure mode effect"
+#~ msgstr "Reprodusí búskeda"
+
+#~ msgid "Create a new failure mode"
+#~ msgstr "Krea un failure mode nobo"
+
+#~ msgid "Failure mode and effects"
+#~ msgstr "No por decodifica e archivo"
+
+#~ msgid "No failure mode effects created."
+#~ msgstr "No por decodifica e archivo"
+
+#~ msgid ""
+#~ "First create failure mode effects which can be added later to a failure "
+#~ "mode."
+#~ msgstr ""
+#~ "Prome krea efektonan di failure mode pa despues añadi esaki na un failure "
+#~ "mode."
+
+#~ msgid "Create failure mode effects"
+#~ msgstr "Reprodusí búskeda"
+
+#~ msgid "Failure mode table:"
+#~ msgstr "Tabèl di failure mode:"
+
+#~ msgid "Risk Class"
+#~ msgstr "Nivel di rísiko"
+
+#~ msgid "Sluit details"
+#~ msgstr "Habri detayes"
+
+#~ msgid "Description:"
+#~ msgstr "Deklarashon"
+
+#~ msgid "Frequency level:"
+#~ msgstr "Nivel di frequencidat:"
+
+#~ msgid "Detectability level:"
+#~ msgstr "Nivel di detektabilidat"
+
+#~ msgid ""
+#~ "\n"
+#~ "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\tEffect and severity level\n"
+#~ "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t"
+#~ msgid_plural ""
+#~ "\n"
+#~ "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\tEffects and severity levels\n"
+#~ "\t\t\t\t\t\t\t\t\t\t\t\t\t\t"
+#~ msgstr[0] ""
+#~ "\n"
+#~ "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\tNivel di efekto i severidat\n"
+#~ "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t"
+#~ msgstr[1] ""
+#~ "\n"
+#~ "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\tNivel di efektonan i severidatnan\n"
+#~ "\t\t\t\t\t\t\t\t\t\t\t\t\t\t"
+
+#~ msgid "Failure mode report"
+#~ msgstr "No por decodifica e archivo"
+
+#~ msgid "Failure mode: "
+#~ msgstr "No por decodifica e archivo"
+
+#~ msgid "Severity: "
+#~ msgstr "Seviridat:"
+
+#~ msgid "Detectability: "
+#~ msgstr "Detektabilidat"
+
+#~ msgid "Frequency: "
+#~ msgstr "Frequencia: "
+
+#~ msgid "Effect: "
+#~ msgstr "Efekto: "
+
+#~ msgid "Description: "
+#~ msgstr "Deklarashon: "
+
+#~ msgid "Affected Departments: "
+#~ msgstr "Departamentonan afekta: "
+
+#~ msgid "Affected OOI's: "
+#~ msgstr "OOI's afekta:"
+
+#~ msgid "Report cannot be viewed, failure mode not found."
+#~ msgstr "Rapòrt no por wordu mira, no por haña failure mode."
+
+#~ msgid "FMEA introduction"
+#~ msgstr "FMEA introdukshon"
+
+#~ msgid ""
+#~ "FMEA (failure mode and effective analysis) is a step-by-step approach for "
+#~ "collecting knowledge about possible points of failure in a design, "
+#~ "manufacturing process, product or service."
+#~ msgstr ""
+#~ "FMEA (failure mode and effective analysis) ta un enfoque paso a paso pa "
+#~ "kolekta konosimentu tokante puntonan posibel di fayo den un diseño, proseso "
+#~ "fabriká, produkto òf servicio."
+
+#~ msgid ""
+#~ "Failure mode (FM) refers to the way in which something might break down and "
+#~ "includes potential errors that may occur, especially errors that may affect "
+#~ "a system. Effective analysis (EA) involves deciphering the consequences of "
+#~ "those break downs by making sure that all failures can be detected, "
+#~ "determining how frequently a failure might occur and identifying which "
+#~ "potential failures should be prioritized."
+#~ msgstr ""
+#~ "Failure mode (FM) ta referi na e manera kaminda algu por posibelmente kibra "
+#~ "i inkluí errornan potenshal ku por okuri, speshalmente errornan ku por "
+#~ "afektá un sistema. Effective analysis (EA) ta envolvi den buska e "
+#~ "konsekuensiasnan di loke por kibra dor di detekta tur failure modes, "
+#~ "determiná kon frequente failure modes ta okuri i identifiká kwa failure "
+#~ "modes mester wordu prioritisa."
+
+#~ msgid "Create affected objects of a failure mode"
+#~ msgstr "Kreá ophetonan afektá di un failure mode"
+
+#~ msgid "View all failure modes"
+#~ msgstr "Mustrami tur failue modes"
+
+#~ msgid "View all failure mode effects"
+#~ msgstr "Mustrami tur efektonan di failure mode"
+
+#~ msgid "View all affected objects for a failure modes"
+#~ msgstr "Mustrami tur ophetonan afektá pa failure modes"
+
+#~ msgid "Heatmap"
+#~ msgstr "Mapa kayente"
+
+#~ msgid "--- Select an option ----"
+#~ msgstr "-- Selecta un opcion --"
+
+#~ msgid "Failure mode affected objects successfully created."
+#~ msgstr "Failure mode i ophetonan afektá a wòrdu kreá ku èksito."
+
+#~ msgid "Create"
+#~ msgstr "Kreá"
+
+#~ msgid "Treeobjects successfully added."
+#~ msgstr "Mapa di ophetonan añadi ku èxito."
+
+#~ msgid "Please select a department or ooi."
+#~ msgstr "Por fabor selekta un departamentu òf ooi."
+
+#~ msgid "Failure mode successfully created."
+#~ msgstr "Failure mode a wòrdu kreá ku èksito."
+
+#~ msgid "Failure mode effect successfully created."
+#~ msgstr "Failure mode a wòrdu kreá ku èksito."
+
+#~ msgid "FMEA"
+#~ msgstr "FMEA"
+
+#~ msgid "Failure mode effects"
+#~ msgstr "Efektonan di failure mode"
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "                            \"Withdraw acceptance of level L%(acl)s clearance and responsibility\"\n"
+#~ "                    "
+#~ msgstr ""
+#~ "\n"
+#~ "\"Retirá aseptashon di nivel di autorisashon L%(acl)s i responsabilidat\"\n"
+#~ " "
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "                        \"Accept level L%(tcl)s clearance and responsibility\"\n"
+#~ "                    "
+#~ msgstr ""
+#~ "\n"
+#~ "\"Aseptá nivel di autorisashon L%(tcl)s i responsabilidat\"\n"
+#~ " "
+
+#~ msgid ""
+#~ "\n"
+#~ "                  Add setting\n"
+#~ "                "
+#~ msgid_plural ""
+#~ "\n"
+#~ "                  Add settings\n"
+#~ "                "
+#~ msgstr[0] ""
+#~ "\n"
+#~ "                        Añadi setting\n"
+#~ "                        "
+#~ msgstr[1] ""
+#~ "\n"
+#~ "                        Añadi settings\n"
+#~ "                      "
+
+#~ msgid "Organization code(s) for raw does not exist in our database"
+#~ msgstr "Codigo di organisashon den e CSV no ta èksisti den nos database"
+
+#~ msgid "Scan OOI"
+#~ msgstr "Skèn OOI"
+
+#~ msgid "Selected OOIs:"
+#~ msgstr "OOI's selektá:"
+
+#~ msgid "Session has terminated, please select OOIs again."
+#~ msgstr "Seshon a wòrdu tèrminá. Por fabor selekta OOIs dinobo."
+
+#~ msgid "Could not connect to Bytes. Service is possibly down"
+#~ msgstr "No por konektá ku Bytes. Servicio ta down"
+
+#~ msgid "Could not connect to Octopoes. Service is possibly down"
+#~ msgstr "No por konektá ku Octopoes. Servicio ta down"
+
+#~ msgid "Could not connect to Scheduler. Service is possibly down"
+#~ msgstr "No por konektá ku Scheduler. Servicio ta down"
+
+#~ msgid "Rocky will not function properly. Not all services are healthy."
+#~ msgstr "Rocky no lo functiona mane debe ser. No tur servicio ta saludabel."
+
+#~ msgid "Failure"
+#~ msgstr "Failure"
+
+#~ msgid "Task details not found."
+#~ msgstr "Detayes di tarea no por wordu haña."
+
+#~ msgid "This name we will use to communicate with you."
+#~ msgstr "E nomber aki nos lo huza pa komuniká ku bo."
+
+#~ msgid "What do we call you?"
+#~ msgstr "Kon nos por jama'bu?"
+
+#~ msgid "Enter your email address."
+#~ msgstr "Yena bo email adres"
+
+#~ msgid "Choose your super secret password"
+#~ msgstr "Skohé bo password super sekreto"
+
+#~ msgid "Enter your new password"
+#~ msgstr "Yena bo password nobo"
+
+#~ msgid "Repeat your new password"
+#~ msgstr "Ripiti bo password nobo"
+
+#~ msgid "Confirm your new password"
+#~ msgstr "Konfirmá bo password nobo"
+
+#~ msgid "List of tasks for "
+#~ msgstr "Lista di tareanan pa "
+
+#~ msgid "No input OOI"
+#~ msgstr "No tin entrada OOI"
+
+#~ msgid ""
+#~ "Can not parse observed_at parameter, falling back to showing current object"
+#~ msgstr ""
+#~ "No por parse e parametro observed_at, regresando na munstra e opheto aktual"
+
+#~ msgid "Scanning successfully scheduled."
+#~ msgstr "Skèn a start ku èxito."

--- a/rocky/rocky/locale/la/LC_MESSAGES/django.po
+++ b/rocky/rocky/locale/la/LC_MESSAGES/django.po
@@ -1,0 +1,10147 @@
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenKAT\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-03-28 14:22+0000\n"
+"PO-Revision-Date: 2026-07-14 00:00+0000\n"
+"Last-Translator: Brenno de Winter <brenno@dewinter.com>\n"
+"Language-Team: Latin <https://hosted.weblate.org/projects/openkat/nl-kat-coordination/la/>\n"
+"Language: la\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Weblate 5.13\n"
+
+#: account/admin.py
+msgid "Permissions"
+msgstr "permissiones"
+
+#: account/admin.py
+msgid "Important dates"
+msgstr "Dies magni"
+
+#: account/forms/account_setup.py crisis_room/forms.py
+#: katalogus/templates/katalogus_settings.html
+#: katalogus/templates/plugin_container_image.html
+#: reports/report_types/dns_report/report.html
+#: reports/report_types/tls_report/report.html
+#: reports/templates/partials/report_names_form.html
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/modal_partials/rename_modal.html
+#: reports/templates/report_overview/modal_partials/rerun_modal.html
+#: reports/templates/report_overview/modal_partials/share_modal.html
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+#: reports/templates/report_overview/subreports_table.html
+#: tools/forms/boefje.py rocky/templates/organizations/organization_list.html
+#: rocky/templates/organizations/organization_settings.html
+#: rocky/templates/partials/ooi_detail_related_object.html
+msgid "Name"
+msgstr "Nomen"
+
+#: account/forms/account_setup.py
+msgid "The name that will be used in order to communicate."
+msgstr "Nomen quod adhibebitur ad communicandum."
+
+#: account/forms/account_setup.py
+msgid "Please provide username"
+msgstr "Quaeso providere usoris"
+
+#: account/forms/account_setup.py
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Email"
+msgstr "Email"
+
+#: account/forms/account_setup.py
+msgid "Enter an email address."
+msgstr "Intra inscriptionem electronicam."
+
+#: account/forms/account_setup.py
+msgid "Password"
+msgstr "Password"
+
+#: account/forms/account_setup.py
+msgid "Choose a super secret password"
+msgstr "Eligite eximius secretum ignoro"
+
+#: account/forms/account_setup.py
+msgid "Choose another email."
+msgstr "Alterum eligere email."
+
+#: account/forms/account_setup.py tools/forms/settings.py
+msgid "--- Please select one of the available options ----"
+msgstr "--- Placere eligere unum ex optiones available ----"
+
+#: account/forms/account_setup.py
+msgid "Account type"
+msgstr "Ratio generis"
+
+#: account/forms/account_setup.py
+msgid "Please select an account type to proceed."
+msgstr "Placere eligere rationem generis procedere."
+
+#: account/forms/account_setup.py
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+msgid "Trusted clearance level"
+msgstr "Speravit alvi gradu"
+
+#: account/forms/account_setup.py
+msgid "Select a clearance level you trust this member with."
+msgstr "Elige alvi deiectio gradu confidis hoc membrum cum."
+
+#: account/forms/account_setup.py onboarding/forms.py tools/forms/ooi.py
+msgid "Please select a clearance level to proceed."
+msgstr "Placere eligere gradu alvi procedere."
+
+#: account/forms/account_setup.py tools/models.py
+msgid "The name of the organization."
+msgstr "nomen regiminis."
+
+#: account/forms/account_setup.py
+msgid "explanation-organization-name"
+msgstr "explicatio-organization-nomen"
+
+#: account/forms/account_setup.py
+#, python-brace-format
+msgid "A unique code of maximum {code_length} characters in length."
+msgstr "Singularis codicis maximi {code_length} characteres longitudinis."
+
+#: account/forms/account_setup.py
+msgid "explanation-organization-code"
+msgstr "explicatio-organization-code"
+
+#: account/forms/account_setup.py
+msgid "Organization name is required to proceed."
+msgstr "Organization nomen procedere debet."
+
+#: account/forms/account_setup.py
+msgid "Choose another organization."
+msgstr "Elige aliam ordinationem."
+
+#: account/forms/account_setup.py
+msgid "Organization code is required to proceed."
+msgstr "Organization code procedat requiritur."
+
+#: account/forms/account_setup.py
+msgid "Choose another code for your organization."
+msgstr "Alterum codicem elige pro organizatione."
+
+#: account/forms/account_setup.py
+msgid ""
+"I declare that OpenKAT may scan the assets of my organization and that I "
+"have permission to scan these assets. I am aware of the implications a scan "
+"(with a higher scan level) brings on my systems."
+msgstr ""
+"Pronuncio OpenKAT bona ordinationis meae lustrare posse et me permisisse ut "
+"haec bona lustrare. Scio effectus scan (cum gradu altiori scan) in "
+"systematibus meis inducit."
+
+#: account/forms/account_setup.py
+msgid ""
+"I declare that I am authorized to give this indemnification on behalf of my "
+"organization. I have the experience and knowledge to know what the "
+"consequences might be and can be held responsible for them."
+msgstr ""
+"Dico me permissum esse ut pro mea ordinatione hanc indemnificationem darem. "
+"Ego experientiam et scientiam habeo, scire quidnam consequatur, et quid "
+"responderi possit."
+
+#: account/forms/account_setup.py
+msgid "Trusted to change Clearance Levels."
+msgstr "Mutare gradus Clearance confidebat."
+
+#: account/forms/account_setup.py
+msgid "Acknowledged to change Clearance Levels."
+msgstr "Agnitum mutare gradus Clearance."
+
+#: account/forms/account_setup.py rocky/forms.py
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Blocked"
+msgstr "Clausus"
+
+#: account/forms/account_setup.py
+msgid ""
+"Set the members status to blocked, so they don't have access to the "
+"organization anymore."
+msgstr ""
+"Statue membra ad impediendum statum, ne accessum ad ordinationem amplius non"
+" habeant."
+
+#: account/forms/account_setup.py
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Accepted clearance level"
+msgstr "Accepit alvi gradu"
+
+#: account/forms/account_setup.py
+msgid "Enter tags separated by comma."
+msgstr "Intra tags separata commate."
+
+#: account/forms/account_setup.py
+msgid "The two password fields didn’t match."
+msgstr "Duo tesserae agri non concordant."
+
+#: account/forms/account_setup.py
+msgid "New password"
+msgstr "Novum password"
+
+#: account/forms/account_setup.py
+msgid "Enter a new password"
+msgstr "Intra novam password"
+
+#: account/forms/account_setup.py
+msgid "New password confirmation"
+msgstr "Novum password confirmatio"
+
+#: account/forms/account_setup.py
+msgid "Repeat the new password"
+msgstr "Iterare novam password"
+
+#: account/forms/account_setup.py
+msgid "Confirm the new password"
+msgstr "Confirmare novum password"
+
+#: account/forms/login.py
+msgid "Please enter a correct email address and password."
+msgstr "Please enter a correct email address and password."
+
+#: account/forms/login.py
+msgid "This account is inactive."
+msgstr "Haec ratio otiosa est."
+
+#: account/forms/login.py
+msgid "Insert the email you registered with or got at OpenKAT installation."
+msgstr ""
+"Inscribe electronicam quam descripseris vel ad institutionem OpenKAT "
+"inveniendam."
+
+#: account/forms/organization.py
+msgid "Organization is required."
+msgstr "Organizatio desideratur."
+
+#: account/forms/organization.py tools/view_helpers.py
+#: rocky/templates/dashboard_redteam.html
+#: rocky/templates/organizations/organization_list.html
+#: rocky/views/organization_add.py
+msgid "Organizations"
+msgstr "Institutiones"
+
+#: account/forms/organization.py
+msgid "The organization from which to clone settings."
+msgstr "Ordinatio a qua usque ad clone occasus."
+
+#: account/forms/password_reset.py account/templates/account_detail.html
+msgid "Email address"
+msgstr "Inscriptio electronica"
+
+#: account/forms/password_reset.py
+msgid "A reset link will be sent to this email"
+msgstr "A link reset mittetur ad hanc epistulam"
+
+#: account/forms/password_reset.py
+msgid "The email address connected to your OpenKAT-account"
+msgstr "Inscriptio electronica coniuncta cum OpenKAT-account"
+
+#: account/forms/token.py
+msgid ""
+"Insert the token generated by the authenticator app to setup the two factor "
+"authentication."
+msgstr ""
+"Inserere signum ab authenticatore app generatum ut habeat duos factores "
+"authenticas."
+
+#: account/forms/token.py
+msgid "Insert the token generated by your token authenticator app."
+msgstr "Generatae a signo tuo signo authenticatori inserta app."
+
+#: account/forms/token.py
+msgid "Backup token"
+msgstr "Tergum indicium"
+
+#: account/mixins.py
+msgid "Clearance level has been set."
+msgstr "Clearance level dictum est."
+
+#: account/mixins.py
+#, python-format
+msgid ""
+"Could not raise clearance level of %s to L%s. Indemnification not present at"
+" organization %s."
+msgstr ""
+"Alvi graduum %s ad L%s movere non potuit. Indemnificatio non adest in "
+"ordinatione %s."
+
+#: account/mixins.py
+#, python-format
+msgid ""
+"Could not raise clearance level of %s to L%s. You were trusted a clearance "
+"level of L%s. Contact your administrator to receive a higher clearance."
+msgstr ""
+"Alvi graduum %s ad L%s movere non potuit. Creditus es alvi planities L%s. "
+"Contact vestri administratorem ad altiorem alvi recipiendam."
+
+#: account/mixins.py
+#, python-format
+msgid ""
+"Could not raise clearance level of %s to L%s. You acknowledged a clearance "
+"level of L%s. Please accept the clearance level first on your profile page "
+"to proceed."
+msgstr ""
+"Alvi graduum %s ad L%s movere non potuit. Alvi planitiem L%s agnovisti. "
+"Accipe alvi gradum primum in pagina profile tuam procedere."
+
+#: account/models.py
+msgid "The email must be set"
+msgstr "In email esse debet"
+
+#: account/models.py
+msgid "Superuser must have is_staff=True."
+msgstr "Superuser debet habere is_staff=Verum."
+
+#: account/models.py
+msgid "Superuser must have is_superuser=True."
+msgstr "Superuser debet habere is_superuser=Verum."
+
+#: account/models.py
+msgid "full name"
+msgstr "plenum nomen"
+
+#: account/models.py
+msgid "email"
+msgstr "inscriptio"
+
+#: account/models.py
+msgid "staff status"
+msgstr "virgam status"
+
+#: account/models.py
+msgid "Designates whether the user can log into this admin site."
+msgstr "Designat num usor in hunc locum admin inire possit."
+
+#: account/models.py tools/models.py
+msgid "active"
+msgstr "active"
+
+#: account/models.py
+msgid ""
+"Designates whether this user should be treated as active. Unselect this "
+"instead of deleting accounts."
+msgstr ""
+"Designat an hic usor ut active tractari debeat. Unselect hoc loco delendo "
+"rationum."
+
+#: account/models.py
+msgid "date joined"
+msgstr "date joined"
+
+#: account/models.py
+msgid "The clearance level of the user for all organizations."
+msgstr "Clearance level of user for all organizations."
+
+#: account/models.py
+msgid "name"
+msgstr "nomen"
+
+#: account/templates/account_detail.html account/views/account.py
+msgid "Account details"
+msgstr "Ratio details"
+
+#: account/templates/account_detail.html account/templates/password_reset.html
+#: account/views/password_reset.py
+msgid "Reset password"
+msgstr "Reset password"
+
+#: account/templates/account_detail.html
+msgid "Full name"
+msgstr "Nomen plenum"
+
+#: account/templates/account_detail.html
+msgid "Member type"
+msgstr "Socius type"
+
+#: account/templates/account_detail.html
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: rocky/templates/tasks/normalizers.html
+msgid "Organization"
+msgstr "Organization"
+
+#: account/templates/account_detail.html
+msgid "Permission to set OOI clearance levels"
+msgstr "Licentia ut OOI alvi deiectio"
+
+#: account/templates/account_detail.html
+msgid "OOI clearance"
+msgstr "OOI alvi"
+
+#: account/templates/account_detail.html
+msgid "You don't have any clearance to scan objects."
+msgstr "Non habes alvi ad scan objecta."
+
+#: account/templates/account_detail.html
+msgid ""
+"Get in contact with the admin to give you the necessary clearance level."
+msgstr ""
+"Accipere contactum cum Administrator tibi necessariam dare alvi gradu."
+
+#: account/templates/account_detail.html
+msgid "You have currently accepted clearance up to level"
+msgstr "Tu currently accepit alvi usque ad planum"
+
+#: account/templates/account_detail.html
+msgid "Explanation OOI Clearance"
+msgstr "Explicatio OOI Clearance"
+
+#: account/templates/account_detail.html
+msgid ""
+"You can withdraw this at anytime you like, but know that you won't be able "
+"to change clearance levels anymore when you do."
+msgstr ""
+"Hoc quovis libet subtrahere potes, sed scito te amplius gradus alvi mutare "
+"non posse cum feceris."
+
+#: account/templates/account_detail.html
+#, python-format
+msgid "Withdraw L%(acl)s clearance and responsibility"
+msgstr "Recede L%(acl)s alvi et responsalitatem"
+
+#: account/templates/account_detail.html
+msgid "Explanation OOI clearance"
+msgstr "Explicatio OOI alvi"
+
+#: account/templates/account_detail.html
+#, python-format
+msgid ""
+"You are granted clearance for level L%(tcl)s by your admin. Before you can "
+"change OOI clearance levels up to this level, you need to accept this "
+"permission. Remember: <strong>with great power comes great "
+"responsibility.</strong>"
+msgstr ""
+"Alvi pro gradu L%(tcl)s conceditur tuo admin. Priusquam alvi deiectionem OOI"
+" gradus mutare possis, hanc licentiam accipere debes. Memento: <strong> "
+"magna cum potestate magna est.</strong>"
+
+#: account/templates/account_detail.html
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+#, python-format
+msgid "Accept level L%(tcl)s clearance and responsibility"
+msgstr "Accipe gradum L%(tcl)s alvi et responsabilitatem"
+
+#: account/templates/password_reset.html
+msgid "Use the form below to reset your password."
+msgstr "Forma infra utere ut reset password."
+
+#: account/templates/password_reset.html
+#: account/templates/password_reset_confirm.html
+msgid "Send"
+msgstr "Mitte"
+
+#: account/templates/password_reset.html
+#: account/templates/password_reset_confirm.html
+msgid "Back"
+msgstr "Retro"
+
+#: account/templates/password_reset_confirm.html
+msgid "Confirm reset password"
+msgstr "Adfirmare reset password"
+
+#: account/templates/password_reset_confirm.html
+msgid "Use the form below to confirm resetting your password"
+msgstr "Forma uti repositione confirmare ignoro"
+
+#: account/templates/password_reset_confirm.html
+msgid "Confirm password"
+msgstr "Adfirmare password"
+
+#: account/templates/password_reset_confirm.html
+msgid "The link is invalid"
+msgstr "Nexum invalidum est"
+
+#: account/templates/password_reset_confirm.html
+msgid ""
+"The password reset link was invalid, possibly because it has already been "
+"used.  Please request a new password reset."
+msgstr ""
+"Tesseras nexus retexere irritum fuit, fortasse quia iam usus est.  Reset "
+"tesseram novam peto."
+
+#: account/templates/password_reset_email.html
+#, python-format
+msgid ""
+"You're receiving this email because you requested a password reset for your "
+"user account at %(site_name)s."
+msgstr ""
+"Hanc epistulam accipis quod tesseram retexere pro usoris ratione apud "
+"%(site_name)s postulasti."
+
+#: account/templates/password_reset_email.html
+#: account/templates/registration_email.html
+msgid "Please go to the following page and choose a new password:"
+msgstr "Cede ad paginam sequentem et tesseram novam elige:"
+
+#: account/templates/password_reset_email.html
+#: account/templates/registration_email.html
+msgid "Sincerely,"
+msgstr "Sincere,"
+
+#: account/templates/password_reset_email.html
+#: account/templates/registration_email.html
+msgid "The OpenKAT team"
+msgstr "Turma OpenKAT"
+
+#: account/templates/password_reset_subject.txt
+#, python-format
+msgid "Password reset on %(site_name)s"
+msgstr "Reset password in %(site_name)s"
+
+#: account/templates/recover_email.html account/views/recover_email.py
+msgid "Recover email address"
+msgstr "Recuperet inscriptio electronica"
+
+#: account/templates/recover_email.html
+msgid "Information on how to recover your connected email address"
+msgstr ""
+"Informationes super quomodo reciperare inscriptionis electronicae connexae"
+
+#: account/templates/recover_email.html
+msgid "Forgotten email address?"
+msgstr "Oblitus electronica inscriptio?"
+
+#: account/templates/recover_email.html
+msgid ""
+"If you don’t remember the email address connected to your account, contact:"
+msgstr ""
+"Si inscriptio electronica cum ratione vestra coniuncta non meministis, "
+"contactus:"
+
+#: account/templates/recover_email.html
+msgid "Please contact the system administrator."
+msgstr "Please contact the system administrator."
+
+#: account/templates/recover_email.html
+msgid "Back to login"
+msgstr "Ad login"
+
+#: account/templates/recover_email.html
+msgid "Back to Home"
+msgstr "Ad Home"
+
+#: account/templates/registration_email.html
+#, python-format
+msgid ""
+"Welcome to OpenKAT. You're receiving this email because you have been added "
+"to organization \"%(organization)s\" at %(site_name)s."
+msgstr ""
+"Grata OpenKAT. Hanc epistulam accipis propterea quod ad ordinationem "
+"\"%(organization)s\" additus es apud %(site_name)s."
+
+#: account/templates/registration_subject.txt
+#, python-format
+msgid "Verify OpenKAT account on %(site_name)s"
+msgstr "Comproba OpenKAT rationem in %(site_name)s"
+
+#: account/validators.py
+msgid ""
+"Your password must contain at least the following but longer passwords are "
+"recommended:"
+msgstr "Tessera tua saltem sequentia, sed longiora Tesserae commendatur:"
+
+#: account/validators.py
+msgid " characters"
+msgstr "characteribus"
+
+#: account/validators.py
+msgid " digits"
+msgstr "numeri"
+
+#: account/validators.py
+msgid " letters"
+msgstr "litterae"
+
+#: account/validators.py
+msgid ""
+" special characters such as: {str(validators.get('special_characters',''))}"
+msgstr "specialia ingenia ut: {str(validators.get('special_characters',''))}"
+
+#: account/validators.py
+msgid " lower case letters"
+msgstr "inferioribus casus litteris"
+
+#: account/validators.py
+msgid " upper case letters"
+msgstr "superius casus litteris"
+
+#: account/views/login.py
+msgid "Your session has timed out. Please login again."
+msgstr "Sessionem tuam opportuno. Please login again."
+
+#: account/views/login.py rocky/templates/header.html
+msgid "OpenKAT"
+msgstr "OpenKAT"
+
+#: account/views/login.py account/views/password_reset.py
+#: account/views/recover_email.py rocky/templates/partials/secondary-menu.html
+#: rocky/templates/two_factor/core/login.html
+msgid "Login"
+msgstr "Login"
+
+#: account/views/login.py
+msgid "Two factor authentication"
+msgstr "Duo factor authenticas"
+
+#: account/views/password_reset.py
+msgid "We couldn't send a password reset link. Contact "
+msgstr "Non potuimus mittere link reset password. Contactus"
+
+#: account/views/password_reset.py
+msgid ""
+"We couldn't send a password reset link. Contact your system administrator."
+msgstr ""
+"Non potuimus mittere link reset password. Contact vestri ratio "
+"administrator."
+
+#: components/modal/template.html
+msgid "Close modal"
+msgstr "prope modal"
+
+#: components/modal/template.html
+#: crisis_room/templates/partials/delete_dashboard_item_modal.html
+#: crisis_room/templates/partials/delete_dashboard_modal.html
+#: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
+#: crisis_room/templates/partials/new_dashboard_item_modal.html
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+#: crisis_room/templates/partials/new_dashboard_modal.html
+#: katalogus/templates/change_clearance_level.html
+#: katalogus/templates/confirmation_clone_settings.html
+#: katalogus/templates/plugin_settings_delete.html
+#: reports/templates/report_overview/modal_partials/enable_disable_schedule_modal.html
+#: reports/templates/report_schedules/delete_recipe_modal.html
+#: rocky/templates/oois/ooi_delete.html
+#: rocky/templates/oois/ooi_mute_finding.html
+#: rocky/templates/organizations/organization_edit.html
+#: rocky/templates/organizations/organization_member_edit.html
+#: rocky/templates/partials/delete_ooi_modal.html
+#: rocky/templates/partials/edit_ooi_clearance_level_modal.html
+#: rocky/templates/partials/mute_findings_modal.html
+#: rocky/templates/two_factor/_wizard_actions.html
+msgid "Cancel"
+msgstr "Cancel"
+
+#: crisis_room/forms.py
+msgid "Title on dashboard"
+msgstr "Titulus in ashboardday"
+
+#: crisis_room/forms.py
+msgid "Dashboard item size"
+msgstr "Dashboard item magnitudine"
+
+#: crisis_room/forms.py
+msgid "Full width"
+msgstr "Plena latitudo"
+
+#: crisis_room/forms.py
+msgid "Half width"
+msgstr "Dimidium latitudo"
+
+#: crisis_room/forms.py
+msgid "An item with that name already exists. Try a different title."
+msgstr "An item cum eo nomine iam exstat. Alio titulo proba."
+
+#: crisis_room/forms.py
+msgid "An error occurred while adding dashboard item."
+msgstr "Error occurrit ashboardday item addit."
+
+#: crisis_room/forms.py
+msgid "Number of rows in list"
+msgstr "Numerus ordinum in album"
+
+#: crisis_room/forms.py
+msgid "List sorting by"
+msgstr "Album genus per"
+
+#: crisis_room/forms.py
+msgid "Type (A-Z)"
+msgstr "Typus (A-Z)"
+
+#: crisis_room/forms.py
+msgid "Type (Z-A)"
+msgstr "Typus (Z-A)"
+
+#: crisis_room/forms.py
+msgid "Clearance level (Low-High)"
+msgstr "Clearance level (Low-High)"
+
+#: crisis_room/forms.py
+msgid "Clearance level (High-Low)"
+msgstr "Clearance level (High-low)"
+
+#: crisis_room/forms.py
+msgid "Show table columns"
+msgstr "Ostende columnas mensa"
+
+#: crisis_room/forms.py
+msgid "Severity (Low-High)"
+msgstr "Severitas (Low-High)"
+
+#: crisis_room/forms.py
+msgid "Severity (High-Low)"
+msgstr "Severitas (High-Low)"
+
+#: crisis_room/forms.py
+msgid "Finding (A-Z)"
+msgstr "Inventio (A-Z)"
+
+#: crisis_room/forms.py
+msgid "Finding (Z-A)"
+msgstr "Inventio (Z-A)"
+
+#: crisis_room/models.py
+msgid "Findings Dashboard"
+msgstr "Inventiones Dashboard"
+
+#: crisis_room/models.py
+msgid ""
+"Where on the dashboard do you want to show the data? Position {} is the most"
+" top level and the max position is {}."
+msgstr ""
+"Ubi in ashboardday vis notitias ostendere? Situs {maximus} est supremus "
+"gradus et positio usoris {est}."
+
+#: crisis_room/models.py
+msgid "Will be displayed on the general crisis room, for all organizations."
+msgstr "Exhibebitur locus in discrimine generali, pro omnibus institutis."
+
+#: crisis_room/models.py
+msgid "Will be displayed on a single organization dashboard"
+msgstr "Proponendum erit in uno ashboardday organization"
+
+#: crisis_room/models.py
+msgid "Will be displayed on the findings dashboard for all organizations"
+msgstr "Ostendetur in ashboardday Inventiones omnes Institutionum"
+
+#: crisis_room/models.py
+msgid "Can change position up or down of a dashboard item."
+msgstr "Potest mutare statum sursum vel deorsum de ashboardday item."
+
+#: crisis_room/models.py
+msgid "You have to choose between a recipe or a query, but not both."
+msgstr "Eligendi habes aliquam consequat vel quaesitum, sed non utrumque."
+
+#: crisis_room/models.py
+msgid "You have set a query and not where it is from. Also set the source."
+msgstr "quaesitum es nec unde sit. Etiam auctor posuere auctor."
+
+#: crisis_room/models.py
+msgid ""
+"DashboardItem must contain at least a 'recipe' or a 'source' with a 'query'."
+msgstr ""
+"DashboardItem debet continere vel 'recipe' vel 'fons' cum 'quaestione'."
+
+#: crisis_room/models.py
+msgid "Max dashboard items reached."
+msgstr "Max ashboardday items perventum est."
+
+#: crisis_room/templates/crisis_room.html
+#: crisis_room/templates/organization_crisis_room.html
+#: rocky/templates/header.html
+msgid "Crisis room"
+msgstr "Crisis locus"
+
+#: crisis_room/templates/crisis_room.html
+msgid "Crisis room overview for all organizations."
+msgstr "Discrimen curriculi perlustratio omnium institutionum."
+
+#: crisis_room/templates/crisis_room_dashboards.html
+msgid "Dashboards"
+msgstr "Dashboards"
+
+#: crisis_room/templates/crisis_room_dashboards.html
+msgid ""
+"On this page you can see an overview of the dashboards for all "
+"organizations. **More context can be written here**"
+msgstr ""
+"In hac pagina videre potes inspectionem ashboardarum omnium Institutorum. "
+"Plures contextui hic scribi possunt."
+
+#: crisis_room/templates/crisis_room_dashboards.html
+msgid "dashboards"
+msgstr "dashboards"
+
+#: crisis_room/templates/crisis_room_dashboards.html
+msgid "There are no dashboards to display."
+msgstr "Nulla dashboards ad propono."
+
+#: crisis_room/templates/crisis_room_findings.html
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: reports/report_types/findings_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Findings overview"
+msgstr "Inventiones Overview"
+
+#: crisis_room/templates/crisis_room_findings.html
+msgid ""
+"\n"
+"                            This overview shows the total number of findings per\n"
+"                            severity that have been identified for all organizations.\n"
+"                            This data is based on the latest Crisis Room Findings Report\n"
+"                            of each organization.\n"
+"                        "
+msgstr ""
+"\n"
+"Haec overview ostendit numerus inventionum per\n"
+"                            severitas quae omnibus consociationibus identificatur.\n"
+"                            Haec notitia nititur in novissima Crisis Room Inventiones Report\n"
+"                            cuiusque ordo."
+
+#: crisis_room/templates/crisis_room_findings.html
+msgid "Findings per organization"
+msgstr "Inventiones per ordinationem"
+
+#: crisis_room/templates/crisis_room_findings.html
+msgid ""
+"This table shows the findings that have been identified for each "
+"organization, sorted by the finding types and grouped by organizations. This"
+" data is based on the latest Crisis Room Findings Report of each "
+"organization."
+msgstr ""
+"Mensa haec indicat inventas quae singulis organisationi notae sunt, per "
+"genera inveniendorum disposita et a Institutis aggregata. Haec notitia "
+"nititur in novissima Crisis Room Inventionum Relatio cuiusque "
+"organizationis."
+
+#: crisis_room/templates/crisis_room_findings.html
+#: reports/report_types/findings_report/report.html
+msgid ""
+"No findings have been identified yet. As soon as they have been identified, "
+"they will be shown on this page."
+msgstr ""
+"No inventa adhuc inventa sunt. Simul ac notae sunt, in hac pagina "
+"ostendentur."
+
+#: crisis_room/templates/crisis_room_findings.html
+msgid ""
+"There are no organizations yet. After creating an organization, the "
+"identified findings will be shown here."
+msgstr ""
+"Nulla sed nulla lacus. Post ordinationem creatam, inventio identificati hic "
+"ostendentur."
+
+#: crisis_room/templates/crisis_room_header.html
+#: crisis_room/templates/organization_crisis_room_header.html
+msgid "Crisis room navigation"
+msgstr "navigationis locus"
+
+#: crisis_room/templates/crisis_room_header.html
+#: crisis_room/templates/partials/new_dashboard_item_action_button.html
+#: reports/report_types/aggregate_organisation_report/findings.html
+#: reports/report_types/aggregate_organisation_report/report.html
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/findings_report/report.html
+#: reports/report_types/mail_report/report.html
+#: reports/report_types/multi_organization_report/report.html
+#: reports/report_types/name_server_report/report.html
+#: reports/report_types/tls_report/report.html
+#: reports/report_types/vulnerability_report/report.html
+#: reports/report_types/web_system_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/partials/report_sidemenu.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
+#: rocky/templates/oois/ooi_detail_findings_list.html
+#: rocky/templates/oois/ooi_detail_findings_overview.html
+#: rocky/templates/oois/ooi_page_tabs.html
+#: rocky/templates/partials/ooi_report_findings_block.html
+#: rocky/templates/partials/ooi_report_findings_block_table.html
+#: rocky/views/finding_list.py rocky/views/finding_type_add.py
+#: rocky/views/ooi_view.py
+msgid "Findings"
+msgstr "Inventiones"
+
+#: crisis_room/templates/organization_crisis_room.html
+msgid "Options for dashboard"
+msgstr "Options pro ashboardday"
+
+#: crisis_room/templates/organization_crisis_room.html
+msgid "Show all descriptions"
+msgstr "Monstra omnia descriptiones"
+
+#: crisis_room/templates/organization_crisis_room.html
+msgid "Hide all descriptions"
+msgstr "Omnes descriptiones celare"
+
+#: crisis_room/templates/organization_crisis_room.html
+#: crisis_room/templates/partials/delete_dashboard_modal.html
+msgid "Delete dashboard"
+msgstr "Delere ashboardday"
+
+#: crisis_room/templates/organization_crisis_room.html
+msgid ""
+"There are no dashboards yet. Click on \"Add dashboard\" to create a new "
+"dashboard."
+msgstr ""
+"Non sunt ashboarddays adhuc. Deprime \"Addere ashboardday\" novum "
+"ashboardday creare."
+
+#: crisis_room/templates/organization_crisis_room_dashboard_items.html
+#: katalogus/templates/partials/objects_to_scan.html
+#: rocky/templates/forms/widgets/checkbox_group_table.html
+#: rocky/templates/oois/ooi_list.html
+msgid "Object list"
+msgstr "Object album"
+
+#: crisis_room/templates/organization_crisis_room_dashboard_items.html
+msgid "Finding list"
+msgstr "invenire album"
+
+#: crisis_room/templates/organization_crisis_room_dashboard_items.html
+#: crisis_room/templates/partials/new_dashboard_item_action_button.html
+msgid "Report section"
+msgstr "Report section"
+
+#: crisis_room/templates/organization_crisis_room_dashboard_items.html
+msgid "There are no dashboard items added yet."
+msgstr "There are no ashboardday items added yet."
+
+#: crisis_room/templates/organization_crisis_room_dashboard_items.html
+msgid ""
+"You can add dashboard items via the filters on the objects and findings page"
+" or you can add a report section."
+msgstr ""
+"ashboardday items per columellas in objectis et inventis paginam addere "
+"potes vel sectionem relationis addere potes."
+
+#: crisis_room/templates/organization_crisis_room_dashboard_items.html
+msgid "Add objects"
+msgstr "Add objects"
+
+#: crisis_room/templates/organization_crisis_room_dashboard_items.html
+msgid "Add findings"
+msgstr "Add Inventiones"
+
+#: crisis_room/templates/organization_crisis_room_dashboard_items.html
+msgid "Add report section"
+msgstr "Add fama sectionem"
+
+#: crisis_room/templates/organization_crisis_room_header.html
+#: crisis_room/templates/partials/new_dashboard_modal.html
+msgid "Add dashboard"
+msgstr "Add ashboardday"
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+msgid "Findings per organization overview"
+msgstr "Inventiones per ordinem overview"
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/partials/report_severity_totals_table.html
+#: tools/forms/finding_type.py
+msgid "Finding types"
+msgstr "Inventis generibus"
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: reports/report_types/dns_report/report.html
+#: reports/report_types/vulnerability_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/partials/report_severity_totals_table.html
+#: rocky/templates/oois/ooi_detail_findings_overview.html
+#: rocky/templates/partials/ooi_report_findings_block_table.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid "Occurrences"
+msgstr "Eventus"
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+msgid "Highest risk level"
+msgstr "Summum periculum gradu"
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+msgid "Critical finding types"
+msgstr "Typi critica inventio"
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: reports/report_types/dns_report/report.html
+#: reports/report_types/vulnerability_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/summary/selected_plugins.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/partials/ooi_report_findings_block_table.html
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
+#: rocky/templates/tasks/ooi_detail_task_list.html
+#: rocky/templates/tasks/plugin_detail_task_list.html
+msgid "Details"
+msgstr "Singula"
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: katalogus/templates/plugin_container_image.html
+#: reports/report_types/dns_report/report.html
+#: reports/report_types/vulnerability_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+#: reports/templates/summary/selected_plugins.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
+#: rocky/templates/tasks/ooi_detail_task_list.html
+#: rocky/templates/tasks/plugin_detail_task_list.html
+msgid "Close details"
+msgstr "Close details"
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: katalogus/templates/plugin_container_image.html
+#: reports/report_types/dns_report/report.html
+#: reports/report_types/vulnerability_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+#: reports/templates/summary/selected_plugins.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
+#: rocky/templates/tasks/ooi_detail_task_list.html
+#: rocky/templates/tasks/plugin_detail_task_list.html
+msgid "Open details"
+msgstr "Open details"
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+msgid ""
+"This overview shows the total number of findings per severity that have been"
+" identified for this organization."
+msgstr ""
+"Haec descriptio indicat numerum inventarum per severitatem quae huic "
+"organizationi notata est."
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: reports/report_types/findings_report/report.html
+msgid "Critical and high findings"
+msgstr "Critica et alta inventa"
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: reports/report_types/findings_report/report.html
+msgid ""
+"This table shows the top 25 critical and high findings that have been "
+"identified for this organization, grouped by finding types. A table with all"
+" the identified findings can be found in the Findings Report."
+msgstr ""
+"Haec mensa ostendit capita 25 criticae et altae inventae quae huic "
+"organizationi notatae sunt, typis inventis aggregatis. Mensa cum omnibus "
+"inventis identificatis inveniri potest in Inventione Report."
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+msgid "No findings have been identified. Check report for more details."
+msgstr "Inventiones nullae inveniuntur. Reprehendo fama pro magis details."
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+msgid "View findings report"
+msgstr "View Inventiones referre"
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Edit report recipe"
+msgstr "Recensere famam recipe"
+
+#: crisis_room/templates/partials/dashboard_finding_list.html
+#, python-format
+msgid "Showing %(length)s findings"
+msgstr "Ostendens %(length)s Inventiones"
+
+#: crisis_room/templates/partials/dashboard_finding_list.html
+msgid "Go to findings"
+msgstr "Vade ad Inventiones"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+msgid "Findings table "
+msgstr "Inventiones mensa"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: crisis_room/templates/partials/dashboard_ooi_list_table.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/oois/ooi_list.html
+msgid "column headers with buttons are sortable"
+msgstr "columna capitis cum bullarum sunt sortable"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+#, python-format
+msgid "Show details for %(finding)s"
+msgstr "Monstrare singula de %(finding)s"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/oois/ooi_page_tabs.html
+#: rocky/templates/partials/elements/ooi_tree_condensed_table.html
+#: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
+#: rocky/views/mixins.py
+msgid "Tree"
+msgstr "Arbor"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/oois/ooi_page_tabs.html
+#: rocky/templates/partials/elements/ooi_tree_condensed_table.html
+#: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
+#: rocky/views/mixins.py
+msgid "Graph"
+msgstr "Aliquam lacinia purus"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: reports/report_types/dns_report/report.html
+#: rocky/templates/oois/ooi_detail_findings_list.html
+#: rocky/templates/oois/ooi_detail_findings_overview.html
+#: rocky/views/mixins.py
+msgid "Severity"
+msgstr "severitas"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: reports/report_types/dns_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+#: rocky/views/mixins.py
+msgid "Finding"
+msgstr "inventum"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/partials/ooi_report_findings_block_table.html
+msgid "Finding type"
+msgstr "Inveniens genus"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+#, python-format
+msgid "Show details for %(finding_type)s"
+msgstr "Monstrare singula de %(finding_type)s"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+msgid "OOI type"
+msgstr "OOI type"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+#, python-format
+msgid "Show %(ooi_type)s objects"
+msgstr "Ostende %(ooi_type)s res"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/views/mixins.py
+msgid "Location"
+msgstr "Locus"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#, python-format
+msgid "Show details for %(ooi)s"
+msgstr "Monstrare singula de %(ooi)s"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+msgid "Risk score"
+msgstr "Periculum score"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: katalogus/templates/normalizer_detail.html
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: reports/report_types/dns_report/report.html
+#: reports/report_types/vulnerability_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/summary/report_asset_overview.html tools/forms/boefje.py
+#: tools/forms/finding_type.py rocky/templates/findings/finding_list.html
+#: rocky/templates/oois/ooi_detail.html
+#: rocky/templates/oois/ooi_detail_findings_list.html
+#: rocky/templates/scan.html
+msgid "Description"
+msgstr "Descriptio"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: reports/report_types/multi_organization_report/recommendations.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/partials/report_severity_totals_table.html
+#: rocky/templates/findings/finding_list.html
+msgid "Recommendation"
+msgstr "Commendatio"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: reports/report_types/vulnerability_report/report.py
+#: reports/templates/partials/report_findings_table.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/oois/ooi_detail_origins_inference.html
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid "Source"
+msgstr "Source"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: reports/templates/partials/report_findings_table.html
+#: rocky/templates/findings/finding_list.html
+msgid "Impact"
+msgstr "Impact"
+
+#: crisis_room/templates/partials/dashboard_item_action_button.html
+msgid "Options for dashboard items"
+msgstr "Options pro ashboardday items"
+
+#: crisis_room/templates/partials/dashboard_item_action_button.html
+msgid "Show description"
+msgstr "Ostende descriptionem"
+
+#: crisis_room/templates/partials/dashboard_item_action_button.html
+msgid "Hide description"
+msgstr "Celare descriptionem"
+
+#: crisis_room/templates/partials/dashboard_item_action_button.html
+msgid "Position up"
+msgstr "Positus est"
+
+#: crisis_room/templates/partials/dashboard_item_action_button.html
+msgid "Position down"
+msgstr "Positus descendit"
+
+#: crisis_room/templates/partials/dashboard_item_action_button.html
+msgid "Rerun report"
+msgstr "Rerum fama"
+
+#: crisis_room/templates/partials/dashboard_item_action_button.html
+#: crisis_room/templates/partials/delete_dashboard_item_modal.html
+msgid "Delete item"
+msgstr "Delere item"
+
+#: crisis_room/templates/partials/dashboard_ooi_list.html
+#, python-format
+msgid "Showing %(length)s objects"
+msgstr "Ostendens %(length)s objects"
+
+#: crisis_room/templates/partials/dashboard_ooi_list.html
+msgid "Go to objects"
+msgstr "Vade ad objecta"
+
+#: crisis_room/templates/partials/dashboard_ooi_list_table.html
+#: rocky/templates/oois/ooi_list.html
+msgid "Objects "
+msgstr "Objects"
+
+#: crisis_room/templates/partials/delete_dashboard_item_modal.html
+#, python-format
+msgid "Are you sure you want to delete '%(name)s' from this dashboard?"
+msgstr "Visne vero '%(name)s delere ex hoc ashboardday?"
+
+#: crisis_room/templates/partials/delete_dashboard_item_modal.html
+#: crisis_room/templates/partials/delete_dashboard_modal.html
+#: katalogus/templates/plugin_settings_delete.html
+#: katalogus/views/plugin_settings_delete.py
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+#: rocky/templates/admin/delete_confirmation.html
+#: rocky/templates/oois/ooi_list.html
+#: rocky/templates/partials/delete_ooi_modal.html rocky/views/ooi_delete.py
+msgid "Delete"
+msgstr "Delere"
+
+#: crisis_room/templates/partials/delete_dashboard_modal.html
+#, python-format
+msgid ""
+"Are you sure you want to delete dashboard '%(dashboard)s'? All the items on "
+"the dashboard will be deleted as well."
+msgstr ""
+"Visne vero ashboardday delere '%(dashboard)s'? Omnia vasa in ashboardday "
+"etiam delebuntur."
+
+#: crisis_room/templates/partials/new_dashboard_item_action_button.html
+msgid "Actions for adding dashboard items"
+msgstr "Actionibus addendo ashboardday items"
+
+#: crisis_room/templates/partials/new_dashboard_item_action_button.html
+msgid "Add item"
+msgstr "Add item"
+
+#: crisis_room/templates/partials/new_dashboard_item_action_button.html
+#: crisis_room/templates/partials/report_dashboard_item_filter.html
+#: reports/templates/partials/report_ooi_list.html
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/summary/ooi_selection.html tools/forms/ooi.py
+#: tools/view_helpers.py rocky/templates/admin/delete_confirmation.html
+#: rocky/templates/admin/delete_selected_confirmation.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
+#: rocky/views/ooi_add.py rocky/views/ooi_list.py rocky/views/ooi_view.py
+#: rocky/views/upload_csv.py rocky/views/upload_raw.py
+msgid "Objects"
+msgstr "Objects"
+
+#: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
+msgid "Add dashboard item"
+msgstr "Add ashboardday item"
+
+#: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
+msgid ""
+"To  add a <strong>report section</strong>, go to the history page and open a"
+" report. Then go to the section that you want to add to your dashboard and "
+"press the options button next to the section name to create a dashboard "
+"item."
+msgstr ""
+"Ut addere <strong>relationem sectionem</strong>, vade ad paginam historiae "
+"et famam aperi. Deinde ad sectionem accede quod vis ashboardday addere tuum "
+"et premere puga optionum proximae sectionis nomen ashboardday item creare."
+
+#: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
+msgid "Go to report history"
+msgstr "Vade ad historiam referre"
+
+#: crisis_room/templates/partials/new_dashboard_item_modal.html
+#, python-format
+msgid ""
+"\n"
+"    Add %(item_type)s to dashboard\n"
+msgstr ""
+"\n"
+"Adde %(item_type)s ad ashboardday\n"
+
+#: crisis_room/templates/partials/new_dashboard_item_modal.html
+#, python-format
+msgid ""
+"Add these %(item_type)s with the selected filters to the dashboard of your "
+"choice."
+msgstr ""
+"His adde %(item_type)s cum eliquationibus selectis ad ashboardday electionis"
+" tuae."
+
+#: crisis_room/templates/partials/new_dashboard_item_modal.html
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+#: katalogus/templates/partials/no_enabling_permission_message.html
+#: katalogus/templates/plugin_container_image.html
+#: rocky/templates/partials/edit_ooi_clearance_level_modal.html
+#: rocky/templates/partials/form/field_input_help_text.html
+#: rocky/templates/partials/notifications_block.html
+#: rocky/templates/two_factor/core/login.html
+msgid "explanation"
+msgstr "explicatio"
+
+#: crisis_room/templates/partials/new_dashboard_item_modal.html
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+msgid "You do not have a custom dashboard yet"
+msgstr "Mos non habes ashboardday sed"
+
+#: crisis_room/templates/partials/new_dashboard_item_modal.html
+#, python-format
+msgid ""
+"In order to add these %(item_type)s to a dashboard, you first need to create"
+" a dashboard. Please add a dashboard in the crisis room of your "
+"organization."
+msgstr ""
+"Ut has %(item_type)s ad ashboardday addere, primum ashboardday creare debes."
+" Quaeso adde ashboardday in discrimine cubiculi tui organizationis."
+
+#: crisis_room/templates/partials/new_dashboard_item_modal.html
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/oois/ooi_list.html
+msgid "Add to dashboard"
+msgstr "Add to ashboardday"
+
+#: crisis_room/templates/partials/new_dashboard_item_modal.html
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+msgid "Go to crisis room"
+msgstr "Ad discrimen locus"
+
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+msgid "Add report section to dashboard"
+msgstr "Addere fama sectionem ad ashboardday"
+
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+msgid ""
+"In order to add this report section to a dashboard, you first need to create"
+" a dashboard. Please create a dashboard in the crisis room of your "
+"organization."
+msgstr ""
+"Ut hanc sectionem relationis ad ashboardday addere, primum ashboardday "
+"creare debes. Quaeso ashboardday creare in cubiculi discriminis tuae "
+"organizatione."
+
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+msgid "Report must be scheduled for dashboard items"
+msgstr "Report debet scheduled pro ashboardday items"
+
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+msgid ""
+"In order for dashboard information to be updated on a regular basis instead "
+"of showing static data, the report should be scheduled. The frequency of the"
+" schedules recurrence determines how fresh the data on the dashboard will "
+"be."
+msgstr ""
+"Ut ashboardday informationes renovarentur in iusto fundamento pro static "
+"notitia ostendendi, relatio accedatur. Frequentia cedularum recursus "
+"determinat quam recens notitia in ashboardday erit."
+
+#: crisis_room/templates/partials/report_dashboard_item_filter.html
+msgid "Applied filters"
+msgstr "Acta Filtra"
+
+#: crisis_room/templates/partials/report_dashboard_item_filter.html
+msgid "Object types"
+msgstr "Object types"
+
+#: crisis_room/templates/partials/report_dashboard_item_filter.html
+#: katalogus/templates/change_clearance_level.html onboarding/forms.py
+#: reports/templates/partials/report_ooi_list.html
+#: reports/templates/summary/ooi_selection.html tools/forms/boefje.py
+#: tools/forms/ooi.py rocky/templates/oois/ooi_page_tabs.html
+#: rocky/templates/partials/explanations.html
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+#: rocky/views/mixins.py
+msgid "Clearance level"
+msgstr "Clearance level"
+
+#: crisis_room/templates/partials/report_dashboard_item_filter.html
+#: reports/templates/partials/report_ooi_list.html
+#: reports/templates/summary/ooi_selection.html tools/forms/ooi.py
+#: rocky/views/mixins.py
+msgid "Clearance type"
+msgstr "Genus Clearance"
+
+#: crisis_room/templates/partials/report_dashboard_item_filter.html
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/modal_partials/rerun_modal.html
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Input objects"
+msgstr "Input objects"
+
+#: crisis_room/templates/partials/report_dashboard_item_filter.html
+msgid "Show all objects"
+msgstr "Ostende omnia objecta"
+
+#: crisis_room/templates/partials/report_dashboard_item_filter.html
+#: reports/templates/partials/report_types_selection.html
+msgid "No filters applied"
+msgstr "Non Filtra applicari"
+
+#: crisis_room/templates/partials/report_section_action_button.html
+msgid "Add section to dashboard"
+msgstr "Addere sectionem ad ashboardday"
+
+#: katalogus/client.py
+msgid ""
+"The KATalogus has an unexpected error. Check the logs for further details."
+msgstr ""
+"KATalogus habet errorem inopinatum. Reprehendo ligna ad singula plura."
+
+#: katalogus/client.py
+#, python-format
+msgid "An HTTP %d error occurred. Check logs for more info."
+msgstr "Error HTTP %d occurrit. Log pro more info."
+
+#: katalogus/client.py
+msgid "An HTTP error occurred. Check logs for more info."
+msgstr "Error HTTP occurrit. Log pro more info."
+
+#: katalogus/client.py
+msgid "Boefje with this name already exists."
+msgstr "Boefje hoc nomine iam exstat."
+
+#: katalogus/client.py
+msgid "Boefje with this ID already exists."
+msgstr "Boefje cum hoc ID iam exstat."
+
+#: katalogus/client.py
+msgid "Access to resource not allowed"
+msgstr "Aditus ad resource non permisit"
+
+#: katalogus/client.py
+msgid "User is not allowed to see plugin settings"
+msgstr "User non licet videre occasus plugin"
+
+#: katalogus/client.py
+msgid "User is not allowed to set plugin settings"
+msgstr "User non licet ut plugin occasus"
+
+#: katalogus/client.py
+msgid "User is not allowed to delete plugin settings"
+msgstr "User non licet delere plugin occasus"
+
+#: katalogus/client.py
+msgid "User is not allowed to view plugin settings"
+msgstr "User non licet inspicere plugin occasus"
+
+#: katalogus/client.py
+msgid "User is not allowed to access the other organization"
+msgstr "User non licet accedere ad alteram ordinationem"
+
+#: katalogus/client.py
+msgid "User is not allowed to enable plugins"
+msgstr "User non licet ut plugins"
+
+#: katalogus/client.py
+msgid "User is not allowed to disable plugins"
+msgstr "User disable plugins non licet"
+
+#: katalogus/client.py
+msgid "User is not allowed to create plugins"
+msgstr "User creare plugins non licet"
+
+#: katalogus/client.py
+msgid "User is not allowed to edit plugins"
+msgstr "User creare plugins non licet"
+
+#: katalogus/forms/katalogus_filter.py
+msgid "Show all"
+msgstr "Monstra omnia"
+
+#: katalogus/forms/katalogus_filter.py
+#: katalogus/templates/partials/enable_disable_plugin.html
+#: katalogus/templates/partials/plugin_tile_modal.html
+#: katalogus/templates/plugin_container_image.html
+#: reports/report_types/dns_report/report.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Enabled"
+msgstr "Enabled"
+
+#: katalogus/forms/katalogus_filter.py
+#: katalogus/templates/partials/enable_disable_plugin.html
+#: katalogus/templates/partials/plugin_tile_modal.html
+#: katalogus/templates/plugin_container_image.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+#: reports/templates/summary/selected_plugins.html
+msgid "Disabled"
+msgstr "debilitatum"
+
+#: katalogus/forms/katalogus_filter.py
+msgid "Enabled-Disabled"
+msgstr "Enabled-Disabled"
+
+#: katalogus/forms/katalogus_filter.py
+msgid "Disabled-Enabled"
+msgstr "Disabled-Enabled"
+
+#: katalogus/forms/katalogus_filter.py
+msgid "Filter options"
+msgstr "Optiones filter"
+
+#: katalogus/forms/katalogus_filter.py
+msgid "Sorting options"
+msgstr "Sorting options"
+
+#: katalogus/forms/plugin_settings.py
+msgid "This field is required."
+msgstr "Hic ager desideratur."
+
+#: katalogus/templates/about_plugins.html
+#: katalogus/templates/partials/plugins_navigation.html
+msgid "About plugins"
+msgstr "De plugins"
+
+#: katalogus/templates/about_plugins.html katalogus/templates/katalogus.html
+msgid ""
+"Plugins gather data, objects and insight. Each plugin has its own focus area"
+" and strengths and may be able to work with other plugins to gain even more "
+"insights."
+msgstr ""
+"Plugins notitia colligitur, res et intellectus. Quisque plugin aream suam et"
+" vires habet et cum aliis plugins operari potest ut plus etiam indagari "
+"possit."
+
+#: katalogus/templates/about_plugins.html katalogus/templates/boefjes.html
+msgid ""
+"Boefjes are used to scan for objects. They detect vulnerabilities, security "
+"issues, and give insight. Each boefje is a separate scan that can run on a "
+"selection of objects."
+msgstr ""
+"Boefjes ad res lustrandas adhibentur. vulnerabilitates deprehendunt, "
+"quaestiones securitatis et perspectum dant. Quisque boefje est separatum "
+"scan quod in obiectis delectu currere potest."
+
+#: katalogus/templates/about_plugins.html katalogus/templates/normalizers.html
+msgid ""
+"Normalizers analyze the information and turn it into objects for the data "
+"model in Octopoes."
+msgstr ""
+"Normalizers informationes resolvere et in obiecta converte ad exemplar "
+"notitiae Octopoes."
+
+#: katalogus/templates/about_plugins.html
+msgid ""
+"Bits are business rules that look for insight within the current dataset and"
+" search for specific insight and draw conclusions."
+msgstr ""
+"Praecepta negotiatio sunt frena quae perspectionem in hodierna notitia "
+"quaerunt et pervestigationem specificam et conclusiones concludunt."
+
+#: katalogus/templates/boefje_detail.html
+#: katalogus/templates/partials/plugin_tile_modal.html
+#: katalogus/templates/plugin_container_image.html
+msgid "Scan level"
+msgstr "Scan planum"
+
+#: katalogus/templates/boefje_detail.html
+#: katalogus/templates/normalizer_detail.html
+msgid "Consumes"
+msgstr "Consumes"
+
+#: katalogus/templates/boefje_detail.html
+#, python-format
+msgid "%(plugin_name)s is able to scan the following object types:"
+msgstr "%(plugin_name)s sequens genera lustrare potest:"
+
+#: katalogus/templates/boefje_detail.html
+#: katalogus/templates/normalizer_detail.html
+#, python-format
+msgid "%(plugin_name)s does not need any input objects."
+msgstr "%(plugin_name)s obiectis initus non eget."
+
+#: katalogus/templates/boefje_detail.html
+#: katalogus/templates/normalizer_detail.html
+#: katalogus/templates/partials/plugin_tile_modal.html
+msgid "Produces"
+msgstr "producit"
+
+#: katalogus/templates/boefje_detail.html
+#: katalogus/templates/normalizer_detail.html
+#: katalogus/templates/partials/plugin_tile_modal.html
+#, python-format
+msgid "%(plugin_name)s can produce the following output:"
+msgstr "%(plugin_name)s hoc output producere potest:"
+
+#: katalogus/templates/boefje_detail.html
+#, python-format
+msgid "%(plugin_name)s doesn't produce any output mime types."
+msgstr "%(plugin_name)s genera output mimi non gignit."
+
+#: katalogus/templates/boefje_setup.html
+msgid "Boefje variant setup"
+msgstr "Boefje variant setup"
+
+#: katalogus/templates/boefje_setup.html
+#: rocky/templates/organizations/organization_member_list.html
+#: rocky/templates/organizations/organization_settings.html
+#: rocky/views/ooi_edit.py rocky/views/organization_edit.py
+msgid "Edit"
+msgstr "Edit"
+
+#: katalogus/templates/boefje_setup.html
+msgid "Boefje setup"
+msgstr "Boefje habeat"
+
+#: katalogus/templates/boefje_setup.html
+msgid ""
+"You can create a new Boefje. If you want more information on this, you can "
+"check out the <a "
+"href=\"https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html\">documentation</a>."
+msgstr ""
+"Novum Boefje creare potes. Si de hac re plura desideras, <a "
+"href=\"https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html\">"
+" documentum </a> inspicere potes."
+
+#: katalogus/templates/boefje_setup.html
+#: rocky/templates/partials/edit_ooi_clearance_level_modal.html
+msgid "Save changes"
+msgstr "Servare mutationes"
+
+#: katalogus/templates/boefje_setup.html
+msgid "Discard changes"
+msgstr "Rudia Relinquere mutationes"
+
+#: katalogus/templates/boefje_setup.html
+msgid "Create variant"
+msgstr "Create variant"
+
+#: katalogus/templates/boefje_setup.html
+msgid "Discard variant"
+msgstr "Relinquere variantia"
+
+#: katalogus/templates/boefje_setup.html
+msgid "Create new Boefje"
+msgstr "Novam Boefje"
+
+#: katalogus/templates/boefje_setup.html
+msgid "Discard new Boefje"
+msgstr "Relinquere novam Boefje"
+
+#: katalogus/templates/boefjes.html
+msgid "Add Boefje"
+msgstr "Adde Boefje"
+
+#: katalogus/templates/boefjes.html katalogus/templates/katalogus.html
+#: katalogus/templates/normalizers.html
+msgid "available"
+msgstr "praesto"
+
+#: katalogus/templates/change_clearance_level.html
+#: katalogus/templates/partials/objects_to_scan.html
+#: reports/templates/partials/report_setup_scan.html
+msgid "scan level warning"
+msgstr "scan campester Admonitio"
+
+#: katalogus/templates/change_clearance_level.html
+#, python-format
+msgid ""
+"%(plugin_name)s will only scan objects with a corresponding clearance level "
+"of <strong>L%(scan_level)s</strong> or higher."
+msgstr ""
+"%(plugin_name)s res tantum lustrabit cum alvi congruenti planities "
+"<strong>L%(scan_level)s</strong> vel altioris."
+
+#: katalogus/templates/change_clearance_level.html
+msgid "Scan object"
+msgstr "Scan object"
+
+#: katalogus/templates/change_clearance_level.html
+#, python-format
+msgid ""
+"The following objects are not yet cleared for level %(scan_level)s, please "
+"be advised that by continuing you will declare a level %(scan_level)s on "
+"these objects."
+msgstr ""
+"Obiecta sequentia pro gradu %(scan_level)s nondum purgata sunt, monendum "
+"placet quod continuando de his obiectis aequalem %(scan_level)s declarabis."
+
+#: katalogus/templates/change_clearance_level.html
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: reports/templates/summary/report_asset_overview.html
+msgid "Selected objects"
+msgstr "Electus obiecti"
+
+#: katalogus/templates/change_clearance_level.html
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/summary/ooi_selection.html rocky/views/mixins.py
+msgid "Object"
+msgstr "Object"
+
+#: katalogus/templates/change_clearance_level.html
+msgid "Are you sure you want to scan anyways?"
+msgstr "Certusne esne usquams lustrare vis?"
+
+#: katalogus/templates/change_clearance_level.html
+#: rocky/templates/oois/ooi_detail.html
+msgid "Scan"
+msgstr "Scan"
+
+#: katalogus/templates/clone_settings.html
+#: katalogus/templates/confirmation_clone_settings.html
+msgid "Clone settings"
+msgstr "Clone occasus"
+
+#: katalogus/templates/clone_settings.html
+#, python-format
+msgid ""
+"Use the form below to clone the settings from "
+"<strong>%(current_organization)s</strong> to the selected organization. This"
+" includes both the KAT-alogus settings as well as enabled and disabled "
+"plugins."
+msgstr ""
+"Utere forma infra ad uncinis cingulis ab "
+"<strong>%(current_organization)s</strong> ad ordinationem selectam. Hoc "
+"includit tum occasus KAT -alogus, tum cinematographica capacia ac debiles."
+
+#: katalogus/templates/confirmation_clone_settings.html
+msgid "Clone"
+msgstr "Clone"
+
+#: katalogus/templates/katalogus.html
+msgid "All plugins"
+msgstr "Omnes plugins"
+
+#: katalogus/templates/katalogus_settings.html
+msgid "KAT-alogus settings"
+msgstr "KAT-alogus occasus"
+
+#: katalogus/templates/katalogus_settings.html
+msgid ""
+"There are currently no settings defined. Add settings at the plugin detail "
+"page."
+msgstr ""
+"Currently nullae uncinis definitae sunt. Optiones addere in pagina pagina "
+"plugin."
+
+#: katalogus/templates/katalogus_settings.html
+#: rocky/templates/two_factor/core/otp_required.html
+msgid "Go back"
+msgstr "Redire"
+
+#: katalogus/templates/katalogus_settings.html
+msgid "This is an overview of the latest settings of all plugins."
+msgstr "Haec est recensio recentissimarum omnium plugins."
+
+#: katalogus/templates/katalogus_settings.html
+msgid "Latest plugin settings"
+msgstr "Tardus plugin occasus"
+
+#: katalogus/templates/katalogus_settings.html
+#: rocky/templates/tasks/ooi_detail_task_list.html
+msgid "Plugin"
+msgstr "Plugin"
+
+#: katalogus/templates/katalogus_settings.html
+#: katalogus/templates/plugin_settings_list.html
+#: rocky/templates/oois/ooi_delete.html
+msgid "Value"
+msgstr "Precium"
+
+#: katalogus/templates/normalizer_detail.html
+#, python-format
+msgid "%(plugin_name)s is able to process the following mime types:"
+msgstr "%(plugin_name)s sequentes mimi rationes procedere potest:"
+
+#: katalogus/templates/partials/boefje_tile.html
+msgid "This object type is required"
+msgstr "Hoc genus est requiri"
+
+#: katalogus/templates/partials/boefje_tile.html
+msgid "Scan level:"
+msgstr "Scan level:"
+
+#: katalogus/templates/partials/boefje_tile.html
+msgid "Publisher:"
+msgstr "Publisher:"
+
+#: katalogus/templates/partials/boefje_tile.html
+#: katalogus/templates/partials/plugin_tile.html
+#: katalogus/templates/partials/plugin_tile_modal.html
+msgid "See details"
+msgstr "Vide singula"
+
+#: katalogus/templates/partials/enable_disable_plugin.html
+msgid "Enable"
+msgstr "Admitte"
+
+#: katalogus/templates/partials/enable_disable_plugin.html
+#: rocky/templates/two_factor/profile/disable.html
+msgid "Disable"
+msgstr "inactivare"
+
+#: katalogus/templates/partials/katalogus_filter.html
+#: rocky/templates/findings/findings_filter.html
+#: rocky/templates/partials/ooi_list_filters.html
+#: rocky/templates/partials/organization_member_list_filters.html
+#: rocky/templates/tasks/partials/task_filter.html
+msgid "Hide filters"
+msgstr "Filtra celare"
+
+#: katalogus/templates/partials/katalogus_filter.html
+#: rocky/templates/findings/findings_filter.html
+#: rocky/templates/partials/ooi_list_filters.html
+#: rocky/templates/partials/organization_member_list_filters.html
+#: rocky/templates/tasks/partials/task_filter.html
+msgid "Show filters"
+msgstr "Filtra monstrare"
+
+#: katalogus/templates/partials/katalogus_filter.html
+#: rocky/templates/findings/findings_filter.html
+#: rocky/templates/partials/ooi_list_filters.html
+#: rocky/templates/partials/organization_member_list_filters.html
+#: rocky/templates/tasks/partials/task_filter.html
+msgid "applied"
+msgstr "applicatas"
+
+#: katalogus/templates/partials/katalogus_filter.html
+msgid "Filter plugins"
+msgstr "Filtrum plugins"
+
+#: katalogus/templates/partials/katalogus_filter.html
+msgid "Clear filter"
+msgstr "Patet filter"
+
+#: katalogus/templates/partials/katalogus_header.html
+#: katalogus/views/change_clearance_level.py katalogus/views/katalogus.py
+#: katalogus/views/katalogus_settings.py katalogus/views/plugin_detail.py
+#: katalogus/views/plugin_settings_add.py
+#: katalogus/views/plugin_settings_delete.py
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
+msgid "KAT-alogus"
+msgstr "KAT-alogus"
+
+#: katalogus/templates/partials/katalogus_header.html
+msgid "An overview of all available plugins."
+msgstr "Recensio omnium in promptu plugins."
+
+#: katalogus/templates/partials/katalogus_header.html
+#: katalogus/templates/plugin_settings_list.html
+#: katalogus/views/katalogus_settings.py tools/view_helpers.py
+#: rocky/templates/header.html
+#: rocky/templates/organizations/organization_list.html
+#: rocky/templates/organizations/organization_settings.html
+msgid "Settings"
+msgstr "Occasus"
+
+#: katalogus/templates/partials/katalogus_toolbar.html
+msgid "Gridview"
+msgstr "Gridview"
+
+#: katalogus/templates/partials/katalogus_toolbar.html
+msgid "Tableview"
+msgstr "Tableview"
+
+#: katalogus/templates/partials/modal_report_types.html
+msgid "Required for"
+msgstr "Requiritur enim"
+
+#: katalogus/templates/partials/modal_report_types.html
+msgid "report types"
+msgstr "referre types"
+
+#: katalogus/templates/partials/modal_report_types.html
+msgid "Report types for "
+msgstr "Report types for"
+
+#: katalogus/templates/partials/no_enabling_permission_message.html
+msgid "No permission to enable/disable plugins"
+msgstr "Nulla permission ut / disable plugins"
+
+#: katalogus/templates/partials/no_enabling_permission_message.html
+msgid "Contact your administrator to request permission."
+msgstr "Contact vestri administrator ad petendi licentiam."
+
+#: katalogus/templates/partials/objects_to_scan.html
+#, python-format
+msgid ""
+"This Boefje will only scan objects with a corresponding clearance level of "
+"<strong>L%(scan_level)s</strong> or higher. There is no indemnification for "
+"this Boefje to scan an OOI with a lower clearance level than "
+"<strong>L%(scan_level)s</strong>. Use the filter to show OOI's with a lower "
+"clearance level."
+msgstr ""
+"Hoc Boefje solum obiecta lustrabit cum alvi congruenti gradu "
+"<strong>L%(scan_level)s</strong> vel altioris. Nulla res indemnitas est "
+"huius Boefje ut emat OOI cum inferiore gradu alvi quam "
+"<strong>L%(scan_level)s</strong>. Colamento utere ut OOI ostendat cum gradu "
+"inferiore alvi."
+
+#: katalogus/templates/partials/objects_to_scan.html
+msgid "Warning scan level:"
+msgstr "Monitum scan planum:"
+
+#: katalogus/templates/partials/objects_to_scan.html
+msgid ""
+"Scanning OOI's with a lower clearance level will result in OpenKAT "
+"increasing the clearance level on that OOI, not only for this scan but from "
+"now on out, until it manually gets set to something else again. This means "
+"that all other enabled Boefjes will use this higher clearance level aswel."
+msgstr ""
+"ENARRATIO OOI' cum gradu alvi minore proveniet in OpenKAT alvi planitiem "
+"crescens in illo OOI, non solum ad hoc scan sed posthac exiens, donec ad "
+"aliud denuo manually recipiatur. Hoc significat omnia alia para Boefjes hac "
+"altiore alvi gradu tam bene utere."
+
+#: katalogus/templates/partials/objects_to_scan.html
+#, python-format
+msgid ""
+"You currently don't have any objects that meet the scan level of %(name)s. "
+"Add objects with a complying clearance level, or alter the clearance level "
+"of existing objects."
+msgstr ""
+"Nunc tibi non habes obiecta quae in %(name)s gradu occurrent. Obiecta addere"
+" cum gradu alvi obtempero, vel alvi deiectio exsistentium immutare gradum."
+
+#: katalogus/templates/partials/objects_to_scan.html
+#, python-format
+msgid ""
+"You currently don't have scannable objects for %(name)s. Add objects to use "
+"this Boefje. This Boefje is able to scan objects of the following types:"
+msgstr ""
+"Nunc es scannabilia obiecta pro %(name)s non habes. Obiecta adde hoc Boefje."
+" Haec Boefje obiecta speculari potest sequentium generum:"
+
+#: katalogus/templates/partials/plugin_settings_required.html
+msgid "The form could not be initialized."
+msgstr "Forma initialized non potest."
+
+#: katalogus/templates/partials/plugin_settings_required.html
+msgid "Required settings"
+msgstr "Requiritur occasus"
+
+#: katalogus/templates/partials/plugin_settings_required.html
+#: rocky/templates/partials/ooi_list_toolbar.html
+msgid "Add"
+msgstr "Add"
+
+#: katalogus/templates/partials/plugin_tile.html
+msgid "Required for:"
+msgstr "Requiritur enim:"
+
+#: katalogus/templates/partials/plugin_tile_modal.html
+msgid "Boefje details"
+msgstr "Boefje singula"
+
+#: katalogus/templates/partials/plugin_tile_modal.html reports/forms.py
+#: reports/templates/report_overview/report_history_table.html
+msgid "Report types"
+msgstr "Types Report"
+
+#: katalogus/templates/partials/plugin_tile_modal.html
+msgid "This boefje is required by the following report types."
+msgstr "Hoc boefje ab sequenti speciei fama requiritur."
+
+#: katalogus/templates/partials/plugin_tile_modal.html
+msgid "Go to boefje detail page"
+msgstr "Perge ad paginam detail boefje"
+
+#: katalogus/templates/partials/plugins.html
+msgid "Plugins overview:"
+msgstr "Plugins overview:"
+
+#: katalogus/templates/partials/plugins.html
+#: reports/templates/summary/selected_plugins.html
+msgid "Plugin name"
+msgstr "Nomen plugin"
+
+#: katalogus/templates/partials/plugins.html
+#: reports/templates/summary/selected_plugins.html
+msgid "Plugin type"
+msgstr "Plugin type"
+
+#: katalogus/templates/partials/plugins.html
+#: reports/templates/summary/selected_plugins.html
+msgid "Plugin description"
+msgstr "Plugin descriptio"
+
+#: katalogus/templates/partials/plugins.html
+#: reports/templates/partials/report_header.html
+#: reports/templates/report_overview/report_history_table.html
+#: rocky/templates/organizations/organization_list.html
+#: rocky/templates/organizations/organization_settings.html
+msgid "Actions"
+msgstr "Actiones"
+
+#: katalogus/templates/partials/plugins.html
+msgid "Detail page"
+msgstr "Detail pagina"
+
+#: katalogus/templates/partials/plugins_navigation.html
+#: reports/templates/report_overview/report_overview_navigation.html
+msgid "Plugins Navigation"
+msgstr "Plugins Navigation"
+
+#: katalogus/templates/partials/plugins_navigation.html
+#: rocky/templates/scan.html rocky/templates/tasks/boefjes.html
+#: rocky/templates/tasks/partials/tab_navigation.html rocky/views/tasks.py
+msgid "Boefjes"
+msgstr "Boefjes"
+
+#: katalogus/templates/partials/plugins_navigation.html
+#: rocky/templates/tasks/normalizers.html
+#: rocky/templates/tasks/partials/tab_navigation.html rocky/views/tasks.py
+msgid "Normalizers"
+msgstr "Normalizers"
+
+#: katalogus/templates/partials/plugins_navigation.html
+#: tools/forms/scheduler.py
+msgid "All"
+msgstr "All"
+
+#: katalogus/templates/plugin_container_image.html tools/forms/boefje.py
+msgid "Container image"
+msgstr "Continens imaginem"
+
+#: katalogus/templates/plugin_container_image.html
+msgid "The container image for this Boefje is:"
+msgstr "Continens imaginem huius Boefje est:"
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Variants"
+msgstr "Variantes"
+
+#: katalogus/templates/plugin_container_image.html
+msgid ""
+"Boefje variants that use the same container image. For more information "
+"about Boefje variants you can read the documentation."
+msgstr ""
+"Boefje variantes qui eadem imagine continente utuntur. Plura de variantibus "
+"Boefje documenta legere potes."
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Add variant"
+msgstr "Adde variant"
+
+#: katalogus/templates/plugin_container_image.html
+#: rocky/templates/partials/notifications_block.html
+msgid "confirmation"
+msgstr "confirmatio"
+
+#: katalogus/templates/plugin_container_image.html
+#, python-format
+msgid "Variant %(plugin.name)s created."
+msgstr "Variant %(plugin.name)s creatum est."
+
+#: katalogus/templates/plugin_container_image.html
+msgid "The Boefje variant is successfully created and can now be used."
+msgstr "Varians Boefje feliciter creatur et nunc adhiberi potest."
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Overview of variants"
+msgstr "Overview of variants"
+
+#: katalogus/templates/plugin_container_image.html
+#: reports/report_types/tls_report/report.html
+#: reports/templates/partials/plugin_overview_table.html
+#: rocky/templates/organizations/organization_member_list.html
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
+#: rocky/templates/tasks/ooi_detail_task_list.html
+#: rocky/templates/tasks/plugin_detail_task_list.html
+#: rocky/templates/tasks/reports.html
+msgid "Status"
+msgstr "Status"
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Age"
+msgstr "Aevum"
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Scan interval"
+msgstr "Scan intervallum"
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Run on"
+msgstr "Curre in"
+
+#: katalogus/templates/plugin_container_image.html
+msgid "current"
+msgstr "current"
+
+#: katalogus/templates/plugin_container_image.html
+#: reports/report_types/dns_report/report.html
+msgid "minutes"
+msgstr "minuta"
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Default system scan frequency"
+msgstr "Default ratio scan frequency"
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Boefje ID"
+msgstr "Boefje ID"
+
+#: katalogus/templates/plugin_container_image.html
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/modal_partials/rerun_modal.html
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/report_overview/subreports_table.html
+#: rocky/templates/tasks/reports.html
+msgid "Creation date"
+msgstr "Dies creationis"
+
+#: katalogus/templates/plugin_container_image.html tools/forms/boefje.py
+msgid "Arguments"
+msgstr "Argumenta"
+
+#: katalogus/templates/plugin_container_image.html
+msgid "The following arguments are used for this Boefje variant:"
+msgstr "Argumenta sequentia ad hoc variantes adhibentur Boefje:"
+
+#: katalogus/templates/plugin_container_image.html
+msgid "There are no arguments used for this Boefje variant."
+msgstr "Nullae rationes variantes huius Boefje adhibitae sunt."
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Edit variant"
+msgstr "Edit variant"
+
+#: katalogus/templates/plugin_container_image.html
+msgid "This Boefje has no variants yet."
+msgstr "Haec Boefje variantes nondum habet."
+
+#: katalogus/templates/plugin_container_image.html
+msgid ""
+"You can make a variant and change the arguments and JSON Schema to customize"
+" it to fit your needs."
+msgstr ""
+"Variare et mutare rationes potes ac Schema JSON ut id ad necessitates tuas "
+"accommodas."
+
+#: katalogus/templates/plugin_settings_add.html
+msgid "Add setting"
+msgid_plural "Add settings"
+msgstr[0] "Addere occasum"
+msgstr[1] "Addere occasus"
+
+#: katalogus/templates/plugin_settings_add.html
+msgid "Setting"
+msgid_plural "Settings"
+msgstr[0] "Profecta"
+msgstr[1] "Occasus"
+
+#: katalogus/templates/plugin_settings_add.html
+msgid "Add setting and enable boefje"
+msgid_plural "Add settings and enable boefje"
+msgstr[0] "Adde occasum et da boefje"
+msgstr[1] "Addere occasus et da boefje"
+
+#: katalogus/templates/plugin_settings_delete.html
+msgid "Delete settings"
+msgstr "Delere occasus"
+
+#: katalogus/templates/plugin_settings_delete.html
+#, python-format
+msgid ""
+"Are you sure you want to delete all settings for the plugin %(plugin_name)s?"
+msgstr "Visne vero omnes occasus pro plugin %(plugin_name)s delere?"
+
+#: katalogus/templates/plugin_settings_list.html
+msgid ""
+"In the table below the settings for this specific Boefje can be seen. Set or"
+" change the value of the variables by editing the settings."
+msgstr ""
+"In tabella infra uncinis pro certis Boefje videri possunt. Pone vel mutare "
+"valorem variabilium per uncinos emendo."
+
+#: katalogus/templates/plugin_settings_list.html
+msgid "Configure Settings"
+msgstr "Configurare Occasus"
+
+#: katalogus/templates/plugin_settings_list.html
+msgid "Overview of settings"
+msgstr "Overview of occasus"
+
+#: katalogus/templates/plugin_settings_list.html
+msgid "Variable"
+msgstr "Variabilis"
+
+#: katalogus/views/change_clearance_level.py
+msgid "Session has terminated, please select objects again."
+msgstr "Sessio finita est, quaeso, selecta iterum obiecta."
+
+#: katalogus/views/change_clearance_level.py
+msgid "Change clearance level"
+msgstr "Mutatio alvi gradu"
+
+#: katalogus/views/katalogus_settings.py
+msgid "Settings from {} to {} successfully cloned."
+msgstr "Occasus ab { } ad { } feliciter cloned ."
+
+#: katalogus/views/katalogus_settings.py
+#: katalogus/views/plugin_settings_list.py
+msgid "Failed getting settings for boefje {}"
+msgstr "Deficio questus occasus pro {boefje}"
+
+#: katalogus/views/mixins.py
+msgid ""
+"Getting information for plugin {} failed. Please check the KATalogus logs."
+msgstr ""
+"Informationes quaerendae pro plugin {} defuit. Quaeso reprehendo KATalogus "
+"acta."
+
+#: katalogus/views/plugin_detail.py
+msgid ""
+"Some selected OOIs needs an increase of clearance level to perform scans. "
+"You do not have the permission to change clearance level."
+msgstr ""
+"Nonnulli selecti OOIs incremento alvi deiectio eget ad lustras faciendas. "
+"Non habes licentiam alvi mutandi gradu."
+
+#: katalogus/views/plugin_enable_disable.py
+msgid "{} '{}' disabled."
+msgstr "{}' {}' disabled."
+
+#: katalogus/views/plugin_enable_disable.py
+msgid "{} '{}' enabled."
+msgstr "{ } ' { } ' enabled."
+
+#: katalogus/views/plugin_enable_disable.py
+msgid ""
+"You have not acknowledged your clearance level. Go to your profile page to "
+"acknowledge your clearance level."
+msgstr ""
+"Alvi deiectio non agnovistis. Vade ad paginam profile tuam ut alvi "
+"deiectionem tuam agnoscas."
+
+#: katalogus/views/plugin_enable_disable.py
+msgid ""
+"Your clearance level is not set. Go to your profile page to see your "
+"clearance or contact the administrator to set a clearance level."
+msgstr ""
+"Alvi vestra gradu non est. Vade ad paginam profile tuam ut alvi tuam alvi "
+"vel contactum videas ut administratorem gradum alvi constituas."
+
+#: katalogus/views/plugin_enable_disable.py
+msgid ""
+"Your clearance level is L{}. Contact your administrator to get a higher "
+"clearance level."
+msgstr ""
+"Tuae alvi deiectio est L{}. Contact vestri administratorem ut alvi altiorem "
+"gradum."
+
+#: katalogus/views/plugin_enable_disable.py
+msgid "To enable {} you need at least a clearance level of L{}. "
+msgstr "Ut {} possis saltem alvi deiectio ad L{}."
+
+#: katalogus/views/plugin_settings_add.py
+msgid "Trying to add settings to boefje without schema"
+msgstr "Conatur addere sine schemate ad occasus boefje"
+
+#: katalogus/views/plugin_settings_add.py
+msgid "No changes to the settings added: no form data present"
+msgstr "Nullae mutationes ad uncinis additae: nulla forma data present!"
+
+#: katalogus/views/plugin_settings_add.py
+msgid "Added settings for '{}'"
+msgstr "Adiectae sunt occasus pro '{}'"
+
+#: katalogus/views/plugin_settings_add.py
+msgid "Failed adding settings"
+msgstr "Deficio addendo occasus"
+
+#: katalogus/views/plugin_settings_add.py
+msgid "Enabling {} failed"
+msgstr "Ut {defecit}"
+
+#: katalogus/views/plugin_settings_add.py
+msgid "Boefje '{}' enabled."
+msgstr "Boefje '{}' enabled."
+
+#: katalogus/views/plugin_settings_add.py
+msgid "Add settings"
+msgstr "Addere occasus"
+
+#: katalogus/views/plugin_settings_delete.py
+msgid "Settings for plugin {} successfully deleted."
+msgstr "Optiones pro plugin {} feliciter deletae."
+
+#: katalogus/views/plugin_settings_delete.py
+msgid "Plugin {} has no settings."
+msgstr "Plugin {} occasus non habet."
+
+#: katalogus/views/plugin_settings_delete.py
+msgid ""
+"Failed deleting Settings for plugin {}. Check the Katalogus logs for more "
+"info."
+msgstr ""
+"Optiones ob plugin {} delendo defecerunt. Compesce tabulas Katalogus pro "
+"more info."
+
+#: onboarding/forms.py
+msgid ""
+"The clearance level determines how aggressive the object can be scanned by "
+"plugins. A higher clearance level means more aggressive scans are allowed."
+msgstr ""
+"Clearance level determines how aggressive the object can be scanned by "
+"plugins. Altior alvi gradu perlustrans infestior permittitur."
+
+#: onboarding/forms.py tools/forms/ooi.py
+msgid "explanation-clearance-level"
+msgstr "explicatio-alvi-gradu"
+
+#: onboarding/forms.py
+msgid "Please enter a valid URL starting with 'http://' or 'https://'."
+msgstr "Validum incipe URL incipiens ab 'http://' vel 'https://'."
+
+#: onboarding/templates/partials/onboarding_header.html
+msgid "Onboarding"
+msgstr "Onboarding"
+
+#: onboarding/templates/partials/step_1_introduction_text.html
+msgid "Welcome to OpenKAT!"
+msgstr "Salve! OpenKAT!"
+
+#: onboarding/templates/partials/step_1_introduction_text.html
+msgid ""
+"Welcome to the onboarding of OpenKAT. We will walk you through some steps to"
+" set everything up."
+msgstr ""
+"Grata in nave OpenKAT. Te per aliquot gradus ad omnia componenda "
+"ambulabimus."
+
+#: onboarding/templates/partials/step_1_introduction_text.html
+msgid ""
+"At the end of this onboarding you have added your first object, created your"
+" first DNS report and learned about some basic concepts used within OpenKAT."
+msgstr ""
+"In fine huius vectionis primum obiectum addidisti, primum tuum DNS famam "
+"creasti et de quibusdam notionibus intra OpenKAT adhibitis didicit."
+
+#: onboarding/templates/partials/step_1_introduction_text.html
+msgid "The full documentation for OpenKAT can be found at:"
+msgstr "Plena documenta de OpenKAT reperiri possunt:"
+
+#: onboarding/templates/partials/step_2_organization_text.html
+#: rocky/templates/organizations/organization_add.html
+msgid "Organization setup"
+msgstr "Organization setup"
+
+#: onboarding/templates/partials/step_2_organization_text.html
+msgid ""
+"Please enter the following organization details. The organization name can "
+"be changed later in the interface. The organization code cannot be changed "
+"as this is used by the database."
+msgstr ""
+"Please enter the following organization details. Nomen regiminis postea in "
+"interface mutari potest. Organizationis signum mutari non potest ut hoc a "
+"database adhibitum est."
+
+#: onboarding/templates/step_10_report.html
+#: reports/report_types/concatenated_report/report.py
+msgid "Report"
+msgstr "Report"
+
+#: onboarding/templates/step_10_report.html
+msgid "Boefjes are scanning"
+msgstr "Boefjes intuens"
+
+#: onboarding/templates/step_10_report.html
+msgid ""
+"The enabled Boefjes are running in the background to gather the data for "
+"your DNS Report. This may take a few minutes."
+msgstr ""
+"Possibile est Boefjes in curriculo currere ad notitias tuas DNS colligendas."
+" Hoc paucis minutis capere potest."
+
+#: onboarding/templates/step_10_report.html
+msgid ""
+"In the meantime you can explore OpenKAT and view your DNS Report on the "
+"Reports page once it has been generated."
+msgstr ""
+"Interim explorare potes OpenKAT et considera tuum DNS Report in "
+"Renuntiationibus pagina semel generata est."
+
+#: onboarding/templates/step_10_report.html
+msgid "Continue to OpenKAT"
+msgstr "Perge ad OpenKAT"
+
+#: onboarding/templates/step_1_introduction_registration.html
+#: onboarding/templates/step_1a_introduction.html
+msgid "Let's get started"
+msgstr "Demus incipias"
+
+#: onboarding/templates/step_2a_organization_setup.html
+#: onboarding/templates/step_2b_organization_update.html
+#: rocky/templates/organizations/organization_add.html
+#: rocky/templates/organizations/organization_settings.html
+#: rocky/templates/partials/organization_properties_table.html
+msgid "Organization details"
+msgstr "Organization details"
+
+#: onboarding/templates/step_2a_organization_setup.html
+#: rocky/templates/forms/json_schema_form.html
+#: rocky/templates/organizations/organization_add.html
+#: rocky/templates/organizations/organization_member_add.html
+#: rocky/templates/organizations/organization_member_add_account_type.html
+#: rocky/templates/partials/elements/ooi_detail_settings.html
+#: rocky/templates/partials/elements/ooi_report_settings.html
+#: rocky/templates/partials/form/indemnification_add_form.html
+#: rocky/templates/two_factor/_wizard_actions.html
+msgid "Submit"
+msgstr "Submit"
+
+#: onboarding/templates/step_2b_organization_update.html
+msgid "Submit changes"
+msgstr "Submit mutationes"
+
+#: onboarding/templates/step_2b_organization_update.html
+#: onboarding/templates/step_3_indemnification_setup.html
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+#: onboarding/templates/step_7_clearance_level_introduction.html
+msgid "Continue"
+msgstr "continue"
+
+#: onboarding/templates/step_3_indemnification_setup.html
+msgid "Indemnification setup"
+msgstr "Indemnification setup"
+
+#: onboarding/templates/step_3_indemnification_setup.html
+msgid "Indemnification on the organization is already present."
+msgstr "Redemptionis in ordinatione iam praesens est."
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+msgid "User clearance level"
+msgstr "User alvi gradu"
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+msgid ""
+"The user clearance level specifies the maximum scan level for security scans"
+" and the maximum clearance level you can assign to objects (e.g. a URL)."
+msgstr ""
+"Gradus alvi usoris designat maximum gradum ad scandendum ad securitatem "
+"lustrat et maximum alvi gradum obiectis assignare potes (v.g. a URL)."
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+msgid ""
+"The administrator assigns a maximum user clearance level to each user. This "
+"will make sure that only trusted users can start more aggressive scans."
+msgstr ""
+"Usor maximus gradus alvi usorum cuilibet administratori tribuit. Hoc fac ut "
+"tantum fiduciae utentes possit incipere incremento lustrat."
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+msgid ""
+"A user must accept a clearance level, before they perform actions in "
+"OpenKAT. Here you may accept the maximum trusted clearance level, as "
+"assigned by your administrator. On your user settings page you can choose to"
+" lower your accepted clearance level after completing the onboarding."
+msgstr ""
+"A user alvi deiectio accipere debet antequam actiones in OpenKAT peragant. "
+"Hic potest accipere gradum maximam alvi creditorum, ab administratore tuo "
+"assignatam. In usoris paginae tuae occasus eligere potes gradum acceptum "
+"alvi demittere, expleto onboarding."
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+msgid "What is my clearance level?"
+msgstr "Quid alvi deiectio mea est?"
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+#, python-format
+msgid ""
+"Unfortunately you cannot continue the onboarding. </br> Your administrator "
+"has trusted you with a clearance level of <strong>L%(tcl)s</strong>. </br> "
+"You need at least a clearance level of "
+"<strong>L%(dns_report_least_clearance_level)s</strong> to scan "
+"<strong>%(ooi)s</strong> </br> Contact your administrator to receive a "
+"higher clearance."
+msgstr ""
+"Infeliciter pergere non potes ad naves. </br> Administrator tuus te alvi "
+"delectu credidit <strong>L%(tcl)s</strong>. </br> Opus saltem alvi delectu "
+"<strong>L%(dns_report_least_clearance_level)s</strong> ad scan "
+"<strong>%(ooi)s</strong> </br> Contactum tuum administratorem ad altiorem "
+"alvi recipiendam."
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+#: onboarding/templates/step_5_add_scan_ooi.html
+#: onboarding/templates/step_6_set_clearance_level.html
+#: onboarding/templates/step_7_clearance_level_introduction.html
+#: onboarding/templates/step_8_setup_scan_select_plugins.html
+#: onboarding/templates/step_9_choose_report_type.html
+#: rocky/templates/partials/form/boefje_tiles_form.html
+msgid "Skip onboarding"
+msgstr "Skip onboarding"
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+#, python-format
+msgid ""
+"Your administrator has trusted you with a clearance level of "
+"<strong>L%(tcl)s</strong>. </br> You must first accept this clearance level "
+"to continue."
+msgstr ""
+"Administrator tuus te credidit gradu alvi de <strong>L%(tcl)s</strong>. "
+"</br> Hanc alvi deiectionem primo debes accipere ut pergas."
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+#, python-format
+msgid ""
+"Your administrator has <strong>trusted</strong> you with a clearance level "
+"of <strong>L%(tcl)s</strong>."
+msgstr ""
+"Administrator tuus <strong>trusit</strong> te alvi gradu "
+"<strong>L%(tcl)s</strong>."
+
+#: onboarding/templates/step_5_add_scan_ooi.html
+msgid "Add an object"
+msgstr "Addere objectum"
+
+#: onboarding/templates/step_5_add_scan_ooi.html
+msgid ""
+"OpenKAT uses various kinds of objects, like IP addresses, hostnames and "
+"URLs. In the onboarding we will add an URL object, such as our vulnerable "
+"OpenKAT website: https://mispo.es."
+msgstr ""
+"OpenKAT variis obiectis generibus utitur, ut IP inscriptiones, nomina et "
+"URLs. In in naves imposito obiecto URL addemus, ut vulnerabilem OpenKAT "
+"locum nostrum: https://mispo.es."
+
+#: onboarding/templates/step_5_add_scan_ooi.html
+#: rocky/templates/partials/ooi_detail_related_object.html
+msgid "Related objects"
+msgstr "Related objects"
+
+#: onboarding/templates/step_5_add_scan_ooi.html
+msgid ""
+"Most objects have dependencies on the existence of related objects. For "
+"example a URL needs to be connected to a network, hostname, fqdn (fully "
+"qualified domain name) and IP address. When possible OpenKAT automatically "
+"collects and adds these related objects by running scans. Objects can also "
+"be manually added."
+msgstr ""
+"Plurima obiecta habent dependentias ab existentia obiectis relatis. Exempli "
+"gratia a URL coniungi debet cum retis, hostname, fqdn (nomen dominii plene "
+"idonei) et IP inscriptionem. Cum fieri potest OpenKAT automatice colligit et"
+" haec obiecta obiecta per lustrat decursa addit. Accusativi etiam manually "
+"addi possunt."
+
+#: onboarding/templates/step_5_add_scan_ooi.html
+msgid "Create object"
+msgstr "Create object"
+
+#: onboarding/templates/step_6_set_clearance_level.html
+msgid "Set object clearance level"
+msgstr "Set quod alvi gradu"
+
+#: onboarding/templates/step_6_set_clearance_level.html
+msgid ""
+"After creating a new object you can set a clearance level for this object. A"
+" clearance level determines how aggressive the object can be scanned. A "
+"higher clearance level, means that more aggressive scans are allowed. "
+"Clearance levels can always be adjusted later on."
+msgstr ""
+"Post novum obiectum creando gradu alvi deiectio ad hoc obiectum potes "
+"ponere. Alvi planities decernit quam infestum obiectum lustrari potest. "
+"Superior alvi gradus, significat quod incremento lustrat permisit. Gradus "
+"Clearance semper postea accommodari possunt."
+
+#: onboarding/templates/step_6_set_clearance_level.html
+#, python-format
+msgid ""
+"For the onboarding we use a clearance level of "
+"L%(dns_report_least_clearance_level)s, meaning only informational scans are "
+"allowed."
+msgstr ""
+"Ad naves alvi utimur in gradu L%(dns_report_least_clearance_level)s, id est "
+"tantum scans informativum concessum est."
+
+#: onboarding/templates/step_6_set_clearance_level.html
+msgid "Set clearance level"
+msgstr "Set alvi gradu"
+
+#: onboarding/templates/step_7_clearance_level_introduction.html
+msgid "Plugin introduction"
+msgstr "Plugin introduction"
+
+#: onboarding/templates/step_7_clearance_level_introduction.html
+msgid ""
+"OpenKAT uses plugins to scan your objects. Each plugin has a scan level to "
+"specify how aggressive the scan is. Plugins can only scan those objects with"
+" a clearance level that is equal to, or higher than the scan level of the "
+"plugin. Plugin scan level are indicated by the number of cat paws."
+msgstr ""
+"OpenKAT plugins utitur ad res tuas lustrandas. Singula plugin gradu scan "
+"habet ut specificare quam pugnax scan sit. Plugins ea tantum scandere potest"
+" cum gradu alvi aequalem, vel altiorem quam scan libram plugin. Plugin scan "
+"planum numerum pedum felis indicantur."
+
+#: onboarding/templates/step_7_clearance_level_introduction.html
+msgid ""
+"The plugin <strong>DNS Zone</strong> has a scan level of 1, meaning that it "
+"performs non-intrusive scans which look for publicly available information. "
+"It scans objects with a clearance level of 1 or higher."
+msgstr ""
+"Plugin <strong>DNS Zona</strong> scapulas 1 habet, id est quod scans non-"
+"intrusivas exercet quae informationes publice praesto exspectant. Lustrat "
+"res cum alvi gradu 1 seu superiore."
+
+#: onboarding/templates/step_7_clearance_level_introduction.html
+msgid ""
+"The plugin <strong>Fierce</strong> has a scan level of 3, meaning that it "
+"more aggressive and could potentially break things. It scans objects with a "
+"clearance level of 3 or higher."
+msgstr ""
+"Plugin <strong>Ferum</strong> scopus habet gradum 3 significans quod "
+"infestior ac potentia res frangere potest. Lustrat res cum alvi gradu III "
+"vel superiore."
+
+#: onboarding/templates/step_8_setup_scan_select_plugins.html
+msgid "Enabling plugins and start scanning"
+msgstr "Enabling plugins et incipit intuens"
+
+#: onboarding/templates/step_8_setup_scan_select_plugins.html
+msgid ""
+"OpenKAT uses plugins to scan, check and analyze. There are three types of "
+"plugins."
+msgstr ""
+"OpenKAT plugins utitur ad lustrandum, reprimendum et resolvendum. Tria "
+"genera pluginorum sunt."
+
+#: onboarding/templates/step_8_setup_scan_select_plugins.html
+msgid ""
+"The first plugin are <b>Boefjes</b>, which scan objects for data. These are "
+"security tools like nmap, LeakIX and WPscan. </p>"
+msgstr ""
+"Primae plugin sunt <b>Boefjes</b>, quae obiecta pro notitia scan. Haec "
+"instrumenta securitatis sicut nmap, LeakIX et WPscan sunt. </p>"
+
+#: onboarding/templates/step_8_setup_scan_select_plugins.html
+msgid ""
+"The other two plugins are <b>Normalizers</b> and <b>Bits</b>, which are used"
+" to process the output of Boefjes. They can create findings and related "
+"objects. Bits are also used to create organization specific findings, based "
+"on policy requirements. </p>"
+msgstr ""
+"Reliqua duo plugins sunt <b>Normalizers</b> et <b> Bits</b>, quae ad "
+"processum extra Boefjes adhibentur. Inventiones et affines res creare "
+"possunt. Frena etiam ad certas inventiones formandas adhibentur, quae ad "
+"consilium requisita pertinent. </p>"
+
+#: onboarding/templates/step_8_setup_scan_select_plugins.html
+msgid ""
+"For the onboarding we will enable the Boefjes shown below. Once enabled "
+"these Boefjes gather publicly available information on suitable objects with"
+" a clearance level of 1 or higher. Normalizers and Bits are enabled by "
+"default."
+msgstr ""
+"In navigiis Boefjes infra ostendetur. Postquam hae Boefjes permiserunt, "
+"palam praesto notitias de rebus opportunis cum alvi gradu 1 vel superiore "
+"colligentes. Normalizers ac frena per defaltam valeant."
+
+#: onboarding/templates/step_8_setup_scan_select_plugins.html
+msgid "Enable and continue"
+msgstr "Admitte ac permanere"
+
+#: onboarding/templates/step_9_choose_report_type.html
+msgid "Generate a report"
+msgstr "Generate fama"
+
+#: onboarding/templates/step_9_choose_report_type.html
+msgid ""
+"Reports can be used to gain more insights in your organizations assets. You "
+"can generate different types of reports in OpenKAT. Each report may require "
+"one or more plugins that provide the input for the report."
+msgstr ""
+"Renuntiationes in bonis Institutis tuis plures perceptiones lucrari possunt."
+" Diversas relationes generare potes in OpenKAT. Quaelibet relatio unum vel "
+"plura plugins requirere potest quae relationem initus praebere potest."
+
+#: onboarding/templates/step_9_choose_report_type.html
+msgid ""
+"For the onboarding we will generate a DNS report for your added URL. In the "
+"previous step you enabled the required plugins for this report."
+msgstr ""
+"In navigio enim generabimus famam DNS tuae additae URL. In priore gradu "
+"plugins inquisitionis huius famae permisistis."
+
+#: onboarding/templates/step_9_choose_report_type.html
+msgid "Generate DNS Report"
+msgstr "Generare DNS Report"
+
+#: onboarding/view_helpers.py
+msgid "1: Welcome"
+msgstr "I: Welcome"
+
+#: onboarding/view_helpers.py
+msgid "2: Organization setup"
+msgstr "II: Organization setup"
+
+#: onboarding/view_helpers.py
+msgid "3: Add object"
+msgstr "III, addere object"
+
+#: onboarding/view_helpers.py
+msgid "4: Plugins"
+msgstr "4: Plugins"
+
+#: onboarding/view_helpers.py
+msgid "5: Generating report"
+msgstr "V;"
+
+#: onboarding/views.py
+#, python-brace-format
+msgid "{org_name} successfully created."
+msgstr "{org_name} feliciter creatus est."
+
+#: onboarding/views.py
+#, python-brace-format
+msgid "{org_name} successfully updated."
+msgstr "{org_name} feliciter renovatum est."
+
+#: onboarding/views.py
+msgid "Creating an object"
+msgstr "Creando objectum"
+
+#: onboarding/views.py
+msgid "Fetch the parent DNS zone of a hostname"
+msgstr "Accipe parentem zonam DNS hostname"
+
+#: onboarding/views.py
+msgid "Finds subdomains by brute force"
+msgstr "Subdomains invenit violente"
+
+#: onboarding/views.py
+msgid "Please select a plugin to proceed."
+msgstr "Placere eligere plugin procedere."
+
+#: onboarding/views.py
+msgid "Please select all required plugins to proceed."
+msgstr "Placere eligere requiritur tincidunt procedere."
+
+#: onboarding/views.py reports/views/aggregate_report.py
+#: reports/views/generate_report.py
+msgid "An error occurred while enabling {}. The plugin is not available."
+msgstr "Error occurrit cum {}. Plugin praesto non est."
+
+#: onboarding/views.py
+msgid "Plugins successfully enabled."
+msgstr "Plugins feliciter para."
+
+#: onboarding/views.py
+msgid "Web URL not found."
+msgstr "Tela URL non invenitur."
+
+#: onboarding/views.py
+msgid ""
+"Your report is scheduled for generation in about 3 minutes, as we are "
+"waiting for Boefjes to complete. In the meantime get familiar with OpenKAT "
+"and visit the Reports History tab later."
+msgstr ""
+"Renuntiatio tua generationi circiter 3 minutarum horarum est, exspectantes "
+"Boefjes ad perficiendum. Interea nota cum OpenKAT ac postea Renuntiationes "
+"Historiae tab visita."
+
+#: reports/forms.py tools/forms/ooi_form.py
+msgid "Filter by OOI types"
+msgstr "Filtrum per OOI genera"
+
+#: reports/forms.py
+msgid "Today"
+msgstr "hodie"
+
+#: reports/forms.py
+msgid "Different date"
+msgstr "Alia date"
+
+#: reports/forms.py
+msgid "No, just once"
+msgstr "Non, semel"
+
+#: reports/forms.py
+msgid "Yes, repeat"
+msgstr "Ita, iterare"
+
+#: reports/forms.py
+msgid "Start date"
+msgstr "Satus date"
+
+#: reports/forms.py
+msgid "Start time (UTC)"
+msgstr "Tempus initium (UTC)"
+
+#: reports/forms.py
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Recurrence"
+msgstr "Recursus"
+
+#: reports/forms.py
+msgid "No recurrence, just once"
+msgstr "Nulla recursu, semel tantum"
+
+#: reports/forms.py
+msgid "Daily"
+msgstr "Cotidiana"
+
+#: reports/forms.py
+msgid "Weekly"
+msgstr "Weekly"
+
+#: reports/forms.py
+msgid "Monthly"
+msgstr "Menstrua"
+
+#: reports/forms.py
+msgid "Yearly"
+msgstr "annuatim"
+
+#: reports/forms.py
+msgid "day"
+msgstr "dies"
+
+#: reports/forms.py
+msgid "week"
+msgstr "hebdomadis"
+
+#: reports/forms.py
+msgid "month"
+msgstr "mensis"
+
+#: reports/forms.py
+msgid "year"
+msgstr "annus"
+
+#: reports/forms.py
+msgid "Never"
+msgstr "numquam"
+
+#: reports/forms.py
+msgid "On"
+msgstr "On"
+
+#: reports/forms.py
+msgid "After"
+msgstr "Post"
+
+#: reports/forms.py
+msgid "Report name format"
+msgstr "Report nomen forma"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: reports/report_types/multi_organization_report/appendix.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Appendix"
+msgstr "Appendix"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Currently filtered on"
+msgstr "Currently percolantur in"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: reports/templates/partials/report_sidemenu.html
+#: reports/templates/summary/report_asset_overview.html
+msgid "Selected Report Types"
+msgstr "Electus Report Genera"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Selected report types"
+msgstr "Types fama electus"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: reports/templates/partials/plugin_overview_table.html
+#: reports/templates/report_overview/modal_partials/rename_modal.html
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+#: reports/templates/report_overview/subreports_table.html
+#: reports/templates/summary/report_asset_overview.html
+msgid "Report type"
+msgstr "Report type"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Service Versions and Health"
+msgstr "Service Version and Health"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Service, version and health"
+msgstr "Operatio, versio et sanitas"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: reports/templates/summary/service_health.html rocky/templates/footer.html
+#: rocky/templates/health.html
+msgid "Service"
+msgstr "Service"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: reports/templates/summary/service_health.html rocky/templates/health.html
+msgid "Version"
+msgstr "Version"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: rocky/templates/footer.html rocky/views/health.py
+msgid "Health"
+msgstr "Salus"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: rocky/templates/health.html
+msgid "Healthy"
+msgstr "Sanus"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Unhealthy"
+msgstr "incuratus"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Used Config objects"
+msgstr "Mando obiecti usus"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Used config objects"
+msgstr "Used aboutconfig objects"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Primary Key"
+msgstr "Primaria Key"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Bit ID"
+msgstr "Bit ID"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Config"
+msgstr "Mando"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "No config objects found."
+msgstr "No aboutconfig objects found."
+
+#: reports/report_types/aggregate_organisation_report/asset_overview.html
+#: reports/report_types/multi_organization_report/asset_overview.html
+#: reports/templates/partials/generate_report_sidemenu.html
+#: reports/templates/partials/report_sidemenu.html
+#: reports/templates/summary/report_asset_overview.html
+msgid "Asset overview"
+msgstr "Asset overview"
+
+#: reports/report_types/aggregate_organisation_report/asset_overview.html
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid ""
+"An overview of the manually released scanned assets. Assets in "
+"<strong>bold</strong> are taken as a starting point, assets that are not in "
+"bold were found by OpenKAT itself."
+msgstr ""
+"Perspectio manually dimissi lustrabat bona. Res in <strong>bold</strong> "
+"initium sumuntur, res quae non audaciter inventae sunt ipsa OpenKAT."
+
+#: reports/report_types/aggregate_organisation_report/basic_security.html
+#: reports/report_types/aggregate_organisation_report/report.html
+msgid "Overview of the basic security status"
+msgstr "Overview of the basic securitatem status"
+
+#: reports/report_types/aggregate_organisation_report/basic_security.html
+msgid ""
+"This table provides an overview of the basic security status of the known "
+"assets. Basic security in order. In principle, all values in this table "
+"should be checked off."
+msgstr ""
+"Haec tabula percontationem praebet status securitatis fundamentalis bonorum "
+"notorum. Praesent ut placerat diam. In principio, omnia bona in hac tabula "
+"cohibenda sunt."
+
+#: reports/report_types/aggregate_organisation_report/basic_security.html
+msgid "Basic security status"
+msgstr "Basic securitatis status"
+
+#: reports/report_types/aggregate_organisation_report/basic_security.html
+#: reports/report_types/ipv6_report/report.html
+#: reports/report_types/multi_organization_report/ipv6.html
+#: reports/report_types/systems_report/report.html
+msgid "System type"
+msgstr "Ratio generis"
+
+#: reports/report_types/aggregate_organisation_report/basic_security.html
+#: reports/report_types/aggregate_organisation_report/report.html
+#: reports/report_types/multi_organization_report/basic_security_details.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Safe connections"
+msgstr "hospites tutum"
+
+#: reports/report_types/aggregate_organisation_report/basic_security.html
+msgid "System Specific"
+msgstr "Systema Imprimis"
+
+#: reports/report_types/aggregate_organisation_report/basic_security.html
+msgid "RPKI"
+msgstr "RPKI"
+
+#: reports/report_types/aggregate_organisation_report/basic_security.html
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/rpki_report/report.html
+#: reports/report_types/safe_connections_report/report.html
+msgid "server"
+msgstr "server"
+
+#: reports/report_types/aggregate_organisation_report/findings.html
+#: reports/report_types/aggregate_organisation_report/report.html
+msgid ""
+"This chapter contains information about the findings that have been "
+"identified for this organization."
+msgstr ""
+"Hoc caput continet informationes de inventionibus quae huic organizationi "
+"notatae sunt."
+
+#: reports/report_types/aggregate_organisation_report/recommendations.html
+#: reports/report_types/multi_organization_report/recommendations.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Recommendations"
+msgstr "Commendationes"
+
+#: reports/report_types/aggregate_organisation_report/recommendations.html
+#, python-format
+msgid "There is <i>%(total_findings)s</i> vulnerability"
+msgid_plural "There are <i>%(total_findings)s</i> vulnerabilities"
+msgstr[0] "Est vulnerabilitas <i>%(total_findings)s</i>"
+msgstr[1] "Sunt vulnerabilities <i>%(total_findings)s</i>"
+
+#: reports/report_types/aggregate_organisation_report/recommendations.html
+#, python-format
+msgid "found on <i>%(total_systems)s</i> system."
+msgid_plural "found on <i>%(total_systems)s</i> systems."
+msgstr[0] "<i>%(total_systems)s</i> invenitur."
+msgstr[1] "inveni in <i>%(total_systems)s</i> systemata."
+
+#: reports/report_types/aggregate_organisation_report/recommendations.html
+#: reports/report_types/multi_organization_report/recommendations.html
+msgid "There are no recommendations."
+msgstr "Commendationes nullae sunt."
+
+#: reports/report_types/aggregate_organisation_report/report.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Basic security"
+msgstr "Basic securitatis"
+
+#: reports/report_types/aggregate_organisation_report/report.html
+msgid ""
+"In this chapter, first a table of compliance checks is displayed, followed "
+"by a detailed examination of compliance issues for each component."
+msgstr ""
+"In hoc capite, primum tabula obsequiorum compescit quae proponitur, deinde "
+"singillatim examini subiciuntur quaestiones pro singulis componentibus."
+
+#: reports/report_types/aggregate_organisation_report/report.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "System specific"
+msgstr "Systema specificum"
+
+#: reports/report_types/aggregate_organisation_report/report.html
+#: reports/report_types/multi_organization_report/basic_security_details.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Resource Public Key Infrastructure"
+msgstr "Resource Publica Key Infrastructure"
+
+#: reports/report_types/aggregate_organisation_report/report.html
+#: reports/report_types/aggregate_organisation_report/vulnerabilities.html
+#: reports/report_types/multi_organization_report/vulnerabilities.html
+#: reports/report_types/vulnerability_report/report.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Vulnerabilities"
+msgstr "Vulnerabilities"
+
+#: reports/report_types/aggregate_organisation_report/report.html
+#: reports/report_types/aggregate_organisation_report/vulnerabilities.html
+msgid "Vulnerabilities found are grouped per system."
+msgstr "Vulnerabilitates inventae per systema comprehenduntur."
+
+#: reports/report_types/aggregate_organisation_report/report.py
+msgid "Aggregate Organisation Report"
+msgstr "Subgenera Unitarum Report"
+
+#: reports/report_types/aggregate_organisation_report/rpki.html
+#: reports/report_types/multi_organization_report/basic_security_details.html
+msgid ""
+"This section contains basic security information about resource public key "
+"infrastructure. If your web server employs RPKI for its IP addresses and "
+"associated nameservers, then it enhances visitor protection against "
+"misconfigurations and malicious route intercepts through verified route "
+"announcements, ensuring reliable server access and secure internet traffic."
+msgstr ""
+"Haec sectio praecipuas informationes securitatis continet de subsidiis "
+"publicis clavibus infrastructuris. Si servo interretiali tuo RPKI adhibito "
+"IP inscriptionibus et nominibus adiunctis adhibitis, tunc visitatorem "
+"praesidium contra deceptiones auget et iter malitiosum per nuntiationes "
+"verificatas intercipit, pro certo servo accessum et securam interretialem "
+"negotiationem."
+
+#: reports/report_types/aggregate_organisation_report/safe_connections.html
+#: reports/report_types/multi_organization_report/basic_security_details.html
+msgid ""
+"In this chapter we check if the connections of all the IP ports of the "
+"system are safe. Safe connections are important to prevent unauthorised "
+"access and data breaches. Strong ciphers are crucial because they ensure "
+"strong encryption which protects the data from interception during "
+"communiction."
+msgstr ""
+"In hoc capite reprimimus si nexus omnium IP portus systematis salvi sunt. "
+"Coniunctiones tutae magni momenti sunt ad impedimenta non legitimis accessus"
+" et notitiae praecavendas. Fortis notae cruciales sunt quia encryptionem "
+"validam curant quae notitias ab interceptione in communicatione custodit."
+
+#: reports/report_types/aggregate_organisation_report/summary.html
+#: reports/report_types/multi_organization_report/summary.html
+#: rocky/views/ooi_tree.py
+msgid "Summary"
+msgstr "Summary"
+
+#: reports/report_types/aggregate_organisation_report/summary.html
+msgid "Critical Vulnerabilities"
+msgstr "Vulnerabilities critica"
+
+#: reports/report_types/aggregate_organisation_report/summary.html
+msgid "IPs scanned"
+msgstr "IPs scanned"
+
+#: reports/report_types/aggregate_organisation_report/summary.html
+msgid "Hostnames scanned"
+msgstr "Hostnames lustrabat lumine"
+
+#: reports/report_types/aggregate_organisation_report/summary.html
+msgid "Terms in report"
+msgstr "Termini in fama"
+
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/rpki_report/report.html
+#: reports/report_types/safe_connections_report/report.html
+#, python-format
+msgid ""
+"This table shows which checks were performed. Following that, the compliance"
+" issues, if any, are shown for each %(type)s Server."
+msgstr ""
+"Haec tabula spectaculorum quae fiebant cohibitae sunt. Post hoc, quaestiones"
+" obsequentes, si quae sunt, singulis %(type)s Servo monstrantur."
+
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+msgid "Check overview"
+msgstr "Reprehendo overview"
+
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/mail_report/report.html
+#: reports/report_types/multi_organization_report/basic_security_details.html
+#: reports/report_types/name_server_report/report.html
+#: reports/report_types/rpki_report/report.html
+#: reports/report_types/safe_connections_report/report.html
+#: reports/report_types/web_system_report/report.html
+msgid "Check"
+msgstr "Check"
+
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/mail_report/report.html
+#: reports/report_types/name_server_report/report.html
+#: reports/report_types/rpki_report/report.html
+#: reports/report_types/safe_connections_report/report.html
+#: reports/report_types/web_system_report/report.html
+msgid "Compliance"
+msgstr "Obsequium"
+
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/rpki_report/report.html
+msgid "IPs are compliant"
+msgstr "IPs obsequentes sunt"
+
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/safe_connections_report/report.html
+#: reports/report_types/vulnerability_report/report.html
+msgid "Host:"
+msgstr "Hospes:"
+
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/mail_report/report.html
+#: reports/report_types/name_server_report/report.html
+#: reports/report_types/rpki_report/report.html
+#: reports/report_types/safe_connections_report/report.html
+#: reports/report_types/web_system_report/report.html
+msgid "Compliance issue"
+msgstr "Obsequium exitus"
+
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/mail_report/report.html
+#: reports/report_types/name_server_report/report.html
+#: reports/report_types/rpki_report/report.html
+#: reports/report_types/safe_connections_report/report.html
+#: reports/report_types/vulnerability_report/report.html
+#: reports/report_types/web_system_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/partials/report_severity_totals_table.html
+#: rocky/templates/partials/ooi_report_findings_block_table.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid "Risk level"
+msgstr "Periculum level"
+
+#: reports/report_types/aggregate_organisation_report/system_specific_overview.html
+#: reports/report_types/multi_organization_report/basic_security_details.html
+msgid ""
+"This is where checks are done that are specific to system types. Different "
+"security and compliance issues come into play for different systems. They "
+"are listed here under each other."
+msgstr ""
+"Hoc est, ubi compescit facta quae sunt propria genera systematis. Diversae "
+"securitatis et obsequii quaestiones pro diversis systematibus oriuntur. Hic "
+"sub invicem recensentur."
+
+#: reports/report_types/aggregate_organisation_report/term_overview.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Term Overview"
+msgstr "Term Overview"
+
+#: reports/report_types/aggregate_organisation_report/term_overview.html
+msgid "For definitions of terms used in this chapter, see the glossary below."
+msgstr "Definitiones vocabulorum in hoc capite, vide Glossarium infra."
+
+#: reports/report_types/aggregate_organisation_report/term_overview.html
+msgid ""
+"Web servers and domains are examples of digital assets within this "
+"framework. Web servers are essential for hosting and serving websites or web"
+" applications, while domains represent the online addresses used to access "
+"these resources. Other examples of assets in the IT realm include databases,"
+" user accounts, software applications, and networking infrastructure. Asset "
+"management is a critical aspect of cybersecurity, involving the "
+"identification, classification, and protection of these assets to safeguard "
+"against threats and ensure the overall security and functionality of an "
+"organization's IT environment."
+msgstr ""
+"Interretiales servientes et dominia exempla bonorum digitalium intra hoc "
+"compage sunt. Servitores interreti necessarii sunt websites vel "
+"applicationes interreti obnoxii et servientes, cum dominia repraesentant "
+"inscriptiones interretiales ad has facultates accedere. Alia exempla bonorum"
+" in IT regno includunt databases, rationes usoris, applicationes software, "
+"et infrastructuram networking. Res procuratio critica aspectus "
+"cyberseculitatis est, quae identificatio, classificationis, et tutela horum "
+"bonorum ad minis tutandum et ad altiorem securitatem et ad functionem "
+"organizationis IT environment pertinet."
+
+#: reports/report_types/aggregate_organisation_report/term_overview.html
+msgid ""
+"Multiple hostnames that resolve to one IP address where at least one of the "
+"hostnames or the IP address has a declared scan level that is at least L1. "
+"Type systems are web servers, mail servers and name servers (DNS)."
+msgstr ""
+"Multiplices hostnames quae uni IP proponunt, ubi saltem unus ex hostnamis "
+"vel IP inscriptionem habet indicatam scapulas quae est saltem L1. Systemata "
+"interretialia sunt servientes, electronici servi et nomen ministrantium "
+"(DNS)."
+
+#: reports/report_types/aggregate_organisation_report/term_overview.html
+msgid ""
+"A fundamental component of the client-server model. A web server uses "
+"protocols like HTTP or HTTPS to facilitate communication between clients and"
+" the server."
+msgstr ""
+"Fundamentum fundamentale exemplar clientis. Servo interretiali protocolla "
+"utitur sicut HTTP vel HTTPS ad communicationem faciliorem inter clientes et "
+"ministratorem."
+
+#: reports/report_types/aggregate_organisation_report/term_overview.html
+msgid ""
+"A mail server is a specialized software application or hardware device that "
+"facilitates the sending, receiving, and storage of emails within a computer "
+"network. Operating on the Simple Mail Transfer Protocol (SMTP) for outgoing "
+"messages and either Internet Message Access Protocol (IMAP) or Post Office "
+"Protocol (POP) for incoming messages, a mail server manages email "
+"communication by routing messages between users and storing them until they "
+"are retrieved. The server ensures the efficient and secure transfer of "
+"emails, handling tasks such as authentication, spam filtering, and message "
+"storage."
+msgstr ""
+"A mail server peculiarised software application vel ferramenta fabrica quae "
+"faciliorem reddit missionem, acceptionem et repositam electronicarum intra "
+"retiaculis computatris. Operans in Simplici Translatio Protocollum (SMTP) "
+"pro nuntiis ac nuntiis interretialibus Obvius Protocollum vel (IMAP) vel "
+"Protocollum Post Office (POP) epistularum ineuntes, electronicae servientis "
+"communicationem electronicam procurant fundis nuntiis inter utentes et "
+"recondendos donec reddantur. Servo efficit efficacem et securam "
+"translationem inscriptionem, negotia tractantem ut authenticas, spamma "
+"eliquandi, nuntium repositionis."
+
+#: reports/report_types/aggregate_organisation_report/term_overview.html
+msgid ""
+"A nameserver, or Domain Name System (DNS) server, is a critical component of"
+" the internet infrastructure responsible for translating human-readable "
+"domain names into IP addresses, enabling the seamless navigation of the web."
+" When a user enters a domain name in a web browser, the nameserver is "
+"queried to obtain the corresponding IP address of the server hosting the "
+"associated website or service."
+msgstr ""
+"A nameservo, seu Systema Domain (DNS) servo criticum est componentia "
+"interrete infrastructure responsabilis nomina domain humana in IP in "
+"inscriptionibus transferendis, ut inconsutilem navigationem interretialem "
+"efficiat. Cum user nomen domain in navigatro interretiali intrat, nominator "
+"queritur ut debitam IP obtineat electronicam servientis website vel servitii"
+" consociati obnoxii."
+
+#: reports/report_types/aggregate_organisation_report/term_overview.html
+msgid ""
+"A DICOM server, which stands for Digital Imaging and Communications in "
+"Medicine, is a specialized server designed for the storage, retrieval, and "
+"exchange of medical images and related information in the healthcare "
+"industry. DICOM is a widely adopted standard that ensures interoperability "
+"and consistency in the communication of medical images and associated data "
+"among different devices and systems, such as medical imaging equipment, "
+"picture archiving and communication systems (PACS), and radiology "
+"information systems (RIS). DICOM servers store and manage patient-specific "
+"medical images, like X-rays, CT scans, and MRIs, utilizing a standardized "
+"format."
+msgstr ""
+"A DICOM cultor, qui stat pro Imaging et Communicationes Digitales in "
+"Medicina, peculiaris est cultor ad repositionis, retrievalis, commutationis "
+"imaginum medicarum et relatarum informationum in cura sanitatis. DICOM "
+"vexillum est late adoptivum quod praestat interoperabilitatem et constantiam"
+" in communicatione imaginum medicarum et inter varias machinas et systemata "
+"sociata, sicut instrumenta imaginatio medicinae, picturae archivi et "
+"systemata communicationis (PACS), et rationum notitiarum radiologiae (RIS). "
+"DICOM servientibus reponunt et disponunt imagines medicas patientis "
+"speciales, sicut X-radii, CT scans, et MRIs, forma normatis adhibendis."
+
+#: reports/report_types/aggregate_organisation_report/vulnerabilities.html
+#: reports/report_types/multi_organization_report/vulnerabilities.html
+msgid "No CVEs have been found."
+msgstr "Nulla CVEs inventa est."
+
+#: reports/report_types/dns_report/report.html
+msgid "Records found"
+msgstr "records found"
+
+#: reports/report_types/dns_report/report.html
+msgid ""
+"The DNS report gives an overview of the DNS records that were found for the "
+"DNSZone. Additionally the security measures table shows whether or not DNS "
+"relating security measures are enabled."
+msgstr ""
+"Renuntiatio DNS recognitionem dat de DNS monumentis qui pro DNSZone reperti "
+"sunt. Accedit quod mensurae securitatis mensam ostendit num DNS necne quae "
+"mensurae securitatis valeant."
+
+#: reports/report_types/dns_report/report.html
+msgid ""
+"<strong>Disclaimer:</strong> Not all DNSRecords are parsed in OpenKAT. DNS "
+"record types that are parsed and could be displayed in the table are:"
+msgstr ""
+"<strong>Disclaimer:</strong> Non omnes DNSRecords in OpenKAT parsed. DNS "
+"genera recordationis parsed et exponi poterant in tabula sunt:"
+
+#: reports/report_types/dns_report/report.html
+msgid "All existing DNS record types can be found here:"
+msgstr "Omnes DNS rationes recordum hic inveniuntur:"
+
+#: reports/report_types/dns_report/report.html
+msgid "Record"
+msgstr "Record"
+
+#: reports/report_types/dns_report/report.html
+msgid "TTL"
+msgstr "TTL"
+
+#: reports/report_types/dns_report/report.html
+msgid "Data"
+msgstr "Data"
+
+#: reports/report_types/dns_report/report.html
+msgid "No records have been found."
+msgstr "No records have been found."
+
+#: reports/report_types/dns_report/report.html
+msgid "Security measures"
+msgstr "Securitatis mensurae"
+
+#: reports/report_types/dns_report/report.html
+msgid ""
+"The security measures table below shows which DNS relating security measures"
+" are enabled based on the contents of the DNS records."
+msgstr ""
+"Mensa securitatis infra mensuras ostendit quibus DNS mensurae securitatis "
+"referentes valeant in contentis in DNS tabulis."
+
+#: reports/report_types/dns_report/report.html
+#: reports/templates/partials/report_ooi_list.html
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/modal_partials/rerun_modal.html
+#: reports/templates/summary/ooi_selection.html tools/forms/ooi.py
+#: rocky/templates/partials/elements/ooi_tree_condensed_table.html
+#: rocky/templates/partials/explanations.html
+#: rocky/templates/partials/ooi_detail_related_object.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+#: rocky/views/mixins.py
+msgid "Type"
+msgstr "Type"
+
+#: reports/report_types/dns_report/report.html
+msgid "Yes"
+msgstr "Ita"
+
+#: reports/report_types/dns_report/report.html
+msgid "No"
+msgstr "No"
+
+#: reports/report_types/dns_report/report.html
+#: reports/templates/partials/report_findings_table.html
+msgid "Other findings found"
+msgstr "Inventa alia"
+
+#: reports/report_types/dns_report/report.html
+msgid "Findings information"
+msgstr "Inventiones informationes"
+
+#: reports/report_types/dns_report/report.py
+msgid "DNS Report"
+msgstr "DNS Report"
+
+#: reports/report_types/dns_report/report.py
+msgid ""
+"DNS reports focus on domain name system configuration and potential "
+"weaknesses."
+msgstr ""
+"DNS refert focus in nomen domain systematis configuratione ac debilitates "
+"potentiales."
+
+#: reports/report_types/findings_report/report.html
+msgid ""
+"The Findings Report contains information about the findings that have been "
+"identified for the selected asset and organization."
+msgstr ""
+"Inventiones Report informationes continet de Inventionibus quae notatae sunt"
+" pro dignissim et ordinandis delectis."
+
+#: reports/report_types/findings_report/report.py
+msgid "Findings Report"
+msgstr "Inventiones Report"
+
+#: reports/report_types/findings_report/report.py
+msgid "Shows all the finding types and their occurrences."
+msgstr "Omnibus inventis generibus earumque eventuum ostendit."
+
+#: reports/report_types/ipv6_report/report.html
+msgid ""
+"The IPv6 report provides an overview of the current IPv6 status of the "
+"identified system. The table below shows whether the domain is reachable "
+"over IPv6 or not. A green compliance check is shown if this is the case. A "
+"grey compliance cross is shown if no IPv6 address was detected."
+msgstr ""
+"Renuntiatio IPv6 prospectum praebet hodiernae IPv6 status systematis "
+"identificati. Mensa infra ostendit utrum dominium per IPv6 attingibile sit "
+"necne. Viridis obsequium perscriptio ostenditur si ita est. Crux obsequio "
+"cinerea ostenditur, si nulla IPv6 inscriptio detecta est."
+
+#: reports/report_types/ipv6_report/report.html
+msgid "IPv6 overview"
+msgstr "IPv6 overview"
+
+#: reports/report_types/ipv6_report/report.html
+#: reports/report_types/systems_report/report.html
+msgid "Domain"
+msgstr "Domain"
+
+#: reports/report_types/ipv6_report/report.py
+msgid "IPv6 Report"
+msgstr "IPv6 Report"
+
+#: reports/report_types/ipv6_report/report.py
+msgid "Check whether hostnames point to IPv6 addresses."
+msgstr "Reprehendo num hostnames designent inscriptiones IPv6."
+
+#: reports/report_types/mail_report/report.html
+msgid ""
+"The Mail Report provides an overview of the compliance checks associated "
+"with email servers. The current compliance checks the presence of SPF, DKIM "
+"and DMARC records. The table below shows for each of these checks how many "
+"of the identified mail servers are compliant, and if applicable a compliance"
+" issue description and risk level. The risk level may be different for your "
+"specific environment."
+msgstr ""
+"Renuntiatio tabellariorum praebet speculationem obsequii coercet qui cum "
+"electronicis servientibus coniungitur. Praesens obsequium praesentiam SPF, "
+"DKIM et DMARC monumentis cohibet. Mensa infra ostendit pro unoquoque horum "
+"stimulorum quot identitatis electronicarum servientium obsequiosae sunt, et "
+"si applicatio obsequii descriptionem ac periculum incurrit. Periculum planum"
+" potest differre pro ambitu specifica."
+
+#: reports/report_types/mail_report/report.html
+msgid "Mailserver compliance"
+msgstr "Mailserver obsequio"
+
+#: reports/report_types/mail_report/report.html
+msgid "mailservers compliant"
+msgstr "mailservers obsecundantia"
+
+#: reports/report_types/mail_report/report.html
+msgid "No mailservers have been found on this system."
+msgstr "Nulli servi de hac systemate inventi sunt."
+
+#: reports/report_types/mail_report/report.py
+msgid "Mail Report"
+msgstr "Mail Report"
+
+#: reports/report_types/mail_report/report.py
+msgid ""
+"System specific Mail Report that focusses on IP addresses and hostnames."
+msgstr ""
+"Systema specificae Epistulae quae in IP inscriptiones et hostnames tendit."
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid "Overview of included assets"
+msgstr "Overview of inclusa bonorum"
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid "Asset"
+msgstr "Asset"
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+#: reports/report_types/multi_organization_report/basic_security_details.html
+msgid "Amount"
+msgstr "Moles"
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid "IP addresses"
+msgstr "IP inscriptiones"
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid "Domain names"
+msgstr "Domain nomina"
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid "Assets with most critical vulnerabilities"
+msgstr "Res cum maxime discrimine vulnerabilities"
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid "Vulnerability"
+msgstr "Vulnerability"
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid "Organisation"
+msgstr "Organization"
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid "No vulnerabilities found."
+msgstr "nuditates nullae inventae sunt."
+
+#: reports/report_types/multi_organization_report/basic_security_details.html
+msgid "Overview of safe connections"
+msgstr "Overview of salvos hospites"
+
+#: reports/report_types/multi_organization_report/basic_security_details.html
+#: reports/report_types/safe_connections_report/report.html
+msgid "Only Safe Ciphers"
+msgstr "Tantum tutus Ciphers"
+
+#: reports/report_types/multi_organization_report/basic_security_details.html
+#: reports/report_types/safe_connections_report/report.html
+msgid "services are compliant"
+msgstr "officia sunt obsecundantia"
+
+#: reports/report_types/multi_organization_report/basic_security_details.html
+msgid "System specific checks"
+msgstr "Ratio specifica checks"
+
+#: reports/report_types/multi_organization_report/ipv6.html
+msgid "IPv6"
+msgstr "IPv6"
+
+#: reports/report_types/multi_organization_report/ipv6.html
+msgid ""
+"IPv6 includes improvements in security features compared to IPv4. While IPv4"
+" can implement security measures, IPv6 was designed with security in mind, "
+"and its adoption can contribute to a more secure internet."
+msgstr ""
+"IPv6 emendationes includit in lineamentis securitatis comparatis IPv4. Dum "
+"IPv4 securitatis mensuras efficere potest, IPv6 cum securitate mente "
+"designatus est, eiusque adoptio ad tutiorem penitus conferre potest."
+
+#: reports/report_types/multi_organization_report/ipv6.html
+msgid "In total "
+msgstr "In summa"
+
+#: reports/report_types/multi_organization_report/ipv6.html
+msgid " out of "
+msgstr "ex *"
+
+#: reports/report_types/multi_organization_report/ipv6.html
+msgid " systems have an IPv6 connection."
+msgstr "systemata nexum IPv6 habent."
+
+#: reports/report_types/multi_organization_report/ipv6.html
+msgid "Overview of IP version compliance"
+msgstr "Overview of IP versionis obsequio"
+
+#: reports/report_types/multi_organization_report/open_ports.html
+msgid ""
+"See an overview of open ports found over all systems and the services these "
+"systems provide."
+msgstr ""
+"Videre inspectionem portuum aperti super omnia systemata inventa et officia "
+"haec systemata praebere."
+
+#: reports/report_types/multi_organization_report/open_ports.html
+msgid "Overview of detected open ports"
+msgstr "Overview deprehensis portibus"
+
+#: reports/report_types/multi_organization_report/open_ports.html
+#: reports/report_types/open_ports_report/report.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Open ports"
+msgstr "Portus apertis"
+
+#: reports/report_types/multi_organization_report/open_ports.html
+msgid "Occurrences (IP addresses)"
+msgstr "Eventus (IP inscriptiones)"
+
+#: reports/report_types/multi_organization_report/open_ports.html
+#: reports/templates/summary/service_health.html
+msgid "Services"
+msgstr "Officia"
+
+#: reports/report_types/multi_organization_report/open_ports.html
+msgid "No open ports found."
+msgstr "Portus apertus nullus inventus est."
+
+#: reports/report_types/multi_organization_report/recommendations.html
+msgid "Overview of recommendations"
+msgstr "Overview of suasiones"
+
+#: reports/report_types/multi_organization_report/recommendations.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid "Occurrence"
+msgstr "Eventum"
+
+#: reports/report_types/multi_organization_report/report.html
+msgid "No findings have been identified yet."
+msgstr "No inventa adhuc inventa sunt."
+
+#: reports/report_types/multi_organization_report/report.py
+msgid "Multi Organization Report"
+msgstr "Multi Organization Report"
+
+#: reports/report_types/multi_organization_report/summary.html
+msgid "Best scoring security check"
+msgstr "Optimus mollis securitatem reprehendo"
+
+#: reports/report_types/multi_organization_report/summary.html
+msgid "Worst scoring security check"
+msgstr "Pessimus mollis tristique securitatem reprehendo"
+
+#: reports/report_types/multi_organization_report/vulnerabilities.html
+msgid ""
+"Vulnerabilities found are grouped per system. Here, we only consider CVE "
+"vulnerabilities."
+msgstr ""
+"Vulnerabilitates inventae per systema comprehenduntur. Hic tantum "
+"vulnerabilitates CVE consideramus."
+
+#: reports/report_types/multi_organization_report/vulnerabilities.html
+msgid "Vulnerabilities grouped per system"
+msgstr "Vulnerabilitates per systema glomerantur"
+
+#: reports/report_types/multi_organization_report/vulnerabilities.html
+msgid "total"
+msgstr "total"
+
+#: reports/report_types/name_server_report/report.html
+msgid ""
+"The Name Server Report provides an overview of the compliance checks that "
+"were performed against the identified Domain Name Servers (DNS). The "
+"compliance checks verify the presence and validity of DNSSEC and whether no "
+"unnecessary ports were identified to be open. The table below gives an "
+"overview of the available checks including whether the system passed the "
+"performed checks. The risk level and reasoning as to why an issue was "
+"identified are shown too. The risk level may be different for your specific "
+"environment."
+msgstr ""
+"Nomen Servo Report praebet recognitionem obsequii compescit quae fiebant "
+"contra idem Nomen Servorum Domain (DNS). Obsequium inhibet comprobationem "
+"praesentiam et validitatem DNSSEC et num portus non necessarii noti sint ut "
+"aperti sint. Mensa infra dat inspectionem rerum suppeditarum quae possidet "
+"an systema peractae retardationis transierit. Periculum planum est et "
+"ratiocinatio quare etiam exitus indicatus est. Periculum planum potest "
+"differre pro ambitu specifica."
+
+#: reports/report_types/name_server_report/report.html
+msgid "Name server compliance"
+msgstr "Nomen servo obsequio"
+
+#: reports/report_types/name_server_report/report.html
+msgid "DNSSEC Present"
+msgstr "DNSSEC Present"
+
+#: reports/report_types/name_server_report/report.html
+msgid "name servers compliant"
+msgstr "nomen servers obsecundantia"
+
+#: reports/report_types/name_server_report/report.html
+msgid "Valid DNSSEC"
+msgstr "Valid DNSSEC"
+
+#: reports/report_types/name_server_report/report.html
+#: reports/report_types/web_system_report/report.html
+msgid "No unnecessary ports open"
+msgstr "Non necesse portus aperire"
+
+#: reports/report_types/name_server_report/report.html
+msgid "No nameservers have been found on this system."
+msgstr "Nulla nominatorum in hac systemate reperta sunt."
+
+#: reports/report_types/name_server_report/report.py
+msgid "Name Server Report"
+msgstr "Nomen Servo Report"
+
+#: reports/report_types/name_server_report/report.py
+msgid "Name Server Report checks name servers on basic security standards."
+msgstr "Nomen Servo Report sistit nomen servers in basic securitatem signa."
+
+#: reports/report_types/open_ports_report/report.html
+msgid ""
+"The Open Ports Report provides an overview of the open ports identified on a"
+" system. The ports that are marked as <b>bold</b> were identified by direct "
+"scans performed by OpenKAT (such as nmap). Ports that are not marked in bold"
+" were identified through external services and/or scans (such as Shodan). "
+"Scans with the same hostnames, ports and IPs are merged."
+msgstr ""
+"Portus Open Report praebet speculationem portuum apertorum, qui in systemate"
+" reperiuntur. Portus, qui ut <b>bold</b> signantur, notantur per lustra "
+"directa per OpenKAT (ut nmap). Portus, qui audacibus non notati sunt, per "
+"officia externa et/vel scans (ut Shodan notantur). Scans cum eisdem "
+"hostnamibus, portubus et IPs immiscentur."
+
+#: reports/report_types/open_ports_report/report.html
+msgid "Overview of open ports found for the scanned assets"
+msgstr "Overview of apertis portubus reperta bonorum lustrabat lumine"
+
+#: reports/report_types/open_ports_report/report.html
+#: reports/report_types/systems_report/report.html
+msgid "IP address"
+msgstr "IP oratio"
+
+#: reports/report_types/open_ports_report/report.html
+msgid "Hostnames"
+msgstr "Hostnames"
+
+#: reports/report_types/open_ports_report/report.html
+msgid "Direct scan"
+msgstr "Recta scan"
+
+#: reports/report_types/open_ports_report/report.py
+msgid "Open Ports Report"
+msgstr "Patefacio Portuum Report"
+
+#: reports/report_types/open_ports_report/report.py
+msgid "Find open ports of IP addresses"
+msgstr "Invenire portas apertas inscriptionum IP"
+
+#: reports/report_types/rpki_report/report.html
+msgid ""
+"This section contains basic security information about Resource Public Key "
+"Infrastructure (RPKI). If your web server employs RPKI for its IP addresses "
+"and associated nameservers, then it enhances visitor protection against "
+"misconfigurations and malicious route intercepts through verified route "
+"announcements, ensuring reliable server access and secure internet traffic."
+msgstr ""
+"Haec sectio praecipuas informationes securitatis continet de Resource Clavis"
+" Publicae Infrastructure (RPKI). Si servo telae tuae RPKI utitur ad "
+"inscriptiones IP et adiunctas nominatores, tunc visitatorem praesidium "
+"contra deceptiones auget et via malitiosa per denuntiationes veri- ficas "
+"iter intercipit, pro certo servo accessum procurans et negotiatio interrete "
+"tuta."
+
+#: reports/report_types/rpki_report/report.html
+msgid ""
+"The RPKI Report shows if an RPKI route announcement was available for the "
+"system and if this announcement is not expired."
+msgstr ""
+"Relatio RPKI ostendit si via nuntiatio RPKI praesto fuit pro ratione et si "
+"haec nuntiatio non exspiravit."
+
+#: reports/report_types/rpki_report/report.html
+msgid "RPKI compliance"
+msgstr "RPKI obsequio"
+
+#: reports/report_types/rpki_report/report.html
+msgid "RPKI Available"
+msgstr "RPKI Available"
+
+#: reports/report_types/rpki_report/report.html
+msgid "RPKI valid"
+msgstr "RPKI valid"
+
+#: reports/report_types/rpki_report/report.html
+msgid "RPKI record is not valid."
+msgstr "RPKI recordum non valet."
+
+#: reports/report_types/rpki_report/report.html
+msgid "RPKI record does not exist."
+msgstr "RPKI recordum non est."
+
+#: reports/report_types/rpki_report/report.html
+#: reports/report_types/safe_connections_report/report.html
+msgid "No IPs have been found on this system."
+msgstr "Nulla IPs in hac systemate inventa est."
+
+#: reports/report_types/rpki_report/report.py
+msgid "RPKI Report"
+msgstr "RPKI Report"
+
+#: reports/report_types/rpki_report/report.py
+msgid ""
+"Shows whether the IP is covered by a valid RPKI ROA. For a hostname it shows"
+" the IP addresses and whether they are covered by a valid RPKI ROA."
+msgstr ""
+"Ostendit utrum IP valido RPKI ROA tegatur. Pro nomine hospitis inscriptiones"
+" IP ostendit et utrum valido RPKI ROA tegantur."
+
+#: reports/report_types/safe_connections_report/report.html
+msgid ""
+"The Safe Connections report provides an overview of the performed checks "
+"with regard to encrypted communication channels such as HTTPS. The table "
+"below gives an overview of the available checks including whether the system"
+" passed the performed checks. The risk level and reasoning as to why an "
+"issue was identified are shown too. The risk level may be different for your"
+" specific environment."
+msgstr ""
+"Renuntiatio tutae nexus praebet perspectum peractae compescendi quoad "
+"canales communicationis encrypted ut HTTPS. Mensa infra dat inspectionem "
+"rerum suppeditarum quae possidet an systema peractae retardationis "
+"transierit. Periculum planum est et ratiocinatio quare etiam exitus "
+"indicatus est. Periculum planum potest differre pro ambitu specifica."
+
+#: reports/report_types/safe_connections_report/report.html
+msgid "Safe connections compliance"
+msgstr "Salvum hospites obsequio"
+
+#: reports/report_types/safe_connections_report/report.py
+msgid "Safe Connections Report"
+msgstr "Report tutum Contrahentes"
+
+#: reports/report_types/safe_connections_report/report.py
+msgid "Shows whether the IPService contains safe ciphers."
+msgstr "Ostendit num IPService tutum notas contineat."
+
+#: reports/report_types/systems_report/report.html
+msgid ""
+"The System Report provides an overview of the system types (types of similar"
+" services) that were identified for each system. The following system types "
+"can be identified: DNS servers, Web servers, Mail servers and those "
+"classified as 'Other' servers. Each hostname and/or IP address is given one "
+"or more system types depending on the identified ports and services. The "
+"table below gives an overview of these results."
+msgstr ""
+"Systema Relatio praebet inspectionem specierum systematis (genera similium "
+"officiorum) quae pro unaquaque ratio identificantur. Genera systematis "
+"sequentia invenire possunt: ​​servientes DNS, servitores interreti, "
+"servitores tabellarii et qui \"Alii servitores\" distinguuntur. Quaelibet "
+"hostname et/vel IP inscriptio datur unum vel plura genera systematis prout "
+"in portubus et officiis identificatis. Mensa infra retractationem horum "
+"eventuum dat."
+
+#: reports/report_types/systems_report/report.html
+msgid "Selected assets"
+msgstr "Electus bonorum"
+
+#: reports/report_types/systems_report/report.html
+msgid "No system types have been identified on this system."
+msgstr "Nulla genera systematis in hac systemate notata sunt."
+
+#: reports/report_types/systems_report/report.py
+msgid "System Report"
+msgstr "Ratio Report"
+
+#: reports/report_types/systems_report/report.py
+msgid "Combine IP addresses, hostnames and services into systems."
+msgstr "Coniunge IP inscriptiones, hostnames et officia in systemata."
+
+#: reports/report_types/tls_report/report.html
+msgid ""
+"The TLS Report shows which TLS protocols and ciphers were identified on the "
+"host for the provided port."
+msgstr ""
+"In TLS Relatio ostendit quae TLS protocolla et notae notae sunt in exercitu "
+"ad portum provisum."
+
+#: reports/report_types/tls_report/report.html
+msgid ""
+"The table below provides an overview of the identified TLS protocols and "
+"ciphers, including a status suggestion."
+msgstr ""
+"Mensa infra retractationem praebet protocolla notarum et notarum TLS, "
+"incluso condicionem suggestionis."
+
+#: reports/report_types/tls_report/report.html
+msgid "Ciphers"
+msgstr "Ciphers"
+
+#: reports/report_types/tls_report/report.html
+msgid "Protocol"
+msgstr "Protocol"
+
+#: reports/report_types/tls_report/report.html
+msgid "Encryption Algorithm"
+msgstr "Encryption Algorithmus"
+
+#: reports/report_types/tls_report/report.html
+msgid "Bits"
+msgstr "Bits"
+
+#: reports/report_types/tls_report/report.html
+msgid "Key Size"
+msgstr "Key Size"
+
+#: reports/report_types/tls_report/report.html
+#: rocky/templates/organizations/organization_list.html
+#: rocky/templates/organizations/organization_settings.html
+msgid "Code"
+msgstr "Code"
+
+#: reports/report_types/tls_report/report.html
+msgid "Phase out"
+msgstr "Phase e"
+
+#: reports/report_types/tls_report/report.html
+msgid "Good"
+msgstr "bonum"
+
+#: reports/report_types/tls_report/report.html
+msgid ""
+"No ciphers were found for this combination of IP address, port and service."
+msgstr ""
+"Nulla notae inventae sunt ad hanc compositionem IP inscriptionis, portus et "
+"muneris."
+
+#: reports/report_types/tls_report/report.html
+msgid ""
+"The list below gives an overview of the findings based on the identified TLS"
+" protocols and ciphers. This includes the reasoning why the cipher or "
+"protocol is marked as a finding."
+msgstr ""
+"Elenchus infra recensitum dat de inventionibus secundum quod TLS protocolla "
+"notis ac notis. Haec includit rationem quare notatur notatio seu protocollum"
+" sicut inventio."
+
+#: reports/report_types/tls_report/report.py
+msgid "TLS Report"
+msgstr "TLS Report"
+
+#: reports/report_types/tls_report/report.py
+msgid ""
+"TLS Report assesses the security of data encryption and transmission "
+"protocols."
+msgstr ""
+"TLS Renuntiatio securitatis datorum encryptionis et protocolla "
+"transmissionis aestimat."
+
+#: reports/report_types/vulnerability_report/report.html
+msgid "No vulnerabilities have been found on this system."
+msgstr "Nullae nuditates in hac systemate inventae sunt."
+
+#: reports/report_types/vulnerability_report/report.html
+msgid ""
+"The Vulnerability Report provides an overview of all identified CVE "
+"vulnerabilities that were identified on the selected systems. For each CVE "
+"the table shows the CVE scoring, the number of occurrences, and the CVE "
+"details."
+msgstr ""
+"Renuntiatio vulnerabilitas inspicienti praebet omnium vulnerabilium CVE quae"
+" in systematibus delectae notantur. Utraque mensa CVE scoring CVE ostendit, "
+"numerum eventuum, et singula CVE."
+
+#: reports/report_types/vulnerability_report/report.html
+msgid "vulnerabilities on this system"
+msgstr "vulnerabilities in hac ratio"
+
+#: reports/report_types/vulnerability_report/report.html
+msgid "Advice"
+msgstr "Admonitio"
+
+#: reports/report_types/vulnerability_report/report.py
+msgid "Vulnerability Report"
+msgstr "Vulnerability Report"
+
+#: reports/report_types/vulnerability_report/report.py
+msgid "Vulnerabilities found are grouped for each system."
+msgstr "Vulnerabilitates inventae pro unaquaque systemate comprehenduntur."
+
+#: reports/report_types/vulnerability_report/report.py
+msgid "First seen"
+msgstr "primum videtur"
+
+#: reports/report_types/vulnerability_report/report.py
+msgid "Last seen"
+msgstr "Last vidistis"
+
+#: reports/report_types/vulnerability_report/report.py
+msgid "Evidence"
+msgstr "Testimonium"
+
+#: reports/report_types/web_system_report/report.html
+msgid ""
+"The Web System Report provides an overview of various web server checks that"
+" were performed against the scanned system(s). For each performed check the "
+"table below shows whether or not the server is compliant with the checks. A "
+"description of why this compliant check failed is also shown, including an "
+"general risk level. The risk level may be different for your specific "
+"environment."
+msgstr ""
+"Relatio interretialis ratio praebet inspectionem variarum servulorum "
+"interretialium quae contra systema lustrale fiebant. Pro unoquoque facto "
+"reprehendo mensam infra ostendit utrum servo obtemperet necne. Descriptio "
+"quare facilis haec repressio incassum etiam ostenditur, incluso gradu "
+"periculo generali. Periculum planum potest differre pro ambitu specifica."
+
+#: reports/report_types/web_system_report/report.html
+msgid "Web system compliance"
+msgstr "Web ratio obsequio"
+
+#: reports/report_types/web_system_report/report.html
+msgid "CSP Present"
+msgstr "CSP Present"
+
+#: reports/report_types/web_system_report/report.html
+msgid "webservers compliant"
+msgstr "webservers obsecundantia"
+
+#: reports/report_types/web_system_report/report.html
+msgid "Secure CSP Header"
+msgstr "Secure CSP Header"
+
+#: reports/report_types/web_system_report/report.html
+msgid "Redirects HTTP to HTTPS"
+msgstr "Redirectiones HTTP ad HTTPS"
+
+#: reports/report_types/web_system_report/report.html
+msgid "Offers HTTPS"
+msgstr "Offert HTTPS"
+
+#: reports/report_types/web_system_report/report.html
+msgid "Has a Security.txt"
+msgstr "Habet Security.txt"
+
+#: reports/report_types/web_system_report/report.html
+msgid "Has a certificate"
+msgstr "Habet libellum"
+
+#: reports/report_types/web_system_report/report.html
+msgid "Certificate is valid"
+msgstr "Testimonium valet"
+
+#: reports/report_types/web_system_report/report.html
+msgid "Certificate is not expiring soon"
+msgstr "Certificatorium non exspirat primum"
+
+#: reports/report_types/web_system_report/report.html
+msgid "No webservers have been found on this system."
+msgstr "Nulla tela in hac systemate inventa sunt."
+
+#: reports/report_types/web_system_report/report.py
+msgid "Web System Report"
+msgstr "Systema interretialem Report"
+
+#: reports/report_types/web_system_report/report.py
+msgid "Web System Reports check web systems on basic security standards."
+msgstr ""
+"Renuntiationes interretiales Renuntiationes systemata interretialem "
+"reprimunt in signis securitatibus fundamentalibus."
+
+#: reports/templates/partials/export_report_settings.html
+msgid "Report schedule"
+msgstr "Report schedule"
+
+#: reports/templates/partials/export_report_settings.html
+msgid ""
+"When scheduling your report, you have two options. You can either choose to "
+"generate it just once now, or set it to run automatically at regular "
+"intervals, like daily, weekly, or monthly. If you need the report just for a"
+" single occasion, select the one-time option."
+msgstr ""
+"Cum scheduling relationem tuam, duas bene habes. Potes vel eligere ut semel "
+"nunc generare, vel statim currere constitue certis intervallis, ut cotidie, "
+"hebdomadae, vel menstruas. Si relationem ad unum tempus eges, elige unum "
+"tempus optionis."
+
+#: reports/templates/partials/export_report_settings.html
+#: reports/templates/report_overview/report_history_table.html
+msgid "Report name"
+msgstr "Report name"
+
+#: reports/templates/partials/export_report_settings.html
+#, python-format, python-brace-format
+msgid ""
+"When generating reports, it is possible to give the report a name. The name "
+"can be static or dynamic. The default format for a report is '${report_type}"
+" for ${oois_count} objects'. These placeholders automatically adapt based on"
+" the report details. This format could for example return 'Aggregate Report "
+"for 15 objects'. Another placeholder that can be used is '${ooi}', which "
+"will show the name of the object when there is only one object. You can also"
+" customize the name by adding prefixes, suffixes, or other formats like "
+"'%%W' for the week number, using options from <a "
+"href=\"https://strftime.org/\" target=\"_blank\" rel=\"noopener\">Python "
+"strftime code</a>."
+msgstr ""
+"Cum relationes generare, nomen referre potest. Nomen potest esse static vel "
+"dynamicus. Defectus forma relationis est \"${report_type} pro ${oois_count} "
+"obiecti'. Hi loci possessores statim accommodare nituntur ad singula "
+"relationis. Forma haec exempli causa reddere potuit 'Agregate Report pro 15 "
+"obiecti'. Alius placeholder qui adhiberi potest est '${ooi}', quod nomen "
+"obiecti ostendet cum unum tantum obiectum sit. Nomen quoque mos est addendo "
+"praefixiones, suffixas vel alias formas sicut '%%W' numero hebdomadis, utens"
+" optionibus <a href=\"https://strftime.org/\" target=\"_blank\" "
+"rel=\"noopener\"> Pythonis strftimo codice</a>."
+
+#: reports/templates/partials/export_report_settings.html
+#: reports/templates/partials/generate_report_header.html
+#: reports/templates/partials/new_report_action_button.html
+#: reports/views/generate_report.py
+msgid "Generate report"
+msgstr "Generare fama"
+
+#: reports/templates/partials/generate_report_header.html
+msgid "To generate an aggregate report, complete the following steps."
+msgstr "Ut fama aggregatum generale, sequentia perficiat vestigia."
+
+#: reports/templates/partials/generate_report_header.html
+msgid "To generate a multi report, complete the following steps."
+msgstr "Ad famam multi generandam, vestigia sequentia complent."
+
+#: reports/templates/partials/generate_report_header.html
+msgid "To generate separate report(s), complete the following steps."
+msgstr "Generare relationem separatam (s), vestigia sequentia perficere."
+
+#: reports/templates/partials/generate_report_sidemenu.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Table of contents"
+msgstr "Tabula contentorum"
+
+#: reports/templates/partials/new_report_action_button.html
+msgid "Actions for creating a new report"
+msgstr "Actus ad partum novum fama"
+
+#: reports/templates/partials/new_report_action_button.html
+msgid "Separate report(s)"
+msgstr "Singula fama (s)"
+
+#: reports/templates/partials/new_report_action_button.html
+#: reports/views/aggregate_report.py
+msgid "Aggregate report"
+msgstr "Subgenera fama"
+
+#: reports/templates/partials/new_report_action_button.html
+#: reports/views/multi_report.py
+msgid "Multi report"
+msgstr "Multi fama"
+
+#: reports/templates/partials/plugin_overview_table.html
+#: reports/templates/partials/report_sidemenu.html
+#: rocky/templates/oois/ooi_page_tabs.html
+msgid "Overview"
+msgstr "Overview"
+
+#: reports/templates/partials/plugin_overview_table.html
+msgid "Plugin overview table"
+msgstr "Plugin overview table"
+
+#: reports/templates/partials/plugin_overview_table.html
+#: reports/templates/partials/report_setup_scan.html
+msgid "Required plugins"
+msgstr "Requiritur plugins"
+
+#: reports/templates/partials/plugin_overview_table.html
+#: reports/templates/partials/report_setup_scan.html
+msgid "Suggested plugins"
+msgstr "Suggessit plugins"
+
+#: reports/templates/partials/plugin_overview_table.html
+msgid "Action required"
+msgstr "Actio requiratur"
+
+#: reports/templates/partials/plugin_overview_table.html
+msgid "Ready"
+msgstr "Paratus"
+
+#: reports/templates/partials/report_findings_table.html
+msgid ""
+"This table provides an overview of the identified findings on the scanned "
+"systems. For each finding type it shows the risk level, the number of "
+"occurrences and the first known occurrence of the finding. The risk level "
+"may be different for your specific environment. The details can be seen when"
+" expanding a row. A description, the source, impact and recommendation of "
+"the finding can be found here. It also shows in which findings the finding "
+"type occurred."
+msgstr ""
+"Haec tabula perspectum praebet inventis identificatis in systematibus "
+"lustratis. Unicuique enim generis inveniens periculum demonstrat gradu, "
+"numero eventuum ac primae notae inveniendi eventum. Periculum planum potest "
+"differre pro ambitu specifica. Retineo videri potest cum ordine expanso. "
+"Descriptio, fons, sol- licitus et commendatio hic reperiri possunt. Etiam "
+"ostendit in quibus inventio generis occurrit."
+
+#: reports/templates/partials/report_findings_table.html
+msgid "First known occurrence"
+msgstr "Primum notum fieri"
+
+#: reports/templates/partials/report_findings_table.html
+msgid "Open in report"
+msgstr "Apertum in fama"
+
+#: reports/templates/partials/report_findings_table.html
+msgid ""
+"No critical and high findings have been identified for this organization."
+msgstr "Nullae criticae et altae inventiones huic organizationi notae sunt."
+
+#: reports/templates/partials/report_findings_table.html
+msgid "No findings have been identified for this organization."
+msgstr "Nullae inventae pro hac ordinatione notatae sunt."
+
+#: reports/templates/partials/report_header.html
+msgid "Download as PDF"
+msgstr "Download as PDF"
+
+#: reports/templates/partials/report_header.html
+#: rocky/templates/partials/ooi_list_toolbar.html
+msgid "Download as JSON"
+msgstr "Download as JSON"
+
+#: reports/templates/partials/report_header.html
+msgid "Open asset reports"
+msgstr "Aperta dignissim tradit"
+
+#: reports/templates/partials/report_header.html
+msgid "This is the OpenKAT report for organization"
+msgstr "Haec est relatio formarum OpenKAT"
+
+#: reports/templates/partials/report_header.html
+msgid ""
+"All selected report types for the selected objects are displayed one below "
+"the other."
+msgstr ""
+"Omnes selectae relationes typi ad objecta selecta unum infra alterum "
+"exhibentur."
+
+#: reports/templates/partials/report_header.html
+msgid "Created with data from:"
+msgstr "Cum notitia ex creatum:"
+
+#: reports/templates/partials/report_header.html
+msgid "Created on:"
+msgstr "Creatus est:"
+
+#: reports/templates/partials/report_header.html
+msgid "Created from recipe:"
+msgstr "Creatum a recipe:"
+
+#: reports/templates/partials/report_header.html
+msgid "Recipe created by:"
+msgstr "Recipe creatum:"
+
+#: reports/templates/partials/report_header.html
+#, python-format
+msgid "This sector contains %(length)s scanned organizations."
+msgstr "Haec provincia %(length)s instituta continet."
+
+#: reports/templates/partials/report_header.html
+msgid "Of these organizations"
+msgstr "De his institutionibus"
+
+#: reports/templates/partials/report_header.html
+msgid "organizations have tag"
+msgstr "organizations habent tag"
+
+#: reports/templates/partials/report_header.html
+msgid "The basic security scores are around "
+msgstr "In basic securitatem scores sunt circa"
+
+#: reports/templates/partials/report_header.html
+#, python-format
+msgid "A total of %(total)s critical vulnerabilities have been identified."
+msgstr "Summa vulnerationum criticarum %(total)s notata est."
+
+#: reports/templates/partials/report_introduction.html
+msgid "Introduction"
+msgstr "Introductio"
+
+#: reports/templates/partials/report_introduction.html
+msgid ""
+"This report gives an overview of the current state of security for your "
+"organisation for the selected date. The summary section provides an overview"
+" of the selected systems (objects), plugins and reports. This is followed "
+"with the findings for each report."
+msgstr ""
+"Haec relatio percontationem dat de statu securitatis hodiernae pro ordine "
+"tuo ad tempus electum. Sectio summaria speculationem systematum delectarum "
+"(objectorum), plugins et relationum praebet. Hoc sequitur in singulis "
+"relationibus inventis."
+
+#: reports/templates/partials/report_names_form.html
+msgid "Report names:"
+msgstr "Referre nomina:"
+
+#: reports/templates/partials/report_names_form.html
+#: rocky/templates/forms/widgets/checkbox_group_table.html
+#: rocky/templates/oois/ooi_detail_add_related_object.html
+#: rocky/templates/partials/edit_ooi_clearance_level_modal.html
+#: rocky/templates/partials/form/field_input.html
+#: rocky/templates/partials/form/field_input_checkbox.html
+#: rocky/templates/partials/form/field_input_multiselect.html
+#: rocky/templates/partials/form/field_input_radio.html
+msgid "Required"
+msgstr "required"
+
+#: reports/templates/partials/report_names_form.html
+msgid "Add reference date"
+msgstr "Add reference date"
+
+#: reports/templates/partials/report_names_form.html
+#: reports/templates/report_overview/modal_partials/rename_modal.html
+msgid "Reset"
+msgstr "Reset"
+
+#: reports/templates/partials/report_names_form.html
+msgid "No reference date"
+msgstr "Non referat diem"
+
+#: reports/templates/partials/report_names_form.html
+msgid "Day"
+msgstr "dies"
+
+#: reports/templates/partials/report_names_form.html
+msgid "Week"
+msgstr "Hebdomada"
+
+#: reports/templates/partials/report_names_form.html
+msgid "Month"
+msgstr "Mensis"
+
+#: reports/templates/partials/report_names_form.html
+msgid "Year"
+msgstr "Annus"
+
+#: reports/templates/partials/report_ooi_list.html
+msgid "Object selection"
+msgstr "Object lectio"
+
+#: reports/templates/partials/report_ooi_list.html
+msgid ""
+"Select which objects you want to include in your report. You can either "
+"continue with a live set or you can select the objects manually from the "
+"table below."
+msgstr ""
+"Elige quae res tuas referre velis includere. Potes vel pergere cum vivo "
+"statuto vel eligere res manuales e mensa infra."
+
+#: reports/templates/partials/report_ooi_list.html
+msgid ""
+"A live set is a set of objects based on the applied filters. Any object that"
+" matches this applied filter (now or in the future) will be used as input "
+"for the scheduled report. If your live set filter (e.g. 'hostnames' with 'L2"
+" clearance' that are 'declared') shows 2 hostnames that match the filter "
+"today, the scheduled report will run for those 2 hostnames. If you add 3 "
+"more hostnames tomorrow (with the same filter criteria), your next scheduled"
+" report will contain 5 hostnames. Your live set will update as you go."
+msgstr ""
+"Vivamus posuere est copia obiecti e filtratibus applicatis. Quaelibet res "
+"quae huic colum applicatae congruit (nunc vel in futuro) pro initus "
+"adhibebitur pro fama cessionis. Si colum vivam pone (exempli gratia "
+"\"hostnames\" cum \"L2 alvi\" quae sunt 'declarata') ostendit 2 hostnames "
+"quae hodie colum aequant, relatio accedet pro illis 2 hostnamis. Si plures "
+"hostnames 3 cras addideris (cum iisdem indiciis colum), fama tua proxima "
+"horarium 5 hostnames continebit. Vivum tuum pone renovabit ut tu es."
+
+#: reports/templates/partials/report_ooi_list.html
+msgid ""
+"Based on the current dataset, your selected filters result in the following "
+"objects."
+msgstr ""
+"Ex hodierna dataset, columellae delegisti in obiectis sequentibus "
+"consequuntur."
+
+#: reports/templates/partials/report_ooi_list.html
+msgid "objects selected"
+msgstr "res delectus"
+
+#: reports/templates/partials/report_ooi_list.html
+msgid "Deselect all objects"
+msgstr "Deselect omnibus obiecti"
+
+#: reports/templates/partials/report_ooi_list.html
+#: rocky/templates/oois/ooi_list.html
+#, python-format
+msgid "Showing %(length)s of %(total)s objects"
+msgstr "Ostendens %(length)s de %(total)s obiecti"
+
+#: reports/templates/partials/report_ooi_list.html
+#, python-format
+msgid "Select all %(total_oois)s object"
+msgid_plural "Select all %(total_oois)s objects"
+msgstr[0] "Elige omnia %(total_oois)s object"
+msgstr[1] "Elige omnia %(total_oois)s obiecta"
+
+#: reports/templates/partials/report_ooi_list.html
+msgid "Object name"
+msgstr "Object nomen"
+
+#: reports/templates/partials/report_ooi_list.html
+msgid "Report(s) may be empty due to no objects in the selected filters."
+msgstr ""
+"Relatione(s) vacua esse potest ob objecta nulla in percolendis delectis."
+
+#: reports/templates/partials/report_ooi_list.html
+msgid ""
+"Reports matching the selected filters will be empty at this moment in time. "
+"Future reports may contain data. It is still possible to generate the "
+"(potentially empty) report."
+msgstr ""
+"Renuntiationes congruentes columellae selectae hoc momento vacuae erunt in "
+"tempore. Futuras tradit notitia contineant. Adhuc potest generare famam."
+
+#: reports/templates/partials/report_ooi_list.html
+msgid "Continue with live set"
+msgstr "Set continue cum vivere"
+
+#: reports/templates/partials/report_ooi_list.html
+#: reports/templates/partials/report_types_selection.html
+msgid "Continue with selection"
+msgstr "Continue cum delectu"
+
+#: reports/templates/partials/report_setup_scan.html
+#: reports/views/aggregate_report.py reports/views/generate_report.py
+#: reports/views/multi_report.py
+msgid "Configuration"
+msgstr "Configurationis"
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Set up the required plugins for this report."
+msgstr "Recita plugins pro hac fama."
+
+#: reports/templates/partials/report_setup_scan.html
+#: reports/templates/summary/selected_plugins.html
+msgid "Plugins"
+msgstr "Plugins"
+
+#: reports/templates/partials/report_setup_scan.html
+msgid ""
+"KAT will be able to generate a full report when all the required and "
+"suggested boefjes are enabled."
+msgstr ""
+"KAT plenam relationem generare poterit cum omnia requisita et proposita "
+"boefjes valeant."
+
+#: reports/templates/partials/report_setup_scan.html
+msgid ""
+"If you choose not to enable a plugin, the data that plugin would collect or "
+"produce will be left out of the report which will then be generated based on"
+" the available data collected by the enabled plugins."
+msgstr ""
+"Si plugin facere non vis, notitia quae plugin colliget vel producet, "
+"relinquentur e relatione quae tunc generabitur secundum notitias in promptu "
+"collectas per enabled plugins."
+
+#: reports/templates/partials/report_setup_scan.html
+msgid ""
+"Some plugins are mandatory as they are crucial for a report type. Reports "
+"that don't have their requirements met will be skipped."
+msgstr ""
+"Aliqua plugina facienda sunt sicut crucialorum relationem generis. "
+"Renuntiationes quae non habent requisita occurrerunt praetermittenda sunt."
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Warning! Before you proceed read the following points:"
+msgstr "Monitum! Priusquam procedas lege sequentia puncta:"
+
+#: reports/templates/partials/report_setup_scan.html
+msgid ""
+"OpenKAT is designed to scan all known objects on a regular basis using the "
+"enabled plugins and set clearance levels. This means that scans will run "
+"automatically. Be patient; plugins may take some time before they have "
+"collected all their data. Enabling them just before report generation will "
+"likely result in inaccurate reports, as plugins have not finished collecting"
+" data."
+msgstr ""
+"OpenKAT ordinatur ad lustrandum omnia obiecta notissima in regulari "
+"fundamento utendo ad plugins capacitatis et alvi gradus pone. Hoc significat"
+" quod automatice lustrat current. Perfer; plugins sumo aliquando ante omnia "
+"eorum notitia. Eas, sicut ante relationem generationis, in nuntiationibus "
+"impropriis eventurum verisimile erit, sicut plugins notitias colligendas non"
+" complevit."
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Good job! All required plugins are enabled."
+msgstr "Bonum officium! Omnes plugins requiri valeant."
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "This report type requires the following plugins to be enabled:"
+msgstr "Haec relatio generis requirit sequentia plugins ut possimus:"
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Toggle all required plugins"
+msgstr "Toggle requiritur plugins"
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Show enabled plugins"
+msgstr "Ostende enabled plugins"
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "There are no required plugins."
+msgstr "Nulla tincidunt volutpat nulla."
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Good job! All suggested plugins are enabled."
+msgstr "Bonum officium! Omnia suggesserant plugins capacia sunt."
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "The following plugins are optional to generate the report:"
+msgstr "Sequentia plugins libitum est relationem generare:"
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Toggle all optional plugins"
+msgstr "Toggle omnia ad libitum plugins"
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Hide suggested plugins"
+msgstr "Celare suggesserant plugins"
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Show more suggested plugins"
+msgstr "Monstra plura suggesserant plugins"
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "There are no optional plugins."
+msgstr "Nulla volutpat libitum."
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Enable selected plugins and continue"
+msgstr "Admitte lectus tincidunt et continue"
+
+#: reports/templates/partials/report_severity_totals_table.html
+msgid ""
+"\n"
+"            This overview shows the total number of findings per\n"
+"            severity that have been identified for this organization.\n"
+"        "
+msgstr ""
+"\n"
+"Haec overview ostendit numerus inventionum per\n"
+"            Severitas quae huic organizationi notata est."
+
+#: reports/templates/partials/report_severity_totals_table.html
+msgid "Total per severity overview"
+msgstr "Summa per severitatem overview"
+
+#: reports/templates/partials/report_severity_totals_table.html
+msgid "Critical"
+msgstr "Critical"
+
+#: reports/templates/partials/report_severity_totals_table.html
+msgid "High"
+msgstr "Summus"
+
+#: reports/templates/partials/report_severity_totals_table.html
+msgid "Medium"
+msgstr "Medium"
+
+#: reports/templates/partials/report_severity_totals_table.html
+msgid "Low"
+msgstr "low"
+
+#: reports/templates/partials/report_severity_totals_table.html
+#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+msgid "Pending"
+msgstr "Eviewray"
+
+#: reports/templates/partials/report_severity_totals_table.html
+msgid "Unknown"
+msgstr "Ignotum"
+
+#: reports/templates/partials/report_severity_totals_table.html
+msgid "Total"
+msgstr "Totalis"
+
+#: reports/templates/partials/report_sidemenu.html
+msgid "Selected Objects"
+msgstr "Objects electus"
+
+#: reports/templates/partials/report_sidemenu.html
+msgid "Selected Plugins"
+msgstr "Electus tincidunt"
+
+#: reports/templates/partials/report_sidemenu.html
+msgid "Used Config Objects"
+msgstr "Used Mando Objects"
+
+#: reports/templates/partials/report_types_selection.html
+msgid "Choose report types"
+msgstr "Elige fama types"
+
+#: reports/templates/partials/report_types_selection.html
+msgid ""
+"Various types of reports, such as DNS reports and TLS reports, are essential"
+" for identifying vulnerabilities in different aspects of a system's "
+"security. DNS reports focus on domain name system configuration and "
+"potential weaknesses, while TLS reports assess the security of data "
+"encryption and transmission protocols, helping organizations pinpoint areas "
+"where security improvements are needed."
+msgstr ""
+"Variae relationum genera, sicut DNS relationum et TLS, essentiales sunt ad "
+"cognoscendas vulnerabilitates in diversis aspectibus securitatis systematis."
+" DNS refert versari in nomine regio systematis configurationis ac "
+"debilitates potentiales, dum TLS tradit securitatem notitiarum encryptionis "
+"et protocolla transmissionis aestimare, Instituta iuvare puncta loca ubi "
+"melioramenta securitatis necessaria sunt."
+
+#: reports/templates/partials/report_types_selection.html
+#, python-format
+msgid "Selected object (%(total_oois)s)"
+msgid_plural "Selected objects (%(total_oois)s)"
+msgstr[0] "Objectum electum (%(total_oois)s)"
+msgstr[1] "Res selectae (%(total_oois)s)"
+
+#: reports/templates/partials/report_types_selection.html
+#, python-format
+msgid ""
+"You have selected a live set in the previous step. Based on the current "
+"dataset, this live set results in %(total_oois)s objects."
+msgstr ""
+"Vivum gradum superiore delegisti. Ex hodierna notitiaset, haec proventus in "
+"%(total_oois)s obiectis habitis."
+
+#: reports/templates/partials/report_types_selection.html
+msgid "Applied filters:"
+msgstr "Filtra applicata:"
+
+#: reports/templates/partials/report_types_selection.html
+#, python-format
+msgid "You have selected %(total_oois)s object in the previous step."
+msgid_plural "You have selected %(total_oois)s objects in the previous step."
+msgstr[0] "%(total_oois)s rem in gradu superiore delegisti."
+msgstr[1] "%(total_oois)s res in priori gradu delegisti."
+
+#: reports/templates/partials/report_types_selection.html
+msgid "Change selection"
+msgstr "Mutatio lectio"
+
+#: reports/templates/partials/report_types_selection.html
+msgid "Available report types"
+msgstr "Praesto fama types"
+
+#: reports/templates/partials/report_types_selection.html
+msgid "All report types that are available for your selection."
+msgstr "Omnes referunt rationes quae in promptu sunt pro delectu tuo."
+
+#: reports/templates/partials/report_types_selection.html
+msgid "Toggle all report types"
+msgstr "Toggle omnes fama types"
+
+#: reports/templates/partials/return_button.html
+#, python-format
+msgid "%(btn_text)s"
+msgstr "%(btn_text)s"
+
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/modal_partials/share_modal.html
+msgid "Delete the following report(s):"
+msgstr "Hoc delere fama (s):"
+
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/modal_partials/share_modal.html
+msgid ""
+"Deleted reports are removed in the view from the moment of deletion. The "
+"report can still be accessed on timestamps before the deletion. Only the "
+"report is removed from the view, not the data it is based on."
+msgstr ""
+"Relationes deletae a momento deletionis in conspectu removentur. Renuntiatio"
+" adhuc accessi potest in indicationibus ante deletionem. Tantum opinio ab "
+"opinione removetur, non notitia innititur."
+
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/modal_partials/share_modal.html
+msgid ""
+"It is still possible to generate a new report for same date. If the report "
+"is part of a combined report, it will remain available in the combined "
+"report."
+msgstr ""
+"Adhuc potest novam relationem in eodem tempore generare. Si fama coniuncta "
+"est pars, praesto erit in fama coniuncta remanebit."
+
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/modal_partials/rerun_modal.html
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+#: reports/templates/report_overview/subreports_table.html
+msgid "Reference date"
+msgstr "Reference date"
+
+#: reports/templates/report_overview/modal_partials/enable_disable_schedule_modal.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Disable schedule"
+msgstr "Inactivare schedule"
+
+#: reports/templates/report_overview/modal_partials/enable_disable_schedule_modal.html
+#, python-format
+msgid ""
+"Are you sure you want to disable the schedule for "
+"<strong>%(report_name)s</strong>? The recipe will still exist and the "
+"schedule can be enabled later on."
+msgstr ""
+"Visne certe ut inactivandi cedulam pro <strong>%(report_name)s</strong>? "
+"Recipe adhuc existere ac cedula postea effici potest."
+
+#: reports/templates/report_overview/modal_partials/rename_modal.html
+msgid "Rename the following report(s):"
+msgstr "Rename sequenti fama(s):"
+
+#: reports/templates/report_overview/modal_partials/rename_modal.html
+#: reports/templates/report_overview/report_history_table.html
+msgid "Rename"
+msgstr "Rename"
+
+#: reports/templates/report_overview/modal_partials/rerun_modal.html
+msgid "Rerun the following report(s):"
+msgstr "Rerun sequentia relatio(s):"
+
+#: reports/templates/report_overview/modal_partials/rerun_modal.html
+msgid ""
+"By submitting you're generating the selected reports again, using the "
+"current data."
+msgstr ""
+"Subdendo tibi generare delectas relationes iterum utens notitia hodierna."
+
+#: reports/templates/report_overview/modal_partials/rerun_modal.html
+#: reports/templates/report_overview/report_history_table.html
+msgid "Rerun"
+msgstr "Rerun"
+
+#: reports/templates/report_overview/report_history.html
+msgid "Reports history"
+msgstr "Refert historia"
+
+#: reports/templates/report_overview/report_history.html
+msgid ""
+"On this page you can see all the reports that have been generated in the "
+"past. To create a new report, click the 'Generate Report' button."
+msgstr ""
+"In hac pagina videre potes omnia relationes quae in praeterito generatae "
+"sunt. Novam famam creare, deprime puga \"Report Generale\"."
+
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/report_overview/subreports.html
+#, python-format
+msgid "Showing %(length)s of %(total)s reports"
+msgstr "Ostendens %(length)s de %(total)s tradit"
+
+#: reports/templates/report_overview/report_history_table.html
+#: rocky/templates/tasks/reports.html
+msgid "Reports:"
+msgstr "Renuntiationes:"
+
+#: reports/templates/report_overview/report_history_table.html
+msgid "Shows parent report details"
+msgstr "Show details parenti fama"
+
+#: reports/templates/report_overview/report_history_table.html
+msgid "Close asset report object details"
+msgstr "Prope res singula fama object"
+
+#: reports/templates/report_overview/report_history_table.html
+msgid "Open asset report object details"
+msgstr "Aperta dignissim fama object details"
+
+#: reports/templates/report_overview/report_history_table.html
+msgid "Asset reports details"
+msgstr "Res singula tradit"
+
+#: reports/templates/report_overview/report_history_table.html
+#, python-format
+msgid ""
+"This report consists of %(counter)s asset report with the following report "
+"type and object:"
+msgid_plural ""
+"This report consists of %(counter)s asset reports with the following report "
+"types and objects:"
+msgstr[0] ""
+"Haec relatio in %(counter)s dignissim fama consistit cum relatione generis "
+"et obiecti sequenti:"
+msgstr[1] ""
+"Haec relatio in %(counter)s dignissim reporta consistit cum relationibus "
+"rationibus et obiectis sequentibus:"
+
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/report_overview/subreports_header.html
+#: reports/templates/report_overview/subreports_table.html
+#: reports/views/report_overview.py
+msgid "Asset reports"
+msgstr "Asset tradit"
+
+#: reports/templates/report_overview/report_history_table.html
+msgid "Shows asset report details"
+msgstr "Renuntiatio ostendit singula dignissim"
+
+#: reports/templates/report_overview/report_history_table.html
+msgid "View all asset reports"
+msgstr "Omnes res tradit"
+
+#: reports/templates/report_overview/report_history_table.html
+msgid "No reports have been generated yet."
+msgstr "No reports have been generated yet."
+
+#: reports/templates/report_overview/report_overview_header.html
+#: reports/views/base.py rocky/templates/header.html
+#: rocky/templates/tasks/partials/tab_navigation.html
+#: rocky/templates/tasks/reports.html rocky/views/tasks.py
+msgid "Reports"
+msgstr "Renuntiationes"
+
+#: reports/templates/report_overview/report_overview_header.html
+msgid "An overview of reports that are scheduled or have been generated."
+msgstr "Recensio relationum quae scheduled aut generatae sunt."
+
+#: reports/templates/report_overview/report_overview_navigation.html
+msgid "Scheduled"
+msgstr "Scheduled"
+
+#: reports/templates/report_overview/report_overview_navigation.html
+msgid "History"
+msgstr "Historia"
+
+#: reports/templates/report_overview/scheduled_reports.html
+msgid "Scheduled reports"
+msgstr "Scheduled tradit"
+
+#: reports/templates/report_overview/scheduled_reports.html
+msgid ""
+"On this page you can see all the reports that are or have been scheduled. To"
+" schedule a report, select a start date and recurrence while generating a "
+"report."
+msgstr ""
+"In hac pagina videre potes omnia relationes quae sunt vel scheduled. "
+"Renuntiationem RATIONARIUM, initium temporis ac recursum elige dum "
+"relationem gignens."
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+#, python-format
+msgid "Showing %(length)s of %(total)s schedules"
+msgstr "Ostendens %(length)s ex %(total)s cedulas"
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Scheduled reports:"
+msgstr "Scheduled tradit:"
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Scheduled for"
+msgstr "Scheduled for"
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Schedule status"
+msgstr "Schedule status"
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Once"
+msgstr "Cum"
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Recent reports"
+msgstr "Recentes tradit"
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Scheduled Reports:"
+msgstr "Scheduled Renuntiationes:"
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Show report details"
+msgstr "Show report details"
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "objects"
+msgstr "obiecti"
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Enable schedule"
+msgstr "Admitte schedule"
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "No scheduled reports have been generated yet."
+msgstr "Nullae relationes accedant adhuc generatae sunt."
+
+#: reports/templates/report_overview/subreports_header.html
+msgid "Back to Reports History"
+msgstr "Ad Renuntiationes Historiae"
+
+#: reports/templates/report_overview/subreports_header.html
+msgid "An overview of all underlying reports of"
+msgstr "Overview of all underlying reports of"
+
+#: reports/templates/report_overview/subreports_header.html
+#: reports/templates/report_overview/subreports_table.html
+msgid "Shows report details"
+msgstr "Referre ostendit singula"
+
+#: reports/templates/report_overview/subreports_table.html
+#: rocky/templates/tasks/boefjes.html
+#: rocky/templates/tasks/plugin_detail_task_list.html
+msgid "Input Object"
+msgstr "Input Object"
+
+#: reports/templates/report_schedules/delete_recipe_modal.html
+msgid "Delete report recipe"
+msgstr "Delete fama recipe"
+
+#: reports/templates/report_schedules/delete_recipe_modal.html
+#, python-format
+msgid "Are you sure you want to delete report recipe \"%(name)s\"?"
+msgstr "Visne vero hanc relationem delere \"%(name)s\"?"
+
+#: reports/templates/report_schedules/delete_recipe_modal.html
+msgid ""
+"Deleting this report recipe means it will be permanently deleted. It will "
+"not be possible anymore to see or enable the schedule. You will find "
+"previously generated reports in the report history tab."
+msgstr ""
+"Recipe hanc relationem delendo modo in perpetuum delebitur. Non poterit "
+"amplius videre aut perfice schedulam. Antea generata in relationibus "
+"historiae tab."
+
+#: reports/templates/summary/report_asset_overview.html
+msgid ""
+"The objects listed in the table below were used to generate this report. For"
+" each object in the table it additionally shows the clearance level and "
+"whether or not the object was added by a user ('Declared') or indirectly "
+"identified through another service or system ('Inherited')."
+msgstr ""
+"Ea quae in tabula infra recensita sunt, hanc relationem generare solebant. "
+"Uterque enim objectum in tabula superaddita alvi planitiem ostendit, et "
+"utrum objectum a usuario additum ('Declaratum') vel indirecte notum per "
+"aliud servitium vel systema ('Hhereded')."
+
+#: reports/templates/summary/report_asset_overview.html
+msgid "No objects found."
+msgstr "Nulla res invenitur."
+
+#: reports/templates/summary/report_asset_overview.html
+msgid ""
+"The table below shows which reports were chosen to generate this report, "
+"including a report description."
+msgstr ""
+"Tabula infra ostendit quae relationes electae sunt ad hanc relationem "
+"generandam, inclusa relatione relationis."
+
+#: reports/templates/summary/report_asset_overview.html
+msgid "No report types found."
+msgstr "Typi nulla fama invenitur."
+
+#: reports/templates/summary/selected_plugins.html
+msgid ""
+"The table below shows all required or optional plugins for the selected "
+"reports."
+msgstr ""
+"Mensa infra ostendit omnia requisita vel plugins libitum pro relationibus "
+"selectis."
+
+#: reports/templates/summary/selected_plugins.html
+msgid "Required and optional plugins"
+msgstr "Requiritur et ad libitum plugins"
+
+#: reports/templates/summary/selected_plugins.html
+msgid "Plugin enabled"
+msgstr "Plugin para"
+
+#: reports/templates/summary/selected_plugins.html
+msgid "Plugin options"
+msgstr "Plugin optiones"
+
+#: reports/templates/summary/selected_plugins.html
+msgid "Plugin scan level"
+msgstr "Scan plugin level"
+
+#: reports/templates/summary/selected_plugins.html
+msgid "Enabled."
+msgstr "Conficere."
+
+#: reports/templates/summary/selected_plugins.html
+msgid "required"
+msgstr "requiritur"
+
+#: reports/templates/summary/selected_plugins.html
+msgid "optional"
+msgstr "ad libitum"
+
+#: reports/templates/summary/selected_plugins.html
+msgid "Plugin extra info"
+msgstr "Plugin extra info"
+
+#: reports/templates/summary/selected_plugins.html
+msgid ""
+"There are no required or optional plugins needed for the selected report "
+"types."
+msgstr ""
+"Nulla plugins requiruntur vel ad libitum necessariae ad genera relationum "
+"selectarum."
+
+#: reports/views/aggregate_report.py reports/views/generate_report.py
+#: reports/views/multi_report.py
+msgid "Select objects"
+msgstr "Lego obiecti"
+
+#: reports/views/aggregate_report.py reports/views/generate_report.py
+#: reports/views/multi_report.py
+msgid "Select report types"
+msgstr "Types fama Select"
+
+#: reports/views/aggregate_report.py reports/views/generate_report.py
+#: reports/views/multi_report.py
+msgid "Export setup"
+msgstr "Export setup"
+
+#: reports/views/aggregate_report.py reports/views/generate_report.py
+msgid "Save report"
+msgstr "Servo fama"
+
+#: reports/views/aggregate_report.py reports/views/generate_report.py
+msgid "You do not have the required permissions to enable plugins."
+msgstr "Non habes permissiones requisitas ut plugins efficias."
+
+#: reports/views/base.py
+msgid "Select at least one OOI to proceed."
+msgstr "Unum saltem OOI procedat."
+
+#: reports/views/base.py
+msgid "Select at least one report type to proceed."
+msgstr "Eligere saltem unum genus fama procedere."
+
+#: reports/views/mixins.py
+msgid ""
+"No data could be found for %(report_types). Object(s) did not exist on "
+"%(date)s."
+msgstr "Nulla notitia pro %(report_types). Object(s) non exstitit %(date)s."
+
+#: reports/views/multi_report.py
+msgid "View report"
+msgstr "Visum fama"
+
+#: reports/views/report_overview.py
+msgid "Not enough permissions"
+msgstr "Non satis permissiones"
+
+#: reports/views/report_overview.py
+msgid "Recipe '{}' deleted successfully"
+msgstr "Recipe '{}' deletum feliciter"
+
+#: reports/views/report_overview.py
+msgid "Recipe not found."
+msgstr "Recipe non inveni."
+
+#: reports/views/report_overview.py
+msgid "No schedule or recipe selected"
+msgstr "Nulla rhoncus vel consequat lectus"
+
+#: reports/views/report_overview.py
+msgid ""
+"Schedule disabled successfully. '{}' will not be generated automatically "
+"until the schedule is enabled again."
+msgstr ""
+"Morbi rhoncus erret feliciter. '{}' non sponte generabitur donec schedularum"
+" iterum restituatur."
+
+#: reports/views/report_overview.py
+msgid ""
+"Schedule enabled successfully. '{}' will be generated according to schedule."
+msgstr "Schedule feliciter enabled. '{}' Generabitur secundum cedulam."
+
+#: reports/views/report_overview.py
+msgid "An unexpected error occurred, please check logs for more info."
+msgstr "Error inopinatus incidit, omnia pro more info reprimendam placet."
+
+#: reports/views/report_overview.py
+msgid "Other OOI type selected than Report"
+msgstr "Aliae OOI genus electae quam Report"
+
+#: reports/views/report_overview.py
+msgid "Deletion successful."
+msgstr "Prosperitas deletionis."
+
+#: reports/views/report_overview.py
+msgid ""
+"Multi organization reports cannot be rescheduled. It consists of imported "
+"data from different organizations and is not based on newly generated data."
+msgstr ""
+"Multi relationes relationum reschedul esse non possunt. Constat ex notitia "
+"ex diversis Institutis importata et in notitia nuper generata non fundatur."
+
+#: reports/views/report_overview.py
+msgid ""
+"Rerun successful. It may take a moment before the new report has been "
+"generated."
+msgstr ""
+"Rerun felix. Licet momentum capere antequam nova relatio generata est."
+
+#: reports/views/report_overview.py
+#, python-format
+msgid ""
+"Couldn't rerun %s, since the recipe for this report has been disabled or "
+"deleted."
+msgstr "Non potuit rerun %s, cum recipe relatio erret vel deleta est."
+
+#: reports/views/report_overview.py
+msgid "Renaming failed. Empty report name found."
+msgstr "Renaming incassum. Fama vana nominis invenitur."
+
+#: reports/views/report_overview.py
+msgid "Report names and reports does not match."
+msgstr "Fama nomina et relationes non congruit."
+
+#: reports/views/report_overview.py
+msgid "Reports successfully renamed."
+msgstr "Refert feliciter appellatum est."
+
+#: reports/views/report_overview.py
+msgid "Report {} could not be renamed."
+msgstr "Fama {} nominari non potuit."
+
+#: reports/views/view_helpers.py
+msgid "1: Select objects"
+msgstr "I: Select obiecti"
+
+#: reports/views/view_helpers.py
+msgid "2: Choose report types"
+msgstr "II: Elige fama types"
+
+#: reports/views/view_helpers.py
+msgid "3: Configuration"
+msgstr "III: configurationis"
+
+#: reports/views/view_helpers.py
+msgid "4: Export setup"
+msgstr "4: Export setup"
+
+#: reports/views/view_helpers.py
+msgid "3: Export setup"
+msgstr "III: Export setup"
+
+#: tools/forms/base.py
+msgid "Date"
+msgstr "Date"
+
+#: tools/forms/boefje.py
+msgid "For example: -sTU --top-ports 1000"
+msgstr "Exempli gratia: -sTU --top-portus 1000"
+
+#: tools/forms/boefje.py
+msgid "JSON Schema"
+msgstr "JSON Schema"
+
+#: tools/forms/boefje.py
+msgid "Input object type"
+msgstr "Input genus object"
+
+#: tools/forms/boefje.py
+msgid "Output mime types"
+msgstr "Output mimum types"
+
+#: tools/forms/boefje.py
+msgid "Scan type"
+msgstr "Scan genus"
+
+#: tools/forms/boefje.py
+msgid "Interval amount"
+msgstr "Intervallum moles"
+
+#: tools/forms/boefje.py
+msgid ""
+"Specify the scanning interval for this Boefje. The default is 24 hours. For "
+"example: 5 minutes will let the Boefje scan every 5 minutes."
+msgstr ""
+"ENARRATIO spatii huius Boefje denota. Default 24 horarum est. Exempli "
+"gratia: 5 minuta Boefje scandet singula 5 minuta."
+
+#: tools/forms/boefje.py
+msgid "Interval frequency"
+msgstr "Intervallum frequentia"
+
+#: tools/forms/boefje.py
+msgid "Object creation/change"
+msgstr "Object creatio / mutatio"
+
+#: tools/forms/boefje.py
+msgid ""
+"Choose weather the Boefje should run after creating and/or changing an "
+"object. "
+msgstr ""
+"Elige tempestatem Boefje debet currere post partum et/vel mutato obiecto."
+
+#: tools/forms/finding_type.py
+msgid "KAT-ID"
+msgstr "KAT-ID"
+
+#: tools/forms/finding_type.py
+msgid "Unique ID within OpenKAT, for this type"
+msgstr "Unicum ID intra OpenKAT, huius generis"
+
+#: tools/forms/finding_type.py
+msgid "Title"
+msgstr "Titulus"
+
+#: tools/forms/finding_type.py
+msgid "Give the finding type a fitting title"
+msgstr "Da invenire genus a decet titulum"
+
+#: tools/forms/finding_type.py
+msgid "Describe the finding type"
+msgstr "Genus inventum describere"
+
+#: tools/forms/finding_type.py
+msgid "Risk"
+msgstr "Risk"
+
+#: tools/forms/finding_type.py
+msgid "Solution"
+msgstr "Solutio"
+
+#: tools/forms/finding_type.py
+msgid "How can this be solved?"
+msgstr "Quomodo hoc solvi potest?"
+
+#: tools/forms/finding_type.py
+msgid "Describe how this type of finding can be solved"
+msgstr "Qualiter hoc genus inventionis solvi possit"
+
+#: tools/forms/finding_type.py
+msgid "References"
+msgstr "References"
+
+#: tools/forms/finding_type.py
+msgid "Please give some references on the solution"
+msgstr "Da quaeso aliqua solutione"
+
+#: tools/forms/finding_type.py
+msgid "Please give sources and references on the suggested solution"
+msgstr "Da fontes et references in suggesserant solutionem"
+
+#: tools/forms/finding_type.py
+msgid "Impact description"
+msgstr "Impulsum descriptionem"
+
+#: tools/forms/finding_type.py
+msgid "Describe the solutions impact"
+msgstr "Solutiones describere impulsum"
+
+#: tools/forms/finding_type.py
+msgid "Solution chance"
+msgstr "Solutio forte"
+
+#: tools/forms/finding_type.py
+msgid "Solution impact"
+msgstr "Solutio impulsum"
+
+#: tools/forms/finding_type.py
+msgid "Solution effort"
+msgstr "Solutio conatus"
+
+#: tools/forms/finding_type.py
+msgid "ID should start with "
+msgstr "Id debet incipere"
+
+#: tools/forms/finding_type.py
+msgid "Finding type already exists"
+msgstr "Iam genus inveniens"
+
+#: tools/forms/finding_type.py
+msgid "Click to select one of the available options"
+msgstr "Click eligere unum praesto optiones"
+
+#: tools/forms/finding_type.py
+#: rocky/templates/partials/finding_occurrence_definition_list.html
+msgid "Proof"
+msgstr "Probatur"
+
+#: tools/forms/finding_type.py
+msgid "Provide evidence of your finding"
+msgstr "Indicio tuae inventione"
+
+#: tools/forms/finding_type.py
+msgid "Describe your finding"
+msgstr "Describere tuum inventum"
+
+#: tools/forms/finding_type.py
+msgid "Reproduce finding"
+msgstr "Reproduce inventum"
+
+#: tools/forms/finding_type.py
+msgid "Please explain how to reproduce your finding"
+msgstr "Explicate quomodo ad repetendum tuum inventum"
+
+#: tools/forms/finding_type.py tools/forms/upload_raw.py
+msgid "Date/Time (UTC)"
+msgstr "Dies/Tempus (UTC)"
+
+#: tools/forms/finding_type.py tools/forms/upload_raw.py
+msgid "Doc! I'm from the future, I'm here to take you back!"
+msgstr "Doc! Ego ex futuro, hic sum ut te reducam!"
+
+#: tools/forms/finding_type.py
+msgid "OOI doesn't exist"
+msgstr "OOI non est"
+
+#: tools/forms/findings.py
+msgid "Show non-muted findings"
+msgstr "Ostende non-commutari Inventiones"
+
+#: tools/forms/findings.py
+msgid "Show muted findings"
+msgstr "Ostende transmutari Inventiones"
+
+#: tools/forms/findings.py
+msgid "Show muted and non-muted findings"
+msgstr "Ostende transmutari et non-commutari Inventiones"
+
+#: tools/forms/findings.py
+msgid "Filter by severity"
+msgstr "Filtrum severitate"
+
+#: tools/forms/findings.py
+msgid "Filter by muted findings"
+msgstr "Filter per transmutari Inventiones"
+
+#: tools/forms/findings.py tools/forms/ooi_form.py tools/forms/scheduler.py
+msgid "Search"
+msgstr "Investigatio"
+
+#: tools/forms/findings.py
+msgid "Object ID contains (case sensitive)"
+msgstr "Object ID continet (si sensitivo)"
+
+#: tools/forms/ooi.py
+msgid "Filter types"
+msgstr "Genera eliquare"
+
+#: tools/forms/ooi.py
+msgid "Clearance Level"
+msgstr "Clearance Level"
+
+#: tools/forms/ooi.py
+msgid "Next scan"
+msgstr "Postero scan"
+
+#: tools/forms/ooi.py
+msgid "Show objects that don't meet the Boefjes scan level."
+msgstr "Ostende obiecta quae in gradu scan Boefjes non concurrunt."
+
+#: tools/forms/ooi.py
+msgid "Show Boefjes that exceed the objects clearance level."
+msgstr "Ostende Boefjes quod obiecti alvi planitiem excedunt."
+
+#: tools/forms/ooi.py
+msgid ""
+"All the boefjes with a scan level below or equal to the clearance level will"
+" be allowed to scan this object."
+msgstr ""
+"Omnes boefjes cum gradu scanni infra vel aequalem alvi gradum licebit hoc "
+"objecto lustrare."
+
+#: tools/forms/ooi.py
+msgid "Expires by (UTC)"
+msgstr "Expirat ab (UTC)"
+
+#: tools/forms/ooi_form.py
+msgid "option"
+msgstr "optio"
+
+#: tools/forms/ooi_form.py
+#, python-brace-format
+msgid "Optionally choose a {option_label}"
+msgstr "Optionally eligere {option_label}"
+
+#: tools/forms/ooi_form.py
+#, python-brace-format
+msgid "Please choose a {option_label}"
+msgstr "Elige {option_label}"
+
+#: tools/forms/ooi_form.py
+msgid "Filter by clearance level"
+msgstr "Filtrum alvi gradu"
+
+#: tools/forms/ooi_form.py
+msgid "Filter by clearance type"
+msgstr "Alvi genus filter"
+
+#: tools/forms/scheduler.py
+msgid "From"
+msgstr "Ex"
+
+#: tools/forms/scheduler.py
+msgid "To"
+msgstr "Ad"
+
+#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+msgid "Cancelled"
+msgstr "Pax"
+
+#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+msgid "Completed"
+msgstr "completed"
+
+#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+msgid "Dispatched"
+msgstr "missum"
+
+#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+msgid "Failed"
+msgstr "Defecit"
+
+#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+msgid "Queued"
+msgstr "Queued"
+
+#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+msgid "Running"
+msgstr "Running"
+
+#: tools/forms/scheduler.py
+msgid "Search by object name"
+msgstr "Search by object name"
+
+#: tools/forms/scheduler.py
+msgid "The selected date is in the future. Please select a different date."
+msgstr "Electus in posterum diem. Placere eligere alium diem."
+
+#: tools/forms/settings.py
+msgid "--- Show all ----"
+msgstr "--- Ostende omnia ----"
+
+#: tools/forms/settings.py
+msgid "recommendation"
+msgstr "commendaticiis"
+
+#: tools/forms/settings.py
+msgid "low"
+msgstr "low"
+
+#: tools/forms/settings.py
+msgid "medium"
+msgstr "medium"
+
+#: tools/forms/settings.py
+msgid "high"
+msgstr "summus"
+
+#: tools/forms/settings.py
+msgid "very high"
+msgstr "valde altus"
+
+#: tools/forms/settings.py
+msgid "critical"
+msgstr "critica"
+
+#: tools/forms/settings.py
+msgid "quickfix"
+msgstr "quickfix"
+
+#: tools/forms/settings.py
+msgid "Declared"
+msgstr "Declaravit"
+
+#: tools/forms/settings.py
+msgid "Inherited"
+msgstr "hereditarium"
+
+#: tools/forms/settings.py
+msgid "Empty"
+msgstr "inanis"
+
+#: tools/forms/settings.py
+msgid "Add one finding type ID per line."
+msgstr "Adde unum genus inveniendi ID per lineam."
+
+#: tools/forms/settings.py
+msgid "Add the date and time of your finding (UTC)"
+msgstr "Adde diem et tempus inveniendi tui (UTC)"
+
+#: tools/forms/settings.py
+msgid "Add the date and time of when the raw file was generated (UTC)"
+msgstr "Adde tempus et tempus quo rudis fasciculus generatus est (UTC)"
+
+#: tools/forms/settings.py
+msgid ""
+"OpenKAT stores a time indication with every observation, so it is possible "
+"to see the status of your network through time. Select a datetime to change "
+"the view to represent that moment in time."
+msgstr ""
+"OpenKAT tempus indicat cum omni observatione indicium, quo fieri potest ut "
+"statum reticuli tui per tempus videre possit. Tempus eligere tempus mutare "
+"sententiam ut illud momentum in tempore repraesentaret."
+
+#: tools/forms/settings.py
+msgid ""
+"<p>The name of the Docker image. For example: "
+"<i>'ghcr.io/minvws/openkat/nmap'</i>. In OpenKAT, all Boefjes with the same "
+"container image will be seen as 'variants' and will be shown together on the"
+" Boefje detail page. </p> "
+msgstr ""
+"<p> Nomen imaginis Docker. Verbi gratia: "
+"<i>'ghcr.io/minvws/openkat/nmap'</i>. In OpenKAT, omnes Boefjes cum eodem "
+"vase imaginis \"variantes\" videbuntur et simul in Boefje pagina singula "
+"ostendentur. </p>"
+
+#: tools/forms/settings.py
+msgid ""
+"A description of the Boefje explaining in short what it can do. This will "
+"both be displayed inside the KAT-alogus and on the Boefje details page."
+msgstr ""
+"Descriptio Boefje breviter explicans quid facere possit. Hoc utrumque intus "
+"ostendetur in KAT-alogo et in Boefje pagina singula."
+
+#: tools/forms/settings.py
+msgid ""
+"Select the object type(s) that your Boefje consumes. To select multiple "
+"objects, press and hold the 'ctrl'/'command' key and then click the items "
+"you want to select. "
+msgstr ""
+"Objectum genus(s) elige quod tuum Boefje consumit. Multa obiecta eligere, "
+"premere ac tenere key imperium 'ctrl'/' ac deinde deprime vasa quae vis "
+"eligere."
+
+#: tools/forms/settings.py
+msgid ""
+"<p>If any other settings are needed for your Boefje, add these as a JSON "
+"Schema, otherwise, leave the field empty or 'null'.</p> <p> This JSON is "
+"used as the basis for a form for the user. When the user enables this Boefje"
+" they can get the option to give extra information. For example, it can "
+"contain an API key that the script requires.</p> <p>More information about "
+"what the schema.json file looks like can be found <a "
+"href='https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html'>"
+" here</a>.</p> "
+msgstr ""
+"<p> Si quis alius occasus necessarius est ad Boefje, his adde ut JSON "
+"Schema, alioquin vacuum agrum relinque vel 'nullum'.</p> <p> Hoc JSON pro "
+"fundamento formae pro utentis ponitur. Cum usor hoc dat Boefje optionem "
+"accipere possunt ad extra informationem da. Exempli gratia, continere potest"
+" clavis API quam scriptura requirit.</p> <p> Plura de eo quod schema.json "
+"fasciculus similis inveniri potest <a "
+"href='https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html'>"
+" hic </a>.</p>"
+
+#: tools/forms/settings.py
+msgid ""
+"<p>Add a set of mime types that are produced by this Boefje, separated by "
+"commas. For example: <i>'text/html'</i>, <i>'image/jpeg'</i> or "
+"<i>'boefje/{boefje-id}'</i></p> <p>These output mime types will be shown on "
+"the Boefje detail page as information for other users. </p> "
+msgstr ""
+"<p>Adde seriem generum MIME quae ab hoc Boefje producuntur, commatibus "
+"separatam. Exempli gratia: <i>'text/html'</i>, <i>'image/jpeg'</i> vel "
+"<i>'boefje/{boefje-id}'</i></p> <p>Haec genera MIME output in pagina "
+"singularum Boefje ostendentur ut informatio pro aliis usoribus. </p> "
+
+#: tools/forms/settings.py
+msgid ""
+"<p>Select a clearance level for your Boefje. For more information about the "
+"different clearance levels please check the <a "
+"href='https://docs.openkat.nl/manual/usermanual.html#scan-levels-clearance-"
+"indemnities'> documentation</a>.</p> "
+msgstr ""
+"<p> alvi deiectio pro Boefje elige. Plura de diversis gradibus alvi "
+"deprimunt, quaeso, <a "
+"href='https://docs.openkat.nl/manual/usermanual.html#scan-levels-clearance-"
+"indemnities'> documenta-</a>.</p>."
+
+#: tools/forms/settings.py
+msgid ""
+"Choose when this Boefje will scan objects. It can run on a given interval or"
+" it can run every time an object has been created or changed. "
+msgstr ""
+"Elige cum haec Boefje obiecta lustrabit. dato spatio currere potest vel "
+"potest currere omne tempus quod creatum est vel mutatum."
+
+#: tools/forms/settings.py
+msgid "Depth of the tree."
+msgstr "Altitudo arboris."
+
+#: tools/forms/upload_csv.py
+msgid "Only CSV file supported"
+msgstr "Solus fasciculus CSV sustentatur"
+
+#: tools/forms/upload_csv.py
+msgid "File could not be decoded"
+msgstr "File non decoded"
+
+#: tools/forms/upload_csv.py
+msgid "No file selected"
+msgstr "Non file electus"
+
+#: tools/forms/upload_csv.py
+msgid "The uploaded file is empty."
+msgstr "Scapus fasciculi inanis est."
+
+#: tools/forms/upload_csv.py
+msgid "The number of columns do not meet the requirements."
+msgstr "Columnarum numerus non metus."
+
+#: tools/forms/upload_csv.py
+msgid "OOI Type in CSV does not meet the criteria."
+msgstr "OOI Typus in CSV criteriis non occurrit."
+
+#: tools/forms/upload_csv.py
+msgid "An error has occurred during the parsing of the csv file:"
+msgstr "Error in parsing fasciculi csv incidit:"
+
+#: tools/forms/upload_csv.py
+msgid "Upload CSV file"
+msgstr "Fasciculus CSV"
+
+#: tools/forms/upload_csv.py
+msgid "Only accepts CSV file."
+msgstr "Tantum fasciculum CSV accipit."
+
+#: tools/forms/upload_oois.py rocky/templates/partials/explanations.html
+msgid "Object Type"
+msgstr "Object Type"
+
+#: tools/forms/upload_oois.py
+msgid "Choose a type of which objects are added."
+msgstr "Elige genus quibus obiecti adduntur."
+
+#: tools/forms/upload_raw.py
+msgid "Mime types"
+msgstr "Mimi types"
+
+#: tools/forms/upload_raw.py
+msgid ""
+"<p>Add a set of mime types, separated by commas, for "
+"example:</p><p><i>\"text/html, image/jpeg\"</i> or <i>\"boefje/dns-"
+"records\"</i>.</p><p>Mime types are used to match the correct normalizer to "
+"a raw file. When the mime type \"boefje/dns-records\" is added, the "
+"normalizer expects the raw file to contain dns scan information.</p>"
+msgstr ""
+"<p>Adde seriem generum MIME, commatibus separatam, exempli "
+"gratia:</p><p><i>\"text/html, image/jpeg\"</i> vel <i>\"boefje/dns-"
+"records\"</i>.</p><p>Genera MIME adhibentur ut rectus normalizer cum tabella"
+" cruda coniungatur. Cum genus MIME \"boefje/dns-records\" additur, "
+"normalizer exspectat tabellam crudam informationem de DNS scan "
+"continere.</p>"
+
+#: tools/forms/upload_raw.py rocky/templates/partials/ooi_list_toolbar.html
+#: rocky/templates/upload_raw.html
+msgid "Upload raw file"
+msgstr "Rudis fasciculus upload"
+
+#: tools/forms/upload_raw.py
+msgid "Input or Scan OOI"
+msgstr "Input or Scan OOI"
+
+#: tools/forms/upload_raw.py
+msgid "Click to select one of the available options, or type one yourself"
+msgstr "Click eligere unum ex optiones available, vel typus unum te ipsum"
+
+#: tools/forms/upload_raw.py
+msgid "OOI doesn't exist, try another valid time"
+msgstr "OOI non est, aliud tempus validum tenta"
+
+#: tools/models.py
+msgid ""
+"A short code containing only lower-case unicode letters, numbers, hyphens or"
+" underscores that will be used in URLs and paths."
+msgstr ""
+"Brevis signum continet litteras tantum-casu unicodes, numeros, hyphenas vel "
+"underscorationes quae in URLs adhibebuntur ac semitis."
+
+#: tools/models.py
+msgid ""
+"This organization code is reserved by OpenKAT and cannot be used. Choose "
+"another organization code."
+msgstr ""
+"Haec norma norma servatur per OpenKAT et adhiberi non potest. Elige aliam "
+"organizationem codice."
+
+#: tools/models.py
+msgid "new"
+msgstr "novus"
+
+#: tools/templatetags/ooi_extra.py
+msgid "Unknown user"
+msgstr "Ignota user"
+
+#: tools/view_helpers.py rocky/templates/header.html
+#: rocky/templates/organizations/organization_member_list.html
+#: rocky/views/organization_member_edit.py
+msgid "Members"
+msgstr "Socii"
+
+#: rocky/forms.py
+msgid "Current status"
+msgstr "Current status"
+
+#: rocky/forms.py rocky/templates/organizations/organization_member_list.html
+msgid "Active"
+msgstr "Active"
+
+#: rocky/forms.py rocky/templates/organizations/organization_member_list.html
+msgid "New"
+msgstr "New"
+
+#: rocky/forms.py
+msgid "Account status"
+msgstr "Ratio status"
+
+#: rocky/forms.py
+msgid "Not blocked"
+msgstr "Non clausus"
+
+#: rocky/messaging.py
+msgid ""
+"You have trusted this member with a clearance level of L{}. This member "
+"needs at least a clearance level of L{} in order to do a proper onboarding. "
+"Edit this member and change the clearance level if necessary."
+msgstr ""
+"Hoc membrum cum alvi deiectio credidisti L{}. Hoc membrum saltem alvi "
+"deiectio eget ad gradum L{} ad faciendum rite invehendum. Hoc membrum emenda"
+" et alvi deiectio si opus est."
+
+#: rocky/paginator.py
+msgid "That page number is not an integer"
+msgstr "Pagina illa numerus non est integer"
+
+#: rocky/paginator.py
+msgid "That page number is less than 1"
+msgstr "Pagina illa numerus minor est quam 1"
+
+#: rocky/paginator.py
+msgid "That page contains no results"
+msgstr "Pagina illa nullos proventus continet"
+
+#: rocky/scheduler.py
+msgid ""
+"The Scheduler has an unexpected error. Check the Scheduler logs for further "
+"details."
+msgstr ""
+"Scheduler errorem inopinatum habet. Reprehendo acta Scheduler ad singula "
+"plura."
+
+#: rocky/scheduler.py
+msgid "Could not connect to Scheduler. Service is possibly down."
+msgstr "Scheduler coniungere potuit. Servitium pos- sunt descendere."
+
+#: rocky/scheduler.py
+msgid "Your request could not be validated."
+msgstr "Petitio tua non convalescit."
+
+#: rocky/scheduler.py
+msgid "Task could not be found."
+msgstr "Negotium inveniri potuit."
+
+#: rocky/scheduler.py
+msgid ""
+"Scheduler is receiving too many requests. Increase SCHEDULER_PQ_MAXSIZE or "
+"wait for task to finish."
+msgstr ""
+"Scheduler nimis multas petitiones accipit. SCHEDULER_PQ_MAXSIZE auge vel "
+"exspecta negotium ut perficias."
+
+#: rocky/scheduler.py
+msgid "Bad request. Your request could not be interpreted by the Scheduler."
+msgstr "Mala postulatio. Petitio tua a Scheduler interpretari non potuit."
+
+#: rocky/scheduler.py
+msgid "The Scheduler has received a conflict. Your task is already in queue."
+msgstr "Scheduler certamen accepit. Tuum negotium iam est in queue."
+
+#: rocky/scheduler.py
+msgid "A HTTPError occurred. See Scheduler logs for more info."
+msgstr "HTTPError occurrit r. Vide Scheduler acta pro more info."
+
+#: rocky/scheduler.py
+msgid "Schedule list: "
+msgstr "Schedule album:"
+
+#: rocky/scheduler.py
+msgid "Task list: "
+msgstr "Negotium album:"
+
+#: rocky/settings.py
+msgid "Blue light"
+msgstr "Caeruleum lux"
+
+#: rocky/settings.py
+msgid "Blue medium"
+msgstr "Caeruleum medium"
+
+#: rocky/settings.py
+msgid "Blue dark"
+msgstr "Blue tenebris"
+
+#: rocky/settings.py
+msgid "Green light"
+msgstr "Green lux"
+
+#: rocky/settings.py
+msgid "Green medium"
+msgstr "Green medium"
+
+#: rocky/settings.py
+msgid "Green dark"
+msgstr "Viridis tenebris"
+
+#: rocky/settings.py
+msgid "Yellow light"
+msgstr "Yellow lux"
+
+#: rocky/settings.py
+msgid "Yellow medium"
+msgstr "Yellow medium"
+
+#: rocky/settings.py
+msgid "Yellow dark"
+msgstr "Yellow tenebris"
+
+#: rocky/settings.py
+msgid "Orange light"
+msgstr "Aliquam lux"
+
+#: rocky/settings.py
+msgid "Orange medium"
+msgstr "Orange medium"
+
+#: rocky/settings.py
+msgid "Orange dark"
+msgstr "Orange tenebris"
+
+#: rocky/settings.py
+msgid "Red light"
+msgstr "Red lux"
+
+#: rocky/settings.py
+msgid "Red medium"
+msgstr "Rubrum medium"
+
+#: rocky/settings.py
+msgid "Red dark"
+msgstr "Rubrum tenebris"
+
+#: rocky/settings.py
+msgid "Violet light"
+msgstr "Lumen violaceum"
+
+#: rocky/settings.py
+msgid "Violet medium"
+msgstr "Viola medium"
+
+#: rocky/settings.py
+msgid "Violet dark"
+msgstr "Hyacinthus tenebris"
+
+#: rocky/settings.py
+msgid "Plain"
+msgstr "Planum"
+
+#: rocky/settings.py
+msgid "Solid"
+msgstr "Firmus"
+
+#: rocky/settings.py
+msgid "Dashed"
+msgstr "elisi"
+
+#: rocky/settings.py
+msgid "Dotted"
+msgstr "Dotted"
+
+#: rocky/templates/403.html
+msgid "Error code 403: Unauthorized"
+msgstr "Error code CDIII: Alienum"
+
+#: rocky/templates/403.html
+msgid "Your account is not authorized to access this page or organization."
+msgstr ""
+"Ratio tua auctoritate hanc paginam or organizationem accedere non est."
+
+#: rocky/templates/403.html
+msgid "Please contact your system administrator."
+msgstr "Contact vestri ratio administrator."
+
+#: rocky/templates/403.html rocky/templates/404.html
+msgid "You may want to go back to the"
+msgstr "Vis redire ad the"
+
+#: rocky/templates/403.html rocky/templates/404.html
+msgid "Crisis Room"
+msgstr "Crisis Room"
+
+#: rocky/templates/404.html
+msgid "Error code 404: Page not found"
+msgstr "Error code CDIV: Page non inveni"
+
+#: rocky/templates/404.html
+msgid ""
+"The page you wanted to see or the file you wanted to view was not found."
+msgstr ""
+"Pagina videre volebas aut tabellam inspicere voluisti, non inventa est."
+
+#: rocky/templates/admin/base.html
+msgid "Skip to main content"
+msgstr "Skip to main content"
+
+#: rocky/templates/admin/base.html
+msgid "Welcome,"
+msgstr "salve,"
+
+#: rocky/templates/admin/base.html
+msgid "View site"
+msgstr "Visum situs"
+
+#: rocky/templates/admin/base.html
+msgid "Documentation"
+msgstr "Documentation"
+
+#: rocky/templates/admin/base.html
+msgid "Change password"
+msgstr "Mutatio password"
+
+#: rocky/templates/admin/base.html
+msgid "Log out"
+msgstr "Log sicco"
+
+#: rocky/templates/admin/base.html rocky/templates/header.html
+msgid "Breadcrumbs"
+msgstr "Panis"
+
+#: rocky/templates/admin/base.html rocky/templates/admin/change_form.html
+#: rocky/templates/admin/change_list.html
+#: rocky/templates/admin/delete_confirmation.html
+#: rocky/templates/admin/delete_selected_confirmation.html
+msgid "Home"
+msgstr "Home"
+
+#: rocky/templates/admin/change_form.html
+#, python-format
+msgid "Add %(name)s"
+msgstr "Adde %(name)s"
+
+#: rocky/templates/admin/change_form.html
+#: rocky/templates/admin/change_list.html
+msgid "Please correct the error below."
+msgid_plural "Please correct the errors below."
+msgstr[0] "Placere errorem infra corrigere."
+msgstr[1] "Errores infra corrige quaeso."
+
+#: rocky/templates/admin/change_list.html
+msgid "Filter"
+msgstr "Filtrum"
+
+#: rocky/templates/admin/change_list.html
+msgid "Hide counts"
+msgstr "Celare comites"
+
+#: rocky/templates/admin/change_list.html
+msgid "Show counts"
+msgstr "Monstra comitum"
+
+#: rocky/templates/admin/change_list.html
+msgid "Clear all filters"
+msgstr "Patet omnia Filtra"
+
+#: rocky/templates/admin/delete_confirmation.html
+#, python-format
+msgid ""
+"Deleting the %(object_name)s '%(escaped_object)s' would result in deleting "
+"related objects, but your account doesn't have permission to delete the "
+"following types of objects"
+msgstr ""
+"Deletis %(object_name)s '%(escaped_object)s' in obiectis relativis delendis "
+"sequeretur, sed ratio vestra non permittitur ut sequentia genera rerum "
+"delere"
+
+#: rocky/templates/admin/delete_confirmation.html
+#, python-format
+msgid ""
+"Deleting the %(object_name)s '%(escaped_object)s' would require deleting the"
+" following protected related objects"
+msgstr ""
+"Deletis %(object_name)s '%(escaped_object)s' requireret delendo sequentia "
+"obiecta obiecta conservata"
+
+#: rocky/templates/admin/delete_confirmation.html
+#, python-format
+msgid ""
+"Are you sure you want to delete the %(object_name)s \"%(escaped_object)s\"? "
+"All of the following related items will be deleted"
+msgstr ""
+"Visne vero %(object_name)s \"%(escaped_object)s delere? Omnes sequentia "
+"paginae cognatae item delebuntur"
+
+#: rocky/templates/admin/delete_confirmation.html
+#: rocky/templates/admin/delete_selected_confirmation.html
+msgid "Yes, I’m sure"
+msgstr "Ita, sum certus"
+
+#: rocky/templates/admin/delete_confirmation.html
+#: rocky/templates/admin/delete_selected_confirmation.html
+msgid "No, take me back"
+msgstr "Imo me recipiat"
+
+#: rocky/templates/admin/delete_selected_confirmation.html
+msgid "Delete multiple objects"
+msgstr "Delere multa objecta"
+
+#: rocky/templates/admin/delete_selected_confirmation.html
+#, python-format
+msgid ""
+"Deleting the selected %(objects_name)s would result in deleting related "
+"objects, but your account doesn't have permission to delete the following "
+"types of objects"
+msgstr ""
+"Deletis delectis %(objects_name)s in rebus actis deletis sequeretur, sed "
+"ratio tua non permittitur delere rationes sequentes obiecti."
+
+#: rocky/templates/admin/delete_selected_confirmation.html
+#, python-format
+msgid ""
+"Deleting the selected %(objects_name)s would require deleting the following "
+"protected related objects"
+msgstr ""
+"Deletis delectis %(objects_name)s deletis sequentibus obiectis relatede "
+"tutis requireret"
+
+#: rocky/templates/admin/delete_selected_confirmation.html
+#, python-format
+msgid ""
+"Are you sure you want to delete the selected %(objects_name)s? All of the "
+"following objects and their related items will be deleted"
+msgstr ""
+"Visne vero electum %(objects_name)s delere? Omnia sequentia obiecta et earum"
+" cognata delebuntur"
+
+#: rocky/templates/admin/popup_response.html
+msgid "Popup closing…"
+msgstr "Populus claudendo…"
+
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
+msgid "Close menu"
+msgstr "Close menu"
+
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
+msgid "Main navigation"
+msgstr "navigatio principalis"
+
+#: rocky/templates/dashboard_client.html
+msgid "Indemnifications"
+msgstr "Indemnificationes"
+
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html
+#: rocky/templates/partials/secondary-menu.html
+msgid "Logout"
+msgstr "Logout"
+
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html
+msgid "Welcome"
+msgstr "Grata"
+
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html
+msgid "User overview"
+msgstr "User overview"
+
+#: rocky/templates/dashboard_redteam.html
+#: rocky/templates/partials/notifications_block.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid "warning"
+msgstr "monitus"
+
+#: rocky/templates/dashboard_redteam.html
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+#: rocky/templates/partials/notifications_block.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid "Warning:"
+msgstr "Monitum:"
+
+#: rocky/templates/dashboard_redteam.html
+msgid "Organization code missing"
+msgstr "Organization code missing"
+
+#: rocky/templates/finding_type_add.html
+#: rocky/templates/partials/findings_list_toolbar.html
+#: rocky/views/finding_type_add.py
+msgid "Add finding type"
+msgstr "Addere genus inventum"
+
+#: rocky/templates/finding_type_add.html
+msgid "Finding Type"
+msgstr "Inveniens Type"
+
+#: rocky/templates/findings/finding_add.html
+#: rocky/templates/oois/ooi_detail_findings_list.html
+#: rocky/templates/oois/ooi_findings.html
+#: rocky/templates/partials/findings_list_toolbar.html
+#: rocky/views/finding_add.py
+msgid "Add finding"
+msgstr "Adde inventum"
+
+#: rocky/templates/findings/finding_list.html
+msgid "Findings "
+msgstr "Inventiones"
+
+#: rocky/templates/findings/finding_list.html
+#, python-format
+msgid ""
+"An overview of all findings OpenKAT found for organization "
+"<strong>%(organization_name)s</strong>. Each finding relates to an object. "
+"Click a finding for additional information."
+msgstr ""
+"Recensio omnium inventionum OpenKAT inventae ad ordinationem "
+"<strong>%(organization_name)s</strong>. Quaelibet inventio obiecti. Inventio"
+" pro informationis Click."
+
+#: rocky/templates/findings/finding_list.html
+#, python-format
+msgid "Showing %(length)s of %(total)s findings"
+msgstr "Ostendens %(length)s de %(total)s inventionibus"
+
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/partials/mute_findings_modal.html
+msgid "Mute findings"
+msgstr "muta inventa"
+
+#: rocky/templates/findings/finding_list.html
+msgid "Unmute findings"
+msgstr "inventis unmute"
+
+#: rocky/templates/findings/findings_filter.html
+#: rocky/templates/partials/elements/ooi_list_settings_form.html
+#: rocky/templates/tasks/partials/task_filter.html
+msgid "Set filters"
+msgstr "Filtra Set"
+
+#: rocky/templates/findings/findings_filter.html
+#: rocky/templates/partials/elements/ooi_list_settings_form.html
+#: rocky/templates/tasks/partials/task_filter.html
+msgid "Clear filters"
+msgstr "Patet Filtra"
+
+#: rocky/templates/footer.html rocky/views/privacy_statement.py
+msgid "Privacy Statement"
+msgstr "Secretum Statement"
+
+#: rocky/templates/forms/json_schema_form.html
+msgid "Fill out this form to answer the Question (again):"
+msgstr "Hanc formam explere ad quaestionem respondendum (iterum);"
+
+#: rocky/templates/graph-d3.html
+msgid ""
+"Click a circle to collapse / expand the tree, click the text to view the "
+"tree from that OOI and hover over the text to see details."
+msgstr ""
+"Preme circulum concidere / expand arborem, preme textum ad contemplandam "
+"arborem OOI et super textum ad singula vide."
+
+#: rocky/templates/graph-d3.html
+msgid "Tree graph"
+msgstr "Lignum graph"
+
+#: rocky/templates/header.html
+msgid "Menu"
+msgstr "Menu"
+
+#: rocky/templates/header.html
+msgid "OpenKAT logo, go to the homepage of OpenKAT"
+msgstr "OpenKAT logo, vade ad paginam OpenKAT"
+
+#: rocky/templates/header.html rocky/templates/tasks/ooi_detail_task_list.html
+#: rocky/templates/tasks/partials/tasks_overview_header.html
+#: rocky/templates/tasks/plugin_detail_task_list.html
+#: rocky/views/task_detail.py rocky/views/tasks.py
+msgid "Tasks"
+msgstr "Tasks"
+
+#: rocky/templates/health.html
+msgid "Health Checks"
+msgstr "Salutem SCUTULATUM"
+
+#: rocky/templates/health.html
+msgid "Health checks"
+msgstr "Salutem checks"
+
+#: rocky/templates/health.html
+msgid "Additional"
+msgstr "Additional"
+
+#: rocky/templates/indemnification_present.html
+msgid "Indemnification"
+msgstr "Indemnification"
+
+#: rocky/templates/indemnification_present.html
+msgid ""
+"Indemnification on the organization present. You may now add objects and "
+"start scans."
+msgstr ""
+"Remuneratio in ordinatione praesenti. Nunc obiecta addere potes et scandere "
+"incipias."
+
+#: rocky/templates/indemnification_present.html
+msgid "Go to Objects"
+msgstr "Vade ad objecta"
+
+#: rocky/templates/indemnification_present.html
+msgid "Go to"
+msgstr "Ite ad"
+
+#: rocky/templates/landing_page.html
+msgid "Welcome to OpenKAT"
+msgstr "OpenKAT"
+
+#: rocky/templates/landing_page.html
+msgid "Kwetsbaarheden Analyse Tool"
+msgstr "Kwetsbaarheden Analyse Tool"
+
+#: rocky/templates/landing_page.html
+msgid "What is OpenKAT?"
+msgstr "Quid est OpenKAT?"
+
+#: rocky/templates/landing_page.html
+msgid ""
+"OpenKAT is a vulnerability analysis tool. An Open Source-project developed "
+"by the Ministry of Health, Welfare and Sport to make your and our world "
+"safer."
+msgstr ""
+"OpenKAT instrumentum vulnerability analysin est. Patefacio Source-projectum "
+"a Ministerio Sanitatis, saluti et ludibrio elaboratum est ut tuum et nostrum"
+" mundum tutius redderet."
+
+#: rocky/templates/landing_page.html
+msgid "OpenKAT sees"
+msgstr "OpenKAT videt"
+
+#: rocky/templates/landing_page.html
+msgid ""
+"Dozens of tools are integrated in OpenKAT to view the world (digital and "
+"analog)."
+msgstr ""
+"Iudicia instrumentorum integrantur in OpenKAT ad mundum speculandum (digital"
+" and analog)."
+
+#: rocky/templates/landing_page.html
+msgid "Our motto is therefore: I see, I see, what you do not see."
+msgstr "Est ergo dictum: Video, video, quod non vides."
+
+#: rocky/templates/landing_page.html
+msgid "OpenKAT knows"
+msgstr "OpenKAT scit"
+
+#: rocky/templates/landing_page.html
+msgid ""
+"OpenKAT does not forget (just like that), and can be queried without "
+"scanning again. Also about a historical situation."
+msgstr ""
+"OpenKAT non obliviscitur (velut id), et queri potest quin iterum "
+"inspiciatur. Item de situ historico."
+
+#: rocky/templates/landing_page.html
+msgid "OpenKAT is secure"
+msgstr "OpenKAT securus est"
+
+#: rocky/templates/landing_page.html
+msgid ""
+"Forensically secured storage of evidence is one of the basic ingredients of "
+"OpenKAT."
+msgstr ""
+"Repositio forensice testimoniorum firmata est una e elementis elementorum "
+"OpenKAT."
+
+#: rocky/templates/landing_page.html
+msgid "OpenKAT is sweet"
+msgstr "OpenKAT dulce est"
+
+#: rocky/templates/landing_page.html
+msgid ""
+"OpenKAT thinks about privacy, and stores what is necessary, within the rules"
+" of your organization and the law."
+msgstr ""
+"OpenKAT de secreto cogitat, ac necessariis reponit, intra regulas tuae "
+"dispositionis ac legis."
+
+#: rocky/templates/landing_page.html
+msgid "A wide playing field"
+msgstr "A agro late ludens"
+
+#: rocky/templates/landing_page.html
+msgid ""
+"OpenKAT makes a copy of the actual reality by means of the integrated tools."
+" Within this copy you can search for answers to countless security and "
+"policy questions. Expected and unexpected changes in the world are made "
+"visible, and where necessary reported or made known directly to the right "
+"people."
+msgstr ""
+"OpenKAT exemplar rei ipsae per instrumenta integralis reddit. In hoc "
+"exemplari potes responsa exquirere cum innumerabilibus quaestionibus "
+"securitatis et consiliorum. Expectatae et inopinatae mutationes in mundo "
+"visibiles fiunt, et ubi necessaria nuntiantur vel manifestantur directe ad "
+"ius hominum."
+
+#: rocky/templates/legal/privacy_statement.html
+msgid "OpenKAT Privacy Statement"
+msgstr "OpenKAT Privacy Statement"
+
+#: rocky/templates/legal/privacy_statement.html
+msgid ""
+"OpenKAT is dedicated to protecting the confidentiality and privacy of "
+"information entrusted to it. As part of this fundamental obligation, OpenKAT"
+" is committed to the appropriate protection and use of personal information "
+"(sometimes referred to as \"personal data\", \"personally identifiable "
+"information\" or \"PII\") that has been collected online."
+msgstr ""
+"OpenKAT secreto ac secreto informationum sibi commissarum tuenda dedicatur. "
+"Pro parte huius obligationis fundamentalis, OpenKAT committitur aptae "
+"tutelae et usui informationum personalium (interdum ut \"notitia "
+"personalis\", \"personalis identificabilis\" vel \"PII\") committitur quae "
+"in online collecta sunt."
+
+#: rocky/templates/oois/error.html
+msgid "Object List"
+msgstr "Object List"
+
+#: rocky/templates/oois/error.html
+msgid "An error occurred. Please contact a system administrator."
+msgstr "Error occurrit. Please contact a system administrator."
+
+#: rocky/templates/oois/ooi_add.html
+#, python-format
+msgid "Add a %(display_type)s"
+msgstr "Adde %(display_type)s"
+
+#: rocky/templates/oois/ooi_add.html
+msgid ""
+"Here you can add the asset of the client. Findings can be added to these in "
+"the findings page."
+msgstr ""
+"Hic addere potes res clientis. His addi possunt Inventiones in pagina."
+
+#: rocky/templates/oois/ooi_add.html
+#, python-format
+msgid "Add %(display_type)s"
+msgstr "Adde %(display_type)s"
+
+#: rocky/templates/oois/ooi_add_type_select.html
+#: rocky/templates/oois/ooi_detail_add_related_object.html
+#: rocky/templates/partials/elements/ooi_add_type_select_form.html
+#: rocky/templates/partials/ooi_list_toolbar.html rocky/views/ooi_add.py
+msgid "Add object"
+msgstr "Add object"
+
+#: rocky/templates/oois/ooi_add_type_select.html
+msgid "Select the type of object you want to create."
+msgstr "Elige genus obiecti quod vis creare."
+
+#: rocky/templates/oois/ooi_delete.html
+#, python-format
+msgid "Delete %(primary_key)s"
+msgstr "Delere %(primary_key)s"
+
+#: rocky/templates/oois/ooi_delete.html
+msgid "Are you sure?"
+msgstr "Certus es?"
+
+#: rocky/templates/oois/ooi_delete.html
+#, python-format
+msgid "Here you can delete the %(display_type)s."
+msgstr "Hic %(display_type)s delere potes."
+
+#: rocky/templates/oois/ooi_delete.html
+msgid "To be deleted object(s)"
+msgstr "Ut deleatur object (s)"
+
+#: rocky/templates/oois/ooi_delete.html
+#: rocky/templates/partials/elements/ooi_tree_condensed_table.html
+msgid "Key"
+msgstr "Clavis"
+
+#: rocky/templates/oois/ooi_delete.html
+#: rocky/templates/partials/ooi_detail_toolbar.html
+#, python-format
+msgid "Delete %(display_type)s"
+msgstr "Delere %(display_type)s"
+
+#: rocky/templates/oois/ooi_delete.html
+msgid "Deletion not possible for types: KATFindingType and CVEFindingType"
+msgstr "Deletio non potest genera: KATFindingType et CVEFindingType"
+
+#: rocky/templates/oois/ooi_detail.html
+msgid "using boefjes"
+msgstr "per boefjes \""
+
+#: rocky/templates/oois/ooi_detail.html
+#: rocky/templates/organizations/organization_settings.html
+msgid "indemnification warning"
+msgstr "indemnificationis monitionem"
+
+#: rocky/templates/oois/ooi_detail.html
+#, python-format
+msgid ""
+"<strong>Warning:</strong> There is no indemnification for this organization."
+" Go to the <a href=\"%(organization_settings)s\">organization settings "
+"page</a> to add one."
+msgstr ""
+"<strong> Admonitio: </strong> Nulla haec norma indemnitatis est. Vade ad <a "
+"href=\"%(organization_settings)s\"> ordinationem paginae</a> adde unam."
+
+#: rocky/templates/oois/ooi_detail.html
+msgid "Permission warning"
+msgstr "permission monitionem"
+
+#: rocky/templates/oois/ooi_detail.html
+msgid ""
+"<strong>Warning:</strong> You don't have the proper permission at the "
+"organizational level to scan objects. Contact your administrator."
+msgstr ""
+"<strong> Admonitio: </strong> Non habes licentiam propriam in ordine normae "
+"ad res lustrandas. Contact vestri administrator."
+
+#: rocky/templates/oois/ooi_detail.html
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Scan warning"
+msgstr "Scan Monitum"
+
+#: rocky/templates/oois/ooi_detail.html
+#, python-format
+msgid ""
+"<strong>Warning:</strong> You are not allowed to scan this OOI. Your maximum"
+" clearance level is %(member_clearance_level)s and this OOI has level "
+"%(boefje_scan_level)s. Go to your <a href=\"%(account_details)s\">account "
+"details</a> to manage your clearance level."
+msgstr ""
+"<strong> Monitum:</strong> Hoc videre non licet OOI. Gradus maximus alvi "
+"tusus est %(member_clearance_level)s et hoc OOI planum habet "
+"%(boefje_scan_level)s. Vade ad <a href=\"%(account_details)s\"> rationum "
+"singularium</a> ad alvi ductionem tuam administrare."
+
+#: rocky/templates/oois/ooi_detail.html rocky/templates/scan.html
+msgid "Boefjes overview"
+msgstr "Boefjes overview"
+
+#: rocky/templates/oois/ooi_detail.html
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+#: rocky/templates/scan.html rocky/templates/tasks/boefjes.html
+#: rocky/templates/tasks/normalizers.html
+msgid "Boefje"
+msgstr "Boefje"
+
+#: rocky/templates/oois/ooi_detail.html rocky/templates/scan.html
+msgid "Scan profile"
+msgstr "Scan profile"
+
+#: rocky/templates/oois/ooi_detail.html
+msgid "Unable to start scan. See the warning for more details."
+msgstr "Non potuit incipere scan. Vide monitum ad plura."
+
+#: rocky/templates/oois/ooi_detail.html
+msgid "Start scan"
+msgstr "Satus scan"
+
+#: rocky/templates/oois/ooi_detail.html
+msgid "There are no boefjes enabled to scan an OOI of type"
+msgstr "Nullae boefjes enabled ad lustrandum OOI generis"
+
+#: rocky/templates/oois/ooi_detail.html
+msgid "See"
+msgstr "Vide"
+
+#: rocky/templates/oois/ooi_detail.html
+msgid "to find and enable boefjes that can scan within the current level."
+msgstr ""
+"ut invenias et efficias boefjes qui intra campum currentem lustrare possunt."
+
+#: rocky/templates/oois/ooi_detail_add_related_object.html
+#: rocky/templates/partials/ooi_detail_related_object.html
+msgid "Add related object"
+msgstr "Add related object"
+
+#: rocky/templates/oois/ooi_detail_add_related_object.html
+#: rocky/templates/oois/ooi_detail_object.html
+msgid "Object details"
+msgstr "Object details"
+
+#: rocky/templates/oois/ooi_detail_add_related_object.html
+#: rocky/templates/partials/elements/ooi_add_type_select_form.html
+msgid "Object type"
+msgstr "Object genus"
+
+#: rocky/templates/oois/ooi_detail_add_related_object.html
+#: rocky/templates/partials/elements/ooi_add_type_select_form.html
+msgid "Choose an object type to add"
+msgstr "Elige quod genus addere"
+
+#: rocky/templates/oois/ooi_detail_add_related_object.html
+#: rocky/templates/partials/elements/ooi_add_type_select_form.html
+msgid "Select an object type to add."
+msgstr "Elige quod genus addere."
+
+#: rocky/templates/oois/ooi_detail_findings_list.html
+msgid "Overview of findings for"
+msgstr "Overview of Inventiones for"
+
+#: rocky/templates/oois/ooi_detail_findings_list.html
+msgid "Score"
+msgstr "score"
+
+#: rocky/templates/oois/ooi_detail_findings_list.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid "Finding details"
+msgstr "Inveniens singula"
+
+#: rocky/templates/oois/ooi_detail_findings_overview.html
+msgid "Overview of the number of findings and their severity found on"
+msgstr "Overview de numero inventionum et eorum severitate reperta"
+
+#: rocky/templates/oois/ooi_detail_findings_overview.html
+msgid ""
+"Findings can occur multiple times. To give better insight the following "
+"table shows the number of unique findings found as well as the number of "
+"occurrences."
+msgstr ""
+"Inventiones pluries fieri possunt. Ut melius perspiciatur sequens tabella "
+"ostendit numerum singularium inventarum et numerum eventuum."
+
+#: rocky/templates/oois/ooi_detail_findings_overview.html
+msgid "See finding details"
+msgstr "Vide invenire details"
+
+#: rocky/templates/oois/ooi_detail_findings_overview.html
+msgid "Total findings"
+msgstr "Totalis Inventiones"
+
+#: rocky/templates/oois/ooi_detail_object.html
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Inactive"
+msgstr "Ut ultrices vestibulum"
+
+#: rocky/templates/oois/ooi_detail_origins_declarations.html
+msgid "Declarations"
+msgstr "Declarationes"
+
+#: rocky/templates/oois/ooi_detail_origins_inference.html
+msgid "Inferred by"
+msgstr "infertur"
+
+#: rocky/templates/oois/ooi_detail_origins_inference.html
+msgid "Bit"
+msgstr "Bit"
+
+#: rocky/templates/oois/ooi_detail_origins_inference.html
+msgid "Parameters"
+msgstr "Morbi laoreet"
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+msgid "Last observed by"
+msgstr "Novissime observatur"
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+msgid "Task ID"
+msgstr "Negotium ID"
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+msgid "When"
+msgstr "cum"
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+#: rocky/templates/tasks/normalizers.html
+msgid "Normalizer"
+msgstr "Normalizer"
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+msgid "This scan was manually created."
+msgstr "Hoc scan manually creatum est."
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+msgid "The boefje has since been deleted or disabled."
+msgstr "Boefje cum deleta vel debilitata est."
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+msgid "No Raw file could be found, this might point to an error in OpenKAT"
+msgstr ""
+"Scapus rudis nulla inveniri potuit, quae errorem demonstraret in OpenKAT"
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Warning"
+msgstr "Monitum"
+
+#: rocky/templates/oois/ooi_edit.html
+#, python-format
+msgid "Edit %(type)s: %(ooi_human_readable)s"
+msgstr "%(type)s: %(ooi_human_readable)s"
+
+#: rocky/templates/oois/ooi_edit.html
+msgid "Primary key fields cannot be edited."
+msgstr "Primaria agri clavis emendari non possunt."
+
+#: rocky/templates/oois/ooi_edit.html
+#, python-format
+msgid "Save %(display_type)s"
+msgstr "Serva %(display_type)s"
+
+#: rocky/templates/oois/ooi_findings.html
+msgid "Currently no findings have been identified for OOI"
+msgstr "In statu notae non inventae sunt de OOI"
+
+#: rocky/templates/oois/ooi_list.html
+#, python-format
+msgid ""
+"An overview of objects found for organization "
+"<strong>%(organization_name)s</strong>. Objects can be added manually or by "
+"running Boefjes. Click an object for additional information."
+msgstr ""
+"Overview of objects found for organization "
+"<strong>%(organization_name)s</strong>. Obiecta manually aut currendo "
+"Boefjes addi possunt. Click obiectum informationis."
+
+#: rocky/templates/oois/ooi_list.html
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Edit clearance level"
+msgstr "Recensere alvi gradu"
+
+#: rocky/templates/oois/ooi_mute_finding.html
+msgid "Mute finding:"
+msgstr "muta inveniendi;"
+
+#: rocky/templates/oois/ooi_mute_finding.html
+msgid "Give a reason below why you want to mute this finding."
+msgstr "Causam infra redde cur hoc inveniendo mutum vis."
+
+#: rocky/templates/oois/ooi_mute_finding.html
+#: rocky/templates/partials/mute_findings_modal.html
+#: rocky/templates/partials/ooi_detail_toolbar.html
+msgid "Mute finding"
+msgstr "muta inventio"
+
+#: rocky/templates/oois/ooi_mute_finding.html
+msgid "Mute"
+msgstr "Mutus"
+
+#: rocky/templates/oois/ooi_page_tabs.html
+msgid "List of views for OOI"
+msgstr "Index sententiarum de OOI"
+
+#: rocky/templates/oois/ooi_past_due_warning.html
+msgid "This object is past due"
+msgstr "Hoc est praeteritum debitum"
+
+#: rocky/templates/oois/ooi_past_due_warning.html
+msgid "This object is past due and has been deleted"
+msgstr "Hoc est praeteritum debitum et deletum est"
+
+#: rocky/templates/oois/ooi_past_due_warning.html
+msgid ""
+"This object is past due. You are viewing the object state in a past state."
+msgstr ""
+"Hoc est praeteritum debitum. Rem publicam spectas in praeterito statu."
+
+#: rocky/templates/oois/ooi_past_due_warning.html
+msgid ""
+"You will not be able to add Findings or other OOI's to past due objects."
+msgstr "Inventiones aliasve OOIs praeteritis obiectis non poteris addere."
+
+#: rocky/templates/oois/ooi_past_due_warning.html
+#: rocky/templates/partials/hyperlink_ooi_id.html
+#, python-format
+msgid "Show details for %(name)s"
+msgstr "Monstrare singula de %(name)s"
+
+#: rocky/templates/oois/ooi_past_due_warning.html
+msgid "View the current state"
+msgstr "Videre hodiernam statum"
+
+#: rocky/templates/oois/ooi_past_due_warning.html
+msgid ""
+"You will not be able to add Findings or other OOI's, this object has been "
+"deleted and is no longer available."
+msgstr ""
+"Inventiones addere vel alias OOI non poteris, hoc obiectum deletum est nec "
+"diutius praesto est."
+
+#: rocky/templates/oois/ooi_summary.html
+msgid "Summary for"
+msgstr "Summarium for"
+
+#: rocky/templates/oois/ooi_summary.html
+msgid "Below you can see findings that were found for"
+msgstr "Infra videre potes inventa quae inventa sunt"
+
+#: rocky/templates/oois/ooi_summary.html
+msgid "and direct  children of this"
+msgstr "et filios huius"
+
+#: rocky/templates/oois/ooi_summary.html
+msgid "This"
+msgstr "Hoc"
+
+#: rocky/templates/oois/ooi_summary.html
+msgid "tree view"
+msgstr "arbor sententia"
+
+#: rocky/templates/oois/ooi_summary.html
+msgid "of the"
+msgstr "de \""
+
+#: rocky/templates/oois/ooi_summary.html
+msgid "shows the same objects."
+msgstr "idem ostendit."
+
+#: rocky/templates/organizations/organization_add.html
+msgid ""
+"Please enter the following organization details. These details can be edited"
+" within the organization page within OpenKAT when necessary."
+msgstr ""
+"Please enter the following organization details. Singula haec edi possunt "
+"intra paginam organizationem intra OpenKAT cum necesse est."
+
+#: rocky/templates/organizations/organization_edit.html
+msgid "Edit organization"
+msgstr "Edit organization"
+
+#: rocky/templates/organizations/organization_edit.html
+msgid "Save organization"
+msgstr "Salvum organization"
+
+#: rocky/templates/organizations/organization_list.html
+msgid "An overview of all organizations you are a member of."
+msgstr "Omnium institutionum inspectio membrum es."
+
+#: rocky/templates/organizations/organization_list.html
+msgid "Add new organization"
+msgstr "Addere novam ordinationem"
+
+#: rocky/templates/organizations/organization_list.html
+#, python-format
+msgid ""
+"\n"
+"                            Showing %(total)s organizations\n"
+"                        "
+msgstr ""
+"\n"
+"Ostendens institutiones %(total)s"
+
+#: rocky/templates/organizations/organization_list.html
+msgid "Organization overview:"
+msgstr "Organization overview:"
+
+#: rocky/templates/organizations/organization_list.html
+#: rocky/templates/organizations/organization_settings.html
+msgid "Tags"
+msgstr "Tags"
+
+#: rocky/templates/organizations/organization_list.html
+msgid "There were no organizations found for your user account"
+msgstr "Nulla instituta pro user ratio"
+
+#: rocky/templates/organizations/organization_list.html
+msgid "Actions to perform for all of your organizations."
+msgstr "Actiones ad faciendas pro omnibus institutis tuis."
+
+#: rocky/templates/organizations/organization_list.html
+#: rocky/templates/organizations/organization_settings.html
+msgid "Rerun all bits"
+msgstr "Rerum omnium frena"
+
+#: rocky/templates/organizations/organization_member_add.html
+msgid "Change account type"
+msgstr "Mutare rationem generis"
+
+#: rocky/templates/organizations/organization_member_add_header.html
+#: rocky/views/organization_member_add.py
+msgid "Add member"
+msgstr "Add membrum"
+
+#: rocky/templates/organizations/organization_member_add_header.html
+#, python-format
+msgid ""
+"Creating a new member of organization <strong>%(organization)s</strong>. For"
+" detailed information about the different account types, check the <a "
+"href=\"https://docs.openkat.nl/basics/users-and-organisations.html#users\" "
+"target=\"_blank\" rel=\"noopener\">documentation</a>."
+msgstr ""
+"Novum membro organizationis creans <strong>%(organization)s</strong>. Ad "
+"melius informationes de generibus rationum diversis, reprehendo <a "
+"href=\"https://docs.openkat.nl/basics/users-and-organisations.html#users\" "
+"target=\"_blank\" rel=\"noopener\"> documentum</a>."
+
+#: rocky/templates/organizations/organization_member_edit.html
+#: rocky/views/organization_member_edit.py
+msgid "Edit member"
+msgstr "Edit membrum"
+
+#: rocky/templates/organizations/organization_member_edit.html
+msgid "Save member"
+msgstr "Salvum membrum"
+
+#: rocky/templates/organizations/organization_member_list.html
+#, python-format
+msgid "An overview of members of <strong>%(organization_name)s</strong>."
+msgstr "Inspectio membrorum <strong>%(organization_name)s</strong>."
+
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Add member(s)"
+msgstr "Add membrum(s)"
+
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Manually"
+msgstr "Manually"
+
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Upload a CSV"
+msgstr "Upload a CSV"
+
+#: rocky/templates/organizations/organization_member_list.html
+#, python-format
+msgid ""
+"\n"
+"                        Showing %(total)s members\n"
+"                    "
+msgstr ""
+"\n"
+"Ostendens membra %(total)s"
+
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Member overview:"
+msgstr "Socius overview:"
+
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Role"
+msgstr "Munus"
+
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Assigned clearance level"
+msgstr "Alvi gradu assignata"
+
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Super user"
+msgstr "Super user"
+
+#: rocky/templates/organizations/organization_member_upload.html
+#: rocky/views/organization_member_add.py
+msgid "Add members"
+msgstr "Add membra"
+
+#: rocky/templates/organizations/organization_member_upload.html
+#, python-format
+msgid ""
+"To upload multiple members at once, you can upload a CSV file or you can <a "
+"href=\"%(download_url)s\">download the template</a>."
+msgstr ""
+"Ad plures simul membra fasciculos, fasciculum CSV fasciculum imponere vel <a"
+" href=\"%(download_url)s\"> template</a> potes."
+
+#: rocky/templates/organizations/organization_member_upload.html
+msgid ""
+"To create a custom CSV file, make sure it meets the following criteria:"
+msgstr "Morem CSV creare, fac ut sequentia criteria occurrat:"
+
+#: rocky/templates/organizations/organization_member_upload.html
+msgid "Upload"
+msgstr "Upload"
+
+#: rocky/templates/organizations/organization_settings.html
+#, python-format
+msgid ""
+"An overview of general information and settings for "
+"<strong>%(organization_name)s</strong>."
+msgstr ""
+"Overview general information and settings for "
+"<strong>%(organization_name)s</strong>."
+
+#: rocky/templates/organizations/organization_settings.html
+msgid ""
+"<strong>Warning:</strong> Indemnification is not set for this organization."
+msgstr "<strong> Admonitio: </strong> Indemnatio haec norma non ponitur."
+
+#: rocky/templates/organizations/organization_settings.html
+#: rocky/views/indemnification_add.py
+msgid "Add indemnification"
+msgstr "Adde indemnificationem"
+
+#: rocky/templates/partials/current_config.html
+msgid "Current configuration"
+msgstr "Current configuratione"
+
+#: rocky/templates/partials/delete_ooi_modal.html
+msgid "Delete objects"
+msgstr "Delete obiecti"
+
+#: rocky/templates/partials/delete_ooi_modal.html
+msgid ""
+"Are you sure you want to delete all the selected objects? The history of the"
+" deleted objects will still be available."
+msgstr ""
+"Certusne esne omnia electa res delere? Historia rerum deletarum adhuc in "
+"promptu erit."
+
+#: rocky/templates/partials/edit_ooi_clearance_level_modal.html
+msgid "Edit clearance level settings"
+msgstr "Recensere alvi gradu occasus"
+
+#: rocky/templates/partials/edit_ooi_clearance_level_modal.html
+msgid "You are editing clearance level of all the selected objects."
+msgstr "Editis alvi gradum omnium objectorum selectorum."
+
+#: rocky/templates/partials/edit_ooi_clearance_level_modal.html
+msgid "Switching between declare and inherit"
+msgstr "Commutatione declaramus et possidemus"
+
+#: rocky/templates/partials/edit_ooi_clearance_level_modal.html
+msgid ""
+"Clearance levels can be automatically inherited or you can manually declare "
+"the clearance level for an object. Switching to inherit clearance level will"
+" also recalculate the clearance levels of objects that inherit from these "
+"clearance levels."
+msgstr ""
+"Gradus alvi automatice hereditari possunt vel manually alvi gradum pro "
+"obiecto declarare potes. Commutatio ad hereditatem alvi graduum etiam alvi "
+"genera rerum quae ex his alvi graduum hereditatibus possident computabit."
+
+#: rocky/templates/partials/elements/ooi_detail_settings.html
+msgid "Observed at"
+msgstr "Observandum"
+
+#: rocky/templates/partials/elements/ooi_detail_settings.html
+#: rocky/templates/partials/elements/ooi_report_settings.html
+msgid "Show settings"
+msgstr "Monstrare occasus"
+
+#: rocky/templates/partials/elements/ooi_detail_settings.html
+#: rocky/templates/partials/elements/ooi_report_settings.html
+msgid "Hide settings"
+msgstr "Celare occasus"
+
+#: rocky/templates/partials/elements/ooi_list_settings_form.html
+msgid "Toggle all OOI types"
+msgstr "Toggle omnia OOI types"
+
+#: rocky/templates/partials/elements/ooi_tree_condensed_table.html
+msgid "Children"
+msgstr "Liberi"
+
+#: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
+#, python-format
+msgid "Show details for %(object_id)s, with %(child_count)s children."
+msgstr "Monstra singula pro %(object_id)s, cum liberis %(child_count)s."
+
+#: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
+#, python-format
+msgid ""
+"Show tree for %(object_id)s with only children of type %(object_ooi_type)s"
+msgstr ""
+"Lignum monstrare pro %(object_id)s cum liberis tantum generis "
+"%(object_ooi_type)s"
+
+#: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
+#, python-format
+msgid "Unfold %(object_id)s with %(child_count)s children"
+msgstr "Explica %(object_id)s cum %(child_count)s liberis"
+
+#: rocky/templates/partials/elements/ooi_tree_table.html
+msgid "go to:"
+msgstr "ire ad;"
+
+#: rocky/templates/partials/elements/ooi_tree_table.html
+msgid "Go to detailpage"
+msgstr "Vade ad detailpage"
+
+#: rocky/templates/partials/elements/ooi_tree_table.html
+msgid "detail"
+msgstr "detail"
+
+#: rocky/templates/partials/elements/ooi_tree_table.html
+msgid "Go to tree view"
+msgstr "Ad visum lignum"
+
+#: rocky/templates/partials/elements/ooi_tree_table.html
+msgid "tree"
+msgstr "arbor"
+
+#: rocky/templates/partials/elements/ooi_tree_table.html
+msgid "Go to graph view"
+msgstr "Vade ad graph visum"
+
+#: rocky/templates/partials/elements/ooi_tree_table.html
+msgid "graph"
+msgstr "graph"
+
+#: rocky/templates/partials/explanations.html
+msgid "Clearance level inheritance"
+msgstr "Alvi gradu hereditatis"
+
+#: rocky/templates/partials/explanations.html
+msgid "OOI"
+msgstr "OOI"
+
+#: rocky/templates/partials/explanations.html
+msgid "This OOI"
+msgstr "Hoc OOI"
+
+#: rocky/templates/partials/explanations.html
+msgid "Origin"
+msgstr "Origin"
+
+#: rocky/templates/partials/explanations.html
+msgid "declared"
+msgstr "declaravit"
+
+#: rocky/templates/partials/explanations.html
+msgid "inherited from ↓"
+msgstr "hereditario"
+
+#: rocky/templates/partials/explanations.html
+msgid "Show clearance level inheritance"
+msgstr "Ostende alvi gradu hereditatis"
+
+#: rocky/templates/partials/finding_occurrence_definition_list.html
+msgid "Reproduction"
+msgstr "Reproduction"
+
+#: rocky/templates/partials/form/checkbox_group_table_form.html
+msgid "Please enable plugin to start scanning."
+msgstr "Please enable plugin to start intuens."
+
+#: rocky/templates/partials/form/field_input.html
+msgid "Not set"
+msgstr "Non posuit"
+
+#: rocky/templates/partials/form/field_input.html
+msgid "Forgot email"
+msgstr "oblitus inscriptio"
+
+#: rocky/templates/partials/form/field_input.html
+msgid "Forgot password"
+msgstr "oblitus es tesserae"
+
+#: rocky/templates/partials/form/field_input_errors.html
+#: rocky/templates/partials/notifications_block.html
+msgid "error"
+msgstr "error"
+
+#: rocky/templates/partials/form/field_input_errors.html
+#: rocky/templates/partials/form/form_errors.html
+#: rocky/templates/partials/notifications_block.html
+msgid "Error:"
+msgstr "Error:"
+
+#: rocky/templates/partials/form/field_input_help_text.html
+msgid "Open explanation"
+msgstr "Aperta explicatio"
+
+#: rocky/templates/partials/form/field_input_help_text.html
+msgid "Close explanation"
+msgstr "Proxima explicatio"
+
+#: rocky/templates/partials/form/field_input_help_text.html
+#: rocky/templates/partials/notifications_block.html
+#: rocky/templates/two_factor/core/login.html
+msgid "Explanation:"
+msgstr "Explicatio:"
+
+#: rocky/templates/partials/form/indemnification_add_form.html
+msgid ""
+"Performing security scans against assets is generally only allowed if you "
+"have permission to scan those assets. Certain scans might also have a "
+"negative impact on (your) assets. Therefore it is important to know and be "
+"aware of the impact of security scans."
+msgstr ""
+"Securitatem lustrat contra res faciendas plerumque tantum permittitur si "
+"permittitur tibi ea bona lustrare. Quaedam lustra possent etiam negativam in"
+" bonis (tuis) habere. Interest igitur scire ac sentire ictum securitatis "
+"lustrat."
+
+#: rocky/templates/partials/form/indemnification_add_form.html
+msgid ""
+"An organization indemnification is required before you can use OpenKAT. With"
+" the indemnification you declare that you, as a person, can be held "
+"accountable."
+msgstr ""
+"Organizationis indemnificationis requiritur antequam OpenKAT uti possis. Te,"
+" ut persona, indemnitatis declaras, imputari posse."
+
+#: rocky/templates/partials/form/indemnification_add_form.html
+msgid "Set an indemnification"
+msgstr "Pone indemnificationem"
+
+#: rocky/templates/partials/hyperlink_ooi_type.html
+#, python-format
+msgid "Only show objects of type %(type)s"
+msgstr "Argumenta typorum tantum monstra %(type)s"
+
+#: rocky/templates/partials/list_filters.html
+msgid "Hide filter options"
+msgstr "Optiones celare filter"
+
+#: rocky/templates/partials/list_filters.html
+msgid "Show filter options"
+msgstr "Ostende optiones filter"
+
+#: rocky/templates/partials/list_paginator.html
+msgid "List pagination"
+msgstr "Index pagination"
+
+#: rocky/templates/partials/list_paginator.html
+msgid "Previous Page"
+msgstr "Pagina prior"
+
+#: rocky/templates/partials/list_paginator.html
+msgid "Previous"
+msgstr "Antecedens"
+
+#: rocky/templates/partials/list_paginator.html
+msgid "Five Pages Back"
+msgstr "Quinque Paginae Back"
+
+#: rocky/templates/partials/list_paginator.html
+#: rocky/templates/partials/pagination.html
+msgid "Page"
+msgstr "Page"
+
+#: rocky/templates/partials/list_paginator.html
+msgid "Current"
+msgstr "Current"
+
+#: rocky/templates/partials/list_paginator.html
+msgid "Five Pages Forward"
+msgstr "Quinque Paginae Ante"
+
+#: rocky/templates/partials/list_paginator.html
+msgid "Next Page"
+msgstr "Proxima pagina"
+
+#: rocky/templates/partials/list_paginator.html
+msgid "Next"
+msgstr "Proximum"
+
+#: rocky/templates/partials/mute_findings_modal.html
+msgid "You are muting the selected findings."
+msgstr "Electa inventa es obmutesco."
+
+#: rocky/templates/partials/mute_findings_modal.html
+msgid "Reason:"
+msgstr "Ratio:"
+
+#: rocky/templates/partials/mute_findings_modal.html
+msgid "Expires by (UTC):"
+msgstr "Expirat ab (UTC);"
+
+#: rocky/templates/partials/notifications_block.html
+msgid "Confirmation:"
+msgstr "Confirmatio:"
+
+#: rocky/templates/partials/ooi_detail_related_object.html
+msgid "No related object known for"
+msgstr "Non related object notum est"
+
+#: rocky/templates/partials/ooi_detail_toolbar.html
+msgid "Generate Report"
+msgstr "Generare Report"
+
+#: rocky/templates/partials/ooi_detail_toolbar.html
+#, python-format
+msgid "Edit %(display_type)s"
+msgstr "Edit %(display_type)s"
+
+#: rocky/templates/partials/ooi_head.html
+msgid "Data from:"
+msgstr "Data inde:"
+
+#: rocky/templates/partials/ooi_head.html
+msgid "(Now)"
+msgstr "(Nunc)"
+
+#: rocky/templates/partials/ooi_list_toolbar.html
+msgid "Scan for objects"
+msgstr "Scan ad objecta"
+
+#: rocky/templates/partials/ooi_list_toolbar.html
+#: rocky/templates/upload_csv.html rocky/views/upload_csv.py
+msgid "Upload CSV"
+msgstr "Index CSV"
+
+#: rocky/templates/partials/ooi_list_toolbar.html
+msgid "Export"
+msgstr "Exportare"
+
+#: rocky/templates/partials/ooi_list_toolbar.html
+msgid "Download as CSV"
+msgstr "Download as CSV"
+
+#: rocky/templates/partials/ooi_report_findings_block.html
+#, python-format
+msgid "%(total)s findings on %(name)s"
+msgstr "%(total)s inventis in %(name)s"
+
+#: rocky/templates/partials/ooi_report_findings_block_table.html
+#, python-format
+msgid "Findings for %(type)s %(name)s on %(observed_at)s:"
+msgstr "Inventiones pro %(type)s %(name)s in %(observed_at)s:"
+
+#: rocky/templates/partials/ooi_report_findings_block_table.html
+msgid "Open finding details"
+msgstr "Apertum inventum details"
+
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+#, python-format
+msgid "Details of %(object_id)s"
+msgstr "Singula ex %(object_id)s"
+
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid ""
+"The severity of this findingtype has not (yet) been determined by the data "
+"source. This situation requires manual investigation of the severity."
+msgstr ""
+"Severitas huius inventionis generis a fonte data non est determinata. Haec "
+"condicio severitatis inquisitionem manualem requirit."
+
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid "Total occurrences"
+msgstr "Summa facta"
+
+#: rocky/templates/partials/ooi_tree_toolbar_bottom.html
+msgid "Tree - dense view"
+msgstr "Arbor - densa sententia"
+
+#: rocky/templates/partials/ooi_tree_toolbar_bottom.html
+msgid "Tree - table view"
+msgstr "Visum lignum - table"
+
+#: rocky/templates/partials/organization_member_list_filters.html
+msgid "Update List"
+msgstr "Update List"
+
+#: rocky/templates/partials/organization_properties_table.html
+msgid "Organization name"
+msgstr "Organization nomen"
+
+#: rocky/templates/partials/organization_properties_table.html
+msgid "Organization code"
+msgstr "Organization code"
+
+#: rocky/templates/partials/organizations_menu_dropdown.html
+msgid "Select organization"
+msgstr "Lego organizatione"
+
+#: rocky/templates/partials/organizations_menu_dropdown.html
+msgid "All organizations"
+msgstr "Omnes institutiones"
+
+#: rocky/templates/partials/page-meta.html
+msgid "Logged in as:"
+msgstr "Initium est:"
+
+#: rocky/templates/partials/pagination.html
+msgid "of"
+msgstr "of *"
+
+#: rocky/templates/partials/pagination.html
+msgid "first"
+msgstr "primum"
+
+#: rocky/templates/partials/pagination.html
+msgid "previous"
+msgstr "prior"
+
+#: rocky/templates/partials/pagination.html
+msgid "next"
+msgstr "deinde"
+
+#: rocky/templates/partials/pagination.html
+msgid "last"
+msgstr "novissime"
+
+#: rocky/templates/partials/secondary-menu.html
+msgid "User navigation"
+msgstr "Usoris navigationis"
+
+#: rocky/templates/partials/secondary-menu.html
+msgid "Close user navigation"
+msgstr "Proxima user navigation"
+
+#: rocky/templates/partials/secondary-menu.html
+msgid "My organizations"
+msgstr "Institutiones meae"
+
+#: rocky/templates/partials/secondary-menu.html
+msgid "Profile"
+msgstr "Profile"
+
+#: rocky/templates/partials/skip-to-content.html
+msgid "Go to content"
+msgstr "Vade ad contentum"
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid ""
+"The clearance level determines the level of boefje scans allowed on this "
+"object. An object inherits its clearance level from neighbouring objects. "
+"This means that the clearance level might stay the same, increase or "
+"decrease, depending on other declared clearance levels."
+msgstr ""
+"Planum alvi determinat gradum boefje scans permissum in hoc obiecto. Res "
+"alvi deiectio a vicinis accipit. Hoc significat ut gradus alvi maneret idem,"
+" augere vel diminuere, secundum alios gradus alvi declaratos."
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Empty clearance level explanation"
+msgstr "Inanis alvi explicatio"
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Empty:"
+msgstr "Vacua:"
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid ""
+"This object has a clearance level of \"empty\". This means that this object "
+"has no clearance level."
+msgstr ""
+"Hoc obiectum habet alvi gradum \"vacuae\". Id quod alvi deiectio non habet."
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Indemnification warning"
+msgstr "Monitum indemnification"
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Indemnification is not set for this organization."
+msgstr "Indemnificatio non ponitur pro hac ordinatione."
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Go to the"
+msgstr "Vade ad"
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "organization settings page"
+msgstr "organization occasus paginam"
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "to add one."
+msgstr "unum addere."
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Set clearance level warning"
+msgstr "Set alvi deiectio"
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid ""
+"You don't have permissions to set the clearance level. Contact your "
+"administrator."
+msgstr "Permissiones non habes ut alvi gradu. Contact vestri administrator."
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+#, python-format
+msgid ""
+"You are not allowed to set the clearance level of this OOI. Your maximum "
+"clearance level is %(member_clearance_level)s and this OOI has level "
+"%(boefje_scan_level)s."
+msgstr ""
+"Non licet huius OOI gradum constituere. Gradus maximus alvi tus tuus est "
+"%(member_clearance_level)s et hoc OOI planum habet %(boefje_scan_level)s."
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Go to your"
+msgstr "Vade ad tuum"
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "account details"
+msgstr "propter singula"
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "to manage your clearance level."
+msgstr "alvi regendi elit."
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Current clearance level"
+msgstr "Current alvi gradu"
+
+#: rocky/templates/tasks/boefje_task_detail.html
+msgid ""
+"An overview of the boefje task, the input OOI and the RAW data it generated."
+msgstr "Perspectio operis boefje, input OOI et RAW notitiae eius generatae."
+
+#: rocky/templates/tasks/boefje_task_detail.html
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Download meta and raw data"
+msgstr "Download meta et rudis notitia"
+
+#: rocky/templates/tasks/boefje_task_detail.html
+msgid "Download meta data"
+msgstr "Meta download data"
+
+#: rocky/templates/tasks/boefje_task_detail.html
+msgid "Input object"
+msgstr "Input object"
+
+#: rocky/templates/tasks/boefjes.html
+msgid "There are no tasks for boefjes."
+msgstr "Nulla opera boefjes."
+
+#: rocky/templates/tasks/boefjes.html
+msgid "List of tasks for boefjes."
+msgstr "Index operum, boefjes."
+
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/reports.html
+msgid "Organization Code"
+msgstr "Organization Code"
+
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
+#: rocky/templates/tasks/ooi_detail_task_list.html
+#: rocky/templates/tasks/plugin_detail_task_list.html
+msgid "Created date"
+msgstr "Creatum diem"
+
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
+#: rocky/templates/tasks/reports.html
+msgid "Modified date"
+msgstr "Modified date"
+
+#: rocky/templates/tasks/normalizers.html
+msgid "There are no tasks for normalizers."
+msgstr "Nulla officia normalizers."
+
+#: rocky/templates/tasks/normalizers.html
+msgid "List of tasks for normalizers."
+msgstr "Index officiorum pro normalizariis."
+
+#: rocky/templates/tasks/normalizers.html
+msgid "Boefje input OOI"
+msgstr "Boefje input OOI"
+
+#: rocky/templates/tasks/normalizers.html
+msgid "Manually added"
+msgstr "manually additae"
+
+#: rocky/templates/tasks/ooi_detail_task_list.html
+msgid "There have been no tasks."
+msgstr "Nulla mihi officia."
+
+#: rocky/templates/tasks/partials/stats.html
+msgid "Task statistics - Last 24 hours"
+msgstr "Negotium statistics - Last XXIV horas"
+
+#: rocky/templates/tasks/partials/stats.html
+msgid "All times in UTC, blocks of 1 hour."
+msgstr "Omnia tempora in UTC, caudices horae 1 sunt."
+
+#: rocky/templates/tasks/partials/stats.html
+msgid "Timeslot"
+msgstr "Timeslot"
+
+#: rocky/templates/tasks/partials/stats.html
+msgid "Could not load stats, Scheduler error."
+msgstr "Civitates onerare non poterant, errore Scheduler."
+
+#: rocky/templates/tasks/partials/tab_navigation.html
+msgid "List of tasks"
+msgstr "Index operum"
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Loading..."
+msgstr "Loading..."
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Yielded objects"
+msgstr "cessit obiecti"
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Yielded raw files"
+msgstr "Rudis cessit files"
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Reschedule"
+msgstr "Reschedule"
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Download task data"
+msgstr "Download negotium notitia"
+
+#: rocky/templates/tasks/partials/tasks_overview_header.html
+#, python-format
+msgid ""
+"An overview of the tasks for <strong>%(organization)s</strong>. Tasks are "
+"divided in Boefjes, Normalizers and Reports. Boefjes scan objects and "
+"Normalizers dispatch on the output mime-type. Additionally, there is a "
+"Report tasks. This task aggregates and presents findings from both Boefjes "
+"and Normalizers."
+msgstr ""
+"Operum inspectio de <strong>%(organization)s</strong>. Munus dividuntur in "
+"Boefjes, Normalizers et Renuntiationes. Boefjes res scan et Normalizers "
+"litterae in output mimi-type. Accedit Indicia quaedam opera. Hoc munus "
+"aggregata et praesentat inventa ab utroque Boefjes et Normalizers."
+
+#: rocky/templates/tasks/plugin_detail_task_list.html
+msgid "There are no tasks for"
+msgstr "Nulla officia for"
+
+#: rocky/templates/tasks/plugin_detail_task_list.html
+msgid "List of tasks for"
+msgstr "Index operum"
+
+#: rocky/templates/tasks/reports.html
+msgid "There are no tasks for reports."
+msgstr "Non sunt operae pro relationibus."
+
+#: rocky/templates/tasks/reports.html
+msgid "List of tasks for reports."
+msgstr "Indicem operum ad tradit."
+
+#: rocky/templates/tasks/reports.html
+msgid "Recipe ID"
+msgstr "id facito"
+
+#: rocky/templates/two_factor/_wizard_actions.html
+msgid "Log in"
+msgstr "Log in"
+
+#: rocky/templates/two_factor/_wizard_actions.html
+msgid "Authenticate"
+msgstr "authenticitate"
+
+#: rocky/templates/two_factor/core/backup_tokens.html
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Backup Tokens"
+msgstr "Tergum signa"
+
+#: rocky/templates/two_factor/core/backup_tokens.html
+msgid ""
+"Backup tokens can be used when your primary and backup phone numbers aren't "
+"available. The backup tokens below can be used for login verification. If "
+"you've used up all your backup tokens, you can generate a new set of backup "
+"tokens. Only the backup tokens shown below will be valid."
+msgstr ""
+"Tergum signa adhiberi possunt cum prima et tergum telephonicum numeri "
+"praesto non sunt. Signa infra tergum pro login verificationis adhiberi "
+"potest. Si omnia signa tergum tuum consumpsi, novum signum tergum generare "
+"potes. Solum tergum signa infra monstrata valida erunt."
+
+#: rocky/templates/two_factor/core/backup_tokens.html
+msgid "Print these tokens and keep them somewhere safe."
+msgstr "Haec signa imprime et alicubi ea incolumem serva."
+
+#: rocky/templates/two_factor/core/backup_tokens.html
+msgid "You don't have any backup codes yet."
+msgstr "Non habes tergum codicibus adhuc."
+
+#: rocky/templates/two_factor/core/backup_tokens.html
+msgid "Generate Tokens"
+msgstr "Generare signa"
+
+#: rocky/templates/two_factor/core/backup_tokens.html
+#: rocky/templates/two_factor/core/setup_complete.html
+msgid "Back to Account Security"
+msgstr "Ad Account Securitatis"
+
+#: rocky/templates/two_factor/core/login.html
+msgid "You are logged in."
+msgstr "Initium es."
+
+#: rocky/templates/two_factor/core/login.html
+msgid "Two factor authentication is enabled for your account."
+msgstr "Duo elementum authenticas in ratione vestra efficax est."
+
+#: rocky/templates/two_factor/core/login.html
+msgid ""
+"Two factor authentication is not enabled for your account. Enable it to "
+"continue."
+msgstr "Duo factor authenticas in ratione vestra non est enabled. Da pergere."
+
+#: rocky/templates/two_factor/core/login.html
+msgid "Setup two factor authentication"
+msgstr "Setup duo elementum authenticas"
+
+#: rocky/templates/two_factor/core/login.html
+msgid "Credentials"
+msgstr "Documentorum"
+
+#: rocky/templates/two_factor/core/login.html
+msgid ""
+"Use this form for entering backup tokens for logging in. These tokens have "
+"been generated for you to print and keep safe. Please enter one of these "
+"backup tokens to login to your account."
+msgstr ""
+"Hac forma utere ad signa tergum ingrediendi ad logging in. Haec signa tibi "
+"generata sunt imprimendi et incolumem serva. Quaeso, unum ex his tergum "
+"signa ad rationem tuam aperias."
+
+#: rocky/templates/two_factor/core/login.html
+msgid "As a last resort, you can use a backup token:"
+msgstr "Ad ultimum recurrendum, signum tergum uti potes:"
+
+#: rocky/templates/two_factor/core/login.html
+msgid "Use Backup Token"
+msgstr "Usus Tergum Thochen"
+
+#: rocky/templates/two_factor/core/otp_required.html
+msgid "Permission Denied"
+msgstr "permission negatum"
+
+#: rocky/templates/two_factor/core/otp_required.html
+msgid ""
+"The page you requested, enforces users to verify using two-factor "
+"authentication for security reasons. You need to enable these security "
+"features in order to access this page."
+msgstr ""
+"Pagina quam postulasti, utentes utentes efficat utentes duos factores "
+"authenticas securitatis rationes. Haec lineamenta securitatis praebere debes"
+" ut hanc paginam accessere."
+
+#: rocky/templates/two_factor/core/otp_required.html
+#: rocky/templates/two_factor/profile/profile.html
+msgid ""
+"Two-factor authentication is not enabled for your account. Enable two-factor"
+" authentication for enhanced account security."
+msgstr ""
+"Duo-factor authenticas in ratione vestra non est enabled. Admitte duos "
+"factor authenticas ad auctam rationem securitatis."
+
+#: rocky/templates/two_factor/core/otp_required.html
+#: rocky/templates/two_factor/core/setup.html
+#: rocky/templates/two_factor/core/setup_complete.html
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Enable Two-Factor Authentication"
+msgstr "Admitte Duo-factor authenticitate"
+
+#: rocky/templates/two_factor/core/phone_register.html
+msgid "Add Backup Phone"
+msgstr "Tergum addere Phone"
+
+#: rocky/templates/two_factor/core/phone_register.html
+msgid ""
+"You'll be adding a backup phone number to your account. This number will be "
+"used if your primary method of registration is not available."
+msgstr ""
+"Tergum phone numerus ad rationem tuam adicies. Hic numerus adhibebitur si "
+"prima methodus adnotationei tuae praesto non est."
+
+#: rocky/templates/two_factor/core/phone_register.html
+msgid ""
+"We've sent a token to your phone number. Please enter the token you've "
+"received."
+msgstr ""
+"Misimus ad signum phone numerus. Please enter the aegotium quod recepisti."
+
+#: rocky/templates/two_factor/core/setup.html
+msgid ""
+"To start using a token generator, please use your smartphone to scan the QR "
+"code below or use the setup key. For example, use GoogleAuthenticator. Then,"
+" enter the token generated by the app."
+msgstr ""
+"Ad generantis signum utere incipias, quaeso utere tuo Mauris quis felis ut "
+"QR codicem infra spectet vel clavis setup utere. For example, utere "
+"GoogleAuthenticator. Deinde signum generatum intrant per app."
+
+#: rocky/templates/two_factor/core/setup.html
+msgid "QR code"
+msgstr "QR code"
+
+#: rocky/templates/two_factor/core/setup.html
+msgid "Setup key"
+msgstr "Clavis setup"
+
+#: rocky/templates/two_factor/core/setup.html
+msgid ""
+"The secret key is a 32 characters representation of the QR code. There are 2"
+" options to setup the two factor authtentication. You can scan the QR code "
+"above or you can insert this key using the secret key option of the "
+"authenticator app."
+msgstr ""
+"Arcanum clavis est 32 characteribus repraesentatio QR code. Sunt 2 optiones "
+"ut duas factores authenticas habeat. QR codicem superius lustrare potes vel "
+"hanc clavem inserere utens optio clavis secreti authentici app."
+
+#: rocky/templates/two_factor/core/setup_complete.html
+msgid ""
+"Congratulations, you've successfully enabled two-factor authentication."
+msgstr "Gratulor, feliciter effice duos factores authenticas."
+
+#: rocky/templates/two_factor/core/setup_complete.html
+msgid "Start using OpenKAT"
+msgstr "Satus usura OpenKAT"
+
+#: rocky/templates/two_factor/core/setup_complete.html
+msgid ""
+"However, it might happen that you don't have access to your primary token "
+"device. To enable account recovery, add a phone number."
+msgstr ""
+"Fieri tamen potest ut ad primum tuum indicium notae aditum non habeas. Ut "
+"recuperatio rationi possit, numerum telephonicum addere."
+
+#: rocky/templates/two_factor/core/setup_complete.html
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Add Phone Number"
+msgstr "Add Phone"
+
+#: rocky/templates/two_factor/profile/disable.html
+msgid "Disable Two-factor Authentication"
+msgstr "Duo inactivare-factor authenticitate"
+
+#: rocky/templates/two_factor/profile/disable.html
+msgid ""
+"You are about to disable two-factor authentication. This weakens your "
+"account security, are you sure?"
+msgstr ""
+"Duos factores authenticas disable incipies. Hanc vestram securitatem "
+"debilitat, certus es?"
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Account Security"
+msgstr "Ratio Securitatis"
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Tokens will be generated by your token generator."
+msgstr "Signis generabitur tuo signo genitor."
+
+#: rocky/templates/two_factor/profile/profile.html
+#, python-format
+msgid "Primary method: %(primary)s"
+msgstr "Methodus primaria: %(primary)s"
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Tokens will be generated by your YubiKey."
+msgstr "Signa generabitur tua YubiKey."
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Backup Phone Numbers"
+msgstr "Tergum Phone Numeri"
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid ""
+"If your primary method is not available, we are able to send backup tokens "
+"to the phone numbers listed below."
+msgstr ""
+"Si methodus primaria tua praesto non est, signa tergum mittere ad numeros "
+"telephonicos infra inscriptos possumus."
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Unregister"
+msgstr "Unregister"
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid ""
+"If you don't have any device with you, you can access your account using "
+"backup tokens."
+msgstr ""
+"Si ullam machinam apud te non habes, rationem tuam utentibus signis accedere"
+" potes."
+
+#: rocky/templates/two_factor/profile/profile.html
+#, python-format
+msgid "You have only one backup token remaining."
+msgid_plural "You have %(counter)s backup tokens remaining."
+msgstr[0] "Unum tantum tergum tessera habes."
+msgstr[1] "Restat tergum signa %(counter)s."
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Show Codes"
+msgstr "Ostendere Codes"
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Disable Two-Factor Authentication"
+msgstr "Inactivare Duo-Factor Auctorizo"
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid ""
+"However we strongly discourage you to do so, you can also disable two-factor"
+" authentication for your account."
+msgstr ""
+"Quamquam nos vehementer te deterreo, etiam duos factores authenticas propter"
+" rationem vestram inactivare potes."
+
+#: rocky/templates/two_factor/twilio/sms_message.html
+#, python-format
+msgid "Your OTP token is %(token)s"
+msgstr "Tuum OTP signum est %(token)s"
+
+#: rocky/templates/upload_csv.html
+msgid "Automate the creation of multiple objects by uploading a CSV file."
+msgstr "Automate creationem plurium objectorum fasciculi impositione CSV."
+
+#: rocky/templates/upload_csv.html
+msgid "These are the criteria for CSV upload:"
+msgstr "Criteria haec sunt CSV notae:"
+
+#: rocky/templates/upload_raw.html
+msgid "Automate the creation of multiple objects by uploading a raw file."
+msgstr "Automate creationem plurium obiecti fasciculi rudis imposuisti."
+
+#: rocky/templates/upload_raw.html
+msgid ""
+"An input OOI can be selected for the normalizer to attach newly yielded OOIs"
+" to. If no input OOI was used for the raw file, a placeholder ExternalScan "
+"OOI can be used. ExternalScan OOIs can be created from the objects page. "
+"When a new version of the raw file is generated, the same ExternalScan OOI "
+"should be chosen to ensure that old results are overwritten."
+msgstr ""
+"Input OOI seligi potest normalizer ut OOIs nuper cedat. Si nullum input OOI "
+"ad documentum rudis adhibitum est, possessor externi OOI adhiberi potest. "
+"ExternalScan OOIs creari potest ex pagina obiecti. Cum nova versio fasciculi"
+" rudis generatur, idem ExternalScan OOI eligendus est ut eventus vetus "
+"overscripte sit."
+
+#: rocky/templates/upload_raw.html rocky/views/upload_raw.py
+msgid "Upload raw"
+msgstr "Rudis upload"
+
+#: rocky/views/bytes_raw.py
+msgid "Getting raw data failed."
+msgstr "Rudis notitia questus defuit."
+
+#: rocky/views/bytes_raw.py
+msgid "The task does not have any raw data."
+msgstr "Negotium notitia rudis non habet."
+
+#: rocky/views/finding_list.py rocky/views/ooi_list.py
+msgid "Unknown action."
+msgstr "Ignota actio."
+
+#: rocky/views/health.py
+msgid "Beautified"
+msgstr "Pulchra"
+
+#: rocky/views/indemnification_add.py
+msgid "Indemnification successfully set."
+msgstr "Remuneratio feliciter posuit."
+
+#: rocky/views/mixins.py
+msgid "The selected date is in the future."
+msgstr "Electus in posterum diem."
+
+#: rocky/views/mixins.py
+msgid "Can not parse date, falling back to show current date."
+msgstr "Parse date non potest, relabens ad hodiernam diem demonstrandam."
+
+#: rocky/views/mixins.py
+#, python-format
+msgid "Could not load origins for OOI: %s from octopoes"
+msgstr "Origines onerare non poterant pro OOI: %s ex polypoes."
+
+#: rocky/views/mixins.py
+msgid "Could not load normalizer metas from bytes"
+msgstr "Non load metas ex bytes normalizer"
+
+#: rocky/views/mixins.py
+#, python-format
+msgid "Could not load boefje %s from katalogus"
+msgstr "Non poterat onerare boefje %s ex katalogo"
+
+#: rocky/views/mixins.py
+msgid "You do not have the permission to add items to a dashboard."
+msgstr "Non habes licentiam addere items in ashboardday."
+
+#: rocky/views/mixins.py
+msgid "Dashboard item has been added."
+msgstr "Dashboard item adiectum est."
+
+#: rocky/views/ooi_add.py
+#, python-format
+msgid "Add %(ooi_type)s"
+msgstr "Adde %(ooi_type)s"
+
+#: rocky/views/ooi_detail.py
+msgid ""
+"Cannot set clearance level. It must be provided and must be a valid number."
+msgstr "Non possum alvi gradu. Provideri debet et numerus validus esse debet."
+
+#: rocky/views/ooi_detail.py
+msgid "Only Question OOIs can be answered."
+msgstr "Quaestio tantum OOIs responderi potest."
+
+#: rocky/views/ooi_detail.py
+msgid "Question has been answered."
+msgstr "Quaestio est."
+
+#: rocky/views/ooi_detail_related_object.py
+msgid " (as "
+msgstr "(as"
+
+#: rocky/views/ooi_findings.py
+msgid "Object findings"
+msgstr "Object Inventiones"
+
+#: rocky/views/ooi_list.py
+msgid "No OOIs selected."
+msgstr "No OOIs lego."
+
+#: rocky/views/ooi_list.py
+#, python-format
+msgid ""
+"Could not raise clearance levels to L%s. Indemnification not present at "
+"organization %s."
+msgstr ""
+"Alvi gradus ad L%s movere non potuit. Indemnificatio non adest in "
+"ordinatione %s."
+
+#: rocky/views/ooi_list.py
+#, python-format
+msgid ""
+"Could not raise clearance level to L%s. You were trusted a clearance level "
+"of L%s. Contact your administrator to receive a higher clearance."
+msgstr ""
+"Alvi planitiem L%s movere non potuit. Creditus es alvi planities L%s. "
+"Contact vestri administratorem ad altiorem alvi recipiendam."
+
+#: rocky/views/ooi_list.py
+#, python-format
+msgid ""
+"Could not raise clearance level to L%s. You acknowledged a clearance level "
+"of L%s. Please accept the clearance level below to proceed."
+msgstr ""
+"Alvi planitiem L%s movere non potuit. Alvi planitiem L%s agnovisti. Accipe "
+"alvi gradum infra procedere."
+
+#: rocky/views/ooi_list.py
+msgid "An error occurred while saving clearance levels."
+msgstr "Error occurrit in gradibus alvi salvis."
+
+#: rocky/views/ooi_list.py
+msgid "One of the OOI's doesn't exist"
+msgstr "Una e OOIs non est"
+
+#: rocky/views/ooi_list.py
+#, python-format
+msgid "Successfully set scan profile to %s for %d OOIs."
+msgstr "Feliciter pro %s pro %d OOIs constitue."
+
+#: rocky/views/ooi_list.py
+msgid "An error occurred while setting clearance levels to inherit."
+msgstr "Error occurrit cum gradus alvi ad hereditatem."
+
+#: rocky/views/ooi_list.py
+msgid ""
+"An error occurred while setting clearance levels to inherit: one of the OOIs"
+" doesn't exist."
+msgstr ""
+"Error occurrit cum gradus alvi ad hereditatem dividendam: unum e OOIs non "
+"est."
+
+#: rocky/views/ooi_list.py
+#, python-format
+msgid "Successfully set %d OOI(s) clearance level to inherit."
+msgstr "Feliciter %d OOI(s) gradu alvi ad heredem."
+
+#: rocky/views/ooi_list.py
+msgid "An error occurred while deleting oois."
+msgstr "Error occurrit in delendo oois."
+
+#: rocky/views/ooi_list.py
+msgid "An error occurred while deleting OOIs: one of the OOIs doesn't exist."
+msgstr "Error occurrit cum OOIs delendo: una e OOIs non est."
+
+#: rocky/views/ooi_list.py
+#, python-format
+msgid ""
+"Successfully deleted %d ooi(s). Note: Bits can recreate objects "
+"automatically."
+msgstr ""
+"Feliciter delevit %d ooi(s). Nota: Bits obiecti statim recreare potest."
+
+#: rocky/views/ooi_mute.py
+msgid "Please select at least one finding."
+msgstr "Quaeso elige unum saltem invenire."
+
+#: rocky/views/ooi_mute.py
+msgid "Finding(s) successfully unmuted."
+msgstr "Inventis (s) feliciter unmuted."
+
+#: rocky/views/ooi_mute.py
+msgid "Finding(s) successfully muted."
+msgstr "Inveniens (s) feliciter transmutari."
+
+#: rocky/views/ooi_tree.py
+msgid "Tree Visualisation"
+msgstr "Arbor Visualization"
+
+#: rocky/views/ooi_tree.py
+msgid "Graph Visualisation"
+msgstr "Aliquam lacinia purus Visualization"
+
+#: rocky/views/ooi_view.py
+msgid "Observed_at: "
+msgstr "Observatum_at:"
+
+#: rocky/views/ooi_view.py
+msgid "OOI types: "
+msgstr "OOI genera:"
+
+#: rocky/views/ooi_view.py
+msgid "Clearance level: "
+msgstr "Clearance level:"
+
+#: rocky/views/ooi_view.py
+msgid "Clearance type: "
+msgstr "Genus Clearance:"
+
+#: rocky/views/ooi_view.py
+msgid "Searching for: "
+msgstr "Quaerendo:"
+
+#: rocky/views/organization_add.py
+msgid "Setup"
+msgstr "Setup"
+
+#: rocky/views/organization_add.py
+msgid "Organization added successfully."
+msgstr "Organization addidit feliciter."
+
+#: rocky/views/organization_add.py
+msgid "You are not allowed to add organizations."
+msgstr "Non licet instituta addere."
+
+#: rocky/views/organization_edit.py
+#, python-format
+msgid "Organization %s successfully updated."
+msgstr "Organizatio %s feliciter renovata est."
+
+#: rocky/views/organization_member_add.py
+msgid "Add column titles, followed by each object on a new line."
+msgstr "Adde titulos columnae, quae sequuntur singula in linea nova."
+
+#: rocky/views/organization_member_add.py
+msgid "The columns are: "
+msgstr "Columnae sunt:"
+
+#: rocky/views/organization_member_add.py
+msgid "Clearance levels should be between -1 and 4."
+msgstr "Clearance levels sit inter -1 et IV."
+
+#: rocky/views/organization_member_add.py
+msgid "Account type can be one of: "
+msgstr "Ratio unius generis potest esse:"
+
+#: rocky/views/organization_member_add.py
+msgid "Member added successfully."
+msgstr "Membrum addidit feliciter."
+
+#: rocky/views/organization_member_add.py
+msgid "The csv file is missing required columns"
+msgstr "Scapus csv in columnas desideratur"
+
+#: rocky/views/organization_member_add.py
+#, python-brace-format
+msgid "Invalid account type: '{account_type}'"
+msgstr "Irrita ratio generis: '{account_type}'"
+
+#: rocky/views/organization_member_add.py
+#, python-brace-format
+msgid "Invalid data for: '{email}'"
+msgstr "Irrita data pro: '{email}'"
+
+#: rocky/views/organization_member_add.py
+#, python-brace-format
+msgid "Invalid email address: '{email}'"
+msgstr "Inscriptio inscriptio invalida: '{email}'"
+
+#: rocky/views/organization_member_add.py
+msgid "Successfully processed users from csv."
+msgstr "Feliciter processit utentes ab csv."
+
+#: rocky/views/organization_member_add.py
+msgid "Error parsing the csv file. Please verify its contents."
+msgstr "Error parsing the csv file. Quaeso cognoscere contenta."
+
+#: rocky/views/organization_member_edit.py
+#, python-format
+msgid "Member %s successfully updated."
+msgstr "Socius %s feliciter renovatus est."
+
+#: rocky/views/organization_member_edit.py
+#, python-format
+msgid ""
+"The updated trusted clearance level of L%s is lower then the member's "
+"acknowledged clearance level of L%s. This member only has clearance for "
+"level L%s. For this reason the acknowledged clearance level has been set at "
+"the same level as trusted clearance level."
+msgstr ""
+"Renovata credita alvi planities L%s inferior est tunc membrum alvi agnitum "
+"gradum L%s. Hoc membrum tantum alvi pro gradu L%s habet. Quam ob rem in "
+"gradu alvi agnitae alvi deiectio in eodem gradu ac fiduciae alvi deiectio "
+"est."
+
+#: rocky/views/organization_member_edit.py
+msgid ""
+"You have trusted this member with a higher trusted level than member "
+"acknowledged. Member must first accept this level to use it."
+msgstr ""
+"Hoc membrum cum altiori gradu confidebat quam socius agnitus es. Socius "
+"primus hoc gradu admittere debet ut eo utatur."
+
+#: rocky/views/organization_member_list.py
+#, python-format
+msgid "Blocked member %s successfully."
+msgstr "Clausus socius %s feliciter."
+
+#: rocky/views/organization_member_list.py
+#, python-format
+msgid "Unblocked member %s successfully."
+msgstr "Membrum expeditum %s feliciter."
+
+#: rocky/views/organization_settings.py
+#, python-brace-format
+msgid "Recalculated {number_of_bits} bits. Duration: {duration}"
+msgstr "Recalculata {number_of_bits} frena. Duratio: {duration}"
+
+#: rocky/views/page_actions.py
+msgid "Could not process your request, action required."
+msgstr "Rogationem tuam non potuisti, actio postulabat."
+
+#: rocky/views/scan_profile.py
+msgid ""
+"Cannot set clearance level. The clearance type must be inherited or "
+"declared."
+msgstr "Non possum alvi gradu. Alvi genus hereditarium est vel declaravit."
+
+#: rocky/views/scans.py
+msgid "Scans"
+msgstr "Scans"
+
+#: rocky/views/scheduler.py
+msgid "Your report has been scheduled."
+msgstr "Your report has been scheduled."
+
+#: rocky/views/scheduler.py
+msgid ""
+"Your task is scheduled and will soon be started in the background. Results "
+"will be added to the object list when they are in. It may take some time, a "
+"refresh of the page may be needed to show the results."
+msgstr ""
+"Negotium tuum horarium est et mox incipietur in curriculo. Proventus ad "
+"indicem adicietur cum in sunt. Licet aliquandiu refectio paginae opus sit ad"
+" eventus demonstrandos."
+
+#: rocky/views/tasks.py
+#, python-brace-format
+msgid "Fetching tasks failed: no connection with scheduler: {error}"
+msgstr "Defecit munera petitio: nulla connexio cum scheduler: {error}"
+
+#: rocky/views/tasks.py
+msgid "All Tasks"
+msgstr "Omnes Tasks"
+
+#: rocky/views/upload_csv.py
+msgid "Add column titles. Followed by each object on a new line."
+msgstr "titulos columnae add. Sequitur unumquodque obiectum in linea nova."
+
+#: rocky/views/upload_csv.py
+msgid ""
+"For URL object type, a column 'raw' with URL values is required, starting "
+"with http:// or https://, optionally a second column 'network' is supported "
+msgstr ""
+"Nam URL ratio obiecti, columna 'rudis' cum URL valores requiritur, incipiens"
+" a http:// vel https://, optionally columna secunda 'network' sustentatur."
+
+#: rocky/views/upload_csv.py
+msgid ""
+"For Hostname object type, a column with 'name' values is required, "
+"optionally a second column 'network' is supported "
+msgstr ""
+"Ad HostnameC genus obiectum, columna cum valores \"nominis\" requiritur, "
+"optio altera columna \"retis\" sustentatur"
+
+#: rocky/views/upload_csv.py
+msgid ""
+"For IPAddressV4 and IPAddressV6 object types, a column of 'address' is "
+"required, optionally a second column 'network' is supported "
+msgstr ""
+"Pro IPAddressV4 et IPAddressV6 objecti typi, columna inscriptionis "
+"requiritur, optio altera columna \"retis\" sustentatur."
+
+#: rocky/views/upload_csv.py
+msgid ""
+"Clearance levels can be controlled by a column 'clearance' taking numerical "
+"values 0, 1, 2, 3, and 4 for the corresponding clearance level (other values"
+" are ignored) "
+msgstr ""
+"Gradus alvi moderari possunt per columnam 'alvitionem' valorum numerorum 0, "
+"1, 2, 3, et 4 pro gradu alvi respondentis (alia neglecta)"
+
+#: rocky/views/upload_csv.py
+msgid "Object(s) could not be created for row number(s): "
+msgstr "Object (s) non est creatus ordo numerus (s):"
+
+#: rocky/views/upload_csv.py
+msgid "Object(s) successfully added."
+msgstr "Object (s) feliciter addit."
+
+#: rocky/views/upload_raw.py
+#, python-format
+msgid "Raw file could not be uploaded to Bytes: status code %d"
+msgstr "Fasciculus rudis ad Bytes non potest uploaded %d"
+
+#: rocky/views/upload_raw.py
+#, python-format
+msgid "Raw file could not be uploaded to Bytes: %s"
+msgstr "Fasciculus rudis ad Bytes non potest immittere: %s"
+
+#: rocky/views/upload_raw.py
+msgid "Raw file successfully added."
+msgstr "Fasciculus rudis feliciter additus est."
+
+#, fuzzy
+#~ msgid "Findings @ "
+#~ msgstr "Diskubrimentu"
+
+#~ msgid "Clearance level has been set"
+#~ msgstr "Nivel di autorisashon a ser poni"
+
+#~ msgid "Add URL"
+#~ msgstr "Añadi URL"
+
+#~ msgid ""
+#~ "Boefjes that has a scan level below or equal to the clearance level, is "
+#~ "permitted to scan an object."
+#~ msgstr ""
+#~ "Boefjes ku tin un nivél di skan mas abou of parew ku e nivél di "
+#~ "autorisashon, tin pèrmit pa skan un opheto."
+
+#~ msgid "Delete object(s)"
+#~ msgstr "Kita opheto(nan)"
+
+#~ msgid "Set clearance level to inherit"
+#~ msgstr "Pone nivél di autorisashon na heredá"
+
+#~ msgid "Set clearance level for:"
+#~ msgstr "Pone nivél di autorisashon pa:"
+
+#~ msgid "Setting the scan level from \\"
+#~ msgstr "Ajustando e nivel di skan for di \\"
+
+#~ msgid "You are about to set the clearance level from \\"
+#~ msgstr "Bo ta na e punto di pone e nivél di autorisashon for di \\"
+
+#~ msgid "Yes, set to inherit"
+#~ msgstr "Si, poné na heredá"
+
+#, python-format
+#~ msgid "Successfully set scan profile to %s for %d oois."
+#~ msgstr "Ku exito a pone profil di skén pa %s pa %d oois."
+
+#, python-format
+#~ msgid "Successfully set %d ooi(s) clearance level to inherit."
+#~ msgstr "Éksito den ajustá %d OOI(s) nivel di autorisashon pa heredá."
+
+#~ msgid "An error occurred while deleting oois: one of the OOIs doesn't exist."
+#~ msgstr ""
+#~ "Un error a sosodé durante e eliminashon di OOI nan: un di e OOI nan no ta "
+#~ "eksistí."
+
+#, python-brace-format
+#~ msgid "Can not reset scan level. Scan level of {ooi_name} not declared"
+#~ msgstr "No por resèt nivél di skan. Nivél di skan òf {ooi_name} no ta deklará"
+
+#~ msgid "The Email must be set"
+#~ msgstr "E email adrès mester wordu yena"
+
+#~ msgid "E-mail address"
+#~ msgstr "Email adrès"
+
+#~ msgid ""
+#~ "Dozens of tools are integrated in OpenKAT to view the world (digital and "
+#~ "analog). <br> Our motto is therefore: I see, I see, what you do not see."
+#~ msgstr ""
+#~ "Dosen di hermentnan ta integrá den OpenKAT pa mira e mundu (digital i "
+#~ "anoloog). <br>Nos lema ta: Mi ta mira, mi ta mira loke bo no ta mira."
+
+#~ msgid "E-mail"
+#~ msgstr "E-korreo"
+
+#, python-brace-format
+#~ msgid "A unique code of {code_length} characters."
+#~ msgstr "Un codigo uniko di {code_length} letras."
+
+#~ msgid ""
+#~ "I declare that OpenKAT may scan the assets of my organization and that I "
+#~ "have permission to scan these assets. I am aware of the implications a scan "
+#~ "with a higher scan level brings on my systems."
+#~ msgstr ""
+#~ "Mi ta deklara ku OpenKAT por skan e propiedatnan di mi organisashon i ku mi "
+#~ "tin pèrmit pa skan e propiedatnan aki. Mi ta konsiente di e implikashonnan "
+#~ "un skan ku nivel di skan haltu tin riba mi sistemanan."
+
+#~ msgid ""
+#~ "I declare that I am authorized to give this indemnification within my "
+#~ "organization. I have the experience and knowledge to know what the "
+#~ "consequences might be and can be held responsible for them."
+#~ msgstr ""
+#~ "Mi ta deklará ku mi tin autorisashon pa duna e indemnisashon aki den mi "
+#~ "organisashon. Mi tin e eksperensia i konosementu pa sa e konsekensianan i mi"
+#~ " por ta responsabel pa nan."
+
+#~ msgid "Register"
+#~ msgstr "Registrá"
+
+#~ msgid "Create a new account for your organization"
+#~ msgstr "Krea un account nobo pa bo organisashon"
+
+#~ msgid ""
+#~ "All user  accounts are part of an organization. So if you’re new and your "
+#~ "company is also new to OpenKAT you can register here to create a OpenKAT "
+#~ "account for your company including an admin account for you. If you like a "
+#~ "user account that is connected to an already existing organization within "
+#~ "OpenKAT you can ask the admin to create an account for you."
+#~ msgstr ""
+#~ "Tur account ta parti di un organisashon. Kèmèn si bo ta nobo i bo kompania "
+#~ "tambe ta nobo na OpenKAT bo por registrá akinan pa krea un OpenKAT account "
+#~ "pa bo kompania inkluéndo un admin account pa bo. Si bo ke un account ku ta "
+#~ "konekta ku un organisashon ku ta èksisti kaba na KAT bo por puntra e admin "
+#~ "pa krea un account pa bo."
+
+#~ msgid "How does OpenKAT work"
+#~ msgstr "Kon OpenKAT ta functiona?"
+
+#~ msgid ""
+#~ "OpenKAT is able to give insight into security risks on your online objects. "
+#~ "For example, your websites, mailservers or online data. OpenKAT uses scans "
+#~ "to find and assess the area's that might be at risk and reports these back "
+#~ "to you. As a user you decide which insight you would like and OpenKAT guides"
+#~ " you to through the process. During this introduction you will be guided "
+#~ "through the steps to create a report."
+#~ msgstr ""
+#~ "OpenKAT tin e posibilidàt di duna informashon mas detaya den riésgonan di "
+#~ "siguridát di bo online ophetonan. Por ehempel, bo websites, mailservers òf "
+#~ "online data. OpenKAT ta úza scans pa enkontra i asertà areanan ku por kore "
+#~ "riésgo i rapòrta esaki bèk na abo. Komo kliente bo ta skohè ki informashon "
+#~ "bo ke i OpenKAT ta guiá'bu dor di e proceso Durante e introdukshon aki bo lo"
+#~ " wòrdu guiá dor di e stapnan pa traha un rapòrt."
+
+#~ msgid "OpenKAT setup"
+#~ msgstr "OpenKAT setup"
+
+#~ msgid ""
+#~ "Please enter the following organization details. These details can be edited"
+#~ " within the organization page within OpenKAT when necessary. Adding a new "
+#~ "organization requires a new database."
+#~ msgstr ""
+#~ "Por fabor pone e detayenan di e siguiente organisashon. E detayenan aki por "
+#~ "wordu editá den e página di organisashon den OpenKAT si ta nesesario. Agregá"
+#~ " un organisashon nobo ta requeri un base di datos nobo."
+
+#~ msgid "Account setup"
+#~ msgstr "Account setup"
+
+#~ msgid "Organization setup with separate accounts:"
+#~ msgstr "Konfigurá organisashon ku accountnan separá:"
+
+#~ msgid ""
+#~ "Within OpenKAT it is possible to create separate user accounts with the "
+#~ "specific roles. Each with their own functionalities and permissions. This is"
+#~ " useful when multiple people will be working with the same OpenKAT-setup. "
+#~ "You can choose to create the separate accounts during this introduction or "
+#~ "when you’re ready from the OpenKAT users page."
+#~ msgstr ""
+#~ "Den OpenKAT ta posibel pa krea accountnan separá ku e ròlnan specìfiko kada "
+#~ "un ku nan mes functionalidat ì pèrmitnan. Esaki ta útil ora mayoria hende ke"
+#~ " traha ku e mesun OpenKAT-setup. Bo por skohé pa krea e accountnan separá "
+#~ "durante e introdukshon aki of ora bo ta kla."
+
+#~ msgid "Single account setup:"
+#~ msgstr "Setup account pa mi mes:"
+
+#~ msgid ""
+#~ "Alternatively it is also an option to run OpenKAT from a single user "
+#~ "account. Which is useful when you are the only user in the account. You will"
+#~ " be able to access the functionality of the different roles from your "
+#~ "account. You can always add additional user accounts If you’re team expands "
+#~ "in the future."
+#~ msgstr ""
+#~ "Alternativamente tambe ta un opshón pa huza OpenKAT for di un solo account. "
+#~ "Ku ta útil si bo ta e úniko usadó di e account. Bo lo por tin e posibilidát "
+#~ "pa tin accesso na functionalidatnan di e diferente ròlnan for di bo account."
+#~ " Abo por semper añadi accountnan adishonál si bo tìm expandé den futuro."
+
+#~ msgid "Create separate accounts"
+#~ msgstr "Krea accountnan separá"
+
+#~ msgid "Continue with this account, onboard me!"
+#~ msgstr "Sigi ku e account aki, abòrdami!"
+
+#~ msgid "Users"
+#~ msgstr "Usarionan"
+
+#~ msgid ""
+#~ "Within OpenKAT there are three types of user accounts. Each has its own "
+#~ "functions."
+#~ msgstr ""
+#~ "Den OpenKAT tin trés diferente tipo di user accounts. Kada ún tin su mes "
+#~ "funkshón."
+
+#~ msgid "Admin"
+#~ msgstr "Admin"
+
+#~ msgid ""
+#~ "Each organization must have an admin. The admin can create and manage user "
+#~ "accounts as well as organization details."
+#~ msgstr ""
+#~ "Kada organisashon mester tin un admin. E admin por krea i manehá accountnan "
+#~ "pa usudonan i tambe detayes di organisashon."
+
+#~ msgid "Red teamer"
+#~ msgstr "Tìm kòrá"
+
+#~ msgid "A red teamer account can run scans and generate reports."
+#~ msgstr "Un account pa tìm kòrá por start scans òf generá rapòrtnan."
+
+#~ msgid "Client account"
+#~ msgstr "Account pa kliénte"
+
+#~ msgid "A client account can access reports."
+#~ msgstr "Un account pa kliénte por tin accesso na rapòrtnan."
+
+#~ msgid ""
+#~ "Each organization requires at least one admin and one red teamer account to "
+#~ "function. This introduction will guide you through the setup of both. After "
+#~ "that you can choose to add a client account as well."
+#~ msgstr ""
+#~ "Kada organisashon ta requerì sikiera ún admin ì ún tìm kòrá account pa "
+#~ "functioná. É introdukshon aki ta guiabu pa setup tur dós. Despues ku bo por "
+#~ "skohé pa añadi ún account pa kliénte tambe."
+
+#~ msgid "Let's add accounts"
+#~ msgstr "Laga nos añadi accounts"
+
+#~ msgid "Admin account setup"
+#~ msgstr "Account setup pa admin"
+
+#~ msgid "Admin details"
+#~ msgstr "Admin detayes"
+
+#~ msgid "Skip this step"
+#~ msgstr "Salta e stèp aki"
+
+#~ msgid "Go back to previous step"
+#~ msgstr "Bai bèk na e stèp anterior"
+
+#~ msgid "Red teamer account setup"
+#~ msgstr "Setup account pa tìm kòrà"
+
+#~ msgid "Red teamer details"
+#~ msgstr "Tìm kòrà detayes"
+
+#~ msgid "Client account setup (optional)"
+#~ msgstr "Setup account pa kliénte (opcionàl)"
+
+#~ msgid ""
+#~ "A client account can access reports. Adding a client account to the "
+#~ "organization is optional."
+#~ msgstr ""
+#~ "Un account pa kliénte por tin accesso na rapòrtnan. Añadi un account pa "
+#~ "kliénte na e organisashon ta optionàl."
+
+#~ msgid "User details"
+#~ msgstr "Usario detayes"
+
+#~ msgid "Finish organization setup"
+#~ msgstr "Finalisá setup organisashon"
+
+#~ msgid ""
+#~ "OpenKAT is the \"Kwetsbaarheden Analyse Tool\" (Vulnerabilities Analysis "
+#~ "Tool). An Open-Source-project developed by the Ministry of Health, Welfare "
+#~ "and Sport to make your and our world a safer place."
+#~ msgstr ""
+#~ "OpenKAT ta e \"Kwetsbaarheden Analyse Tool\" (tool pa hasi análisis di "
+#~ "bulerabilidat). Un proyekto Open Source desaroyá pa Ministerio di Salú "
+#~ "Públiko, Salú i Deporte pa hasi nos mundu un lugar mas sigur pa bo i nos."
+
+#~ msgid ""
+#~ "OpenKAT is able to give insight into security risks on your online objects. "
+#~ "For example, your websites, mailservers or online data."
+#~ msgstr ""
+#~ "OpenKAT tin e abilidát di duna revelashon di riésgonan di siguridát di bo "
+#~ "online ophetonan. Por ehèmpel, bo website nan, mailservers òf online data."
+
+#~ msgid ""
+#~ "OpenKAT uses plugins to find and assess the area's that might be at risk and"
+#~ " reports these back to you. Each plugin has its own skillset which could be "
+#~ "scanning, normalizing or analyzing data. As a user you decide which areas "
+#~ "you would like to monitor or scan and which insight you would like to "
+#~ "receive."
+#~ msgstr ""
+#~ "OpenKAT ta huza plugins pa deskubrì i evalúa e areanan ku por ta un riésgo i"
+#~ " rapòrta esaki bèk na bo. Kada plugin tin nan mes sèt di abilidát ku por ta "
+#~ "scan, nòrmalisá òf analisá data. Komo usario bo ta disidì kwa area bo tin "
+#~ "gana di monitoriá òf skan i tambe ki tipo di revelashon bo tin gana di "
+#~ "recibí."
+
+#~ msgid ""
+#~ "Within OpenKAT you can view the insights as well as all the data OpenKAT has"
+#~ " found. You can choose to browse through the data or view reports."
+#~ msgstr ""
+#~ "Den OpenKAT bo por mira e insights i tambe tur data ku KAT a deskubrì. Bo "
+#~ "por skohé pa buska den e data òf wak rapòrt nan."
+
+#~ msgid ""
+#~ "During this introduction you will be guided through the steps to create a "
+#~ "report."
+#~ msgstr ""
+#~ "Durante e introdukshon aki bo lo wordu guiá dor di e stap nan pa krea un "
+#~ "rapòrt."
+
+#~ msgid "OpenKAT introduction"
+#~ msgstr "OpenKAT introdukshon"
+
+#~ msgid "Choose a report - Introduction"
+#~ msgstr "Skohé un rapòrt - Introduskhon"
+
+#~ msgid ""
+#~ "Reports within OpenKAT contain an overview of the scanned objects, issues "
+#~ "found within them and known security risks that the object might be "
+#~ "vulnerable to. Each report gives a high overview of the state of the object "
+#~ "as well as detailed information on what OpenKAT found and possible "
+#~ "solutions."
+#~ msgstr ""
+#~ "Rapòrtnan den OpenKAT ta kontene un lista di ophetonan di skan, problemanan "
+#~ "haña serka nan i riesgo di siguridat nan ku e opheto por ta vulnerabel na "
+#~ "dje. Kada rapòrt ta duna un lista prioritá di e estado di e opheto i tambe "
+#~ "informashon detaya di tur loke KAT a enkontra i solushonanan posibel."
+
+#~ msgid ""
+#~ "OpenKAT can scan and analyze by using plugins. Each plugin has it's unique "
+#~ "skillset and will collect specific data or give specific insights. You "
+#~ "manage the plugins within your account which let's OpenKAT know which "
+#~ "plugins to run and on which objects or areas."
+#~ msgstr ""
+#~ "OpenKAT por skan i analisá dor di huza plugins. Kada plugin tin nan mas sèt "
+#~ "di skills uniko i lo kolekta data spesifiko of duna mas informashon "
+#~ "spesifiko. Bo ta maneha plugins den bo account ku ta laga OpenKAT sa kwa "
+#~ "plugins mester huza riba kwa opheto òf areanan."
+
+#~ msgid "Generating a report"
+#~ msgstr "Generándo un rapport"
+
+#~ msgid ""
+#~ "When you choose a report type OpenKAT will guide you through the setup. "
+#~ "OpenKAT will ask the necessary questions based on the input the report "
+#~ "needs, as well as asks for permission to run plugins that you haven’t "
+#~ "enabled yet but are needed to collect or analyze the data."
+#~ msgstr ""
+#~ "Ora bo selektá un tipo di informe, OpenKAT lo guia bo den e ajuste. OpenKAT "
+#~ "lo hasi e preguntanan necesario basá riba e entrada ku e informe ta "
+#~ "nesesitá, tambe lo pidi permiso pa eksekutá plug-innan ku ainda bo no a "
+#~ "habilidá, pero ku ta nesesario pa kolektá òf analisá e datonan."
+
+#~ msgid ""
+#~ "You can also choose to look at the collected data directly or generate your "
+#~ "own report by selecting and running plugins on objects of your choice. "
+#~ "OpenKAT will present the results."
+#~ msgstr ""
+#~ "Bo por tambe skohé pa mira e data kolekta direktamente òf genera bo mes "
+#~ "rapòrt dor di selekta i start plugins riba ophetonan si bo eskoho. OpenKAT "
+#~ "lo presentabu ku e resultadonan."
+
+#~ msgid "Permission"
+#~ msgstr "Permiso Nenga"
+
+#~ msgid ""
+#~ "Plugins can be provided by OpenKAT but they can also come from the "
+#~ "community. Before a plugin can run, you need to give it permission by "
+#~ "enabling it."
+#~ msgstr ""
+#~ "Plugins ta bin di OpenKAT pero nan tambe por bini dor di e komunidát. Promé "
+#~ "un plugin por wordu huza, bo mester dunele pèrmiso dor di activé"
+
+#~ msgid ""
+#~ "When you generate a report. OpenKAT will let you know which plugins it "
+#~ "requires or suggests so you can choose to enable them."
+#~ msgstr ""
+#~ "Ora bo genera un rapòrt. OpenKAT ta lagabu sa kwa plugins e mester òf "
+#~ "duna'bu sugerencias pa skohé kwa pa activá."
+
+#~ msgid "Let's choose a report"
+#~ msgstr "Ban skohé un rapòrt"
+
+#~ msgid "Choose a report - Type"
+#~ msgstr "Skohé un rapòrt - Tipo"
+
+#~ msgid ""
+#~ "When you start to generate this report. OpenKAT will guide you through the "
+#~ "necessary steps."
+#~ msgstr ""
+#~ "Ora bo kuminsa generá e rapòrt aki. OpenKAT lo guiá'bu dor di e stapnan "
+#~ "necesario."
+
+#~ msgid "Setup scan"
+#~ msgstr "Setup skan"
+
+#~ msgid "Let OpenKAT know what object to scan"
+#~ msgstr "Laga OpenKAT sa kwa opheto e tinku skan"
+
+#~ msgid ""
+#~ "Plugins scan and analyze objects. OpenKAT needs to know which object(s) you "
+#~ "would like to scan and analyze for the DNS-report. So it can tell you which "
+#~ "plugins are available for the chosen object."
+#~ msgstr ""
+#~ "Plug-innan skan i analisá objektonan. OpenKAT mester sa kua objèkto(s) bo "
+#~ "kier skan i analisá pa e informe DNS. Asina ku por bisa bo ku kuál plug-"
+#~ "innan ta disponibel pa e objèkto selektá."
+
+#~ msgid "Understanding objects"
+#~ msgstr "Kompronde ophetonan"
+
+#~ msgid "Creating, adding and editing objects"
+#~ msgstr "Kreando, añadiando i editá ophetonan"
+
+#~ msgid ""
+#~ "Within OpenKAT you can view, add and edit objects from the organization’s "
+#~ "object page."
+#~ msgstr ""
+#~ "Den OpenKAT bo por mira, añadi i editá ophetonan di e organisashon su page "
+#~ "di opheto."
+
+#~ msgid ""
+#~ "Let’s add an object to scan for the DNS-Report. For this introduction we "
+#~ "suggest adding a URL."
+#~ msgstr ""
+#~ "Ban añadi un opheto pa skan pa traha e DNS-rapòrt. Pa e introdukshon aki nos"
+#~ " ta sugerí añadi un URL."
+
+#~ msgid "Create your first object, a URL by filling out the form below."
+#~ msgstr "Krea bo promé opheto, un URL dor di yena e formulario abou."
+
+#~ msgid ""
+#~ "Additional details and examples can be found by pressing on the help button "
+#~ "next to the input field."
+#~ msgstr ""
+#~ "Detayesnan i ehempelnan adishonal bo por haña dor di primi e help botón "
+#~ "banda di e vèld."
+
+#~ msgid "Dependencies"
+#~ msgstr "Dependesianan"
+
+#~ msgid ""
+#~ "The additional objects that OpenKAT created will be added to your object "
+#~ "list as separate objects. If OpenKAT can’t add them automatically it will "
+#~ "guide you through the process of creating them manually."
+#~ msgstr ""
+#~ "E ophetonan adishonal ku OpenKAT á krea lo wordu agregá na e lista di opehto"
+#~ " komo ophetonan separá. Si OpenKAT no por agregá esakinan automatikamente e "
+#~ "ta guia'bu dor di e processo pa kreanan manualmente."
+
+#~ msgid ""
+#~ "Based on the url you provided OpenKAT added the necessary additional objects"
+#~ " to create a url object."
+#~ msgstr ""
+#~ "Basá riba e URL ku bo a duna, OpenKAT a agrega e ophetonan adishonal "
+#~ "necesario pa krea un opheto di URL."
+
+#~ msgid "URL"
+#~ msgstr "URL"
+
+#~ msgid "Path"
+#~ msgstr "Routa"
+
+#~ msgid "Hostname"
+#~ msgstr "Hostname"
+
+#~ msgid "scheme"
+#~ msgstr "programa"
+
+#~ msgid "Network"
+#~ msgstr "Nètwèrk"
+
+#~ msgid "Start scanning"
+#~ msgstr "Start skan"
+
+#~ msgid "OpenKAT Introduction"
+#~ msgstr "OpenKAT Introdukshon"
+
+#~ msgid "Setup scan - OOI clearance for"
+#~ msgstr "Sètup skan- OOI autorisashon pa"
+
+#~ msgid ""
+#~ "Some scans are lightweight while others might be a bit more aggressive with "
+#~ "their scanning. OpenKAT requires you to set a clearance level for each "
+#~ "object to prevent you from unintentionally running aggressive scans. For "
+#~ "example you might have the right to run any type of scan on your own server "
+#~ "but you probably don’t have the right to do so for objects owned by other "
+#~ "people of companies."
+#~ msgstr ""
+#~ "Algun skan ta ligero, i otro por ta un tiki mas agresivo den nan skaneo. "
+#~ "OpenKAT ta requeri bo pa ajustá un nivel di autorisashon pa kada opheto pa "
+#~ "evitá ku b'a sende skan agresivo sin intenshón. Por ehèmpel, bo por tin e "
+#~ "derechi pa skan kualkier tipo di opheto riba bo propio server, pero "
+#~ "probabelmente bo no tin e derechi pa hasi meskos ku ophetonan ku ta "
+#~ "pertenese na otro personanan of kompanianan."
+
+#~ msgid "How to know required clearance level"
+#~ msgstr "Kon pa sa nivél di autorisashon requerí"
+
+#~ msgid ""
+#~ "Each plugin that scans will have a scan intensity score. The intensity of "
+#~ "the scan must be equal to or below the clearance level you set for your "
+#~ "object. If the scan has an intensity level that is too high, OpenKAT will "
+#~ "notify you before running it. Visually clearance levels and intensity scores"
+#~ " are indicated with little cat paws."
+#~ msgstr ""
+#~ "Kada plug-in ku skan ta tin un puntu di intensidat di skaneo. E intensidat "
+#~ "di e skaneo mester ta igual òf mas abou ku e nivel di autorisashon ku bo a "
+#~ "ajustá pa bo opheto. Si e skaneo tin un nivel di intensidat ku ta hopi "
+#~ "haltu, OpenKAT lo notifiká bo promé di eksekutá e skaneo. Visualmente, "
+#~ "nivelnan di autorisashon i punto di intensidat ta indiká ku patanan di "
+#~ "pushi."
+
+#~ msgid ""
+#~ "This scan has a scan intensity score of 1, requiring a level 1 clearance "
+#~ "level to be run. This means that the scan does not touch the object itself, "
+#~ "but only searches for information about the object."
+#~ msgstr ""
+#~ "E skan tin un score di nivél di intensidat di 1, ku ta requerí nivél 1 di "
+#~ "autorisashon pa start. Esaki ta nifika ku e skan no ta mishi ku e opheto "
+#~ "riba su mes, pero solamente ta buska informashon tokante e opheto."
+
+#~ msgid ""
+#~ "An example of a more aggressive scan. Which has a scan intensity score of 3."
+#~ " Meaning it requires at least a level 3 clearance level to be set on your "
+#~ "object."
+#~ msgstr ""
+#~ "Un ehèmpel di un skaneo mas agresivo. Ku tin un puntu di intensidat di "
+#~ "skaneo di 3. Esaki ta nifiká ku mester tin por lo menos un nivel di "
+#~ "autorisashon di 3 pa wordu ajustá riba bo opheto."
+
+#~ msgid "Acknowledge clearance level"
+#~ msgstr "Rekonosé nivel di autorisashon"
+
+#~ msgid "Setup scan - Set clearance level for"
+#~ msgstr "Sètup skan- Pone nivel di autorisashon pa"
+
+#, python-format
+#~ msgid ""
+#~ "After creating a new object OpenKAT will ask you to set a clearance level. "
+#~ "On the object detail page you can always change the clearance level. For the"
+#~ " onboarding we will suggest to set the clearance level to "
+#~ "L%(dns_report_least_clearance_level)s."
+#~ msgstr ""
+#~ "Despues di krea un opheto nobo, OpenKAT lo puntra bo pa pone un nivel di "
+#~ "autorisashon. Na e página di detaye di e opheto, bo por kambia e nivel di "
+#~ "autorisashon semper. Pa e proceso di onboarding nos lo sugeri pa pone e "
+#~ "nivel di autorisashon na L%(dns_report_least_clearance_level)s."
+
+#~ msgid "Setup scan - Enable plugins"
+#~ msgstr "Configurá skan - Aktivá plugins"
+
+#~ msgid "Plugins introduction"
+#~ msgstr "Plugins su introduskhon"
+
+#~ msgid ""
+#~ "OpenKAT uses plugins to scan, check and analyze. Each plugin will bring a "
+#~ "specific skillset that will help to generate your report. There are three "
+#~ "types of plugins."
+#~ msgstr ""
+#~ "OpenKAT ta huza plugins pa scan, check i analisá. Kada plugin ta trese un "
+#~ "abilidát specifikó ku lo juda pa generá bo rapòrt. Tin tres tipo di plugins."
+
+#~ msgid ""
+#~ "Scan objects for data. Each boefje has a scan intensity score to prevent "
+#~ "invasive scanning on objects where you don’t have the clearance to do so."
+#~ msgstr ""
+#~ "Skèn ophetonan pa data. Kada boefje tin un intesidát score pa skan pa "
+#~ "prevení scannan invasivo riba opheto kaminda bo no tin autorisashon pa hasi "
+#~ "esaki."
+
+#~ msgid ""
+#~ "Check the data for specific objects and add these object to your object "
+#~ "list."
+#~ msgstr ""
+#~ "Chèk e data pa ophetonan specifikó i añadi e ophetonan aki na bo lista di "
+#~ "opheto."
+
+#~ msgid "Analyze the available data to come to insights and conclusions."
+#~ msgstr "Analisá e data disponibel pa yega na konklushonnan i perspectivanan."
+
+#~ msgid ""
+#~ "OpenKAT will be able to generate a full report when all the required and "
+#~ "suggested plugins are enabled. If you choose not to give a plugin permission"
+#~ " to run, the data that plugin would collect or produce will be left out of "
+#~ "the report which will then be generated based on the available data "
+#~ "collected by the enabled plugins. Below are the suggested and required "
+#~ "plugins for this report."
+#~ msgstr ""
+#~ "OpenKAT ta dispuesto pa generá un fúl rapòrt ora tur e plugins nan requerí i"
+#~ " sugerá ta aktivá. Si bo skohé pa no duna un plugin pèrmiso  pa start, e "
+#~ "data ku e plugin lo mester kolektá òf produsí lo wordu saka for di e rapòrt "
+#~ "ku lo generá a base di e data ku tin disponibel kolektá pa e plugins aktivo."
+#~ " Abou bo por mira e plugins nan ku ta requerí pa e rapòrt aki."
+
+#~ msgid "Let’s setup your scan by enabling the plugins of your choice below."
+#~ msgstr "Laga nos ban setup e skan dor di aktivá e plugins di bo eskoho abou."
+
+#~ msgid ""
+#~ "The enabled boefjes are collecting the data needed to generate the DNS-"
+#~ "report. This may take some time based on the type of scans and the number of"
+#~ " objects found. For the current scan we expect boefjes to take about 3 "
+#~ "minutes."
+#~ msgstr ""
+#~ "E Boefjes nan aktivá ta bezig ta kolektando e data necesario pa generá e "
+#~ "DNS-rapòrt. Esaki ta bai tuma tempu a base di e tipo di scannan i e kantidát"
+#~ " di ophetonan enkontrá."
+
+#~ msgid ""
+#~ "During this introduction we ask you to wait till the scan is ready. After "
+#~ "which you can view the report."
+#~ msgstr ""
+#~ "Durante e introdukshon aki nos ta pidibu pa warda te ora e skan kaba. "
+#~ "Despues bo por mira e rapòrt."
+
+#~ msgid ""
+#~ "After the onboarding, boefjes run in the background. This enables you to use"
+#~ " OpenKAT in the meantime without waiting for scans to finish. When you would"
+#~ " like to see the status of a scan you can open the \"tasks\" page."
+#~ msgstr ""
+#~ "Despues di e onboarding, boefjes nan ta sigi den background. Esaki ta pone "
+#~ "ku bo por uza OpenKAT mientras tantu sin mester warda te ora e skannan kaba."
+#~ " Kaminda bo lo por ke mira e status di un skan bo por habri e pagina di "
+#~ "\"tarea\". "
+
+#~ msgid "Open my DNS-report"
+#~ msgstr "Habri mi DNS-rapòrt"
+
+#~ msgid "1: Introduction"
+#~ msgstr "Introdukshon"
+
+#~ msgid "2: Choose a report"
+#~ msgstr "Skohé un rapòrt"
+
+#~ msgid "3: Setup scan"
+#~ msgstr "Setup scan"
+
+#~ msgid "4: Open report"
+#~ msgstr "Habri rapòrt"
+
+#~ msgid "3: Indemnification"
+#~ msgstr "3: Indemnizashon"
+
+#~ msgid "4: Account setup"
+#~ msgstr "4: Account setup"
+
+#~ msgid "OpenKAT Setup"
+#~ msgstr "OpenKAT Setup"
+
+#, python-brace-format
+#~ msgid "{name} successfully created."
+#~ msgstr "{name} a wòrdu krea ku èksito."
+
+#~ msgid "The name of the organisation"
+#~ msgstr "E nòmber di e organisashon"
+
+#~ msgid ""
+#~ "A slug containing only lower-case unicode letters, numbers, hyphens or "
+#~ "underscores that will be used in URLs and paths"
+#~ msgstr ""
+#~ "Un slug ta kontene solamente lower-case unicode letras, numbernan, hyphens "
+#~ "òf underscores ku lo wordu huza den URLs i paths"
+
+#~ msgid ""
+#~ "Before you're able to add assets to OpenKAT and to assign clearance levels, "
+#~ "you have to give indemnification on the organization and declare that you as"
+#~ " a person can be held accountable."
+#~ msgstr ""
+#~ "Prome ku bo por añadi propiedatnan na OpenKAT i pone nivelnan di "
+#~ "authorisashon, bo mester duna indemnizashon na e organisashon i deklara ku "
+#~ "abo komo persona por wordu pone responsabel."
+
+#~ msgid "Register an indemnification"
+#~ msgstr "Registrá un indemnizashon"
+
+#~ msgid "Add Finding"
+#~ msgstr "Añadí Diskubrimentu"
+
+#~ msgid "Mute Findings"
+#~ msgstr "Muta Diskubrimentu"
+
+#~ msgid "Mute Finding"
+#~ msgstr "Muta diskubrimentu"
+
+#~ msgid "Account Type"
+#~ msgstr "Tipo di account"
+
+#~ msgid "Every member of OpenKAT must be part of an account type."
+#~ msgstr "Kada miembro di OpenKAT mester ta parti di un tipo di kuenta."
+
+#~ msgid "Source OOI"
+#~ msgstr "Orígen OOI"
+
+#~ msgid "Manual creation"
+#~ msgstr "Kreashon manual"
+
+#~ msgid " member account setup"
+#~ msgstr " konfigurashon di kuenta di miembro"
+
+#~ msgid "Member details"
+#~ msgstr "Detayes di miembro"
+
+#~ msgid "Member account type setup"
+#~ msgstr "Konfigurashon di tipo di kuenta di miembro"
+
+#~ msgid "Choose an account type for this new member."
+#~ msgstr "Selekshoná un tipo di kuenta pa e miembro nobo aki."
+
+#~ msgid "Account type details"
+#~ msgstr "Detayenan di tipo di kuenta"
+
+#~ msgid "Upload a csv file with members for organisation"
+#~ msgstr "Subi un archivo csv ku miembronan pa e organisashon"
+
+#~ msgid "Download the template"
+#~ msgstr "Download e template"
+
+#~ msgid "or create a csv file with the following criteria"
+#~ msgstr "òf krea un archivo csv ku e kriterionan sigiente"
+
+#~ msgid "Shown status types"
+#~ msgstr "Muestra di tiponan di status"
+
+#~ msgid "Blocked status"
+#~ msgstr "Status blòkiá"
+
+#~ msgid "Type select"
+#~ msgstr "Selektá tipo"
+
+#~ msgid "Add Account Type"
+#~ msgstr "Añadi Tipo di account"
+
+#~ msgid "Add Member"
+#~ msgstr "Añadí miembro"
+
+#~ msgid ""
+#~ "An overview of the top 10 most severe findings OpenKAT found. Check the "
+#~ "detail section for additional severity information."
+#~ msgstr ""
+#~ "Un bista general di e 10 diskubrimentunan mas serio ku OpenKAT a haña. Chèk "
+#~ "den seccion di detaye pa informashon adishonal tokante severidat."
+
+#~ msgid "Top 10 most severe Findings"
+#~ msgstr "Top 10 di e diskubrimentunan mas serio."
+
+#~ msgid "Showing "
+#~ msgstr "Mustra "
+
+#~ msgid "findings"
+#~ msgstr "diskubrimentunan"
+
+#~ msgid "Finding type:"
+#~ msgstr "Tipo di diskubrimentu:"
+
+#~ msgid "OOI type:"
+#~ msgstr "Tipo di opheto"
+
+#~ msgid "Source OOI:"
+#~ msgstr "Orígen OOI:"
+
+#~ msgid "KAT-alogus Settings"
+#~ msgstr "KAT-alogus Settings"
+
+#~ msgid ""
+#~ "There are currently no settings defined. Add settings at plugin detail page."
+#~ msgstr ""
+#~ "Na e momentonan aki no tin settings pone. Añadi settings na e página detaya "
+#~ "di plugin."
+
+#, python-format
+#~ msgid ""
+#~ "These are the findings of a OpenKAT-analysis (%(observed_at)s). Click a "
+#~ "finding for more detailed information about the issue, its origin, severity "
+#~ "and possible solutions."
+#~ msgstr ""
+#~ "Esakinan ta e resultadonan di un OpenKAT-analysis riba %(observed_at)s. "
+#~ "Click un resultadopa mas informashon detayá tokante e problema, su orígen, "
+#~ "severidat i posibel solushonnan."
+
+#~ msgid "DNS Tree"
+#~ msgstr "DNS Mapa"
+
+#~ msgid "Total findings:"
+#~ msgstr "Totál diskubrimentu:"
+
+#~ msgid "An overview of"
+#~ msgstr "Resúmen di resultado"
+
+#~ msgid "object type"
+#~ msgstr "tipo di opheto"
+
+#~ msgid ""
+#~ "This shows general information and its related objects. It also gives the "
+#~ "possibility to add additional related objects, or to scan for them."
+#~ msgstr ""
+#~ "Esaki ta mustra informashon general i e ophetonan relashoná. Tambe ta brinda"
+#~ " e posibilidat pa agrega ophetonan relashoná adishonal, òf pa skan pa nan."
+
+#~ msgid "Unique"
+#~ msgstr "Úniko"
+
+#~ msgid "There are no tasks for boefjes"
+#~ msgstr "No tin tareanan pa boefjes"
+
+#~ msgid "List of tasks for boefjes"
+#~ msgstr "Lista di tareanan pa boefjes"
+
+#~ msgid "There are no tasks for normalizers"
+#~ msgstr "No tin tareanan pa normalizers"
+
+#~ msgid "List of tasks for normalizers"
+#~ msgstr "Lista di tareanan pa normalizers"
+
+#~ msgid "Your password must contain at least the following:"
+#~ msgstr "Bo password mester kontené por lo menos lo siguinte:"
+
+#~ msgid " special characters such as: "
+#~ msgstr " karakternan speshal manera: "
+
+#~ msgid ""
+#~ "Failed to get list of findings for organization {}, check server logs for "
+#~ "more details."
+#~ msgstr ""
+#~ "No por a optené lista di diskubrimentu pa e organisashon {}, kontrolá "
+#~ "registro di servidor pa detayenan mas."
+
+#~ msgid ""
+#~ "An overview of all (critical) findings OpenKAT found. Check the detail "
+#~ "section for additional severity information."
+#~ msgstr ""
+#~ "Un relato general di tur diskubrimentu (krítiko) ku OpenKAT a enkontrá. Chèk"
+#~ " e sekshon detayá pa informashon addishonal severo."
+
+#~ msgid "Total Findings"
+#~ msgstr "Diskubrimentu Totál"
+
+#~ msgid " Finding Details"
+#~ msgstr "Detayes di diskubrimentu"
+
+#~ msgid "Top critical organizations"
+#~ msgstr "Top organisashonnan krítiko"
+
+#~ msgid "Critical findings"
+#~ msgstr "Diskubrimentu Kritiko"
+
+#~ msgid "Critical Findings"
+#~ msgstr "Diskubrimentu Kritiko"
+
+#~ msgid "this field is required"
+#~ msgstr "E vèld aki ta obligatorio"
+
+#~ msgid "This field is required"
+#~ msgstr "E vèld aki ta obligatorio"
+
+#~ msgid ""
+#~ "\n"
+#~ "                            You don't have any clearance to scan objects.<br>\n"
+#~ "                            Get in contact with the admin to give you the necessary clearance level.\n"
+#~ "                        "
+#~ msgstr ""
+#~ "\n"
+#~ " Bo no tin ningun nivel di autorisashon pa skan ophetonan.<br>\n"
+#~ " Tuma kontakto ku e administradó pa duna bo e nivel di autorisashon nesesario.\n"
+#~ " "
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "        Use the form below to clone the settings from <i>%(current_organization)s</i> to the selected organization.\n"
+#~ "        This includes both the KAT-alogus settings as well as enabled and disabled plugins.\n"
+#~ "      "
+#~ msgstr ""
+#~ "\n"
+#~ " Uza e formulario abou pa kopia e konfigurashon di <i>%(current_organization)s</i> pa e organisashon selektá.\n"
+#~ " Esaki ta inkluí tanto e konfigurashonnan di KAT-alogus manera tambe e plug-innan aktivá i desaktivá.\n"
+#~ "      "
+
+#~ msgid ""
+#~ "\n"
+#~ "                            Plugin available\n"
+#~ "                        "
+#~ msgid_plural ""
+#~ "\n"
+#~ "                            Plugins available\n"
+#~ "                        "
+#~ msgstr[0] ""
+#~ "\n"
+#~ "                        Plug-in disponibel\n"
+#~ "                        "
+#~ msgstr[1] ""
+#~ "\n"
+#~ "                        Plug-ins disponibel\n"
+#~ "                      "
+
+#~ msgid ""
+#~ "\n"
+#~ "            Add setting\n"
+#~ "          "
+#~ msgid_plural ""
+#~ "\n"
+#~ "            Add settings\n"
+#~ "          "
+#~ msgstr[0] ""
+#~ "\n"
+#~ "            Añadi configurashon\n"
+#~ "          "
+#~ msgstr[1] ""
+#~ "\n"
+#~ "            Añadi configurashonnan\n"
+#~ "          "
+
+#~ msgid ""
+#~ "\n"
+#~ "            Setting\n"
+#~ "          "
+#~ msgid_plural ""
+#~ "\n"
+#~ "            Settings\n"
+#~ "          "
+#~ msgstr[0] ""
+#~ "\n"
+#~ "            Configurashon\n"
+#~ "          "
+#~ msgstr[1] ""
+#~ "\n"
+#~ "            Configurashonnan\n"
+#~ "          "
+
+#~ msgid ""
+#~ "\n"
+#~ "                  Add setting and enable boefje\n"
+#~ "                "
+#~ msgid_plural ""
+#~ "\n"
+#~ "                  Add settings and enable boefje\n"
+#~ "                "
+#~ msgstr[0] ""
+#~ "\n"
+#~ "                        Pone setting i sende boefje\n"
+#~ "                        "
+#~ msgstr[1] ""
+#~ "\n"
+#~ "                        Pone settings i sende boefje\n"
+#~ "                      "
+
+#~ msgid ""
+#~ "\n"
+#~ "                    OpenKAT has a permission system that allows administrators to\n"
+#~ "                    configure which users can set a certain clearance level. The will make sure\n"
+#~ "                    that only users that are trusted can start the more aggressive scans.\n"
+#~ "                "
+#~ msgstr ""
+#~ "\n"
+#~ "OpenKAT tin un sistema di permiso ku ta laga administratornan\n"
+#~ "configure kua usuarionan por pone un nivel di autorisashon determiná. Esaki lo segurá\n"
+#~ "ku solamente usuarionan ku ta konfiable por inisiá e skaneonan mas agresivo.\n"
+#~ " "
+
+#~ msgid ""
+#~ "\n"
+#~ "                    Before a member is granted the ability to set clearance levels on an object,\n"
+#~ "                    they must first acknowledge and accept the clearance level set by the administrators.\n"
+#~ "                    The maximum scanning level permitted for a member is aligned with the trusted clearance level.\n"
+#~ "                    By acknowledging the trusted clearance level, this member formally agrees to abide by\n"
+#~ "                    this permission and gains the capability to perform scans only up to this trusted clearance level.\n"
+#~ "                    This two-step process ensures that the member operates within authorized boundaries.\n"
+#~ "                "
+#~ msgstr ""
+#~ "\n"
+#~ "Promé ku un miembro ta otorgá e habilidat pa pone nivelnan di autorisashon riba un opheto,\n"
+#~ "promé nan mester reconosé i aseptá e nivel di autorisashon poni pa e administratornan.\n"
+#~ "E nivel máksimo di skaneo permití pa un miembro ta aliná ku e nivel di autorisashon konfiable.\n"
+#~ "Pa reconosé e nivel di autorisashon konfiable, e miembro aki formalmente ta akordá pa kumpli ku\n"
+#~ "e permiso aki i ta haña e kapasidat pa realizá skaneonan solamente te na e nivel di autorisashon konfiable aki.\n"
+#~ "E proheso di dos pason aki ta garantisá ku e miembro ta operá den fronteranan autorisá.\n"
+#~ " "
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "                                Unfortunately you cannot continue the onboarding. </br>\n"
+#~ "                                Your administrator has trusted you with a clearance level of <strong>L%(tcl)s</strong>.</br>\n"
+#~ "                                You need at least a clearance level of <strong>L%(dns_report_least_clearance_level)s</strong> to scan <strong>%(ooi)s</strong></br>\n"
+#~ "                                Contact your administrator to receive a higher clearance.\n"
+#~ "                            "
+#~ msgstr ""
+#~ "\n"
+#~ " Desafortunadamente bo no por sigui ku e proceso di onboarding. </br>\n"
+#~ " Bo administrator a konfia bo ku un nivel di autorisashon di <strong>L%(tcl)s</strong>.</br>\n"
+#~ " Bo mester tin almenos un nivel di autorisashon di <strong>L%(dns_report_least_clearance_level)s</strong> pa skaneá\n"
+#~ " <strong>%(ooi)s</strong></br>\n"
+#~ " Tuma kontakto ku bo administrator pa risibí un nivel di autorisashon mas haltu.\n"
+#~ " "
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "                            Your administrator has trusted you with a clearance level of <strong>L%(tcl)s</strong>.</br>\n"
+#~ "                            You must first accept this clearance level to continue.\n"
+#~ "                            "
+#~ msgstr ""
+#~ "\n"
+#~ " Bo administrator a konfia bo ku un nivel di autorisashon di <strong>L%(tcl)s</strong>.</br>\n"
+#~ " Promé bo mester aseptá e nivel di autorisashon aki pa por sigui.\n"
+#~ " "
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "                            Accept level L%(tcl)s clearance and responsibility\n"
+#~ "                        "
+#~ msgstr ""
+#~ "\n"
+#~ "Aseptá nivel di autorisashon L%(tcl)s i responsabilidat\n"
+#~ "                        "
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "                            Your administrator has <strong>trusted</strong> you with a clearance level of <strong>L%(tcl)s</strong>.</br>\n"
+#~ "                            You have also <strong>acknowledged</strong> to use this clearance level of <strong>L%(acl)s</strong>.\n"
+#~ "                            "
+#~ msgstr ""
+#~ "\n"
+#~ " Bo administrator a <strong>konfia</strong> bo ku un nivel di autorisashon di <strong>L%(tcl)s</strong>.</br>\n"
+#~ " Bo tambe a <strong>rekonosé</strong> pa usa e nivel di autorisashon aki di <strong>L%(acl)s</strong>.\n"
+#~ " "
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "                            <strong>Warning:</strong>\n"
+#~ "                            Indemnification is not set for this organization.\n"
+#~ "                            Go to the <a href=\"%(organization_settings)s\">organization settings page</a> to add one.\n"
+#~ "                        "
+#~ msgstr ""
+#~ "\n"
+#~ " <strong>Advertensia:</strong>\n"
+#~ " Indemnisashon no ta ajustá pa e organisashon aki.\n"
+#~ " Bishitá e <a href=\"%(organization_settings)s\">página di ajuste di organisashon</a> pa agregá un.\n"
+#~ "                        "
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "                    An overview of \"%(organization_name)s\" its members.\n"
+#~ "                "
+#~ msgstr ""
+#~ "\n"
+#~ " Un bista general di e miembronan di \"%(organization_name)s\".\n"
+#~ "                "
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "            An overview of \"%(organization_name)s\". This shows general information and its settings.\n"
+#~ "          "
+#~ msgstr ""
+#~ "\n"
+#~ " Un bista general di \"%(organization_name)s\". Esaki ta mustra informashon general i su ajustenan.\n"
+#~ "          "
+
+#~ msgid ""
+#~ "\n"
+#~ "              <strong>Warning:</strong>\n"
+#~ "              Indemnification is not set for this organization.\n"
+#~ "            "
+#~ msgstr ""
+#~ "\n"
+#~ " <strong>Advertensia:</strong>\n"
+#~ " Indemnisashon no ta ajustá pa e organisashon aki.\n"
+#~ "            "
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "              This means that this object will be scanned by Boefjes with scan level\n"
+#~ "              %(scan_level)s and lower. Setting the clearance level from “declared”\n"
+#~ "              to “inherit” means that this object will inherit its level from neighbouring\n"
+#~ "              objects. This means that the clearance level might stay the same, increase,\n"
+#~ "              or decrease depending on other declared clearance levels. Clearance levels\n"
+#~ "              of objects that inherit from this clearance level will also be recalculated.\n"
+#~ "            "
+#~ msgstr ""
+#~ "\n"
+#~ "              Esaki ta nifiká ku e opheto aki lo wordu di skan dor di Boefjes ku nivél di skan\n"
+#~ "              %(scan_level)s i mas abou. Pone e nivél di autorisashon for di deklará\n"
+#~ "              na “heredá” ta nifiká ku e opheto aki lo heredá su nivél for di ophetonan den bisindario.\n"
+#~ "              Esaki ta nifiká ku e nivél di autorisashon por keda meskos, subi,\n"
+#~ "              òf baha depende di e otro nivél di autorisashonnan. Nivél di autorisashonnan\n"
+#~ "              di ophetonan ku ta heredá for di e nivél di autorisashon tambe lo wordu rekalkulá.\n"
+#~ "            "
+
+#~ msgid ""
+#~ "\n"
+#~ "                This object has a clearance level of \"L0\". This means that this object will not be scanned by any Boefje until that\n"
+#~ "                Boefje is run manually for this object again. Objects with a clearance level higher than \"L0\" will be scanned automatically by Boefjes with\n"
+#~ "                corresponding scan levels.\n"
+#~ "            "
+#~ msgstr ""
+#~ "\n"
+#~ "                E opheto aki tin un nivel di authorisashon di \"L0\". Esaki ta nifika ku e opheto aki no por wòrdu di skan dor di ningun Boefje te ora\n"
+#~ "                e Boefje aki ta wordu di skan manualmente atrobe pe e opheto. Ophetonan ku un nivel di authorisashon mas haltu ku \"L0\" ta wòrdu di skan automatikamente dor di Boefjes ku\n"
+#~ "                nivelnan di skan korespondiente.\n"
+#~ "            "
+
+#~ msgid "Download PDF"
+#~ msgstr "Download PDF"
+
+#~ msgid "There are no boefjes available within the current clearance level of"
+#~ msgstr "No tin boefjes disponibel den e nivel di authorisashon di"
+
+#~ msgid "Or if you have the authorization, upgrade the clearance level of"
+#~ msgstr "Òf si bo tin authorisashon, subi e nivel di authorisason di"
+
+#~ msgid "Accounts"
+#~ msgstr "Habri detayes"
+
+#~ msgid "Currently there are no findings for OOI"
+#~ msgstr "Aktualmente no a diskubri nada pa OOI"
+
+#~ msgid "Select your language"
+#~ msgstr "Selekshoná bo idioma"
+
+#, python-format
+#~ msgid ""
+#~ "Current language is %(current_language)s. Choose your preferred language."
+#~ msgstr "Idioma aktual ta %(current_language)s. Escoge bo idioma preferí."
+
+#, python-format
+#~ msgid "Findings report for %(name)s"
+#~ msgstr "Rapport di resultadonan pa %(name)s"
+
+#, python-format
+#~ msgid ""
+#~ "These are the findings of a OpenKAT-analysis on %(observed_at)s. Click a "
+#~ "finding for more detailed information about the issue, its origin, severity "
+#~ "and possible solutions."
+#~ msgstr ""
+#~ "Esakinan ta e resultadonan di un OpenKAT-analysis riba %(observed_at)s. "
+#~ "Click un resultadopa mas informashon detayá tokante e problema, su orígen, "
+#~ "severidat i posibel solushonnan."
+
+#, python-format
+#~ msgid "A report for %(name)s wasn't found."
+#~ msgstr "Un rapport pa %(name)s no por a wordu haña."
+
+#, python-format
+#~ msgid ""
+#~ "Perhaps it never was, perhaps it just didn't exist on %(observed_at)s <br> "
+#~ "Try some other dates!"
+#~ msgstr ""
+#~ "Probablemente e no tabata, probablemente e nunka a eksistí riba "
+#~ "%(observed_at)s<br> Purba algun otro fechanan!"
+
+#~ msgid "You can't generate a report for an OOI on a date in the future."
+#~ msgstr "Bo no por generà un rapòrt pa un OOI ku un fecha den futuro."
+
+#~ msgid "Findings report"
+#~ msgstr "Rapòrt di diskubrimentu"
+
+#~ msgid "Generating report failed. See Keiko logs for more information."
+#~ msgstr ""
+#~ "Falamentu den generashon di rapòrt. Wak Keiko logs pa mas informashon."
+
+#~ msgid ""
+#~ "Timeout reached generating report. See Keiko logs for more information."
+#~ msgstr ""
+#~ "Tempo di espera a yega na su fin den generashon di rapòrt. Wak e Keiko logs "
+#~ "pa mas informashon."
+
+#~ msgid ""
+#~ "Boefjes gather factual information, such as by calling an external scanning "
+#~ "tool like nmap or using a database like shodan."
+#~ msgstr ""
+#~ "Boefjes ta reuni informashon faktuál, huzando tools manera nmap òf usando un"
+#~ " base di datos manera shodan."
+
+#~ msgid " Details"
+#~ msgstr "Detayes"
+
+#~ msgid "Action"
+#~ msgstr "Akshon"
+
+#~ msgid "Unset"
+#~ msgstr "Bashi"
+
+#~ msgid "Failed fetching settings for {}. Is the Katalogus up?"
+#~ msgstr "No por a enkontra e ajustamentunan pa {}. Katalogus ta disponibel?"
+
+#~ msgid "Before enabling, please set the required settings for '{}'."
+#~ msgstr "Promé ku aktivá, por fabor pone e ajustamentunan necesario pa '{}'."
+
+#~ msgid "Currently filtered on:"
+#~ msgstr "Aktuálmente filtrá riba:"
+
+#~ msgid "Object tree"
+#~ msgstr "Mapa di opheto"
+
+#~ msgid "Please select an OOI to start scan."
+#~ msgstr "Por fabor, selekshoná un OOI pa kuminsá skan."
+
+#~ msgid "Task queue is full, please try again later."
+#~ msgstr "Lista di trabou ta yen, por fabor purba atrobe mas laat."
+
+#~ msgid "Task is invalid."
+#~ msgstr "Tarea ta inbalido"
+
+#~ msgid "Task already queued."
+#~ msgstr "Tarea ta pone kla kaba."
+
+#~ msgid "Observed by"
+#~ msgstr "Obserbá pa"
+
+#~ msgid "Select status"
+#~ msgstr "Selektá status"
+
+#~ msgid "Success"
+#~ msgstr "Èxito"
+
+#~ msgid "No scans found for this object."
+#~ msgstr "Ningun skan enkontra pa e opheto."
+
+#~ msgid "all"
+#~ msgstr "tur"
+
+#~ msgid "Fetching tasks failed: no connection with scheduler"
+#~ msgstr "No por haña tarea: no tin konekshon ku scheduler"
+
+#~ msgid "Latest plugin settings:"
+#~ msgstr "Reciente plugin settings:"
+
+#~ msgid "Overview of settings:"
+#~ msgstr "Relato di settings:"
+
+#~ msgid "For this tutorial we suggest a DNS-report to get you started."
+#~ msgstr "Pa a tutoriál aki nos ta sugerí un DNS-rapòrt pa kuminsa ku ne."
+
+#~ msgid "DNS report"
+#~ msgstr "DNS Rapòrt"
+
+#~ msgid "User overview:"
+#~ msgstr "Resúmen di kliente:"
+
+#~ msgid "Boefjes overview:"
+#~ msgstr "Relato general di Boefjes:"
+
+#~ msgid ""
+#~ "Within OpenKAT you can view reports for each of your current objects. For "
+#~ "specific reports you can choose one of the available report types and "
+#~ "generate a report. Such as a pen-test, a DNS-report or a mail report to give"
+#~ " some examples."
+#~ msgstr ""
+#~ "Den OpenKAT bo por mira rapòrtnan pa kada un di bo ophetonan. Pa rapòrtnan "
+#~ "specifikó bo por skohé un di e tipo rapòrtnan obtenibel i generá un rapòrt. "
+#~ "Manera un pen-test, un DNS-rapòrt òf un mail rapòrt pa duna algun ehempel."
+
+#~ msgid ""
+#~ "A lot of things can be an object within the scope of OpenKAT. For example a "
+#~ "mailserver, an ip-address, a URL, a DNS record, a hostname or a network to "
+#~ "name a few.  While these objects can be related to each other they are all "
+#~ "objects within OpenKAT that can be scanned to gain valuable insight."
+#~ msgstr ""
+#~ "Hopi kos por ta un opheto den di e alkanse di OpenKAT. Por ehempel un "
+#~ "mailserver, un ip-adrès, un URL, un DNS record, un hostname òf un netwèrk pa"
+#~ " nombra un par. Mientras tantu e ophetonan aki por ta relatá na otro nan tur"
+#~ " ta ophetonan den di OpenKAT ku por wordu di skan pa haña informashon "
+#~ "balioso."
+
+#~ msgid ""
+#~ "Most objects have dependencies on the existence of other objects. For "
+#~ "example a URL needs to be connected to a network, hostname, fqdn (fully "
+#~ "qualified domain name) and ip-address. OpenKAT collects these additional "
+#~ "object automatically when possible. By running plugins to collect or extract"
+#~ " this data."
+#~ msgstr ""
+#~ "Mayoria ophetonan tin dependesianan riba e exsistencia di otro ophetonan. "
+#~ "Por ehempel un URL mester ta konektá ku un nètwèrk, hostname, fqdn (fúl "
+#~ "kwalifiká nòmber di domèin) i ip-adrès. OpenKAT ta kolektá e ophetonan "
+#~ "adishonal automatikamente si ta posibel. Dor di start plugins pa kolektá òf "
+#~ "extrahé data."
+
+#~ msgid "Risk score:"
+#~ msgstr "Puntuashon di riesgo:"
+
+#~ msgid "Permission to set OOI clearance levels "
+#~ msgstr "Pèrmit pa pone nivél di autorisashonnan pa OOI "
+
+#~ msgid "You have currently accepted clearance up to level "
+#~ msgstr "Bo aktualmente a aseptá e nivel di autorisashon te na nivel "
+
+#~ msgid ""
+#~ "If you don’t remember the email address connected to your account, contact: "
+#~ msgstr ""
+#~ "Si bo no ta kòrda e email adrès konektá ku bo account, tuma kontákto ku: "
+
+#~ msgid "Publisher"
+#~ msgstr "Editora"
+
+#~ msgid "You don't have permission to enable "
+#~ msgstr "Bo no tin permiso pa aktivá "
+
+#, fuzzy
+#~ msgid ""
+#~ "<span>Warning scan level:</span> Scanning OOI's with a lower clearance level"
+#~ " will result in OpenKAT increasing the clearance level on that OOI, not only"
+#~ " for this scan but from now on out, until it manually gets set to something "
+#~ "else again. This means that all other enabled Boefjes will use this higher "
+#~ "clearance level aswel."
+#~ msgstr ""
+#~ "\n"
+#~ "          <span>Advertensia nivel di skan:</span>\n"
+#~ "          Skèn OOI's ku nivel di authorisashon mas abou lo resulta ku OpenKAT mester subi e nivel di authorisashon pa e OOI,\n"
+#~ "          no solamente pa e skan aki for di awor i adelante, te ora manualmente e wordu pone na algu otro atrobe.\n"
+#~ "          Esaki ta nifika ku tur otro Boefjes aktivo lo huza e nivel di authorisashon  aki tambe.\n"
+#~ "        "
+
+#~ msgid "Reason"
+#~ msgstr "Motibu"
+
+#~ msgid "Overview of findings for "
+#~ msgstr "Reprodusí búskeda"
+
+#~ msgid "Error"
+#~ msgstr "Error"
+
+#~ msgid "Explanation"
+#~ msgstr "Deklarashon"
+
+#~ msgid "Here, an indemnification can be given on behalf of your organization"
+#~ msgstr "Akinan, un indemnizashon por wordu duna p’e organisashon"
+
+#~ msgid "Confirmation"
+#~ msgstr "Indemnizashon"
+
+#~ msgid "No related objects added to "
+#~ msgstr "Ningún ophetonan relatá añadi na"
+
+#~ msgid "Use the button below to add a related object. "
+#~ msgstr "Huza e botón abou pa añadi un opheto relatá. "
+
+#~ msgid "Logged in as"
+#~ msgstr "Logged in komo"
+
+#, python-format
+#~ msgid ""
+#~ "Could not raise clearance level of %s to L%s.                             "
+#~ "Indemnification not present at organization %s."
+#~ msgstr ""
+#~ "No por subi e nivel di autorisashon di %s pa L%s. Indemnisashon no ta "
+#~ "presente na organisashon %s."
+
+#~ msgid "DNS Zone"
+#~ msgstr "Zona DNS"
+
+#~ msgid ""
+#~ "OpenKAT added the following required object to your object list to complete "
+#~ "your request: {}"
+#~ msgstr ""
+#~ "OpenKAT a añadi e siguinte opheton na bo lista di ophetonan pa kompleta bo "
+#~ "petishon: {}"
+
+#, python-format
+#~ msgid ""
+#~ "Could not raise clearance level of %s to L%s.                 "
+#~ "Indemnification not present at organization %s."
+#~ msgstr ""
+#~ "No por a subi e nivel di autorisashon di %s pa L%s. Indemnisashon no ta "
+#~ "presente pa organisashon %s."
+
+#~ msgid ""
+#~ "Not all required boefjes are selected. Please select all required boefjes."
+#~ msgstr ""
+#~ "No tur boefjes necesario ta selektá. Por fabor selektá tur boefjes "
+#~ "necesario."
+
+#, python-format
+#~ msgid ""
+#~ "Could not raise clearance level of %s to L%s.                         "
+#~ "Indemnification not present at organization %s."
+#~ msgstr ""
+#~ "No por a subi e nivel di autorisashon di %s pa L%s. Indemnisashon no ta "
+#~ "presente pa organisashon %s."
+
+#, python-format
+#~ msgid ""
+#~ "Could not raise clearance level of %s to L%s. You acknowledged a clearance "
+#~ "level of L%s. Please accept the clearance level below to proceed."
+#~ msgstr ""
+#~ "No por a subi e nivel di autorisashon di %s pa L%s. Bo a rekonosé un nivel "
+#~ "di autorisashon di L%s. Por fabor, akseptá e nivel di autorisashon mas abou "
+#~ "pa por sigui."
+
+#~ msgid "Choose a valid level"
+#~ msgstr "Skohé un nivél balido"
+
+#, python-format
+#~ msgid "Raw file could not be uploaded to Bytes: status code %s"
+#~ msgstr "No por a subi e arkivo na Bytes: status code %s"
+
+#~ msgid "Failure mode"
+#~ msgstr "Failure mode"
+
+#~ msgid "Frequency Level"
+#~ msgstr "Nivél di frequensidat"
+
+#~ msgid "Detectability Level"
+#~ msgstr "Nivél di detectabilidat"
+
+#~ msgid "Effect(s)"
+#~ msgstr "Efekto"
+
+#~ msgid "Describe in one sentence what type of failure mode you are creating."
+#~ msgstr "Deskribi den un sentencia ki tipo di failure mode bo ta kreando."
+
+#~ msgid "Describe the failure mode in details."
+#~ msgstr "Reprodusí búskeda"
+
+#~ msgid ""
+#~ "From 1 to 5, how often does this failure mode occurs. 1: Almost unthinkable "
+#~ "and 5: occurs daily."
+#~ msgstr ""
+#~ "Di 1 te 5, kwantu biaha e failure mode aki ta occurí. 1: Kasi imposibeli 5: "
+#~ "occurí diariamente."
+
+#~ msgid ""
+#~ "Is this failure mode easy detectable? Give it a score from 1 to 5. 1: always"
+#~ " detectable and 5: almost undetectable."
+#~ msgstr ""
+#~ "E failure mode aki por wordu detektá fasil? Duné un score for di 1 te 5. 1: "
+#~ "semper detektábel i 5: kasi imposibel."
+
+#~ msgid "Describe the type of failure mode"
+#~ msgstr "Deskribi e tipo di failure mode"
+
+#~ msgid "explanation-failure-mode"
+#~ msgstr "splikashon-failure-mode"
+
+#~ msgid "Describe in more detail what the failure mode is about."
+#~ msgstr "Deskribi mas detayá kiko e failure mode aki ta."
+
+#~ msgid "explanation-description"
+#~ msgstr "splikashon-diskripshon"
+
+#~ msgid "explanation-frequency-level"
+#~ msgstr "splikashon-nivel-di-freqeuncia"
+
+#~ msgid "explanation-detectability_level"
+#~ msgstr "splikashon-nivel-detektebilidat"
+
+#~ msgid "You must at least set a failure mode."
+#~ msgstr "Bo mester por lo menos pone un failure mode."
+
+#~ msgid "Choose a frequency level."
+#~ msgstr "Nivél di frequensidat"
+
+#~ msgid "Choose a detectability level."
+#~ msgstr "Nivél di detectabilidat"
+
+#~ msgid "Choose at least one effect."
+#~ msgstr "Skohé por lo menos ùn efekto"
+
+#~ msgid "Affected Department"
+#~ msgstr "Departamentu afektá"
+
+#~ msgid "Affected Objects"
+#~ msgstr "Ophetonan afektá"
+
+#~ msgid "Choose a failure mode which applies to "
+#~ msgstr "Skohé un failure mode ku ta aplika na "
+
+#~ msgid "When this failure mode occurs, which department is affected?"
+#~ msgstr "Ora a failure mode aki occurí, kwa departamentu ta afekta?"
+
+#~ msgid "Which objects does this failure mode affect when it occurs?"
+#~ msgstr "Kwa opheto e failure mode aki ta afekta ora e occurí?"
+
+#~ msgid "explanation-affected-ooi-type"
+#~ msgstr "splikashon-tipo-di-ooi-afekta"
+
+#~ msgid "Effect"
+#~ msgstr "Efekto"
+
+#~ msgid "Severity Level"
+#~ msgstr "Nivél di severedat"
+
+#~ msgid "Name a possible effect of any type of failure mode that can occur."
+#~ msgstr "Duna un ehempel di un posibel efekto di e failre mode aki."
+
+#~ msgid ""
+#~ "Describe the severity of this effect ex. 1: not severe and 5: catastrophic"
+#~ msgstr ""
+#~ "Diskribi e seviridat di e efekto aki, por ehempel 1: no severo i 5: "
+#~ "katastrófiko"
+
+#~ msgid "Describe a possible effect for FMEA"
+#~ msgstr "Deskibri un posibel efekto pa FMEA"
+
+#~ msgid "explanation-effect"
+#~ msgstr "splikashon-efekto"
+
+#~ msgid "explanation-severity-level"
+#~ msgstr "splikashon-nivel-severo"
+
+#~ msgid "The effect is required."
+#~ msgstr "E vak aki ta obligatorio"
+
+#~ msgid "This effect already exists."
+#~ msgstr "E organisashon aki ta eksistí kaba"
+
+#~ msgid "Choose a severity level."
+#~ msgstr "Nivel di rísiko"
+
+#~ msgid "Finances"
+#~ msgstr "Finansiasnan"
+
+#~ msgid "Marketing"
+#~ msgstr "Marketing"
+
+#~ msgid "Human Resources"
+#~ msgstr "Human Resources"
+
+#~ msgid "Research & Development"
+#~ msgstr "Research & Development"
+
+#~ msgid "Administration"
+#~ msgstr "Indemnizashon"
+
+#~ msgid "Level 1: Not Severe"
+#~ msgstr "Nivèl 1: No Severo"
+
+#~ msgid "Level 2: Harmful"
+#~ msgstr "Nivel 2: Dañoso"
+
+#~ msgid "Level 3: Severe"
+#~ msgstr "Nivel 3: Severo"
+
+#~ msgid "Level 4: Very Harmful"
+#~ msgstr "Nivel 4: Hopi Dañoso"
+
+#~ msgid "Level 5: Catastrophic"
+#~ msgstr "Nivel 5: Katastrófiko"
+
+#~ msgid ""
+#~ "Level 1: Very Rare. Incident (almost) never occurs, almost unthinkable."
+#~ msgstr ""
+#~ "Nivel 1: Hopi Straño. Insidente (kasi) nunka ta okuri, kasi inpensabel."
+
+#~ msgid "Level 2: Rare. Incidents occur less than once a year (3-5)."
+#~ msgstr "Nivel 2: Straño. Insidente ta okuri menos ku un biaha pa aña (3-5)."
+
+#~ msgid "Level 3: Occurs. Incidents occur several times a year."
+#~ msgstr "Nivel 3: Ta okuri, Insidente ta okuri par di biaha pa aña."
+
+#~ msgid "Level 4: Regularly. Incidents occur weekly."
+#~ msgstr "Nivel 4: Regularmente. Insidente ta pasa tur siman."
+
+#~ msgid "Level 5: Frequent. Incidents occur daily."
+#~ msgstr "Nivel 5: Frquente. Incidente ta pasa tur dia."
+
+#~ msgid ""
+#~ "Level 1: Always Detectable. Incident (almost) never occurs, almost "
+#~ "unthinkable."
+#~ msgstr ""
+#~ "Nivel 1: Semper Detektabel. Insidente (kasi) nunka ta okuri, kasi imposibel."
+
+#~ msgid ""
+#~ "Level 2: Usually Detectable. Incidents occur less than once a year (3-5)."
+#~ msgstr ""
+#~ "Nivel 2: Normalmente Dektetabel. Insidente ta okuri menos ku un biaha pa aña"
+#~ " (3-5)."
+
+#~ msgid "Level 3: Detectable. Failure mode is detectable with effort."
+#~ msgstr "Nivel 3: Detektabel. Faillure mode ta detektabel ku eksfuerzo."
+
+#~ msgid "Level 4: Poorly Detectable. Detecting the failure mode is difficult."
+#~ msgstr "Nivel 4: Malu Detectabel. Detektá e failure mode ta difícil."
+
+#~ msgid ""
+#~ "Level 5: Almost Undetectable. Failure mode detection is very difficult or "
+#~ "nearly impossible."
+#~ msgstr ""
+#~ "Nivel 5: Pobremente Detektabel. Faillure mode detekshon ta hopi difisil òf "
+#~ "kasi imposibel."
+
+#~ msgid "Failure modes"
+#~ msgstr "Failure modes"
+
+#~ msgid "Failure Mode Affected Objects"
+#~ msgstr "Failure Mode Ophetonan afektá"
+
+#~ msgid "FMEA Departments Heatmap:"
+#~ msgstr "Departamento di FMEA Heatmap:"
+
+#~ msgid "No data to build heatmap"
+#~ msgstr "Ningun data pa kontruí heatmap "
+
+#~ msgid "Failure mode affected object table:"
+#~ msgstr "Failure mode tabèl di opheto afektá "
+
+#~ msgid "Affected Object"
+#~ msgstr "Ophetonan afektá"
+
+#~ msgid "Failure mode affected objects cannot be found."
+#~ msgstr "No por decodifica e archivo"
+
+#~ msgid "Define which objects are affected for a failure mode"
+#~ msgstr "Defini kwa ophetonan ta afekta pa un failure mode"
+
+#~ msgid "Failure mode affected objects"
+#~ msgstr "No por decódifica e archivo"
+
+#~ msgid "Save"
+#~ msgstr "Warda"
+
+#~ msgid "No failure mode yet defined."
+#~ msgstr "Ningun failure mode ahinda defini"
+
+#~ msgid "To add affected objects to a failure mode, first create one."
+#~ msgstr "Pa agregá ophetonan afektá na un failure mode, krea un prome."
+
+#~ msgid "Create failure mode"
+#~ msgstr "Krea failure mode"
+
+#~ msgid "Failure mode affected objects table:"
+#~ msgstr "Failure mode tabèl di ophetonan afekta:"
+
+#~ msgid "No failure mode affected objects yet defined."
+#~ msgstr "Ningun failure mode ophetonan afekta ahinda defini."
+
+#~ msgid "Create failure mode Affected Objects"
+#~ msgstr "Reprodusí búskeda"
+
+#~ msgid "Departments failure modes"
+#~ msgstr "Failure modes departamentonan"
+
+#~ msgid "Failure modes and affected departments table:"
+#~ msgstr "Failure modes i tabèl di departamentonan afekta:"
+
+#~ msgid "Failure Mode"
+#~ msgstr "Failure Mode"
+
+#~ msgid "Affected Departments"
+#~ msgstr "Departementonan Afektá"
+
+#~ msgid "Nothing found."
+#~ msgstr "Nada enkontra."
+
+#~ msgid "Failure mode properties"
+#~ msgstr "No por decodifica e archivo"
+
+#~ msgid "Properties"
+#~ msgstr "Karakteristikanan"
+
+#~ msgid "Risk class"
+#~ msgstr "Nivel di rísiko"
+
+#~ msgid "Frequency level"
+#~ msgstr "Nivel di frequensidat"
+
+#~ msgid "Detectability level"
+#~ msgstr "Nivel di detektabilidat"
+
+#~ msgid ""
+#~ "\n"
+#~ "                        Effect and severity level\n"
+#~ "                        "
+#~ msgid_plural ""
+#~ "\n"
+#~ "                        Effects and severity levels\n"
+#~ "                      "
+#~ msgstr[0] ""
+#~ "\n"
+#~ "                        Nivel di efekto i severidat\n"
+#~ "                        "
+#~ msgstr[1] ""
+#~ "\n"
+#~ "                        Nivel di efektonan i severidatnan\n"
+#~ "                      "
+
+#~ msgid "Failure mode effect"
+#~ msgstr "No por decodifica e archivo"
+
+#~ msgid "Failure mode effect properties"
+#~ msgstr "No por decodifica e archivo"
+
+#~ msgid "FMEA effect and severity"
+#~ msgstr "FMEA efekto i seviridat"
+
+#~ msgid "FMEA effect"
+#~ msgstr "FMEA efekto"
+
+#~ msgid "Failure mode effects table:"
+#~ msgstr "Tabèl di Efektonan di Modo di Falla"
+
+#~ msgid "Severity level"
+#~ msgstr "Nivel di rísiko"
+
+#~ msgid "No failure mode effect yet defined."
+#~ msgstr "No por decodifica e archivo"
+
+#~ msgid "Create a failure mode effect"
+#~ msgstr "Reprodusí búskeda"
+
+#~ msgid "Create a new failure mode"
+#~ msgstr "Krea un failure mode nobo"
+
+#~ msgid "Failure mode and effects"
+#~ msgstr "No por decodifica e archivo"
+
+#~ msgid "No failure mode effects created."
+#~ msgstr "No por decodifica e archivo"
+
+#~ msgid ""
+#~ "First create failure mode effects which can be added later to a failure "
+#~ "mode."
+#~ msgstr ""
+#~ "Prome krea efektonan di failure mode pa despues añadi esaki na un failure "
+#~ "mode."
+
+#~ msgid "Create failure mode effects"
+#~ msgstr "Reprodusí búskeda"
+
+#~ msgid "Failure mode table:"
+#~ msgstr "Tabèl di failure mode:"
+
+#~ msgid "Risk Class"
+#~ msgstr "Nivel di rísiko"
+
+#~ msgid "Sluit details"
+#~ msgstr "Habri detayes"
+
+#~ msgid "Description:"
+#~ msgstr "Deklarashon"
+
+#~ msgid "Frequency level:"
+#~ msgstr "Nivel di frequencidat:"
+
+#~ msgid "Detectability level:"
+#~ msgstr "Nivel di detektabilidat"
+
+#~ msgid ""
+#~ "\n"
+#~ "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\tEffect and severity level\n"
+#~ "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t"
+#~ msgid_plural ""
+#~ "\n"
+#~ "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\tEffects and severity levels\n"
+#~ "\t\t\t\t\t\t\t\t\t\t\t\t\t\t"
+#~ msgstr[0] ""
+#~ "\n"
+#~ "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\tNivel di efekto i severidat\n"
+#~ "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t"
+#~ msgstr[1] ""
+#~ "\n"
+#~ "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\tNivel di efektonan i severidatnan\n"
+#~ "\t\t\t\t\t\t\t\t\t\t\t\t\t\t"
+
+#~ msgid "Failure mode report"
+#~ msgstr "No por decodifica e archivo"
+
+#~ msgid "Failure mode: "
+#~ msgstr "No por decodifica e archivo"
+
+#~ msgid "Severity: "
+#~ msgstr "Seviridat:"
+
+#~ msgid "Detectability: "
+#~ msgstr "Detektabilidat"
+
+#~ msgid "Frequency: "
+#~ msgstr "Frequencia: "
+
+#~ msgid "Effect: "
+#~ msgstr "Efekto: "
+
+#~ msgid "Description: "
+#~ msgstr "Deklarashon: "
+
+#~ msgid "Affected Departments: "
+#~ msgstr "Departamentonan afekta: "
+
+#~ msgid "Affected OOI's: "
+#~ msgstr "OOI's afekta:"
+
+#~ msgid "Report cannot be viewed, failure mode not found."
+#~ msgstr "Rapòrt no por wordu mira, no por haña failure mode."
+
+#~ msgid "FMEA introduction"
+#~ msgstr "FMEA introdukshon"
+
+#~ msgid ""
+#~ "FMEA (failure mode and effective analysis) is a step-by-step approach for "
+#~ "collecting knowledge about possible points of failure in a design, "
+#~ "manufacturing process, product or service."
+#~ msgstr ""
+#~ "FMEA (failure mode and effective analysis) ta un enfoque paso a paso pa "
+#~ "kolekta konosimentu tokante puntonan posibel di fayo den un diseño, proseso "
+#~ "fabriká, produkto òf servicio."
+
+#~ msgid ""
+#~ "Failure mode (FM) refers to the way in which something might break down and "
+#~ "includes potential errors that may occur, especially errors that may affect "
+#~ "a system. Effective analysis (EA) involves deciphering the consequences of "
+#~ "those break downs by making sure that all failures can be detected, "
+#~ "determining how frequently a failure might occur and identifying which "
+#~ "potential failures should be prioritized."
+#~ msgstr ""
+#~ "Failure mode (FM) ta referi na e manera kaminda algu por posibelmente kibra "
+#~ "i inkluí errornan potenshal ku por okuri, speshalmente errornan ku por "
+#~ "afektá un sistema. Effective analysis (EA) ta envolvi den buska e "
+#~ "konsekuensiasnan di loke por kibra dor di detekta tur failure modes, "
+#~ "determiná kon frequente failure modes ta okuri i identifiká kwa failure "
+#~ "modes mester wordu prioritisa."
+
+#~ msgid "Create affected objects of a failure mode"
+#~ msgstr "Kreá ophetonan afektá di un failure mode"
+
+#~ msgid "View all failure modes"
+#~ msgstr "Mustrami tur failue modes"
+
+#~ msgid "View all failure mode effects"
+#~ msgstr "Mustrami tur efektonan di failure mode"
+
+#~ msgid "View all affected objects for a failure modes"
+#~ msgstr "Mustrami tur ophetonan afektá pa failure modes"
+
+#~ msgid "Heatmap"
+#~ msgstr "Mapa kayente"
+
+#~ msgid "--- Select an option ----"
+#~ msgstr "-- Selecta un opcion --"
+
+#~ msgid "Failure mode affected objects successfully created."
+#~ msgstr "Failure mode i ophetonan afektá a wòrdu kreá ku èksito."
+
+#~ msgid "Create"
+#~ msgstr "Kreá"
+
+#~ msgid "Treeobjects successfully added."
+#~ msgstr "Mapa di ophetonan añadi ku èxito."
+
+#~ msgid "Please select a department or ooi."
+#~ msgstr "Por fabor selekta un departamentu òf ooi."
+
+#~ msgid "Failure mode successfully created."
+#~ msgstr "Failure mode a wòrdu kreá ku èksito."
+
+#~ msgid "Failure mode effect successfully created."
+#~ msgstr "Failure mode a wòrdu kreá ku èksito."
+
+#~ msgid "FMEA"
+#~ msgstr "FMEA"
+
+#~ msgid "Failure mode effects"
+#~ msgstr "Efektonan di failure mode"
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "                            \"Withdraw acceptance of level L%(acl)s clearance and responsibility\"\n"
+#~ "                    "
+#~ msgstr ""
+#~ "\n"
+#~ "\"Retirá aseptashon di nivel di autorisashon L%(acl)s i responsabilidat\"\n"
+#~ " "
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "                        \"Accept level L%(tcl)s clearance and responsibility\"\n"
+#~ "                    "
+#~ msgstr ""
+#~ "\n"
+#~ "\"Aseptá nivel di autorisashon L%(tcl)s i responsabilidat\"\n"
+#~ " "
+
+#~ msgid ""
+#~ "\n"
+#~ "                  Add setting\n"
+#~ "                "
+#~ msgid_plural ""
+#~ "\n"
+#~ "                  Add settings\n"
+#~ "                "
+#~ msgstr[0] ""
+#~ "\n"
+#~ "                        Añadi setting\n"
+#~ "                        "
+#~ msgstr[1] ""
+#~ "\n"
+#~ "                        Añadi settings\n"
+#~ "                      "
+
+#~ msgid "Organization code(s) for raw does not exist in our database"
+#~ msgstr "Codigo di organisashon den e CSV no ta èksisti den nos database"
+
+#~ msgid "Scan OOI"
+#~ msgstr "Skèn OOI"
+
+#~ msgid "Selected OOIs:"
+#~ msgstr "OOI's selektá:"
+
+#~ msgid "Session has terminated, please select OOIs again."
+#~ msgstr "Seshon a wòrdu tèrminá. Por fabor selekta OOIs dinobo."
+
+#~ msgid "Could not connect to Bytes. Service is possibly down"
+#~ msgstr "No por konektá ku Bytes. Servicio ta down"
+
+#~ msgid "Could not connect to Octopoes. Service is possibly down"
+#~ msgstr "No por konektá ku Octopoes. Servicio ta down"
+
+#~ msgid "Could not connect to Scheduler. Service is possibly down"
+#~ msgstr "No por konektá ku Scheduler. Servicio ta down"
+
+#~ msgid "Rocky will not function properly. Not all services are healthy."
+#~ msgstr "Rocky no lo functiona mane debe ser. No tur servicio ta saludabel."
+
+#~ msgid "Failure"
+#~ msgstr "Failure"
+
+#~ msgid "Task details not found."
+#~ msgstr "Detayes di tarea no por wordu haña."
+
+#~ msgid "This name we will use to communicate with you."
+#~ msgstr "E nomber aki nos lo huza pa komuniká ku bo."
+
+#~ msgid "What do we call you?"
+#~ msgstr "Kon nos por jama'bu?"
+
+#~ msgid "Enter your email address."
+#~ msgstr "Yena bo email adres"
+
+#~ msgid "Choose your super secret password"
+#~ msgstr "Skohé bo password super sekreto"
+
+#~ msgid "Enter your new password"
+#~ msgstr "Yena bo password nobo"
+
+#~ msgid "Repeat your new password"
+#~ msgstr "Ripiti bo password nobo"
+
+#~ msgid "Confirm your new password"
+#~ msgstr "Konfirmá bo password nobo"
+
+#~ msgid "List of tasks for "
+#~ msgstr "Lista di tareanan pa "
+
+#~ msgid "No input OOI"
+#~ msgstr "No tin entrada OOI"
+
+#~ msgid ""
+#~ "Can not parse observed_at parameter, falling back to showing current object"
+#~ msgstr ""
+#~ "No por parse e parametro observed_at, regresando na munstra e opheto aktual"
+
+#~ msgid "Scanning successfully scheduled."
+#~ msgstr "Skèn a start ku èxito."

--- a/rocky/rocky/locale/pl/LC_MESSAGES/django.po
+++ b/rocky/rocky/locale/pl/LC_MESSAGES/django.po
@@ -1,0 +1,10271 @@
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenKAT\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-03-28 14:22+0000\n"
+"PO-Revision-Date: 2026-07-14 00:00+0000\n"
+"Last-Translator: Brenno de Winter <brenno@dewinter.com>\n"
+"Language-Team: Polish <https://hosted.weblate.org/projects/openkat/nl-kat-coordination/pl/>\n"
+"Language: pl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2;\n"
+"X-Generator: Weblate 5.13\n"
+
+#: account/admin.py
+msgid "Permissions"
+msgstr "Uprawnienia"
+
+#: account/admin.py
+msgid "Important dates"
+msgstr "Ważne daty"
+
+#: account/forms/account_setup.py crisis_room/forms.py
+#: katalogus/templates/katalogus_settings.html
+#: katalogus/templates/plugin_container_image.html
+#: reports/report_types/dns_report/report.html
+#: reports/report_types/tls_report/report.html
+#: reports/templates/partials/report_names_form.html
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/modal_partials/rename_modal.html
+#: reports/templates/report_overview/modal_partials/rerun_modal.html
+#: reports/templates/report_overview/modal_partials/share_modal.html
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+#: reports/templates/report_overview/subreports_table.html
+#: tools/forms/boefje.py rocky/templates/organizations/organization_list.html
+#: rocky/templates/organizations/organization_settings.html
+#: rocky/templates/partials/ooi_detail_related_object.html
+msgid "Name"
+msgstr "Nazwa"
+
+#: account/forms/account_setup.py
+msgid "The name that will be used in order to communicate."
+msgstr "Imię, które będzie używane do komunikacji."
+
+#: account/forms/account_setup.py
+msgid "Please provide username"
+msgstr "Proszę podać nazwę użytkownika"
+
+#: account/forms/account_setup.py
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Email"
+msgstr "E-mail"
+
+#: account/forms/account_setup.py
+msgid "Enter an email address."
+msgstr "Wpisz adres e-mail."
+
+#: account/forms/account_setup.py
+msgid "Password"
+msgstr "Hasło"
+
+#: account/forms/account_setup.py
+msgid "Choose a super secret password"
+msgstr "Wybierz super tajne hasło"
+
+#: account/forms/account_setup.py
+msgid "Choose another email."
+msgstr "Wybierz inny adres e-mail."
+
+#: account/forms/account_setup.py tools/forms/settings.py
+msgid "--- Please select one of the available options ----"
+msgstr "--- Proszę wybrać jedną z dostępnych opcji ----"
+
+#: account/forms/account_setup.py
+msgid "Account type"
+msgstr "Typ konta"
+
+#: account/forms/account_setup.py
+msgid "Please select an account type to proceed."
+msgstr "Aby kontynuować, wybierz typ konta."
+
+#: account/forms/account_setup.py
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+msgid "Trusted clearance level"
+msgstr "Zaufany poziom uprawnień"
+
+#: account/forms/account_setup.py
+msgid "Select a clearance level you trust this member with."
+msgstr "Wybierz poziom uprawnień, którym ufasz temu członkowi."
+
+#: account/forms/account_setup.py onboarding/forms.py tools/forms/ooi.py
+msgid "Please select a clearance level to proceed."
+msgstr "Aby kontynuować, wybierz poziom uprawnień."
+
+#: account/forms/account_setup.py tools/models.py
+msgid "The name of the organization."
+msgstr "Nazwa organizacji."
+
+#: account/forms/account_setup.py
+msgid "explanation-organization-name"
+msgstr "wyjaśnienie-nazwa-organizacji"
+
+#: account/forms/account_setup.py
+#, python-brace-format
+msgid "A unique code of maximum {code_length} characters in length."
+msgstr "Unikalny kod o maksymalnej długości {code_length} znaków."
+
+#: account/forms/account_setup.py
+msgid "explanation-organization-code"
+msgstr "kod-wyjaśnienia-organizacji"
+
+#: account/forms/account_setup.py
+msgid "Organization name is required to proceed."
+msgstr "Aby kontynuować, wymagana jest nazwa organizacji."
+
+#: account/forms/account_setup.py
+msgid "Choose another organization."
+msgstr "Wybierz inną organizację."
+
+#: account/forms/account_setup.py
+msgid "Organization code is required to proceed."
+msgstr "Aby kontynuować, wymagany jest kod organizacji."
+
+#: account/forms/account_setup.py
+msgid "Choose another code for your organization."
+msgstr "Wybierz inny kod dla swojej organizacji."
+
+#: account/forms/account_setup.py
+msgid ""
+"I declare that OpenKAT may scan the assets of my organization and that I "
+"have permission to scan these assets. I am aware of the implications a scan "
+"(with a higher scan level) brings on my systems."
+msgstr ""
+"Oświadczam, że OpenKAT może skanować zasoby mojej organizacji oraz że "
+"posiadam pozwolenie na skanowanie tych zasobów. Jestem świadomy "
+"konsekwencji, jakie skanowanie (z wyższym poziomem skanowania) niesie dla "
+"moich systemów."
+
+#: account/forms/account_setup.py
+msgid ""
+"I declare that I am authorized to give this indemnification on behalf of my "
+"organization. I have the experience and knowledge to know what the "
+"consequences might be and can be held responsible for them."
+msgstr ""
+"Oświadczam, że jestem upoważniony do udzielenia tego zabezpieczenia w "
+"imieniu mojej organizacji. Mam doświadczenie i wiedzę, aby wiedzieć, jakie "
+"mogą być konsekwencje, i mogę ponieść za nie odpowiedzialność."
+
+#: account/forms/account_setup.py
+msgid "Trusted to change Clearance Levels."
+msgstr "Zaufany, jeśli chodzi o zmianę poziomów zezwoleń."
+
+#: account/forms/account_setup.py
+msgid "Acknowledged to change Clearance Levels."
+msgstr "Potwierdzono zmianę poziomów zezwoleń."
+
+#: account/forms/account_setup.py rocky/forms.py
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Blocked"
+msgstr "Zablokowany"
+
+#: account/forms/account_setup.py
+msgid ""
+"Set the members status to blocked, so they don't have access to the "
+"organization anymore."
+msgstr ""
+"Ustaw status członków na zablokowanych, aby nie mieli już dostępu do "
+"organizacji."
+
+#: account/forms/account_setup.py
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Accepted clearance level"
+msgstr "Akceptowany poziom zezwolenia"
+
+#: account/forms/account_setup.py
+msgid "Enter tags separated by comma."
+msgstr "Wprowadź tagi oddzielone przecinkami."
+
+#: account/forms/account_setup.py
+msgid "The two password fields didn’t match."
+msgstr "Obydwa pola hasła nie pasują do siebie."
+
+#: account/forms/account_setup.py
+msgid "New password"
+msgstr "Nowe hasło"
+
+#: account/forms/account_setup.py
+msgid "Enter a new password"
+msgstr "Wprowadź nowe hasło"
+
+#: account/forms/account_setup.py
+msgid "New password confirmation"
+msgstr "Potwierdzenie nowego hasła"
+
+#: account/forms/account_setup.py
+msgid "Repeat the new password"
+msgstr "Powtórz nowe hasło"
+
+#: account/forms/account_setup.py
+msgid "Confirm the new password"
+msgstr "Potwierdź nowe hasło"
+
+#: account/forms/login.py
+msgid "Please enter a correct email address and password."
+msgstr "Proszę podać poprawny adres e-mail i hasło."
+
+#: account/forms/login.py
+msgid "This account is inactive."
+msgstr "To konto jest nieaktywne."
+
+#: account/forms/login.py
+msgid "Insert the email you registered with or got at OpenKAT installation."
+msgstr ""
+"Wpisz adres e-mail, na który zarejestrowałeś się lub który otrzymałeś "
+"podczas instalacji OpenKAT."
+
+#: account/forms/organization.py
+msgid "Organization is required."
+msgstr "Wymagana jest organizacja."
+
+#: account/forms/organization.py tools/view_helpers.py
+#: rocky/templates/dashboard_redteam.html
+#: rocky/templates/organizations/organization_list.html
+#: rocky/views/organization_add.py
+msgid "Organizations"
+msgstr "Organizacje"
+
+#: account/forms/organization.py
+msgid "The organization from which to clone settings."
+msgstr "Organizacja, z której mają być klonowane ustawienia."
+
+#: account/forms/password_reset.py account/templates/account_detail.html
+msgid "Email address"
+msgstr "Adres e-mail"
+
+#: account/forms/password_reset.py
+msgid "A reset link will be sent to this email"
+msgstr "Na ten e-mail zostanie wysłany link resetujący"
+
+#: account/forms/password_reset.py
+msgid "The email address connected to your OpenKAT-account"
+msgstr "Adres e-mail powiązany z Twoim kontem OpenKAT"
+
+#: account/forms/token.py
+msgid ""
+"Insert the token generated by the authenticator app to setup the two factor "
+"authentication."
+msgstr ""
+"Włóż token wygenerowany przez aplikację uwierzytelniającą, aby skonfigurować"
+" uwierzytelnianie dwuskładnikowe."
+
+#: account/forms/token.py
+msgid "Insert the token generated by your token authenticator app."
+msgstr "Włóż token wygenerowany przez aplikację uwierzytelniającą token."
+
+#: account/forms/token.py
+msgid "Backup token"
+msgstr "Token zapasowy"
+
+#: account/mixins.py
+msgid "Clearance level has been set."
+msgstr "Poziom zezwolenia został ustawiony."
+
+#: account/mixins.py
+#, python-format
+msgid ""
+"Could not raise clearance level of %s to L%s. Indemnification not present at"
+" organization %s."
+msgstr ""
+"Nie można podnieść poziomu zezwolenia %s do L%s. Brak zabezpieczenia w "
+"organizacji %s."
+
+#: account/mixins.py
+#, python-format
+msgid ""
+"Could not raise clearance level of %s to L%s. You were trusted a clearance "
+"level of L%s. Contact your administrator to receive a higher clearance."
+msgstr ""
+"Nie można podnieść poziomu zezwolenia %s do L%s. Zaufano Ci na poziomie "
+"uprawnień L%s. Skontaktuj się z administratorem, aby otrzymać wyższe "
+"zezwolenie."
+
+#: account/mixins.py
+#, python-format
+msgid ""
+"Could not raise clearance level of %s to L%s. You acknowledged a clearance "
+"level of L%s. Please accept the clearance level first on your profile page "
+"to proceed."
+msgstr ""
+"Nie można podnieść poziomu zezwolenia %s do L%s. Zatwierdziłeś poziom "
+"zezwolenia L%s. Aby kontynuować, najpierw zaakceptuj poziom uprawnień na "
+"stronie profilu."
+
+#: account/models.py
+msgid "The email must be set"
+msgstr "Adres e-mail musi być ustawiony"
+
+#: account/models.py
+msgid "Superuser must have is_staff=True."
+msgstr "Superużytkownik musi mieć is_staff=True."
+
+#: account/models.py
+msgid "Superuser must have is_superuser=True."
+msgstr "Superużytkownik musi mieć wartość is_superuser=True."
+
+#: account/models.py
+msgid "full name"
+msgstr "pełne imię i nazwisko"
+
+#: account/models.py
+msgid "email"
+msgstr "e-mail"
+
+#: account/models.py
+msgid "staff status"
+msgstr "stan personelu"
+
+#: account/models.py
+msgid "Designates whether the user can log into this admin site."
+msgstr ""
+"Określa, czy użytkownik może zalogować się do tej witryny administracyjnej."
+
+#: account/models.py tools/models.py
+msgid "active"
+msgstr "aktywny"
+
+#: account/models.py
+msgid ""
+"Designates whether this user should be treated as active. Unselect this "
+"instead of deleting accounts."
+msgstr ""
+"Określa, czy ten użytkownik powinien być traktowany jako aktywny. Odznacz tę"
+" opcję zamiast usuwać konta."
+
+#: account/models.py
+msgid "date joined"
+msgstr "data dołączenia"
+
+#: account/models.py
+msgid "The clearance level of the user for all organizations."
+msgstr "Poziom uprawnień użytkownika dla wszystkich organizacji."
+
+#: account/models.py
+msgid "name"
+msgstr "nazwa"
+
+#: account/templates/account_detail.html account/views/account.py
+msgid "Account details"
+msgstr "Szczegóły konta"
+
+#: account/templates/account_detail.html account/templates/password_reset.html
+#: account/views/password_reset.py
+msgid "Reset password"
+msgstr "Zresetuj hasło"
+
+#: account/templates/account_detail.html
+msgid "Full name"
+msgstr "Pełne imię i nazwisko"
+
+#: account/templates/account_detail.html
+msgid "Member type"
+msgstr "Typ członka"
+
+#: account/templates/account_detail.html
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: rocky/templates/tasks/normalizers.html
+msgid "Organization"
+msgstr "Organizacja"
+
+#: account/templates/account_detail.html
+msgid "Permission to set OOI clearance levels"
+msgstr "Zezwolenie na ustawienie poziomów uprawnień OOI"
+
+#: account/templates/account_detail.html
+msgid "OOI clearance"
+msgstr "Zezwolenie OOI"
+
+#: account/templates/account_detail.html
+msgid "You don't have any clearance to scan objects."
+msgstr "Nie masz uprawnień do skanowania obiektów."
+
+#: account/templates/account_detail.html
+msgid ""
+"Get in contact with the admin to give you the necessary clearance level."
+msgstr ""
+"Skontaktuj się z administratorem, aby uzyskać niezbędny poziom uprawnień."
+
+#: account/templates/account_detail.html
+msgid "You have currently accepted clearance up to level"
+msgstr "Obecnie zaakceptowałeś zezwolenie do poziomu"
+
+#: account/templates/account_detail.html
+msgid "Explanation OOI Clearance"
+msgstr "Wyjaśnienie OOI Dopuszczenie"
+
+#: account/templates/account_detail.html
+msgid ""
+"You can withdraw this at anytime you like, but know that you won't be able "
+"to change clearance levels anymore when you do."
+msgstr ""
+"Możesz to wycofać w dowolnym momencie, ale pamiętaj, że nie będziesz już "
+"mógł zmienić poziomu zezwolenia, gdy to zrobisz."
+
+#: account/templates/account_detail.html
+#, python-format
+msgid "Withdraw L%(acl)s clearance and responsibility"
+msgstr "Cofnij zezwolenie i odpowiedzialność L%(acl)s"
+
+#: account/templates/account_detail.html
+msgid "Explanation OOI clearance"
+msgstr "Wyjaśnienie OOI zezwolenie"
+
+#: account/templates/account_detail.html
+#, python-format
+msgid ""
+"You are granted clearance for level L%(tcl)s by your admin. Before you can "
+"change OOI clearance levels up to this level, you need to accept this "
+"permission. Remember: <strong>with great power comes great "
+"responsibility.</strong>"
+msgstr ""
+"Otrzymałeś zezwolenie na poziom L%(tcl)s od swojego administratora. Zanim "
+"będziesz mógł zmienić poziomy uprawnień OOI do tego poziomu, musisz "
+"zaakceptować to uprawnienie. Pamiętaj: <strong>z wielką mocą wiąże się "
+"wielka odpowiedzialność.</strong>"
+
+#: account/templates/account_detail.html
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+#, python-format
+msgid "Accept level L%(tcl)s clearance and responsibility"
+msgstr "Zaakceptuj uprawnienia i odpowiedzialność na poziomie L%(tcl)s"
+
+#: account/templates/password_reset.html
+msgid "Use the form below to reset your password."
+msgstr "Skorzystaj z poniższego formularza, aby zresetować hasło."
+
+#: account/templates/password_reset.html
+#: account/templates/password_reset_confirm.html
+msgid "Send"
+msgstr "Wysłać"
+
+#: account/templates/password_reset.html
+#: account/templates/password_reset_confirm.html
+msgid "Back"
+msgstr "Z powrotem"
+
+#: account/templates/password_reset_confirm.html
+msgid "Confirm reset password"
+msgstr "Potwierdź resetowanie hasła"
+
+#: account/templates/password_reset_confirm.html
+msgid "Use the form below to confirm resetting your password"
+msgstr ""
+"Skorzystaj z poniższego formularza, aby potwierdzić zresetowanie hasła"
+
+#: account/templates/password_reset_confirm.html
+msgid "Confirm password"
+msgstr "Potwierdź hasło"
+
+#: account/templates/password_reset_confirm.html
+msgid "The link is invalid"
+msgstr "Link jest nieprawidłowy"
+
+#: account/templates/password_reset_confirm.html
+msgid ""
+"The password reset link was invalid, possibly because it has already been "
+"used.  Please request a new password reset."
+msgstr ""
+"Link do resetowania hasła był nieprawidłowy, prawdopodobnie dlatego, że "
+"został już użyty.  Poproś o zresetowanie nowego hasła."
+
+#: account/templates/password_reset_email.html
+#, python-format
+msgid ""
+"You're receiving this email because you requested a password reset for your "
+"user account at %(site_name)s."
+msgstr ""
+"Otrzymujesz tego e-maila, ponieważ poprosiłeś o zresetowanie hasła do "
+"swojego konta użytkownika pod adresem %(site_name)s."
+
+#: account/templates/password_reset_email.html
+#: account/templates/registration_email.html
+msgid "Please go to the following page and choose a new password:"
+msgstr "Przejdź na następującą stronę i wybierz nowe hasło:"
+
+#: account/templates/password_reset_email.html
+#: account/templates/registration_email.html
+msgid "Sincerely,"
+msgstr "Z poważaniem,"
+
+#: account/templates/password_reset_email.html
+#: account/templates/registration_email.html
+msgid "The OpenKAT team"
+msgstr "Zespół OpenKAT"
+
+#: account/templates/password_reset_subject.txt
+#, python-format
+msgid "Password reset on %(site_name)s"
+msgstr "Reset hasła w dniu %(site_name)s"
+
+#: account/templates/recover_email.html account/views/recover_email.py
+msgid "Recover email address"
+msgstr "Odzyskaj adres e-mail"
+
+#: account/templates/recover_email.html
+msgid "Information on how to recover your connected email address"
+msgstr "Informacje o tym, jak odzyskać połączony adres e-mail"
+
+#: account/templates/recover_email.html
+msgid "Forgotten email address?"
+msgstr "Zapomniałeś adresu e-mail?"
+
+#: account/templates/recover_email.html
+msgid ""
+"If you don’t remember the email address connected to your account, contact:"
+msgstr ""
+"Jeśli nie pamiętasz adresu e-mail powiązanego z Twoim kontem, skontaktuj się"
+" z:"
+
+#: account/templates/recover_email.html
+msgid "Please contact the system administrator."
+msgstr "Skontaktuj się z administratorem systemu."
+
+#: account/templates/recover_email.html
+msgid "Back to login"
+msgstr "Powrót do logowania"
+
+#: account/templates/recover_email.html
+msgid "Back to Home"
+msgstr "Powrót do domu"
+
+#: account/templates/registration_email.html
+#, python-format
+msgid ""
+"Welcome to OpenKAT. You're receiving this email because you have been added "
+"to organization \"%(organization)s\" at %(site_name)s."
+msgstr ""
+"Witamy w OpenKAT. Otrzymujesz tego e-maila, ponieważ dodano Cię do "
+"organizacji „%(organization)s” pod adresem %(site_name)s."
+
+#: account/templates/registration_subject.txt
+#, python-format
+msgid "Verify OpenKAT account on %(site_name)s"
+msgstr "Zweryfikuj konto OpenKAT na %(site_name)s"
+
+#: account/validators.py
+msgid ""
+"Your password must contain at least the following but longer passwords are "
+"recommended:"
+msgstr ""
+"Twoje hasło musi zawierać co najmniej następujące elementy, ale zalecane są "
+"dłuższe hasła:"
+
+#: account/validators.py
+msgid " characters"
+msgstr "pismo"
+
+#: account/validators.py
+msgid " digits"
+msgstr "cyfry"
+
+#: account/validators.py
+msgid " letters"
+msgstr "beletrystyka"
+
+#: account/validators.py
+msgid ""
+" special characters such as: {str(validators.get('special_characters',''))}"
+msgstr ""
+"znaki specjalne, takie jak: {str(validators.get('special_characters',''))}"
+
+#: account/validators.py
+msgid " lower case letters"
+msgstr "małe litery"
+
+#: account/validators.py
+msgid " upper case letters"
+msgstr "wielkie litery"
+
+#: account/views/login.py
+msgid "Your session has timed out. Please login again."
+msgstr "Twoja sesja wygasła. Proszę zalogować się ponownie."
+
+#: account/views/login.py rocky/templates/header.html
+msgid "OpenKAT"
+msgstr "OpenKAT"
+
+#: account/views/login.py account/views/password_reset.py
+#: account/views/recover_email.py rocky/templates/partials/secondary-menu.html
+#: rocky/templates/two_factor/core/login.html
+msgid "Login"
+msgstr "Login"
+
+#: account/views/login.py
+msgid "Two factor authentication"
+msgstr "Uwierzytelnianie dwuskładnikowe"
+
+#: account/views/password_reset.py
+msgid "We couldn't send a password reset link. Contact "
+msgstr "Nie mogliśmy wysłać linku do resetowania hasła. Kontakt"
+
+#: account/views/password_reset.py
+msgid ""
+"We couldn't send a password reset link. Contact your system administrator."
+msgstr ""
+"Nie mogliśmy wysłać linku do resetowania hasła. Skontaktuj się z "
+"administratorem systemu."
+
+#: components/modal/template.html
+msgid "Close modal"
+msgstr "Zamknij moduł"
+
+#: components/modal/template.html
+#: crisis_room/templates/partials/delete_dashboard_item_modal.html
+#: crisis_room/templates/partials/delete_dashboard_modal.html
+#: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
+#: crisis_room/templates/partials/new_dashboard_item_modal.html
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+#: crisis_room/templates/partials/new_dashboard_modal.html
+#: katalogus/templates/change_clearance_level.html
+#: katalogus/templates/confirmation_clone_settings.html
+#: katalogus/templates/plugin_settings_delete.html
+#: reports/templates/report_overview/modal_partials/enable_disable_schedule_modal.html
+#: reports/templates/report_schedules/delete_recipe_modal.html
+#: rocky/templates/oois/ooi_delete.html
+#: rocky/templates/oois/ooi_mute_finding.html
+#: rocky/templates/organizations/organization_edit.html
+#: rocky/templates/organizations/organization_member_edit.html
+#: rocky/templates/partials/delete_ooi_modal.html
+#: rocky/templates/partials/edit_ooi_clearance_level_modal.html
+#: rocky/templates/partials/mute_findings_modal.html
+#: rocky/templates/two_factor/_wizard_actions.html
+msgid "Cancel"
+msgstr "Anulować"
+
+#: crisis_room/forms.py
+msgid "Title on dashboard"
+msgstr "Tytuł na desce rozdzielczej"
+
+#: crisis_room/forms.py
+msgid "Dashboard item size"
+msgstr "Rozmiar elementu pulpitu nawigacyjnego"
+
+#: crisis_room/forms.py
+msgid "Full width"
+msgstr "Pełna szerokość"
+
+#: crisis_room/forms.py
+msgid "Half width"
+msgstr "Połowa szerokości"
+
+#: crisis_room/forms.py
+msgid "An item with that name already exists. Try a different title."
+msgstr "Element o tej nazwie już istnieje. Wypróbuj inny tytuł."
+
+#: crisis_room/forms.py
+msgid "An error occurred while adding dashboard item."
+msgstr "Wystąpił błąd podczas dodawania elementu pulpitu nawigacyjnego."
+
+#: crisis_room/forms.py
+msgid "Number of rows in list"
+msgstr "Liczba wierszy na liście"
+
+#: crisis_room/forms.py
+msgid "List sorting by"
+msgstr "Sortowanie listy według"
+
+#: crisis_room/forms.py
+msgid "Type (A-Z)"
+msgstr "Typ (A-Z)"
+
+#: crisis_room/forms.py
+msgid "Type (Z-A)"
+msgstr "Typ (Z-A)"
+
+#: crisis_room/forms.py
+msgid "Clearance level (Low-High)"
+msgstr "Poziom luzu (niski-wysoki)"
+
+#: crisis_room/forms.py
+msgid "Clearance level (High-Low)"
+msgstr "Poziom luzu (wysoki-niski)"
+
+#: crisis_room/forms.py
+msgid "Show table columns"
+msgstr "Pokaż kolumny tabeli"
+
+#: crisis_room/forms.py
+msgid "Severity (Low-High)"
+msgstr "Dotkliwość (niska-wysoka)"
+
+#: crisis_room/forms.py
+msgid "Severity (High-Low)"
+msgstr "Dotkliwość (wysoka-niska)"
+
+#: crisis_room/forms.py
+msgid "Finding (A-Z)"
+msgstr "Znalezienie (A-Z)"
+
+#: crisis_room/forms.py
+msgid "Finding (Z-A)"
+msgstr "Znalezienie (Z-A)"
+
+#: crisis_room/models.py
+msgid "Findings Dashboard"
+msgstr "Panel wyników"
+
+#: crisis_room/models.py
+msgid ""
+"Where on the dashboard do you want to show the data? Position {} is the most"
+" top level and the max position is {}."
+msgstr ""
+"Gdzie na dashboardzie chcesz pokazać dane? Pozycja {} to najwyższy poziom, a"
+" maksymalna pozycja to {}."
+
+#: crisis_room/models.py
+msgid "Will be displayed on the general crisis room, for all organizations."
+msgstr ""
+"Zostanie wywieszony w ogólnym pokoju kryzysowym dla wszystkich organizacji."
+
+#: crisis_room/models.py
+msgid "Will be displayed on a single organization dashboard"
+msgstr "Będą wyświetlane na panelu kontrolnym pojedynczej organizacji"
+
+#: crisis_room/models.py
+msgid "Will be displayed on the findings dashboard for all organizations"
+msgstr "Zostaną wyświetlone na panelu wyników dla wszystkich organizacji"
+
+#: crisis_room/models.py
+msgid "Can change position up or down of a dashboard item."
+msgstr ""
+"Może zmieniać położenie elementu na desce rozdzielczej w górę lub w dół."
+
+#: crisis_room/models.py
+msgid "You have to choose between a recipe or a query, but not both."
+msgstr ""
+"Musisz wybrać pomiędzy przepisem a zapytaniem, ale nie jednym i drugim."
+
+#: crisis_room/models.py
+msgid "You have set a query and not where it is from. Also set the source."
+msgstr "Ustawiłeś zapytanie, a nie skąd ono pochodzi. Ustaw także źródło."
+
+#: crisis_room/models.py
+msgid ""
+"DashboardItem must contain at least a 'recipe' or a 'source' with a 'query'."
+msgstr ""
+"DashboardItem musi zawierać co najmniej „przepis” lub „źródło” z "
+"„zapytaniem”."
+
+#: crisis_room/models.py
+msgid "Max dashboard items reached."
+msgstr "Osiągnięto maksymalną liczbę elementów panelu."
+
+#: crisis_room/templates/crisis_room.html
+#: crisis_room/templates/organization_crisis_room.html
+#: rocky/templates/header.html
+msgid "Crisis room"
+msgstr "Pokój kryzysowy"
+
+#: crisis_room/templates/crisis_room.html
+msgid "Crisis room overview for all organizations."
+msgstr "Przegląd pokoju kryzysowego dla wszystkich organizacji."
+
+#: crisis_room/templates/crisis_room_dashboards.html
+msgid "Dashboards"
+msgstr "Pulpity nawigacyjne"
+
+#: crisis_room/templates/crisis_room_dashboards.html
+msgid ""
+"On this page you can see an overview of the dashboards for all "
+"organizations. **More context can be written here**"
+msgstr ""
+"Na tej stronie możesz zobaczyć przegląd dashboardów dla wszystkich "
+"organizacji. **Więcej kontekstu można napisać tutaj**"
+
+#: crisis_room/templates/crisis_room_dashboards.html
+msgid "dashboards"
+msgstr "pulpity nawigacyjne"
+
+#: crisis_room/templates/crisis_room_dashboards.html
+msgid "There are no dashboards to display."
+msgstr "Brak pulpitów nawigacyjnych do wyświetlenia."
+
+#: crisis_room/templates/crisis_room_findings.html
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: reports/report_types/findings_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Findings overview"
+msgstr "Przegląd wyników"
+
+#: crisis_room/templates/crisis_room_findings.html
+msgid ""
+"\n"
+"                            This overview shows the total number of findings per\n"
+"                            severity that have been identified for all organizations.\n"
+"                            This data is based on the latest Crisis Room Findings Report\n"
+"                            of each organization.\n"
+"                        "
+msgstr ""
+"\n"
+"Przegląd ten pokazuje całkowitą liczbę wyników przypadającą na jeden\n"
+"                            dotkliwości, które zostały zidentyfikowane dla wszystkich organizacji.\n"
+"                            Dane te opierają się na najnowszym raporcie Crisis Room Findings Report\n"
+"                            każdej organizacji."
+
+#: crisis_room/templates/crisis_room_findings.html
+msgid "Findings per organization"
+msgstr "Wyniki według organizacji"
+
+#: crisis_room/templates/crisis_room_findings.html
+msgid ""
+"This table shows the findings that have been identified for each "
+"organization, sorted by the finding types and grouped by organizations. This"
+" data is based on the latest Crisis Room Findings Report of each "
+"organization."
+msgstr ""
+"W poniższej tabeli przedstawiono ustalenia zidentyfikowane dla każdej "
+"organizacji, posortowane według typów ustaleń i pogrupowane według "
+"organizacji. Dane te opierają się na najnowszym raporcie z ustaleń Crisis "
+"Room Findings Report każdej organizacji."
+
+#: crisis_room/templates/crisis_room_findings.html
+#: reports/report_types/findings_report/report.html
+msgid ""
+"No findings have been identified yet. As soon as they have been identified, "
+"they will be shown on this page."
+msgstr ""
+"Nie zidentyfikowano jeszcze żadnych ustaleń. Gdy tylko zostaną "
+"zidentyfikowane, zostaną wyświetlone na tej stronie."
+
+#: crisis_room/templates/crisis_room_findings.html
+msgid ""
+"There are no organizations yet. After creating an organization, the "
+"identified findings will be shown here."
+msgstr ""
+"Nie ma jeszcze żadnych organizacji. Po utworzeniu organizacji "
+"zidentyfikowane ustalenia zostaną tutaj pokazane."
+
+#: crisis_room/templates/crisis_room_header.html
+#: crisis_room/templates/organization_crisis_room_header.html
+msgid "Crisis room navigation"
+msgstr "Nawigacja po pokoju kryzysowym"
+
+#: crisis_room/templates/crisis_room_header.html
+#: crisis_room/templates/partials/new_dashboard_item_action_button.html
+#: reports/report_types/aggregate_organisation_report/findings.html
+#: reports/report_types/aggregate_organisation_report/report.html
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/findings_report/report.html
+#: reports/report_types/mail_report/report.html
+#: reports/report_types/multi_organization_report/report.html
+#: reports/report_types/name_server_report/report.html
+#: reports/report_types/tls_report/report.html
+#: reports/report_types/vulnerability_report/report.html
+#: reports/report_types/web_system_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/partials/report_sidemenu.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
+#: rocky/templates/oois/ooi_detail_findings_list.html
+#: rocky/templates/oois/ooi_detail_findings_overview.html
+#: rocky/templates/oois/ooi_page_tabs.html
+#: rocky/templates/partials/ooi_report_findings_block.html
+#: rocky/templates/partials/ooi_report_findings_block_table.html
+#: rocky/views/finding_list.py rocky/views/finding_type_add.py
+#: rocky/views/ooi_view.py
+msgid "Findings"
+msgstr "Ustalenia"
+
+#: crisis_room/templates/organization_crisis_room.html
+msgid "Options for dashboard"
+msgstr "Opcje pulpitu nawigacyjnego"
+
+#: crisis_room/templates/organization_crisis_room.html
+msgid "Show all descriptions"
+msgstr "Pokaż wszystkie opisy"
+
+#: crisis_room/templates/organization_crisis_room.html
+msgid "Hide all descriptions"
+msgstr "Ukryj wszystkie opisy"
+
+#: crisis_room/templates/organization_crisis_room.html
+#: crisis_room/templates/partials/delete_dashboard_modal.html
+msgid "Delete dashboard"
+msgstr "Usuń pulpit nawigacyjny"
+
+#: crisis_room/templates/organization_crisis_room.html
+msgid ""
+"There are no dashboards yet. Click on \"Add dashboard\" to create a new "
+"dashboard."
+msgstr ""
+"Nie ma jeszcze żadnych dashboardów. Kliknij „Dodaj pulpit nawigacyjny”, aby "
+"utworzyć nowy pulpit nawigacyjny."
+
+#: crisis_room/templates/organization_crisis_room_dashboard_items.html
+#: katalogus/templates/partials/objects_to_scan.html
+#: rocky/templates/forms/widgets/checkbox_group_table.html
+#: rocky/templates/oois/ooi_list.html
+msgid "Object list"
+msgstr "Lista obiektów"
+
+#: crisis_room/templates/organization_crisis_room_dashboard_items.html
+msgid "Finding list"
+msgstr "Lista znalezisk"
+
+#: crisis_room/templates/organization_crisis_room_dashboard_items.html
+#: crisis_room/templates/partials/new_dashboard_item_action_button.html
+msgid "Report section"
+msgstr "Sekcja raportu"
+
+#: crisis_room/templates/organization_crisis_room_dashboard_items.html
+msgid "There are no dashboard items added yet."
+msgstr "Nie dodano jeszcze żadnych elementów panelu."
+
+#: crisis_room/templates/organization_crisis_room_dashboard_items.html
+msgid ""
+"You can add dashboard items via the filters on the objects and findings page"
+" or you can add a report section."
+msgstr ""
+"Możesz dodać elementy panelu za pomocą filtrów na stronie obiektów i "
+"wniosków lub możesz dodać sekcję raportu."
+
+#: crisis_room/templates/organization_crisis_room_dashboard_items.html
+msgid "Add objects"
+msgstr "Dodaj obiekty"
+
+#: crisis_room/templates/organization_crisis_room_dashboard_items.html
+msgid "Add findings"
+msgstr "Dodaj ustalenia"
+
+#: crisis_room/templates/organization_crisis_room_dashboard_items.html
+msgid "Add report section"
+msgstr "Dodaj sekcję raportu"
+
+#: crisis_room/templates/organization_crisis_room_header.html
+#: crisis_room/templates/partials/new_dashboard_modal.html
+msgid "Add dashboard"
+msgstr "Dodaj pulpit nawigacyjny"
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+msgid "Findings per organization overview"
+msgstr "Przegląd wyników według organizacji"
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/partials/report_severity_totals_table.html
+#: tools/forms/finding_type.py
+msgid "Finding types"
+msgstr "Znajdowanie typów"
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: reports/report_types/dns_report/report.html
+#: reports/report_types/vulnerability_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/partials/report_severity_totals_table.html
+#: rocky/templates/oois/ooi_detail_findings_overview.html
+#: rocky/templates/partials/ooi_report_findings_block_table.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid "Occurrences"
+msgstr "Zdarzenia"
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+msgid "Highest risk level"
+msgstr "Najwyższy poziom ryzyka"
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+msgid "Critical finding types"
+msgstr "Krytyczne typy wyników"
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: reports/report_types/dns_report/report.html
+#: reports/report_types/vulnerability_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/summary/selected_plugins.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/partials/ooi_report_findings_block_table.html
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
+#: rocky/templates/tasks/ooi_detail_task_list.html
+#: rocky/templates/tasks/plugin_detail_task_list.html
+msgid "Details"
+msgstr "Bliższe dane"
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: katalogus/templates/plugin_container_image.html
+#: reports/report_types/dns_report/report.html
+#: reports/report_types/vulnerability_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+#: reports/templates/summary/selected_plugins.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
+#: rocky/templates/tasks/ooi_detail_task_list.html
+#: rocky/templates/tasks/plugin_detail_task_list.html
+msgid "Close details"
+msgstr "Zamknij szczegóły"
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: katalogus/templates/plugin_container_image.html
+#: reports/report_types/dns_report/report.html
+#: reports/report_types/vulnerability_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+#: reports/templates/summary/selected_plugins.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
+#: rocky/templates/tasks/ooi_detail_task_list.html
+#: rocky/templates/tasks/plugin_detail_task_list.html
+msgid "Open details"
+msgstr "Otwórz szczegóły"
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+msgid ""
+"This overview shows the total number of findings per severity that have been"
+" identified for this organization."
+msgstr ""
+"Przegląd ten przedstawia całkowitą liczbę ustaleń według wagi "
+"zidentyfikowanych dla tej organizacji."
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: reports/report_types/findings_report/report.html
+msgid "Critical and high findings"
+msgstr "Krytyczne i wysokie ustalenia"
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: reports/report_types/findings_report/report.html
+msgid ""
+"This table shows the top 25 critical and high findings that have been "
+"identified for this organization, grouped by finding types. A table with all"
+" the identified findings can be found in the Findings Report."
+msgstr ""
+"W poniższej tabeli przedstawiono 25 najważniejszych i najważniejszych "
+"ustaleń zidentyfikowanych dla tej organizacji, pogrupowanych według typów "
+"wyników. Tabela zawierająca wszystkie zidentyfikowane ustalenia znajduje się"
+" w Raporcie z ustaleń."
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+msgid "No findings have been identified. Check report for more details."
+msgstr ""
+"Nie stwierdzono żadnych ustaleń. Sprawdź raport, aby uzyskać więcej "
+"szczegółów."
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+msgid "View findings report"
+msgstr "Zobacz raport z ustaleń"
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Edit report recipe"
+msgstr "Edytuj przepis na raport"
+
+#: crisis_room/templates/partials/dashboard_finding_list.html
+#, python-format
+msgid "Showing %(length)s findings"
+msgstr "Wyświetlanie %(length)s wyników"
+
+#: crisis_room/templates/partials/dashboard_finding_list.html
+msgid "Go to findings"
+msgstr "Przejdź do ustaleń"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+msgid "Findings table "
+msgstr "Tabela ustaleń"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: crisis_room/templates/partials/dashboard_ooi_list_table.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/oois/ooi_list.html
+msgid "column headers with buttons are sortable"
+msgstr "nagłówki kolumn z przyciskami można sortować"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+#, python-format
+msgid "Show details for %(finding)s"
+msgstr "Pokaż szczegóły dla %(finding)s"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/oois/ooi_page_tabs.html
+#: rocky/templates/partials/elements/ooi_tree_condensed_table.html
+#: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
+#: rocky/views/mixins.py
+msgid "Tree"
+msgstr "Drzewo"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/oois/ooi_page_tabs.html
+#: rocky/templates/partials/elements/ooi_tree_condensed_table.html
+#: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
+#: rocky/views/mixins.py
+msgid "Graph"
+msgstr "Wykres"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: reports/report_types/dns_report/report.html
+#: rocky/templates/oois/ooi_detail_findings_list.html
+#: rocky/templates/oois/ooi_detail_findings_overview.html
+#: rocky/views/mixins.py
+msgid "Severity"
+msgstr "Powaga"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: reports/report_types/dns_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+#: rocky/views/mixins.py
+msgid "Finding"
+msgstr "Odkrycie"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/partials/ooi_report_findings_block_table.html
+msgid "Finding type"
+msgstr "Znalezienie typu"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+#, python-format
+msgid "Show details for %(finding_type)s"
+msgstr "Pokaż szczegóły dla %(finding_type)s"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+msgid "OOI type"
+msgstr "Typ OOI"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+#, python-format
+msgid "Show %(ooi_type)s objects"
+msgstr "Pokaż obiekty %(ooi_type)s"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/views/mixins.py
+msgid "Location"
+msgstr "Lokalizacja"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#, python-format
+msgid "Show details for %(ooi)s"
+msgstr "Pokaż szczegóły dla %(ooi)s"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+msgid "Risk score"
+msgstr "Ocena ryzyka"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: katalogus/templates/normalizer_detail.html
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: reports/report_types/dns_report/report.html
+#: reports/report_types/vulnerability_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/summary/report_asset_overview.html tools/forms/boefje.py
+#: tools/forms/finding_type.py rocky/templates/findings/finding_list.html
+#: rocky/templates/oois/ooi_detail.html
+#: rocky/templates/oois/ooi_detail_findings_list.html
+#: rocky/templates/scan.html
+msgid "Description"
+msgstr "Opis"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: reports/report_types/multi_organization_report/recommendations.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/partials/report_severity_totals_table.html
+#: rocky/templates/findings/finding_list.html
+msgid "Recommendation"
+msgstr "Zalecenie"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: reports/report_types/vulnerability_report/report.py
+#: reports/templates/partials/report_findings_table.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/oois/ooi_detail_origins_inference.html
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid "Source"
+msgstr "Źródło"
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: reports/templates/partials/report_findings_table.html
+#: rocky/templates/findings/finding_list.html
+msgid "Impact"
+msgstr "Uderzenie"
+
+#: crisis_room/templates/partials/dashboard_item_action_button.html
+msgid "Options for dashboard items"
+msgstr "Opcje elementów pulpitu nawigacyjnego"
+
+#: crisis_room/templates/partials/dashboard_item_action_button.html
+msgid "Show description"
+msgstr "Pokaż opis"
+
+#: crisis_room/templates/partials/dashboard_item_action_button.html
+msgid "Hide description"
+msgstr "Ukryj opis"
+
+#: crisis_room/templates/partials/dashboard_item_action_button.html
+msgid "Position up"
+msgstr "Pozycja w górę"
+
+#: crisis_room/templates/partials/dashboard_item_action_button.html
+msgid "Position down"
+msgstr "Pozycja w dół"
+
+#: crisis_room/templates/partials/dashboard_item_action_button.html
+msgid "Rerun report"
+msgstr "Uruchom ponownie raport"
+
+#: crisis_room/templates/partials/dashboard_item_action_button.html
+#: crisis_room/templates/partials/delete_dashboard_item_modal.html
+msgid "Delete item"
+msgstr "Usuń element"
+
+#: crisis_room/templates/partials/dashboard_ooi_list.html
+#, python-format
+msgid "Showing %(length)s objects"
+msgstr "Wyświetlanie obiektów %(length)s"
+
+#: crisis_room/templates/partials/dashboard_ooi_list.html
+msgid "Go to objects"
+msgstr "Przejdź do obiektów"
+
+#: crisis_room/templates/partials/dashboard_ooi_list_table.html
+#: rocky/templates/oois/ooi_list.html
+msgid "Objects "
+msgstr "Obiekty"
+
+#: crisis_room/templates/partials/delete_dashboard_item_modal.html
+#, python-format
+msgid "Are you sure you want to delete '%(name)s' from this dashboard?"
+msgstr "Czy na pewno chcesz usunąć „%(name)s” z tego panelu?"
+
+#: crisis_room/templates/partials/delete_dashboard_item_modal.html
+#: crisis_room/templates/partials/delete_dashboard_modal.html
+#: katalogus/templates/plugin_settings_delete.html
+#: katalogus/views/plugin_settings_delete.py
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+#: rocky/templates/admin/delete_confirmation.html
+#: rocky/templates/oois/ooi_list.html
+#: rocky/templates/partials/delete_ooi_modal.html rocky/views/ooi_delete.py
+msgid "Delete"
+msgstr "Usuwać"
+
+#: crisis_room/templates/partials/delete_dashboard_modal.html
+#, python-format
+msgid ""
+"Are you sure you want to delete dashboard '%(dashboard)s'? All the items on "
+"the dashboard will be deleted as well."
+msgstr ""
+"Czy na pewno chcesz usunąć panel „%(dashboard)s”? Wszystkie elementy na "
+"pulpicie nawigacyjnym również zostaną usunięte."
+
+#: crisis_room/templates/partials/new_dashboard_item_action_button.html
+msgid "Actions for adding dashboard items"
+msgstr "Akcje dodawania elementów panelu kontrolnego"
+
+#: crisis_room/templates/partials/new_dashboard_item_action_button.html
+msgid "Add item"
+msgstr "Dodaj element"
+
+#: crisis_room/templates/partials/new_dashboard_item_action_button.html
+#: crisis_room/templates/partials/report_dashboard_item_filter.html
+#: reports/templates/partials/report_ooi_list.html
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/summary/ooi_selection.html tools/forms/ooi.py
+#: tools/view_helpers.py rocky/templates/admin/delete_confirmation.html
+#: rocky/templates/admin/delete_selected_confirmation.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
+#: rocky/views/ooi_add.py rocky/views/ooi_list.py rocky/views/ooi_view.py
+#: rocky/views/upload_csv.py rocky/views/upload_raw.py
+msgid "Objects"
+msgstr "Obiekty"
+
+#: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
+msgid "Add dashboard item"
+msgstr "Dodaj element pulpitu nawigacyjnego"
+
+#: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
+msgid ""
+"To  add a <strong>report section</strong>, go to the history page and open a"
+" report. Then go to the section that you want to add to your dashboard and "
+"press the options button next to the section name to create a dashboard "
+"item."
+msgstr ""
+"Aby dodać <strong>sekcję raportu</strong>, przejdź do strony historii i "
+"otwórz raport. Następnie przejdź do sekcji, którą chcesz dodać do swojego "
+"dashboardu i naciśnij przycisk opcji obok nazwy sekcji, aby utworzyć element"
+" dashboardu."
+
+#: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
+msgid "Go to report history"
+msgstr "Przejdź do historii raportów"
+
+#: crisis_room/templates/partials/new_dashboard_item_modal.html
+#, python-format
+msgid ""
+"\n"
+"    Add %(item_type)s to dashboard\n"
+msgstr ""
+"\n"
+"Dodaj %(item_type)s do dashboardu\n"
+
+#: crisis_room/templates/partials/new_dashboard_item_modal.html
+#, python-format
+msgid ""
+"Add these %(item_type)s with the selected filters to the dashboard of your "
+"choice."
+msgstr "Dodaj te %(item_type)s z wybranymi filtrami do wybranego panelu."
+
+#: crisis_room/templates/partials/new_dashboard_item_modal.html
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+#: katalogus/templates/partials/no_enabling_permission_message.html
+#: katalogus/templates/plugin_container_image.html
+#: rocky/templates/partials/edit_ooi_clearance_level_modal.html
+#: rocky/templates/partials/form/field_input_help_text.html
+#: rocky/templates/partials/notifications_block.html
+#: rocky/templates/two_factor/core/login.html
+msgid "explanation"
+msgstr "wyjaśnienie"
+
+#: crisis_room/templates/partials/new_dashboard_item_modal.html
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+msgid "You do not have a custom dashboard yet"
+msgstr "Nie masz jeszcze niestandardowego pulpitu nawigacyjnego"
+
+#: crisis_room/templates/partials/new_dashboard_item_modal.html
+#, python-format
+msgid ""
+"In order to add these %(item_type)s to a dashboard, you first need to create"
+" a dashboard. Please add a dashboard in the crisis room of your "
+"organization."
+msgstr ""
+"Aby dodać te %(item_type)s do dashboardu, musisz najpierw utworzyć "
+"dashboard. Dodaj dashboard w pokoju kryzysowym swojej organizacji."
+
+#: crisis_room/templates/partials/new_dashboard_item_modal.html
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/oois/ooi_list.html
+msgid "Add to dashboard"
+msgstr "Dodaj do panelu"
+
+#: crisis_room/templates/partials/new_dashboard_item_modal.html
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+msgid "Go to crisis room"
+msgstr "Idź do pokoju kryzysowego"
+
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+msgid "Add report section to dashboard"
+msgstr "Dodaj sekcję raportu do dashboardu"
+
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+msgid ""
+"In order to add this report section to a dashboard, you first need to create"
+" a dashboard. Please create a dashboard in the crisis room of your "
+"organization."
+msgstr ""
+"Aby dodać tę sekcję raportu do dashboardu, musisz najpierw utworzyć "
+"dashboard. Utwórz dashboard w pokoju kryzysowym swojej organizacji."
+
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+msgid "Report must be scheduled for dashboard items"
+msgstr "Raport musi być zaplanowany dla elementów pulpitu nawigacyjnego"
+
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+msgid ""
+"In order for dashboard information to be updated on a regular basis instead "
+"of showing static data, the report should be scheduled. The frequency of the"
+" schedules recurrence determines how fresh the data on the dashboard will "
+"be."
+msgstr ""
+"Aby informacje w dashboardzie były na bieżąco aktualizowane, zamiast "
+"pokazywać statyczne dane, należy zaplanować raport. Częstotliwość "
+"powtarzania harmonogramów decyduje o tym, jak świeże będą dane na "
+"dashboardzie."
+
+#: crisis_room/templates/partials/report_dashboard_item_filter.html
+msgid "Applied filters"
+msgstr "Zastosowane filtry"
+
+#: crisis_room/templates/partials/report_dashboard_item_filter.html
+msgid "Object types"
+msgstr "Typy obiektów"
+
+#: crisis_room/templates/partials/report_dashboard_item_filter.html
+#: katalogus/templates/change_clearance_level.html onboarding/forms.py
+#: reports/templates/partials/report_ooi_list.html
+#: reports/templates/summary/ooi_selection.html tools/forms/boefje.py
+#: tools/forms/ooi.py rocky/templates/oois/ooi_page_tabs.html
+#: rocky/templates/partials/explanations.html
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+#: rocky/views/mixins.py
+msgid "Clearance level"
+msgstr "Poziom rozliczenia"
+
+#: crisis_room/templates/partials/report_dashboard_item_filter.html
+#: reports/templates/partials/report_ooi_list.html
+#: reports/templates/summary/ooi_selection.html tools/forms/ooi.py
+#: rocky/views/mixins.py
+msgid "Clearance type"
+msgstr "Rodzaj rozliczenia"
+
+#: crisis_room/templates/partials/report_dashboard_item_filter.html
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/modal_partials/rerun_modal.html
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Input objects"
+msgstr "Obiekty wejściowe"
+
+#: crisis_room/templates/partials/report_dashboard_item_filter.html
+msgid "Show all objects"
+msgstr "Pokaż wszystkie obiekty"
+
+#: crisis_room/templates/partials/report_dashboard_item_filter.html
+#: reports/templates/partials/report_types_selection.html
+msgid "No filters applied"
+msgstr "Nie zastosowano żadnych filtrów"
+
+#: crisis_room/templates/partials/report_section_action_button.html
+msgid "Add section to dashboard"
+msgstr "Dodaj sekcję do dashboardu"
+
+#: katalogus/client.py
+msgid ""
+"The KATalogus has an unexpected error. Check the logs for further details."
+msgstr ""
+"KATAlogus zawiera nieoczekiwany błąd. Sprawdź dzienniki, aby uzyskać więcej "
+"szczegółów."
+
+#: katalogus/client.py
+#, python-format
+msgid "An HTTP %d error occurred. Check logs for more info."
+msgstr ""
+"Wystąpił błąd HTTP %d. Sprawdź dzienniki, aby uzyskać więcej informacji."
+
+#: katalogus/client.py
+msgid "An HTTP error occurred. Check logs for more info."
+msgstr "Wystąpił błąd HTTP. Sprawdź dzienniki, aby uzyskać więcej informacji."
+
+#: katalogus/client.py
+msgid "Boefje with this name already exists."
+msgstr "Boefje o tej nazwie już istnieje."
+
+#: katalogus/client.py
+msgid "Boefje with this ID already exists."
+msgstr "Boefje o tym identyfikatorze już istnieje."
+
+#: katalogus/client.py
+msgid "Access to resource not allowed"
+msgstr "Dostęp do zasobu nie jest dozwolony"
+
+#: katalogus/client.py
+msgid "User is not allowed to see plugin settings"
+msgstr "Użytkownik nie ma dostępu do ustawień wtyczki"
+
+#: katalogus/client.py
+msgid "User is not allowed to set plugin settings"
+msgstr "Użytkownik nie może zmieniać ustawień wtyczki"
+
+#: katalogus/client.py
+msgid "User is not allowed to delete plugin settings"
+msgstr "Użytkownikowi nie wolno usuwać ustawień wtyczki"
+
+#: katalogus/client.py
+msgid "User is not allowed to view plugin settings"
+msgstr "Użytkownik nie ma uprawnień do przeglądania ustawień wtyczki"
+
+#: katalogus/client.py
+msgid "User is not allowed to access the other organization"
+msgstr "Użytkownik nie ma dostępu do innej organizacji"
+
+#: katalogus/client.py
+msgid "User is not allowed to enable plugins"
+msgstr "Użytkownik nie może włączać wtyczek"
+
+#: katalogus/client.py
+msgid "User is not allowed to disable plugins"
+msgstr "Użytkownikowi nie wolno wyłączać wtyczek"
+
+#: katalogus/client.py
+msgid "User is not allowed to create plugins"
+msgstr "Użytkownikowi nie wolno tworzyć wtyczek"
+
+#: katalogus/client.py
+msgid "User is not allowed to edit plugins"
+msgstr "Użytkownikowi nie wolno edytować wtyczek"
+
+#: katalogus/forms/katalogus_filter.py
+msgid "Show all"
+msgstr "Pokaż wszystko"
+
+#: katalogus/forms/katalogus_filter.py
+#: katalogus/templates/partials/enable_disable_plugin.html
+#: katalogus/templates/partials/plugin_tile_modal.html
+#: katalogus/templates/plugin_container_image.html
+#: reports/report_types/dns_report/report.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Enabled"
+msgstr "Włączony"
+
+#: katalogus/forms/katalogus_filter.py
+#: katalogus/templates/partials/enable_disable_plugin.html
+#: katalogus/templates/partials/plugin_tile_modal.html
+#: katalogus/templates/plugin_container_image.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+#: reports/templates/summary/selected_plugins.html
+msgid "Disabled"
+msgstr "Wyłączony"
+
+#: katalogus/forms/katalogus_filter.py
+msgid "Enabled-Disabled"
+msgstr "Włączone-wyłączone"
+
+#: katalogus/forms/katalogus_filter.py
+msgid "Disabled-Enabled"
+msgstr "Wyłączone-włączone"
+
+#: katalogus/forms/katalogus_filter.py
+msgid "Filter options"
+msgstr "Opcje filtrowania"
+
+#: katalogus/forms/katalogus_filter.py
+msgid "Sorting options"
+msgstr "Opcje sortowania"
+
+#: katalogus/forms/plugin_settings.py
+msgid "This field is required."
+msgstr "To pole jest wymagane."
+
+#: katalogus/templates/about_plugins.html
+#: katalogus/templates/partials/plugins_navigation.html
+msgid "About plugins"
+msgstr "O wtyczkach"
+
+#: katalogus/templates/about_plugins.html katalogus/templates/katalogus.html
+msgid ""
+"Plugins gather data, objects and insight. Each plugin has its own focus area"
+" and strengths and may be able to work with other plugins to gain even more "
+"insights."
+msgstr ""
+"Wtyczki gromadzą dane, obiekty i spostrzeżenia. Każda wtyczka ma swój własny"
+" obszar zainteresowań i mocne strony i może współpracować z innymi "
+"wtyczkami, aby uzyskać jeszcze więcej informacji."
+
+#: katalogus/templates/about_plugins.html katalogus/templates/boefjes.html
+msgid ""
+"Boefjes are used to scan for objects. They detect vulnerabilities, security "
+"issues, and give insight. Each boefje is a separate scan that can run on a "
+"selection of objects."
+msgstr ""
+"Boefjes służą do skanowania w poszukiwaniu obiektów. Wykrywają luki w "
+"zabezpieczeniach, problemy związane z bezpieczeństwem i dają wgląd. Każde "
+"boefje to oddzielne skanowanie, które można uruchomić na wybranych "
+"obiektach."
+
+#: katalogus/templates/about_plugins.html katalogus/templates/normalizers.html
+msgid ""
+"Normalizers analyze the information and turn it into objects for the data "
+"model in Octopoes."
+msgstr ""
+"Normalizers przeanalizuj informacje i zamień je w obiekty dla modelu danych "
+"w Octopoes."
+
+#: katalogus/templates/about_plugins.html
+msgid ""
+"Bits are business rules that look for insight within the current dataset and"
+" search for specific insight and draw conclusions."
+msgstr ""
+"Bity to reguły biznesowe, które wyszukują wgląd w bieżący zbiór danych, "
+"szukają konkretnych informacji i wyciągają wnioski."
+
+#: katalogus/templates/boefje_detail.html
+#: katalogus/templates/partials/plugin_tile_modal.html
+#: katalogus/templates/plugin_container_image.html
+msgid "Scan level"
+msgstr "Poziom skanowania"
+
+#: katalogus/templates/boefje_detail.html
+#: katalogus/templates/normalizer_detail.html
+msgid "Consumes"
+msgstr "Konsumuje"
+
+#: katalogus/templates/boefje_detail.html
+#, python-format
+msgid "%(plugin_name)s is able to scan the following object types:"
+msgstr "%(plugin_name)s może skanować następujące typy obiektów:"
+
+#: katalogus/templates/boefje_detail.html
+#: katalogus/templates/normalizer_detail.html
+#, python-format
+msgid "%(plugin_name)s does not need any input objects."
+msgstr "%(plugin_name)s nie potrzebuje żadnych obiektów wejściowych."
+
+#: katalogus/templates/boefje_detail.html
+#: katalogus/templates/normalizer_detail.html
+#: katalogus/templates/partials/plugin_tile_modal.html
+msgid "Produces"
+msgstr "Produkuje"
+
+#: katalogus/templates/boefje_detail.html
+#: katalogus/templates/normalizer_detail.html
+#: katalogus/templates/partials/plugin_tile_modal.html
+#, python-format
+msgid "%(plugin_name)s can produce the following output:"
+msgstr "%(plugin_name)s może wygenerować następujące dane wyjściowe:"
+
+#: katalogus/templates/boefje_detail.html
+#, python-format
+msgid "%(plugin_name)s doesn't produce any output mime types."
+msgstr "%(plugin_name)s nie tworzy żadnych wyjściowych typów MIME."
+
+#: katalogus/templates/boefje_setup.html
+msgid "Boefje variant setup"
+msgstr "Konfiguracja wariantu Boefje"
+
+#: katalogus/templates/boefje_setup.html
+#: rocky/templates/organizations/organization_member_list.html
+#: rocky/templates/organizations/organization_settings.html
+#: rocky/views/ooi_edit.py rocky/views/organization_edit.py
+msgid "Edit"
+msgstr "Redagować"
+
+#: katalogus/templates/boefje_setup.html
+msgid "Boefje setup"
+msgstr "Konfiguracja Boefje"
+
+#: katalogus/templates/boefje_setup.html
+msgid ""
+"You can create a new Boefje. If you want more information on this, you can "
+"check out the <a "
+"href=\"https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html\">documentation</a>."
+msgstr ""
+"Możesz utworzyć nowy Boefje. Jeśli chcesz uzyskać więcej informacji na ten "
+"temat, zapoznaj się z <a "
+"href=\"https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html\">dokumentacją</a>."
+
+#: katalogus/templates/boefje_setup.html
+#: rocky/templates/partials/edit_ooi_clearance_level_modal.html
+msgid "Save changes"
+msgstr "Zapisz zmiany"
+
+#: katalogus/templates/boefje_setup.html
+msgid "Discard changes"
+msgstr "Odrzuć zmiany"
+
+#: katalogus/templates/boefje_setup.html
+msgid "Create variant"
+msgstr "Utwórz wariant"
+
+#: katalogus/templates/boefje_setup.html
+msgid "Discard variant"
+msgstr "Odrzuć wariant"
+
+#: katalogus/templates/boefje_setup.html
+msgid "Create new Boefje"
+msgstr "Utwórz nowy Boefje"
+
+#: katalogus/templates/boefje_setup.html
+msgid "Discard new Boefje"
+msgstr "Odrzuć nowy Boefje"
+
+#: katalogus/templates/boefjes.html
+msgid "Add Boefje"
+msgstr "Dodaj Boefje"
+
+#: katalogus/templates/boefjes.html katalogus/templates/katalogus.html
+#: katalogus/templates/normalizers.html
+msgid "available"
+msgstr "dostępny"
+
+#: katalogus/templates/change_clearance_level.html
+#: katalogus/templates/partials/objects_to_scan.html
+#: reports/templates/partials/report_setup_scan.html
+msgid "scan level warning"
+msgstr "ostrzeżenie o poziomie skanowania"
+
+#: katalogus/templates/change_clearance_level.html
+#, python-format
+msgid ""
+"%(plugin_name)s will only scan objects with a corresponding clearance level "
+"of <strong>L%(scan_level)s</strong> or higher."
+msgstr ""
+"%(plugin_name)s będzie skanować tylko obiekty z odpowiednim poziomem dostępu"
+" wynoszącym <strong>L%(scan_level)s</strong> lub wyższym."
+
+#: katalogus/templates/change_clearance_level.html
+msgid "Scan object"
+msgstr "Zeskanuj obiekt"
+
+#: katalogus/templates/change_clearance_level.html
+#, python-format
+msgid ""
+"The following objects are not yet cleared for level %(scan_level)s, please "
+"be advised that by continuing you will declare a level %(scan_level)s on "
+"these objects."
+msgstr ""
+"Następujące obiekty nie zostały jeszcze dopuszczone do poziomu "
+"%(scan_level)s, informujemy, że kontynuując zadeklarujesz dla tych obiektów "
+"poziom %(scan_level)s."
+
+#: katalogus/templates/change_clearance_level.html
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: reports/templates/summary/report_asset_overview.html
+msgid "Selected objects"
+msgstr "Wybrane obiekty"
+
+#: katalogus/templates/change_clearance_level.html
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/summary/ooi_selection.html rocky/views/mixins.py
+msgid "Object"
+msgstr "Obiekt"
+
+#: katalogus/templates/change_clearance_level.html
+msgid "Are you sure you want to scan anyways?"
+msgstr "Czy na pewno chcesz mimo to skanować?"
+
+#: katalogus/templates/change_clearance_level.html
+#: rocky/templates/oois/ooi_detail.html
+msgid "Scan"
+msgstr "Skandować"
+
+#: katalogus/templates/clone_settings.html
+#: katalogus/templates/confirmation_clone_settings.html
+msgid "Clone settings"
+msgstr "Ustawienia klonowania"
+
+#: katalogus/templates/clone_settings.html
+#, python-format
+msgid ""
+"Use the form below to clone the settings from "
+"<strong>%(current_organization)s</strong> to the selected organization. This"
+" includes both the KAT-alogus settings as well as enabled and disabled "
+"plugins."
+msgstr ""
+"Skorzystaj z poniższego formularza, aby sklonować ustawienia z "
+"<strong>%(current_organization)s</strong> do wybranej organizacji. Dotyczy "
+"to zarówno ustawień KAT-alogus, jak i włączonych i wyłączonych wtyczek."
+
+#: katalogus/templates/confirmation_clone_settings.html
+msgid "Clone"
+msgstr "Klon"
+
+#: katalogus/templates/katalogus.html
+msgid "All plugins"
+msgstr "Wszystkie wtyczki"
+
+#: katalogus/templates/katalogus_settings.html
+msgid "KAT-alogus settings"
+msgstr "KAT - ustawienia analogowe"
+
+#: katalogus/templates/katalogus_settings.html
+msgid ""
+"There are currently no settings defined. Add settings at the plugin detail "
+"page."
+msgstr ""
+"Obecnie nie zdefiniowano żadnych ustawień. Dodaj ustawienia na stronie "
+"szczegółów wtyczki."
+
+#: katalogus/templates/katalogus_settings.html
+#: rocky/templates/two_factor/core/otp_required.html
+msgid "Go back"
+msgstr "Wracać"
+
+#: katalogus/templates/katalogus_settings.html
+msgid "This is an overview of the latest settings of all plugins."
+msgstr "To jest przegląd najnowszych ustawień wszystkich wtyczek."
+
+#: katalogus/templates/katalogus_settings.html
+msgid "Latest plugin settings"
+msgstr "Najnowsze ustawienia wtyczki"
+
+#: katalogus/templates/katalogus_settings.html
+#: rocky/templates/tasks/ooi_detail_task_list.html
+msgid "Plugin"
+msgstr "Wtyczka"
+
+#: katalogus/templates/katalogus_settings.html
+#: katalogus/templates/plugin_settings_list.html
+#: rocky/templates/oois/ooi_delete.html
+msgid "Value"
+msgstr "Wartość"
+
+#: katalogus/templates/normalizer_detail.html
+#, python-format
+msgid "%(plugin_name)s is able to process the following mime types:"
+msgstr "%(plugin_name)s potrafi przetwarzać następujące typy MIME:"
+
+#: katalogus/templates/partials/boefje_tile.html
+msgid "This object type is required"
+msgstr "Ten typ obiektu jest wymagany"
+
+#: katalogus/templates/partials/boefje_tile.html
+msgid "Scan level:"
+msgstr "Poziom skanowania:"
+
+#: katalogus/templates/partials/boefje_tile.html
+msgid "Publisher:"
+msgstr "Wydawca:"
+
+#: katalogus/templates/partials/boefje_tile.html
+#: katalogus/templates/partials/plugin_tile.html
+#: katalogus/templates/partials/plugin_tile_modal.html
+msgid "See details"
+msgstr "Zobacz szczegóły"
+
+#: katalogus/templates/partials/enable_disable_plugin.html
+msgid "Enable"
+msgstr "Włączać"
+
+#: katalogus/templates/partials/enable_disable_plugin.html
+#: rocky/templates/two_factor/profile/disable.html
+msgid "Disable"
+msgstr "Wyłączyć"
+
+#: katalogus/templates/partials/katalogus_filter.html
+#: rocky/templates/findings/findings_filter.html
+#: rocky/templates/partials/ooi_list_filters.html
+#: rocky/templates/partials/organization_member_list_filters.html
+#: rocky/templates/tasks/partials/task_filter.html
+msgid "Hide filters"
+msgstr "Ukryj filtry"
+
+#: katalogus/templates/partials/katalogus_filter.html
+#: rocky/templates/findings/findings_filter.html
+#: rocky/templates/partials/ooi_list_filters.html
+#: rocky/templates/partials/organization_member_list_filters.html
+#: rocky/templates/tasks/partials/task_filter.html
+msgid "Show filters"
+msgstr "Pokaż filtry"
+
+#: katalogus/templates/partials/katalogus_filter.html
+#: rocky/templates/findings/findings_filter.html
+#: rocky/templates/partials/ooi_list_filters.html
+#: rocky/templates/partials/organization_member_list_filters.html
+#: rocky/templates/tasks/partials/task_filter.html
+msgid "applied"
+msgstr "stosowany"
+
+#: katalogus/templates/partials/katalogus_filter.html
+msgid "Filter plugins"
+msgstr "Filtruj wtyczki"
+
+#: katalogus/templates/partials/katalogus_filter.html
+msgid "Clear filter"
+msgstr "Wyczyść filtr"
+
+#: katalogus/templates/partials/katalogus_header.html
+#: katalogus/views/change_clearance_level.py katalogus/views/katalogus.py
+#: katalogus/views/katalogus_settings.py katalogus/views/plugin_detail.py
+#: katalogus/views/plugin_settings_add.py
+#: katalogus/views/plugin_settings_delete.py
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
+msgid "KAT-alogus"
+msgstr "KAT-alog"
+
+#: katalogus/templates/partials/katalogus_header.html
+msgid "An overview of all available plugins."
+msgstr "Przegląd wszystkich dostępnych wtyczek."
+
+#: katalogus/templates/partials/katalogus_header.html
+#: katalogus/templates/plugin_settings_list.html
+#: katalogus/views/katalogus_settings.py tools/view_helpers.py
+#: rocky/templates/header.html
+#: rocky/templates/organizations/organization_list.html
+#: rocky/templates/organizations/organization_settings.html
+msgid "Settings"
+msgstr "Ustawienia"
+
+#: katalogus/templates/partials/katalogus_toolbar.html
+msgid "Gridview"
+msgstr "Widok siatki"
+
+#: katalogus/templates/partials/katalogus_toolbar.html
+msgid "Tableview"
+msgstr "Widok stołu"
+
+#: katalogus/templates/partials/modal_report_types.html
+msgid "Required for"
+msgstr "Wymagane dla"
+
+#: katalogus/templates/partials/modal_report_types.html
+msgid "report types"
+msgstr "typy raportów"
+
+#: katalogus/templates/partials/modal_report_types.html
+msgid "Report types for "
+msgstr "Typy raportów dla"
+
+#: katalogus/templates/partials/no_enabling_permission_message.html
+msgid "No permission to enable/disable plugins"
+msgstr "Brak uprawnień do włączania/wyłączania wtyczek"
+
+#: katalogus/templates/partials/no_enabling_permission_message.html
+msgid "Contact your administrator to request permission."
+msgstr "Skontaktuj się z administratorem, aby poprosić o pozwolenie."
+
+#: katalogus/templates/partials/objects_to_scan.html
+#, python-format
+msgid ""
+"This Boefje will only scan objects with a corresponding clearance level of "
+"<strong>L%(scan_level)s</strong> or higher. There is no indemnification for "
+"this Boefje to scan an OOI with a lower clearance level than "
+"<strong>L%(scan_level)s</strong>. Use the filter to show OOI's with a lower "
+"clearance level."
+msgstr ""
+"To Boefje będzie skanować tylko obiekty z odpowiednim poziomem dostępu "
+"<strong>L%(scan_level)s</strong> lub wyższym. Nie przysługuje żadne "
+"zabezpieczenie w przypadku Boefje skanowania OOI z niższym poziomem "
+"zezwolenia niż <strong>L%(scan_level)s</strong>. Użyj filtra, aby wyświetlić"
+" OOI z niższym poziomem zezwolenia."
+
+#: katalogus/templates/partials/objects_to_scan.html
+msgid "Warning scan level:"
+msgstr "Poziom skanowania ostrzeżeń:"
+
+#: katalogus/templates/partials/objects_to_scan.html
+msgid ""
+"Scanning OOI's with a lower clearance level will result in OpenKAT "
+"increasing the clearance level on that OOI, not only for this scan but from "
+"now on out, until it manually gets set to something else again. This means "
+"that all other enabled Boefjes will use this higher clearance level aswel."
+msgstr ""
+"Skanowanie OOI z niższym poziomem zezwolenia spowoduje OpenKAT zwiększenie "
+"poziomu zezwolenia na OOI, nie tylko dla tego skanowania, ale od teraz, aż "
+"do ręcznego ustawienia go na coś innego. Oznacza to, że wszystkie inne "
+"włączone Boefjes będą używać tego wyższego poziomu uprawnień."
+
+#: katalogus/templates/partials/objects_to_scan.html
+#, python-format
+msgid ""
+"You currently don't have any objects that meet the scan level of %(name)s. "
+"Add objects with a complying clearance level, or alter the clearance level "
+"of existing objects."
+msgstr ""
+"Obecnie nie masz żadnych obiektów spełniających poziom skanowania %(name)s. "
+"Dodaj obiekty o odpowiednim poziomie prześwitu lub zmień poziom prześwitu "
+"istniejących obiektów."
+
+#: katalogus/templates/partials/objects_to_scan.html
+#, python-format
+msgid ""
+"You currently don't have scannable objects for %(name)s. Add objects to use "
+"this Boefje. This Boefje is able to scan objects of the following types:"
+msgstr ""
+"Obecnie nie masz obiektów do skanowania dla %(name)s. Dodaj obiekty, aby "
+"użyć tego Boefje. To Boefje potrafi skanować obiekty następujących typów:"
+
+#: katalogus/templates/partials/plugin_settings_required.html
+msgid "The form could not be initialized."
+msgstr "Nie można zainicjować formularza."
+
+#: katalogus/templates/partials/plugin_settings_required.html
+msgid "Required settings"
+msgstr "Wymagane ustawienia"
+
+#: katalogus/templates/partials/plugin_settings_required.html
+#: rocky/templates/partials/ooi_list_toolbar.html
+msgid "Add"
+msgstr "Dodać"
+
+#: katalogus/templates/partials/plugin_tile.html
+msgid "Required for:"
+msgstr "Wymagane dla:"
+
+#: katalogus/templates/partials/plugin_tile_modal.html
+msgid "Boefje details"
+msgstr "Boefje szczegóły"
+
+#: katalogus/templates/partials/plugin_tile_modal.html reports/forms.py
+#: reports/templates/report_overview/report_history_table.html
+msgid "Report types"
+msgstr "Typy raportów"
+
+#: katalogus/templates/partials/plugin_tile_modal.html
+msgid "This boefje is required by the following report types."
+msgstr "To boefje jest wymagane w przypadku następujących typów raportów."
+
+#: katalogus/templates/partials/plugin_tile_modal.html
+msgid "Go to boefje detail page"
+msgstr "Przejdź do strony szczegółów boefje"
+
+#: katalogus/templates/partials/plugins.html
+msgid "Plugins overview:"
+msgstr "Przegląd wtyczek:"
+
+#: katalogus/templates/partials/plugins.html
+#: reports/templates/summary/selected_plugins.html
+msgid "Plugin name"
+msgstr "Nazwa wtyczki"
+
+#: katalogus/templates/partials/plugins.html
+#: reports/templates/summary/selected_plugins.html
+msgid "Plugin type"
+msgstr "Typ wtyczki"
+
+#: katalogus/templates/partials/plugins.html
+#: reports/templates/summary/selected_plugins.html
+msgid "Plugin description"
+msgstr "Opis wtyczki"
+
+#: katalogus/templates/partials/plugins.html
+#: reports/templates/partials/report_header.html
+#: reports/templates/report_overview/report_history_table.html
+#: rocky/templates/organizations/organization_list.html
+#: rocky/templates/organizations/organization_settings.html
+msgid "Actions"
+msgstr "Działania"
+
+#: katalogus/templates/partials/plugins.html
+msgid "Detail page"
+msgstr "Strona ze szczegółami"
+
+#: katalogus/templates/partials/plugins_navigation.html
+#: reports/templates/report_overview/report_overview_navigation.html
+msgid "Plugins Navigation"
+msgstr "Nawigacja po wtyczkach"
+
+#: katalogus/templates/partials/plugins_navigation.html
+#: rocky/templates/scan.html rocky/templates/tasks/boefjes.html
+#: rocky/templates/tasks/partials/tab_navigation.html rocky/views/tasks.py
+msgid "Boefjes"
+msgstr "Boefjes"
+
+#: katalogus/templates/partials/plugins_navigation.html
+#: rocky/templates/tasks/normalizers.html
+#: rocky/templates/tasks/partials/tab_navigation.html rocky/views/tasks.py
+msgid "Normalizers"
+msgstr "Normalizers"
+
+#: katalogus/templates/partials/plugins_navigation.html
+#: tools/forms/scheduler.py
+msgid "All"
+msgstr "Wszystko"
+
+#: katalogus/templates/plugin_container_image.html tools/forms/boefje.py
+msgid "Container image"
+msgstr "Obraz kontenera"
+
+#: katalogus/templates/plugin_container_image.html
+msgid "The container image for this Boefje is:"
+msgstr "Obraz kontenera dla tego Boefje to:"
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Variants"
+msgstr "Warianty"
+
+#: katalogus/templates/plugin_container_image.html
+msgid ""
+"Boefje variants that use the same container image. For more information "
+"about Boefje variants you can read the documentation."
+msgstr ""
+"Boefje warianty korzystające z tego samego obrazu kontenera. Więcej "
+"informacji na temat wariantów Boefje można znaleźć w dokumentacji."
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Add variant"
+msgstr "Dodaj wariant"
+
+#: katalogus/templates/plugin_container_image.html
+#: rocky/templates/partials/notifications_block.html
+msgid "confirmation"
+msgstr "potwierdzenie"
+
+#: katalogus/templates/plugin_container_image.html
+#, python-format
+msgid "Variant %(plugin.name)s created."
+msgstr "Utworzono wariant %(plugin.name)s."
+
+#: katalogus/templates/plugin_container_image.html
+msgid "The Boefje variant is successfully created and can now be used."
+msgstr "Wariant Boefje został pomyślnie utworzony i można go teraz używać."
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Overview of variants"
+msgstr "Przegląd wariantów"
+
+#: katalogus/templates/plugin_container_image.html
+#: reports/report_types/tls_report/report.html
+#: reports/templates/partials/plugin_overview_table.html
+#: rocky/templates/organizations/organization_member_list.html
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
+#: rocky/templates/tasks/ooi_detail_task_list.html
+#: rocky/templates/tasks/plugin_detail_task_list.html
+#: rocky/templates/tasks/reports.html
+msgid "Status"
+msgstr "Status"
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Age"
+msgstr "Wiek"
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Scan interval"
+msgstr "Interwał skanowania"
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Run on"
+msgstr "Biegnij dalej"
+
+#: katalogus/templates/plugin_container_image.html
+msgid "current"
+msgstr "aktualny"
+
+#: katalogus/templates/plugin_container_image.html
+#: reports/report_types/dns_report/report.html
+msgid "minutes"
+msgstr "protokół"
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Default system scan frequency"
+msgstr "Domyślna częstotliwość skanowania systemu"
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Boefje ID"
+msgstr "Boefje Identyfikator"
+
+#: katalogus/templates/plugin_container_image.html
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/modal_partials/rerun_modal.html
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/report_overview/subreports_table.html
+#: rocky/templates/tasks/reports.html
+msgid "Creation date"
+msgstr "Data utworzenia"
+
+#: katalogus/templates/plugin_container_image.html tools/forms/boefje.py
+msgid "Arguments"
+msgstr "Argumenty"
+
+#: katalogus/templates/plugin_container_image.html
+msgid "The following arguments are used for this Boefje variant:"
+msgstr "W przypadku tego wariantu Boefje używane są następujące argumenty:"
+
+#: katalogus/templates/plugin_container_image.html
+msgid "There are no arguments used for this Boefje variant."
+msgstr "Dla tego wariantu Boefje nie używa się żadnych argumentów."
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Edit variant"
+msgstr "Edytuj wariant"
+
+#: katalogus/templates/plugin_container_image.html
+msgid "This Boefje has no variants yet."
+msgstr "Ten Boefje nie ma jeszcze żadnych wariantów."
+
+#: katalogus/templates/plugin_container_image.html
+msgid ""
+"You can make a variant and change the arguments and JSON Schema to customize"
+" it to fit your needs."
+msgstr ""
+"Możesz stworzyć wariant i zmienić argumenty oraz schemat JSON, aby "
+"dostosować go do swoich potrzeb."
+
+#: katalogus/templates/plugin_settings_add.html
+msgid "Add setting"
+msgid_plural "Add settings"
+msgstr[0] "Dodaj ustawienie"
+msgstr[1] "Dodaj ustawienia"
+msgstr[2] "Dodaj ustawienia"
+
+#: katalogus/templates/plugin_settings_add.html
+msgid "Setting"
+msgid_plural "Settings"
+msgstr[0] "Ustawienie"
+msgstr[1] "Ustawienia"
+msgstr[2] "Ustawienia"
+
+#: katalogus/templates/plugin_settings_add.html
+msgid "Add setting and enable boefje"
+msgid_plural "Add settings and enable boefje"
+msgstr[0] "Dodaj ustawienie i włącz boefje"
+msgstr[1] "Dodaj ustawienia i włącz boefje"
+msgstr[2] "Dodaj ustawienia i włącz boefje"
+
+#: katalogus/templates/plugin_settings_delete.html
+msgid "Delete settings"
+msgstr "Usuń ustawienia"
+
+#: katalogus/templates/plugin_settings_delete.html
+#, python-format
+msgid ""
+"Are you sure you want to delete all settings for the plugin %(plugin_name)s?"
+msgstr ""
+"Czy na pewno chcesz usunąć wszystkie ustawienia wtyczki %(plugin_name)s?"
+
+#: katalogus/templates/plugin_settings_list.html
+msgid ""
+"In the table below the settings for this specific Boefje can be seen. Set or"
+" change the value of the variables by editing the settings."
+msgstr ""
+"W poniższej tabeli można zobaczyć ustawienia dla tego konkretnego Boefje. "
+"Ustaw lub zmień wartość zmiennych, edytując ustawienia."
+
+#: katalogus/templates/plugin_settings_list.html
+msgid "Configure Settings"
+msgstr "Skonfiguruj ustawienia"
+
+#: katalogus/templates/plugin_settings_list.html
+msgid "Overview of settings"
+msgstr "Przegląd ustawień"
+
+#: katalogus/templates/plugin_settings_list.html
+msgid "Variable"
+msgstr "Zmienny"
+
+#: katalogus/views/change_clearance_level.py
+msgid "Session has terminated, please select objects again."
+msgstr "Sesja została zakończona. Wybierz obiekty ponownie."
+
+#: katalogus/views/change_clearance_level.py
+msgid "Change clearance level"
+msgstr "Zmień poziom zezwolenia"
+
+#: katalogus/views/katalogus_settings.py
+msgid "Settings from {} to {} successfully cloned."
+msgstr "Ustawienia od {} do {} pomyślnie sklonowano."
+
+#: katalogus/views/katalogus_settings.py
+#: katalogus/views/plugin_settings_list.py
+msgid "Failed getting settings for boefje {}"
+msgstr "Nie udało się pobrać ustawień dla boefje {}"
+
+#: katalogus/views/mixins.py
+msgid ""
+"Getting information for plugin {} failed. Please check the KATalogus logs."
+msgstr ""
+"Pobieranie informacji o wtyczce {} nie powiodło się. Proszę sprawdzić logi "
+"KATalogus."
+
+#: katalogus/views/plugin_detail.py
+msgid ""
+"Some selected OOIs needs an increase of clearance level to perform scans. "
+"You do not have the permission to change clearance level."
+msgstr ""
+"Niektóre wybrane OOIs wymagają zwiększenia poziomu uprawnień, aby móc "
+"skanować. Nie masz uprawnień do zmiany poziomu uprawnień."
+
+#: katalogus/views/plugin_enable_disable.py
+msgid "{} '{}' disabled."
+msgstr "{} '{}' wyłączony."
+
+#: katalogus/views/plugin_enable_disable.py
+msgid "{} '{}' enabled."
+msgstr "{} '{}' włączony."
+
+#: katalogus/views/plugin_enable_disable.py
+msgid ""
+"You have not acknowledged your clearance level. Go to your profile page to "
+"acknowledge your clearance level."
+msgstr ""
+"Nie potwierdziłeś swojego poziomu uprawnień. Przejdź do strony swojego "
+"profilu, aby potwierdzić swój poziom uprawnień."
+
+#: katalogus/views/plugin_enable_disable.py
+msgid ""
+"Your clearance level is not set. Go to your profile page to see your "
+"clearance or contact the administrator to set a clearance level."
+msgstr ""
+"Poziom uprawnień nie jest ustawiony. Przejdź do strony swojego profilu, aby "
+"zobaczyć swoje uprawnienia lub skontaktuj się z administratorem, aby ustawić"
+" poziom uprawnień."
+
+#: katalogus/views/plugin_enable_disable.py
+msgid ""
+"Your clearance level is L{}. Contact your administrator to get a higher "
+"clearance level."
+msgstr ""
+"Twój poziom uprawnień to L{}. Skontaktuj się z administratorem, aby uzyskać "
+"wyższy poziom uprawnień."
+
+#: katalogus/views/plugin_enable_disable.py
+msgid "To enable {} you need at least a clearance level of L{}. "
+msgstr "Aby włączyć {}, potrzebujesz co najmniej poziomu uprawnień L{}."
+
+#: katalogus/views/plugin_settings_add.py
+msgid "Trying to add settings to boefje without schema"
+msgstr "Próbuję dodać ustawienia do boefje bez schematu"
+
+#: katalogus/views/plugin_settings_add.py
+msgid "No changes to the settings added: no form data present"
+msgstr "Nie dodano żadnych zmian w ustawieniach: brak danych formularza"
+
+#: katalogus/views/plugin_settings_add.py
+msgid "Added settings for '{}'"
+msgstr "Dodano ustawienia dla „{}”"
+
+#: katalogus/views/plugin_settings_add.py
+msgid "Failed adding settings"
+msgstr "Nie udało się dodać ustawień"
+
+#: katalogus/views/plugin_settings_add.py
+msgid "Enabling {} failed"
+msgstr "Włączenie {} nie powiodło się"
+
+#: katalogus/views/plugin_settings_add.py
+msgid "Boefje '{}' enabled."
+msgstr "Boefje '{}' włączone."
+
+#: katalogus/views/plugin_settings_add.py
+msgid "Add settings"
+msgstr "Dodaj ustawienia"
+
+#: katalogus/views/plugin_settings_delete.py
+msgid "Settings for plugin {} successfully deleted."
+msgstr "Ustawienia wtyczki {} zostały pomyślnie usunięte."
+
+#: katalogus/views/plugin_settings_delete.py
+msgid "Plugin {} has no settings."
+msgstr "Wtyczka {} nie ma żadnych ustawień."
+
+#: katalogus/views/plugin_settings_delete.py
+msgid ""
+"Failed deleting Settings for plugin {}. Check the Katalogus logs for more "
+"info."
+msgstr ""
+"Nie udało się usunąć ustawień wtyczki {}. Więcej informacji znajdziesz w "
+"dziennikach Katalogus."
+
+#: onboarding/forms.py
+msgid ""
+"The clearance level determines how aggressive the object can be scanned by "
+"plugins. A higher clearance level means more aggressive scans are allowed."
+msgstr ""
+"Poziom zezwolenia określa, jak agresywnie obiekt może być skanowany przez "
+"wtyczki. Wyższy poziom zezwolenia oznacza, że ​​dozwolone są bardziej "
+"agresywne skany."
+
+#: onboarding/forms.py tools/forms/ooi.py
+msgid "explanation-clearance-level"
+msgstr "poziom wyjaśnienia"
+
+#: onboarding/forms.py
+msgid "Please enter a valid URL starting with 'http://' or 'https://'."
+msgstr ""
+"Proszę wprowadzić prawidłowy URL rozpoczynający się od 'http://' lub "
+"'https://'."
+
+#: onboarding/templates/partials/onboarding_header.html
+msgid "Onboarding"
+msgstr "Proces wdrażania do firmy nowego pracownika"
+
+#: onboarding/templates/partials/step_1_introduction_text.html
+msgid "Welcome to OpenKAT!"
+msgstr "Witamy w OpenKAT!"
+
+#: onboarding/templates/partials/step_1_introduction_text.html
+msgid ""
+"Welcome to the onboarding of OpenKAT. We will walk you through some steps to"
+" set everything up."
+msgstr ""
+"Witamy na pokładzie OpenKAT. Przeprowadzimy Cię przez kilka kroków, aby "
+"wszystko skonfigurować."
+
+#: onboarding/templates/partials/step_1_introduction_text.html
+msgid ""
+"At the end of this onboarding you have added your first object, created your"
+" first DNS report and learned about some basic concepts used within OpenKAT."
+msgstr ""
+"Pod koniec tego wdrożenia dodałeś swój pierwszy obiekt, stworzyłeś swój "
+"pierwszy raport DNS i poznałeś kilka podstawowych pojęć używanych w OpenKAT."
+
+#: onboarding/templates/partials/step_1_introduction_text.html
+msgid "The full documentation for OpenKAT can be found at:"
+msgstr "Pełną dokumentację dla OpenKAT można znaleźć pod adresem:"
+
+#: onboarding/templates/partials/step_2_organization_text.html
+#: rocky/templates/organizations/organization_add.html
+msgid "Organization setup"
+msgstr "Konfiguracja organizacji"
+
+#: onboarding/templates/partials/step_2_organization_text.html
+msgid ""
+"Please enter the following organization details. The organization name can "
+"be changed later in the interface. The organization code cannot be changed "
+"as this is used by the database."
+msgstr ""
+"Proszę wprowadzić następujące dane organizacyjne. Nazwę organizacji można "
+"zmienić później w interfejsie. Kodu organizacji nie można zmienić, ponieważ "
+"jest on używany przez bazę danych."
+
+#: onboarding/templates/step_10_report.html
+#: reports/report_types/concatenated_report/report.py
+msgid "Report"
+msgstr "Raport"
+
+#: onboarding/templates/step_10_report.html
+msgid "Boefjes are scanning"
+msgstr "Boefjes skanują"
+
+#: onboarding/templates/step_10_report.html
+msgid ""
+"The enabled Boefjes are running in the background to gather the data for "
+"your DNS Report. This may take a few minutes."
+msgstr ""
+"Włączone Boefjes działają w tle, aby zebrać dane do Twojego raportu DNS. "
+"Może to potrwać kilka minut."
+
+#: onboarding/templates/step_10_report.html
+msgid ""
+"In the meantime you can explore OpenKAT and view your DNS Report on the "
+"Reports page once it has been generated."
+msgstr ""
+"W międzyczasie możesz zapoznać się z OpenKAT i wyświetlić swój raport DNS na"
+" stronie Raporty po jego wygenerowaniu."
+
+#: onboarding/templates/step_10_report.html
+msgid "Continue to OpenKAT"
+msgstr "Przejdź do OpenKAT"
+
+#: onboarding/templates/step_1_introduction_registration.html
+#: onboarding/templates/step_1a_introduction.html
+msgid "Let's get started"
+msgstr "Zacznijmy"
+
+#: onboarding/templates/step_2a_organization_setup.html
+#: onboarding/templates/step_2b_organization_update.html
+#: rocky/templates/organizations/organization_add.html
+#: rocky/templates/organizations/organization_settings.html
+#: rocky/templates/partials/organization_properties_table.html
+msgid "Organization details"
+msgstr "Szczegóły organizacji"
+
+#: onboarding/templates/step_2a_organization_setup.html
+#: rocky/templates/forms/json_schema_form.html
+#: rocky/templates/organizations/organization_add.html
+#: rocky/templates/organizations/organization_member_add.html
+#: rocky/templates/organizations/organization_member_add_account_type.html
+#: rocky/templates/partials/elements/ooi_detail_settings.html
+#: rocky/templates/partials/elements/ooi_report_settings.html
+#: rocky/templates/partials/form/indemnification_add_form.html
+#: rocky/templates/two_factor/_wizard_actions.html
+msgid "Submit"
+msgstr "Składać"
+
+#: onboarding/templates/step_2b_organization_update.html
+msgid "Submit changes"
+msgstr "Prześlij zmiany"
+
+#: onboarding/templates/step_2b_organization_update.html
+#: onboarding/templates/step_3_indemnification_setup.html
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+#: onboarding/templates/step_7_clearance_level_introduction.html
+msgid "Continue"
+msgstr "Kontynuować"
+
+#: onboarding/templates/step_3_indemnification_setup.html
+msgid "Indemnification setup"
+msgstr "Konfiguracja zabezpieczenia"
+
+#: onboarding/templates/step_3_indemnification_setup.html
+msgid "Indemnification on the organization is already present."
+msgstr "Zabezpieczenie dla organizacji już istnieje."
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+msgid "User clearance level"
+msgstr "Poziom uprawnień użytkownika"
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+msgid ""
+"The user clearance level specifies the maximum scan level for security scans"
+" and the maximum clearance level you can assign to objects (e.g. a URL)."
+msgstr ""
+"Poziom uprawnień użytkownika określa maksymalny poziom uprawnień dla skanów "
+"bezpieczeństwa oraz maksymalny poziom uprawnień, jaki możesz przypisać do "
+"obiektów (np. URL)."
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+msgid ""
+"The administrator assigns a maximum user clearance level to each user. This "
+"will make sure that only trusted users can start more aggressive scans."
+msgstr ""
+"Administrator przypisuje każdemu użytkownikowi maksymalny poziom uprawnień "
+"użytkownika. Dzięki temu tylko zaufani użytkownicy będą mogli rozpocząć "
+"bardziej agresywne skanowanie."
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+msgid ""
+"A user must accept a clearance level, before they perform actions in "
+"OpenKAT. Here you may accept the maximum trusted clearance level, as "
+"assigned by your administrator. On your user settings page you can choose to"
+" lower your accepted clearance level after completing the onboarding."
+msgstr ""
+"Użytkownik musi zaakceptować poziom uprawnień, zanim podejmie działania w "
+"OpenKAT. Tutaj możesz zaakceptować maksymalny poziom zaufanego "
+"uwierzytelnienia przypisany przez administratora. Na stronie ustawień "
+"użytkownika możesz obniżyć akceptowany poziom uprawnień po zakończeniu "
+"wdrażania."
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+msgid "What is my clearance level?"
+msgstr "Jaki jest mój poziom uprawnień?"
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+#, python-format
+msgid ""
+"Unfortunately you cannot continue the onboarding. </br> Your administrator "
+"has trusted you with a clearance level of <strong>L%(tcl)s</strong>. </br> "
+"You need at least a clearance level of "
+"<strong>L%(dns_report_least_clearance_level)s</strong> to scan "
+"<strong>%(ooi)s</strong> </br> Contact your administrator to receive a "
+"higher clearance."
+msgstr ""
+"Niestety nie możesz kontynuować wdrażania. </br> Twój administrator "
+"powierzył Ci poziom uprawnień <strong>L%(tcl)s</strong>. </br> Potrzebujesz "
+"poziomu uprawnień co najmniej "
+"<strong>L%(dns_report_least_clearance_level)s</strong>, aby skanować "
+"<strong>%(ooi)s</strong> </br> Skontaktuj się z administratorem, aby "
+"otrzymać wyższe zezwolenie."
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+#: onboarding/templates/step_5_add_scan_ooi.html
+#: onboarding/templates/step_6_set_clearance_level.html
+#: onboarding/templates/step_7_clearance_level_introduction.html
+#: onboarding/templates/step_8_setup_scan_select_plugins.html
+#: onboarding/templates/step_9_choose_report_type.html
+#: rocky/templates/partials/form/boefje_tiles_form.html
+msgid "Skip onboarding"
+msgstr "Pomiń wdrażanie"
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+#, python-format
+msgid ""
+"Your administrator has trusted you with a clearance level of "
+"<strong>L%(tcl)s</strong>. </br> You must first accept this clearance level "
+"to continue."
+msgstr ""
+"Twój administrator powierzył Ci poziom uprawnień <strong>L%(tcl)s</strong>. "
+"</br> Aby kontynuować, musisz najpierw zaakceptować ten poziom uprawnień."
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+#, python-format
+msgid ""
+"Your administrator has <strong>trusted</strong> you with a clearance level "
+"of <strong>L%(tcl)s</strong>."
+msgstr ""
+"Twój administrator powierzył Ci <strong></strong> poziom uprawnień "
+"<strong>L%(tcl)s</strong>."
+
+#: onboarding/templates/step_5_add_scan_ooi.html
+msgid "Add an object"
+msgstr "Dodaj obiekt"
+
+#: onboarding/templates/step_5_add_scan_ooi.html
+msgid ""
+"OpenKAT uses various kinds of objects, like IP addresses, hostnames and "
+"URLs. In the onboarding we will add an URL object, such as our vulnerable "
+"OpenKAT website: https://mispo.es."
+msgstr ""
+"OpenKAT używa różnego rodzaju obiektów, takich jak adresy IP, nazwy hostów i"
+" URLs. Podczas onboardingu dodamy obiekt URL, taki jak nasza podatna na "
+"ataki witryna OpenKAT: https://mispo.es."
+
+#: onboarding/templates/step_5_add_scan_ooi.html
+#: rocky/templates/partials/ooi_detail_related_object.html
+msgid "Related objects"
+msgstr "Powiązane obiekty"
+
+#: onboarding/templates/step_5_add_scan_ooi.html
+msgid ""
+"Most objects have dependencies on the existence of related objects. For "
+"example a URL needs to be connected to a network, hostname, fqdn (fully "
+"qualified domain name) and IP address. When possible OpenKAT automatically "
+"collects and adds these related objects by running scans. Objects can also "
+"be manually added."
+msgstr ""
+"Większość obiektów ma zależności od istnienia powiązanych obiektów. Na "
+"przykład URL musi być podłączony do sieci, nazwy hosta, fqdn (pełna nazwa "
+"domeny) i adresu IP. Jeśli to możliwe, OpenKAT automatycznie zbiera i dodaje"
+" powiązane obiekty, uruchamiając skanowanie. Obiekty można także dodawać "
+"ręcznie."
+
+#: onboarding/templates/step_5_add_scan_ooi.html
+msgid "Create object"
+msgstr "Utwórz obiekt"
+
+#: onboarding/templates/step_6_set_clearance_level.html
+msgid "Set object clearance level"
+msgstr "Ustaw poziom prześwitu obiektu"
+
+#: onboarding/templates/step_6_set_clearance_level.html
+msgid ""
+"After creating a new object you can set a clearance level for this object. A"
+" clearance level determines how aggressive the object can be scanned. A "
+"higher clearance level, means that more aggressive scans are allowed. "
+"Clearance levels can always be adjusted later on."
+msgstr ""
+"Po utworzeniu nowego obiektu możesz ustawić poziom zezwolenia dla tego "
+"obiektu. Poziom zezwolenia określa, jak agresywnie można skanować obiekt. "
+"Wyższy poziom zezwolenia oznacza, że ​​dozwolone są bardziej agresywne "
+"skany. Poziomy luzu można zawsze dostosować później."
+
+#: onboarding/templates/step_6_set_clearance_level.html
+#, python-format
+msgid ""
+"For the onboarding we use a clearance level of "
+"L%(dns_report_least_clearance_level)s, meaning only informational scans are "
+"allowed."
+msgstr ""
+"Do wdrożenia używamy poziomu uprawnień "
+"L%(dns_report_least_clearance_level)s, co oznacza, że ​​dozwolone są tylko "
+"skany informacyjne."
+
+#: onboarding/templates/step_6_set_clearance_level.html
+msgid "Set clearance level"
+msgstr "Ustaw poziom luzu"
+
+#: onboarding/templates/step_7_clearance_level_introduction.html
+msgid "Plugin introduction"
+msgstr "Wprowadzenie do wtyczki"
+
+#: onboarding/templates/step_7_clearance_level_introduction.html
+msgid ""
+"OpenKAT uses plugins to scan your objects. Each plugin has a scan level to "
+"specify how aggressive the scan is. Plugins can only scan those objects with"
+" a clearance level that is equal to, or higher than the scan level of the "
+"plugin. Plugin scan level are indicated by the number of cat paws."
+msgstr ""
+"OpenKAT używa wtyczek do skanowania Twoich obiektów. Każda wtyczka ma poziom"
+" skanowania, który określa, jak agresywne jest skanowanie. Wtyczki mogą "
+"skanować tylko te obiekty z poziomem uprawnień równym lub wyższym od poziomu"
+" skanowania wtyczki. Poziom skanowania wtyczki jest wskazywany przez liczbę "
+"kocich łap."
+
+#: onboarding/templates/step_7_clearance_level_introduction.html
+msgid ""
+"The plugin <strong>DNS Zone</strong> has a scan level of 1, meaning that it "
+"performs non-intrusive scans which look for publicly available information. "
+"It scans objects with a clearance level of 1 or higher."
+msgstr ""
+"Wtyczka <strong>DNS Strefa</strong> ma poziom skanowania 1, co oznacza, że "
+"​​wykonuje nieinwazyjne skanowanie w poszukiwaniu publicznie dostępnych "
+"informacji. Skanuje obiekty o poziomie prześwitu 1 lub wyższym."
+
+#: onboarding/templates/step_7_clearance_level_introduction.html
+msgid ""
+"The plugin <strong>Fierce</strong> has a scan level of 3, meaning that it "
+"more aggressive and could potentially break things. It scans objects with a "
+"clearance level of 3 or higher."
+msgstr ""
+"Wtyczka <strong>Fierce</strong> ma poziom skanowania 3, co oznacza, że "
+"​​jest bardziej agresywna i może potencjalnie coś zepsuć. Skanuje obiekty o "
+"poziomie prześwitu 3 lub wyższym."
+
+#: onboarding/templates/step_8_setup_scan_select_plugins.html
+msgid "Enabling plugins and start scanning"
+msgstr "Włącz wtyczki i rozpocznij skanowanie"
+
+#: onboarding/templates/step_8_setup_scan_select_plugins.html
+msgid ""
+"OpenKAT uses plugins to scan, check and analyze. There are three types of "
+"plugins."
+msgstr ""
+"OpenKAT używa wtyczek do skanowania, sprawdzania i analizowania. Istnieją "
+"trzy typy wtyczek."
+
+#: onboarding/templates/step_8_setup_scan_select_plugins.html
+msgid ""
+"The first plugin are <b>Boefjes</b>, which scan objects for data. These are "
+"security tools like nmap, LeakIX and WPscan. </p>"
+msgstr ""
+"Pierwsza wtyczka to <b>Boefjes</b>, która skanuje obiekty w poszukiwaniu "
+"danych. Są to narzędzia bezpieczeństwa, takie jak nmap, LeakIX i WPscan. "
+"</p>"
+
+#: onboarding/templates/step_8_setup_scan_select_plugins.html
+msgid ""
+"The other two plugins are <b>Normalizers</b> and <b>Bits</b>, which are used"
+" to process the output of Boefjes. They can create findings and related "
+"objects. Bits are also used to create organization specific findings, based "
+"on policy requirements. </p>"
+msgstr ""
+"Pozostałe dwie wtyczki to <b>Normalizers</b> i <b>Bits</b>, które służą do "
+"przetwarzania danych wyjściowych Boefjes. Mogą tworzyć znaleziska i "
+"powiązane obiekty. Bity są również wykorzystywane do tworzenia wniosków "
+"specyficznych dla organizacji, w oparciu o wymagania polityczne. </p>"
+
+#: onboarding/templates/step_8_setup_scan_select_plugins.html
+msgid ""
+"For the onboarding we will enable the Boefjes shown below. Once enabled "
+"these Boefjes gather publicly available information on suitable objects with"
+" a clearance level of 1 or higher. Normalizers and Bits are enabled by "
+"default."
+msgstr ""
+"Na potrzeby wdrożenia włączymy Boefjes pokazane poniżej. Po włączeniu te "
+"Boefjes zbierają publicznie dostępne informacje o odpowiednich obiektach z "
+"poziomem dostępu 1 lub wyższym. Normalizers i Bitsy są domyślnie włączone."
+
+#: onboarding/templates/step_8_setup_scan_select_plugins.html
+msgid "Enable and continue"
+msgstr "Włącz i kontynuuj"
+
+#: onboarding/templates/step_9_choose_report_type.html
+msgid "Generate a report"
+msgstr "Wygeneruj raport"
+
+#: onboarding/templates/step_9_choose_report_type.html
+msgid ""
+"Reports can be used to gain more insights in your organizations assets. You "
+"can generate different types of reports in OpenKAT. Each report may require "
+"one or more plugins that provide the input for the report."
+msgstr ""
+"Raporty można wykorzystać do uzyskania większej wiedzy na temat zasobów "
+"organizacji. Możesz generować różne typy raportów w OpenKAT. Każdy raport "
+"może wymagać jednej lub większej liczby wtyczek zapewniających dane "
+"wejściowe do raportu."
+
+#: onboarding/templates/step_9_choose_report_type.html
+msgid ""
+"For the onboarding we will generate a DNS report for your added URL. In the "
+"previous step you enabled the required plugins for this report."
+msgstr ""
+"Na potrzeby wdrożenia wygenerujemy raport DNS dla Twojego dodanego URL. W "
+"poprzednim kroku włączyłeś wymagane wtyczki dla tego raportu."
+
+#: onboarding/templates/step_9_choose_report_type.html
+msgid "Generate DNS Report"
+msgstr "Wygeneruj raport DNS"
+
+#: onboarding/view_helpers.py
+msgid "1: Welcome"
+msgstr "1: Witamy"
+
+#: onboarding/view_helpers.py
+msgid "2: Organization setup"
+msgstr "2: Konfiguracja organizacji"
+
+#: onboarding/view_helpers.py
+msgid "3: Add object"
+msgstr "3: Dodaj obiekt"
+
+#: onboarding/view_helpers.py
+msgid "4: Plugins"
+msgstr "4: Wtyczki"
+
+#: onboarding/view_helpers.py
+msgid "5: Generating report"
+msgstr "5: Generowanie raportu"
+
+#: onboarding/views.py
+#, python-brace-format
+msgid "{org_name} successfully created."
+msgstr "{org_name} pomyślnie utworzono."
+
+#: onboarding/views.py
+#, python-brace-format
+msgid "{org_name} successfully updated."
+msgstr "{org_name} pomyślnie zaktualizowano."
+
+#: onboarding/views.py
+msgid "Creating an object"
+msgstr "Tworzenie obiektu"
+
+#: onboarding/views.py
+msgid "Fetch the parent DNS zone of a hostname"
+msgstr "Pobierz strefę nadrzędną DNS nazwy hosta"
+
+#: onboarding/views.py
+msgid "Finds subdomains by brute force"
+msgstr "Znajduje subdomeny metodą brutalnej siły"
+
+#: onboarding/views.py
+msgid "Please select a plugin to proceed."
+msgstr "Aby kontynuować, wybierz wtyczkę."
+
+#: onboarding/views.py
+msgid "Please select all required plugins to proceed."
+msgstr "Aby kontynuować, wybierz wszystkie wymagane wtyczki."
+
+#: onboarding/views.py reports/views/aggregate_report.py
+#: reports/views/generate_report.py
+msgid "An error occurred while enabling {}. The plugin is not available."
+msgstr "Wystąpił błąd podczas włączania {}. Wtyczka nie jest dostępna."
+
+#: onboarding/views.py
+msgid "Plugins successfully enabled."
+msgstr "Wtyczki zostały pomyślnie włączone."
+
+#: onboarding/views.py
+msgid "Web URL not found."
+msgstr "Nie znaleziono sieci URL."
+
+#: onboarding/views.py
+msgid ""
+"Your report is scheduled for generation in about 3 minutes, as we are "
+"waiting for Boefjes to complete. In the meantime get familiar with OpenKAT "
+"and visit the Reports History tab later."
+msgstr ""
+"Wygenerowanie Twojego raportu zaplanowano na około 3 minuty, ponieważ "
+"czekamy na zakończenie Boefjes. W międzyczasie zapoznaj się z OpenKAT i "
+"odwiedź później kartę Historia raportów."
+
+#: reports/forms.py tools/forms/ooi_form.py
+msgid "Filter by OOI types"
+msgstr "Filtruj według typów OOI"
+
+#: reports/forms.py
+msgid "Today"
+msgstr "Dzisiaj"
+
+#: reports/forms.py
+msgid "Different date"
+msgstr "Inna data"
+
+#: reports/forms.py
+msgid "No, just once"
+msgstr "Nie, tylko raz"
+
+#: reports/forms.py
+msgid "Yes, repeat"
+msgstr "Tak, powtórz"
+
+#: reports/forms.py
+msgid "Start date"
+msgstr "Data rozpoczęcia"
+
+#: reports/forms.py
+msgid "Start time (UTC)"
+msgstr "Czas rozpoczęcia (UTC)"
+
+#: reports/forms.py
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Recurrence"
+msgstr "Nawrót"
+
+#: reports/forms.py
+msgid "No recurrence, just once"
+msgstr "Żadnych powtórzeń, tylko raz"
+
+#: reports/forms.py
+msgid "Daily"
+msgstr "Codziennie"
+
+#: reports/forms.py
+msgid "Weekly"
+msgstr "Tygodnik"
+
+#: reports/forms.py
+msgid "Monthly"
+msgstr "Miesięczny"
+
+#: reports/forms.py
+msgid "Yearly"
+msgstr "Rocznie"
+
+#: reports/forms.py
+msgid "day"
+msgstr "dzień"
+
+#: reports/forms.py
+msgid "week"
+msgstr "tydzień"
+
+#: reports/forms.py
+msgid "month"
+msgstr "miesiąc"
+
+#: reports/forms.py
+msgid "year"
+msgstr "rok"
+
+#: reports/forms.py
+msgid "Never"
+msgstr "Nigdy"
+
+#: reports/forms.py
+msgid "On"
+msgstr "NA"
+
+#: reports/forms.py
+msgid "After"
+msgstr "Po"
+
+#: reports/forms.py
+msgid "Report name format"
+msgstr "Format nazwy raportu"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: reports/report_types/multi_organization_report/appendix.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Appendix"
+msgstr "Załącznik"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Currently filtered on"
+msgstr "Aktualnie filtrowane"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: reports/templates/partials/report_sidemenu.html
+#: reports/templates/summary/report_asset_overview.html
+msgid "Selected Report Types"
+msgstr "Wybrane typy raportów"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Selected report types"
+msgstr "Wybrane typy raportów"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: reports/templates/partials/plugin_overview_table.html
+#: reports/templates/report_overview/modal_partials/rename_modal.html
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+#: reports/templates/report_overview/subreports_table.html
+#: reports/templates/summary/report_asset_overview.html
+msgid "Report type"
+msgstr "Typ raportu"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Service Versions and Health"
+msgstr "Wersje usług i kondycja"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Service, version and health"
+msgstr "Serwis, wersja i stan zdrowia"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: reports/templates/summary/service_health.html rocky/templates/footer.html
+#: rocky/templates/health.html
+msgid "Service"
+msgstr "Praca"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: reports/templates/summary/service_health.html rocky/templates/health.html
+msgid "Version"
+msgstr "Wersja"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: rocky/templates/footer.html rocky/views/health.py
+msgid "Health"
+msgstr "Zdrowie"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: rocky/templates/health.html
+msgid "Healthy"
+msgstr "Zdrowy"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Unhealthy"
+msgstr "Niezdrowy"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Used Config objects"
+msgstr "Używane obiekty konfiguracyjne"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Used config objects"
+msgstr "Używane obiekty konfiguracyjne"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Primary Key"
+msgstr "Klucz podstawowy"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Bit ID"
+msgstr "Identyfikator bitowy"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Config"
+msgstr "Konfig"
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "No config objects found."
+msgstr "Nie znaleziono obiektów konfiguracyjnych."
+
+#: reports/report_types/aggregate_organisation_report/asset_overview.html
+#: reports/report_types/multi_organization_report/asset_overview.html
+#: reports/templates/partials/generate_report_sidemenu.html
+#: reports/templates/partials/report_sidemenu.html
+#: reports/templates/summary/report_asset_overview.html
+msgid "Asset overview"
+msgstr "Przegląd zasobów"
+
+#: reports/report_types/aggregate_organisation_report/asset_overview.html
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid ""
+"An overview of the manually released scanned assets. Assets in "
+"<strong>bold</strong> are taken as a starting point, assets that are not in "
+"bold were found by OpenKAT itself."
+msgstr ""
+"Przegląd ręcznie zwolnionych zeskanowanych zasobów. Zasoby oznaczone "
+"<strong>pogrubione</strong> są brane za punkt wyjścia, zasoby, które nie są "
+"pogrubione, zostały znalezione przez samo OpenKAT."
+
+#: reports/report_types/aggregate_organisation_report/basic_security.html
+#: reports/report_types/aggregate_organisation_report/report.html
+msgid "Overview of the basic security status"
+msgstr "Przegląd podstawowego stanu bezpieczeństwa"
+
+#: reports/report_types/aggregate_organisation_report/basic_security.html
+msgid ""
+"This table provides an overview of the basic security status of the known "
+"assets. Basic security in order. In principle, all values in this table "
+"should be checked off."
+msgstr ""
+"Tabela ta zawiera przegląd podstawowego stanu zabezpieczeń znanych zasobów. "
+"Podstawowe zabezpieczenia w porządku. W zasadzie wszystkie wartości w tej "
+"tabeli należy zaznaczyć."
+
+#: reports/report_types/aggregate_organisation_report/basic_security.html
+msgid "Basic security status"
+msgstr "Podstawowy stan bezpieczeństwa"
+
+#: reports/report_types/aggregate_organisation_report/basic_security.html
+#: reports/report_types/ipv6_report/report.html
+#: reports/report_types/multi_organization_report/ipv6.html
+#: reports/report_types/systems_report/report.html
+msgid "System type"
+msgstr "Typ systemu"
+
+#: reports/report_types/aggregate_organisation_report/basic_security.html
+#: reports/report_types/aggregate_organisation_report/report.html
+#: reports/report_types/multi_organization_report/basic_security_details.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Safe connections"
+msgstr "Bezpieczne połączenia"
+
+#: reports/report_types/aggregate_organisation_report/basic_security.html
+msgid "System Specific"
+msgstr "Specyficzne dla systemu"
+
+#: reports/report_types/aggregate_organisation_report/basic_security.html
+msgid "RPKI"
+msgstr "RPKI"
+
+#: reports/report_types/aggregate_organisation_report/basic_security.html
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/rpki_report/report.html
+#: reports/report_types/safe_connections_report/report.html
+msgid "server"
+msgstr "serwer"
+
+#: reports/report_types/aggregate_organisation_report/findings.html
+#: reports/report_types/aggregate_organisation_report/report.html
+msgid ""
+"This chapter contains information about the findings that have been "
+"identified for this organization."
+msgstr ""
+"W tym rozdziale znajdują się informacje na temat ustaleń zidentyfikowanych w"
+" przypadku tej organizacji."
+
+#: reports/report_types/aggregate_organisation_report/recommendations.html
+#: reports/report_types/multi_organization_report/recommendations.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Recommendations"
+msgstr "Zalecenia"
+
+#: reports/report_types/aggregate_organisation_report/recommendations.html
+#, python-format
+msgid "There is <i>%(total_findings)s</i> vulnerability"
+msgid_plural "There are <i>%(total_findings)s</i> vulnerabilities"
+msgstr[0] "Występuje luka w zabezpieczeniach <i>%(total_findings)s</i>"
+msgstr[1] "Występują <i>%(total_findings)s</i> luki w zabezpieczeniach"
+msgstr[2] "Występują <i>%(total_findings)s</i> luki w zabezpieczeniach"
+
+#: reports/report_types/aggregate_organisation_report/recommendations.html
+#, python-format
+msgid "found on <i>%(total_systems)s</i> system."
+msgid_plural "found on <i>%(total_systems)s</i> systems."
+msgstr[0] "znaleziony w systemie <i>%(total_systems)s</i>."
+msgstr[1] "znaleziony w systemach <i>%(total_systems)s</i>."
+msgstr[2] "znaleziony w systemach <i>%(total_systems)s</i>."
+
+#: reports/report_types/aggregate_organisation_report/recommendations.html
+#: reports/report_types/multi_organization_report/recommendations.html
+msgid "There are no recommendations."
+msgstr "Nie ma żadnych zaleceń."
+
+#: reports/report_types/aggregate_organisation_report/report.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Basic security"
+msgstr "Podstawowe bezpieczeństwo"
+
+#: reports/report_types/aggregate_organisation_report/report.html
+msgid ""
+"In this chapter, first a table of compliance checks is displayed, followed "
+"by a detailed examination of compliance issues for each component."
+msgstr ""
+"W tym rozdziale najpierw wyświetlana jest tabela kontroli zgodności, a "
+"następnie szczegółowe badanie kwestii zgodności dla każdego komponentu."
+
+#: reports/report_types/aggregate_organisation_report/report.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "System specific"
+msgstr "Specyficzne dla systemu"
+
+#: reports/report_types/aggregate_organisation_report/report.html
+#: reports/report_types/multi_organization_report/basic_security_details.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Resource Public Key Infrastructure"
+msgstr "Infrastruktura klucza publicznego zasobów"
+
+#: reports/report_types/aggregate_organisation_report/report.html
+#: reports/report_types/aggregate_organisation_report/vulnerabilities.html
+#: reports/report_types/multi_organization_report/vulnerabilities.html
+#: reports/report_types/vulnerability_report/report.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Vulnerabilities"
+msgstr "Luki"
+
+#: reports/report_types/aggregate_organisation_report/report.html
+#: reports/report_types/aggregate_organisation_report/vulnerabilities.html
+msgid "Vulnerabilities found are grouped per system."
+msgstr "Wykryte luki są pogrupowane według systemów."
+
+#: reports/report_types/aggregate_organisation_report/report.py
+msgid "Aggregate Organisation Report"
+msgstr "Zbiorczy raport organizacji"
+
+#: reports/report_types/aggregate_organisation_report/rpki.html
+#: reports/report_types/multi_organization_report/basic_security_details.html
+msgid ""
+"This section contains basic security information about resource public key "
+"infrastructure. If your web server employs RPKI for its IP addresses and "
+"associated nameservers, then it enhances visitor protection against "
+"misconfigurations and malicious route intercepts through verified route "
+"announcements, ensuring reliable server access and secure internet traffic."
+msgstr ""
+"Ta sekcja zawiera podstawowe informacje dotyczące bezpieczeństwa dotyczące "
+"infrastruktury klucza publicznego zasobów. Jeśli Twój serwer internetowy "
+"wykorzystuje RPKI dla swoich adresów IP i powiązanych serwerów nazw, "
+"zwiększa ochronę odwiedzających przed błędnymi konfiguracjami i złośliwym "
+"przechwytywaniem tras poprzez zweryfikowane ogłoszenia o trasach, "
+"zapewniając niezawodny dostęp do serwera i bezpieczny ruch internetowy."
+
+#: reports/report_types/aggregate_organisation_report/safe_connections.html
+#: reports/report_types/multi_organization_report/basic_security_details.html
+msgid ""
+"In this chapter we check if the connections of all the IP ports of the "
+"system are safe. Safe connections are important to prevent unauthorised "
+"access and data breaches. Strong ciphers are crucial because they ensure "
+"strong encryption which protects the data from interception during "
+"communiction."
+msgstr ""
+"W tym rozdziale sprawdzamy czy połączenia wszystkich portów IP systemu są "
+"bezpieczne. Bezpieczne połączenia są ważne, aby zapobiec nieautoryzowanemu "
+"dostępowi i naruszeniom danych. Silne szyfry są kluczowe, ponieważ "
+"zapewniają silne szyfrowanie, które chroni dane przed przechwyceniem podczas"
+" komunikacji."
+
+#: reports/report_types/aggregate_organisation_report/summary.html
+#: reports/report_types/multi_organization_report/summary.html
+#: rocky/views/ooi_tree.py
+msgid "Summary"
+msgstr "Streszczenie"
+
+#: reports/report_types/aggregate_organisation_report/summary.html
+msgid "Critical Vulnerabilities"
+msgstr "Krytyczne luki w zabezpieczeniach"
+
+#: reports/report_types/aggregate_organisation_report/summary.html
+msgid "IPs scanned"
+msgstr "IPs zeskanowano"
+
+#: reports/report_types/aggregate_organisation_report/summary.html
+msgid "Hostnames scanned"
+msgstr "Przeskanowano nazwy hostów"
+
+#: reports/report_types/aggregate_organisation_report/summary.html
+msgid "Terms in report"
+msgstr "Warunki w raporcie"
+
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/rpki_report/report.html
+#: reports/report_types/safe_connections_report/report.html
+#, python-format
+msgid ""
+"This table shows which checks were performed. Following that, the compliance"
+" issues, if any, are shown for each %(type)s Server."
+msgstr ""
+"W poniższej tabeli przedstawiono, jakie kontrole zostały przeprowadzone. "
+"Następnie dla każdego serwera %(type)s zostaną wyświetlone ewentualne "
+"problemy ze zgodnością."
+
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+msgid "Check overview"
+msgstr "Sprawdź przegląd"
+
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/mail_report/report.html
+#: reports/report_types/multi_organization_report/basic_security_details.html
+#: reports/report_types/name_server_report/report.html
+#: reports/report_types/rpki_report/report.html
+#: reports/report_types/safe_connections_report/report.html
+#: reports/report_types/web_system_report/report.html
+msgid "Check"
+msgstr "Sprawdzać"
+
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/mail_report/report.html
+#: reports/report_types/name_server_report/report.html
+#: reports/report_types/rpki_report/report.html
+#: reports/report_types/safe_connections_report/report.html
+#: reports/report_types/web_system_report/report.html
+msgid "Compliance"
+msgstr "Zgodność"
+
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/rpki_report/report.html
+msgid "IPs are compliant"
+msgstr "IPs są zgodne"
+
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/safe_connections_report/report.html
+#: reports/report_types/vulnerability_report/report.html
+msgid "Host:"
+msgstr "Gospodarz:"
+
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/mail_report/report.html
+#: reports/report_types/name_server_report/report.html
+#: reports/report_types/rpki_report/report.html
+#: reports/report_types/safe_connections_report/report.html
+#: reports/report_types/web_system_report/report.html
+msgid "Compliance issue"
+msgstr "Problem zgodności"
+
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/mail_report/report.html
+#: reports/report_types/name_server_report/report.html
+#: reports/report_types/rpki_report/report.html
+#: reports/report_types/safe_connections_report/report.html
+#: reports/report_types/vulnerability_report/report.html
+#: reports/report_types/web_system_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/partials/report_severity_totals_table.html
+#: rocky/templates/partials/ooi_report_findings_block_table.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid "Risk level"
+msgstr "Poziom ryzyka"
+
+#: reports/report_types/aggregate_organisation_report/system_specific_overview.html
+#: reports/report_types/multi_organization_report/basic_security_details.html
+msgid ""
+"This is where checks are done that are specific to system types. Different "
+"security and compliance issues come into play for different systems. They "
+"are listed here under each other."
+msgstr ""
+"W tym miejscu przeprowadzane są kontrole specyficzne dla typów systemów. W "
+"przypadku różnych systemów wchodzą w grę różne kwestie związane z "
+"bezpieczeństwem i zgodnością. Są one wymienione tutaj pod sobą."
+
+#: reports/report_types/aggregate_organisation_report/term_overview.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Term Overview"
+msgstr "Przegląd terminów"
+
+#: reports/report_types/aggregate_organisation_report/term_overview.html
+msgid "For definitions of terms used in this chapter, see the glossary below."
+msgstr ""
+"Definicje terminów używanych w tym rozdziale można znaleźć w słowniczku "
+"poniżej."
+
+#: reports/report_types/aggregate_organisation_report/term_overview.html
+msgid ""
+"Web servers and domains are examples of digital assets within this "
+"framework. Web servers are essential for hosting and serving websites or web"
+" applications, while domains represent the online addresses used to access "
+"these resources. Other examples of assets in the IT realm include databases,"
+" user accounts, software applications, and networking infrastructure. Asset "
+"management is a critical aspect of cybersecurity, involving the "
+"identification, classification, and protection of these assets to safeguard "
+"against threats and ensure the overall security and functionality of an "
+"organization's IT environment."
+msgstr ""
+"Serwery internetowe i domeny są przykładami zasobów cyfrowych w tym "
+"kontekście. Serwery internetowe są niezbędne do hostingu i obsługi witryn "
+"internetowych lub aplikacji internetowych, natomiast domeny reprezentują "
+"adresy internetowe używane w celu uzyskania dostępu do tych zasobów. Inne "
+"przykłady zasobów w dziedzinie IT obejmują bazy danych, konta użytkowników, "
+"aplikacje i infrastrukturę sieciową. Zarządzanie aktywami to krytyczny "
+"aspekt cyberbezpieczeństwa, obejmujący identyfikację, klasyfikację i ochronę"
+" tych aktywów w celu ochrony przed zagrożeniami oraz zapewnienia ogólnego "
+"bezpieczeństwa i funkcjonalności środowiska IT organizacji."
+
+#: reports/report_types/aggregate_organisation_report/term_overview.html
+msgid ""
+"Multiple hostnames that resolve to one IP address where at least one of the "
+"hostnames or the IP address has a declared scan level that is at least L1. "
+"Type systems are web servers, mail servers and name servers (DNS)."
+msgstr ""
+"Wiele nazw hostów dających się rozwiązać na jeden adres IP, gdzie co "
+"najmniej jedna z nazw hostów lub adres IP ma zadeklarowany poziom skanowania"
+" co najmniej L1. Systemy typów to serwery WWW, serwery pocztowe i serwery "
+"nazw (DNS)."
+
+#: reports/report_types/aggregate_organisation_report/term_overview.html
+msgid ""
+"A fundamental component of the client-server model. A web server uses "
+"protocols like HTTP or HTTPS to facilitate communication between clients and"
+" the server."
+msgstr ""
+"Podstawowy element modelu klient-serwer. Serwer WWW używa protokołów takich "
+"jak HTTP lub HTTPS w celu ułatwienia komunikacji pomiędzy klientami a "
+"serwerem."
+
+#: reports/report_types/aggregate_organisation_report/term_overview.html
+msgid ""
+"A mail server is a specialized software application or hardware device that "
+"facilitates the sending, receiving, and storage of emails within a computer "
+"network. Operating on the Simple Mail Transfer Protocol (SMTP) for outgoing "
+"messages and either Internet Message Access Protocol (IMAP) or Post Office "
+"Protocol (POP) for incoming messages, a mail server manages email "
+"communication by routing messages between users and storing them until they "
+"are retrieved. The server ensures the efficient and secure transfer of "
+"emails, handling tasks such as authentication, spam filtering, and message "
+"storage."
+msgstr ""
+"Serwer pocztowy to wyspecjalizowana aplikacja lub urządzenie sprzętowe, "
+"które ułatwia wysyłanie, odbieranie i przechowywanie wiadomości e-mail w "
+"sieci komputerowej. Działając w oparciu o protokół Simple Mail Transfer "
+"Protocol (SMTP) dla wiadomości wychodzących oraz protokół Internet Message "
+"Access Protocol (IMAP) lub protokół Post Office (POP) dla wiadomości "
+"przychodzących, serwer pocztowy zarządza komunikacją e-mail, kierując "
+"wiadomości między użytkownikami i przechowując je do czasu ich pobrania. "
+"Serwer zapewnia sprawny i bezpieczny transfer poczty elektronicznej, "
+"obsługując takie zadania jak uwierzytelnianie, filtrowanie spamu i "
+"przechowywanie wiadomości."
+
+#: reports/report_types/aggregate_organisation_report/term_overview.html
+msgid ""
+"A nameserver, or Domain Name System (DNS) server, is a critical component of"
+" the internet infrastructure responsible for translating human-readable "
+"domain names into IP addresses, enabling the seamless navigation of the web."
+" When a user enters a domain name in a web browser, the nameserver is "
+"queried to obtain the corresponding IP address of the server hosting the "
+"associated website or service."
+msgstr ""
+"Serwer nazw, czyli serwer systemu nazw domen (DNS), to krytyczny element "
+"infrastruktury internetowej odpowiedzialny za tłumaczenie czytelnych dla "
+"człowieka nazw domen na adresy IP, umożliwiające bezproblemową nawigację w "
+"sieci. Kiedy użytkownik wprowadza nazwę domeny w przeglądarce internetowej, "
+"serwer nazw jest proszony o uzyskanie odpowiedniego adresu IP serwera "
+"hostującego powiązaną witrynę lub usługę."
+
+#: reports/report_types/aggregate_organisation_report/term_overview.html
+msgid ""
+"A DICOM server, which stands for Digital Imaging and Communications in "
+"Medicine, is a specialized server designed for the storage, retrieval, and "
+"exchange of medical images and related information in the healthcare "
+"industry. DICOM is a widely adopted standard that ensures interoperability "
+"and consistency in the communication of medical images and associated data "
+"among different devices and systems, such as medical imaging equipment, "
+"picture archiving and communication systems (PACS), and radiology "
+"information systems (RIS). DICOM servers store and manage patient-specific "
+"medical images, like X-rays, CT scans, and MRIs, utilizing a standardized "
+"format."
+msgstr ""
+"Serwer DICOM, czyli Digital Imaging and Communications in Medicine, to "
+"wyspecjalizowany serwer przeznaczony do przechowywania, wyszukiwania i "
+"wymiany obrazów medycznych i powiązanych informacji w branży opieki "
+"zdrowotnej. DICOM to powszechnie przyjęty standard zapewniający "
+"interoperacyjność i spójność w przesyłaniu obrazów medycznych i powiązanych "
+"danych pomiędzy różnymi urządzeniami i systemami, takimi jak sprzęt do "
+"obrazowania medycznego, systemy archiwizacji zdjęć i komunikacji (PACS) oraz"
+" radiologiczne systemy informacyjne (RIS). Serwery DICOM przechowują i "
+"zarządzają obrazami medycznymi specyficznymi dla pacjenta, takimi jak "
+"zdjęcia rentgenowskie, tomografia komputerowa i rezonans magnetyczny, "
+"wykorzystując ustandaryzowany format."
+
+#: reports/report_types/aggregate_organisation_report/vulnerabilities.html
+#: reports/report_types/multi_organization_report/vulnerabilities.html
+msgid "No CVEs have been found."
+msgstr "Nie znaleziono żadnych CVE."
+
+#: reports/report_types/dns_report/report.html
+msgid "Records found"
+msgstr "Znaleziono zapisy"
+
+#: reports/report_types/dns_report/report.html
+msgid ""
+"The DNS report gives an overview of the DNS records that were found for the "
+"DNSZone. Additionally the security measures table shows whether or not DNS "
+"relating security measures are enabled."
+msgstr ""
+"Raport DNS zawiera przegląd rekordów DNS znalezionych dla strefy DNSZone. "
+"Dodatkowo tabela środków bezpieczeństwa pokazuje, czy DNS powiązane środki "
+"bezpieczeństwa są włączone."
+
+#: reports/report_types/dns_report/report.html
+msgid ""
+"<strong>Disclaimer:</strong> Not all DNSRecords are parsed in OpenKAT. DNS "
+"record types that are parsed and could be displayed in the table are:"
+msgstr ""
+"<strong>Zastrzeżenie:</strong> Nie wszystkie rekordy DNS są analizowane w "
+"OpenKAT. DNS typy rekordów, które są analizowane i które można wyświetlić w "
+"tabeli to:"
+
+#: reports/report_types/dns_report/report.html
+msgid "All existing DNS record types can be found here:"
+msgstr "Wszystkie istniejące typy rekordów DNS można znaleźć tutaj:"
+
+#: reports/report_types/dns_report/report.html
+msgid "Record"
+msgstr "Nagrywać"
+
+#: reports/report_types/dns_report/report.html
+msgid "TTL"
+msgstr "TTL"
+
+#: reports/report_types/dns_report/report.html
+msgid "Data"
+msgstr "Dane"
+
+#: reports/report_types/dns_report/report.html
+msgid "No records have been found."
+msgstr "Nie znaleziono żadnych zapisów."
+
+#: reports/report_types/dns_report/report.html
+msgid "Security measures"
+msgstr "Środki bezpieczeństwa"
+
+#: reports/report_types/dns_report/report.html
+msgid ""
+"The security measures table below shows which DNS relating security measures"
+" are enabled based on the contents of the DNS records."
+msgstr ""
+"Poniższa tabela środków bezpieczeństwa pokazuje, które DNS powiązane środki "
+"bezpieczeństwa są włączone w oparciu o zawartość rekordów DNS."
+
+#: reports/report_types/dns_report/report.html
+#: reports/templates/partials/report_ooi_list.html
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/modal_partials/rerun_modal.html
+#: reports/templates/summary/ooi_selection.html tools/forms/ooi.py
+#: rocky/templates/partials/elements/ooi_tree_condensed_table.html
+#: rocky/templates/partials/explanations.html
+#: rocky/templates/partials/ooi_detail_related_object.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+#: rocky/views/mixins.py
+msgid "Type"
+msgstr "Typ"
+
+#: reports/report_types/dns_report/report.html
+msgid "Yes"
+msgstr "Tak"
+
+#: reports/report_types/dns_report/report.html
+msgid "No"
+msgstr "NIE"
+
+#: reports/report_types/dns_report/report.html
+#: reports/templates/partials/report_findings_table.html
+msgid "Other findings found"
+msgstr "Znaleziono inne ustalenia"
+
+#: reports/report_types/dns_report/report.html
+msgid "Findings information"
+msgstr "Informacje o wynikach"
+
+#: reports/report_types/dns_report/report.py
+msgid "DNS Report"
+msgstr "DNS Raport"
+
+#: reports/report_types/dns_report/report.py
+msgid ""
+"DNS reports focus on domain name system configuration and potential "
+"weaknesses."
+msgstr ""
+"Raporty DNS skupiają się na konfiguracji systemu nazw domen i potencjalnych "
+"słabych stronach."
+
+#: reports/report_types/findings_report/report.html
+msgid ""
+"The Findings Report contains information about the findings that have been "
+"identified for the selected asset and organization."
+msgstr ""
+"Raport ustaleń zawiera informacje o ustaleniach zidentyfikowanych dla "
+"wybranego zasobu i organizacji."
+
+#: reports/report_types/findings_report/report.py
+msgid "Findings Report"
+msgstr "Raport z ustaleń"
+
+#: reports/report_types/findings_report/report.py
+msgid "Shows all the finding types and their occurrences."
+msgstr "Pokazuje wszystkie typy wyników i ich wystąpienia."
+
+#: reports/report_types/ipv6_report/report.html
+msgid ""
+"The IPv6 report provides an overview of the current IPv6 status of the "
+"identified system. The table below shows whether the domain is reachable "
+"over IPv6 or not. A green compliance check is shown if this is the case. A "
+"grey compliance cross is shown if no IPv6 address was detected."
+msgstr ""
+"Raport IPv6 zawiera przegląd bieżącego stanu IPv6 zidentyfikowanego systemu."
+" Poniższa tabela pokazuje, czy domena jest osiągalna przez IPv6, czy nie. W "
+"takim przypadku wyświetlana jest zielona kontrola zgodności. Jeśli nie "
+"wykryto adresu IPv6, wyświetlany jest szary krzyżyk zgodności."
+
+#: reports/report_types/ipv6_report/report.html
+msgid "IPv6 overview"
+msgstr "Przegląd IPv6"
+
+#: reports/report_types/ipv6_report/report.html
+#: reports/report_types/systems_report/report.html
+msgid "Domain"
+msgstr "Domena"
+
+#: reports/report_types/ipv6_report/report.py
+msgid "IPv6 Report"
+msgstr "IPv6 Raport"
+
+#: reports/report_types/ipv6_report/report.py
+msgid "Check whether hostnames point to IPv6 addresses."
+msgstr "Sprawdź, czy nazwy hostów wskazują adresy IPv6."
+
+#: reports/report_types/mail_report/report.html
+msgid ""
+"The Mail Report provides an overview of the compliance checks associated "
+"with email servers. The current compliance checks the presence of SPF, DKIM "
+"and DMARC records. The table below shows for each of these checks how many "
+"of the identified mail servers are compliant, and if applicable a compliance"
+" issue description and risk level. The risk level may be different for your "
+"specific environment."
+msgstr ""
+"Raport poczty zawiera przegląd kontroli zgodności związanych z serwerami "
+"poczty e-mail. Aktualna zgodność sprawdza obecność rekordów SPF, DKIM i "
+"DMARC. Poniższa tabela pokazuje dla każdej z tych kontroli, ile "
+"zidentyfikowanych serwerów pocztowych jest zgodnych oraz, jeśli ma to "
+"zastosowanie, opis problemu związanego ze zgodnością i poziom ryzyka. Poziom"
+" ryzyka może być inny w zależności od konkretnego środowiska."
+
+#: reports/report_types/mail_report/report.html
+msgid "Mailserver compliance"
+msgstr "Zgodność serwera pocztowego"
+
+#: reports/report_types/mail_report/report.html
+msgid "mailservers compliant"
+msgstr "zgodne z serwerami pocztowymi"
+
+#: reports/report_types/mail_report/report.html
+msgid "No mailservers have been found on this system."
+msgstr "W tym systemie nie znaleziono żadnych serwerów pocztowych."
+
+#: reports/report_types/mail_report/report.py
+msgid "Mail Report"
+msgstr "Raport pocztowy"
+
+#: reports/report_types/mail_report/report.py
+msgid ""
+"System specific Mail Report that focusses on IP addresses and hostnames."
+msgstr ""
+"Raport pocztowy specyficzny dla systemu, który koncentruje się na adresach "
+"IP i nazwach hostów."
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid "Overview of included assets"
+msgstr "Przegląd uwzględnionych zasobów"
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid "Asset"
+msgstr "Zaleta"
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+#: reports/report_types/multi_organization_report/basic_security_details.html
+msgid "Amount"
+msgstr "Kwota"
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid "IP addresses"
+msgstr "IP adresy"
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid "Domain names"
+msgstr "Nazwy domen"
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid "Assets with most critical vulnerabilities"
+msgstr "Zasoby z najbardziej krytycznymi lukami w zabezpieczeniach"
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid "Vulnerability"
+msgstr "Wrażliwość"
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid "Organisation"
+msgstr "Organizacja"
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid "No vulnerabilities found."
+msgstr "Nie znaleziono żadnych luk."
+
+#: reports/report_types/multi_organization_report/basic_security_details.html
+msgid "Overview of safe connections"
+msgstr "Przegląd bezpiecznych połączeń"
+
+#: reports/report_types/multi_organization_report/basic_security_details.html
+#: reports/report_types/safe_connections_report/report.html
+msgid "Only Safe Ciphers"
+msgstr "Tylko bezpieczne szyfry"
+
+#: reports/report_types/multi_organization_report/basic_security_details.html
+#: reports/report_types/safe_connections_report/report.html
+msgid "services are compliant"
+msgstr "usługi są zgodne"
+
+#: reports/report_types/multi_organization_report/basic_security_details.html
+msgid "System specific checks"
+msgstr "Kontrole specyficzne dla systemu"
+
+#: reports/report_types/multi_organization_report/ipv6.html
+msgid "IPv6"
+msgstr "IPv6"
+
+#: reports/report_types/multi_organization_report/ipv6.html
+msgid ""
+"IPv6 includes improvements in security features compared to IPv4. While IPv4"
+" can implement security measures, IPv6 was designed with security in mind, "
+"and its adoption can contribute to a more secure internet."
+msgstr ""
+"IPv6 zawiera ulepszenia funkcji bezpieczeństwa w porównaniu do IPv4. Chociaż"
+" IPv4 może wdrożyć środki bezpieczeństwa, IPv6 został zaprojektowany z myślą"
+" o bezpieczeństwie, a jego przyjęcie może przyczynić się do "
+"bezpieczniejszego Internetu."
+
+#: reports/report_types/multi_organization_report/ipv6.html
+msgid "In total "
+msgstr "W sumie"
+
+#: reports/report_types/multi_organization_report/ipv6.html
+msgid " out of "
+msgstr "z"
+
+#: reports/report_types/multi_organization_report/ipv6.html
+msgid " systems have an IPv6 connection."
+msgstr "systemy mają połączenie IPv6."
+
+#: reports/report_types/multi_organization_report/ipv6.html
+msgid "Overview of IP version compliance"
+msgstr "Omówienie zgodności wersji IP"
+
+#: reports/report_types/multi_organization_report/open_ports.html
+msgid ""
+"See an overview of open ports found over all systems and the services these "
+"systems provide."
+msgstr ""
+"Zobacz przegląd otwartych portów znalezionych we wszystkich systemach i "
+"usługach świadczonych przez te systemy."
+
+#: reports/report_types/multi_organization_report/open_ports.html
+msgid "Overview of detected open ports"
+msgstr "Przegląd wykrytych otwartych portów"
+
+#: reports/report_types/multi_organization_report/open_ports.html
+#: reports/report_types/open_ports_report/report.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Open ports"
+msgstr "Otwórz porty"
+
+#: reports/report_types/multi_organization_report/open_ports.html
+msgid "Occurrences (IP addresses)"
+msgstr "Zdarzenia (adresy IP)"
+
+#: reports/report_types/multi_organization_report/open_ports.html
+#: reports/templates/summary/service_health.html
+msgid "Services"
+msgstr "Usługi"
+
+#: reports/report_types/multi_organization_report/open_ports.html
+msgid "No open ports found."
+msgstr "Nie znaleziono otwartych portów."
+
+#: reports/report_types/multi_organization_report/recommendations.html
+msgid "Overview of recommendations"
+msgstr "Przegląd zaleceń"
+
+#: reports/report_types/multi_organization_report/recommendations.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid "Occurrence"
+msgstr "Występowanie"
+
+#: reports/report_types/multi_organization_report/report.html
+msgid "No findings have been identified yet."
+msgstr "Nie zidentyfikowano jeszcze żadnych ustaleń."
+
+#: reports/report_types/multi_organization_report/report.py
+msgid "Multi Organization Report"
+msgstr "Raport wielu organizacji"
+
+#: reports/report_types/multi_organization_report/summary.html
+msgid "Best scoring security check"
+msgstr "Najlepsza kontrola bezpieczeństwa punktacji"
+
+#: reports/report_types/multi_organization_report/summary.html
+msgid "Worst scoring security check"
+msgstr "Najgorsza kontrola bezpieczeństwa punktacji"
+
+#: reports/report_types/multi_organization_report/vulnerabilities.html
+msgid ""
+"Vulnerabilities found are grouped per system. Here, we only consider CVE "
+"vulnerabilities."
+msgstr ""
+"Wykryte luki są pogrupowane według systemów. W tym przypadku bierzemy pod "
+"uwagę jedynie luki w zabezpieczeniach CVE."
+
+#: reports/report_types/multi_organization_report/vulnerabilities.html
+msgid "Vulnerabilities grouped per system"
+msgstr "Luki pogrupowane według systemu"
+
+#: reports/report_types/multi_organization_report/vulnerabilities.html
+msgid "total"
+msgstr "całkowity"
+
+#: reports/report_types/name_server_report/report.html
+msgid ""
+"The Name Server Report provides an overview of the compliance checks that "
+"were performed against the identified Domain Name Servers (DNS). The "
+"compliance checks verify the presence and validity of DNSSEC and whether no "
+"unnecessary ports were identified to be open. The table below gives an "
+"overview of the available checks including whether the system passed the "
+"performed checks. The risk level and reasoning as to why an issue was "
+"identified are shown too. The risk level may be different for your specific "
+"environment."
+msgstr ""
+"Raport serwera nazw zawiera przegląd kontroli zgodności przeprowadzonych w "
+"odniesieniu do zidentyfikowanych serwerów nazw domen (DNS). Kontrole "
+"zgodności sprawdzają obecność i ważność DNSSEC oraz czy nie zidentyfikowano "
+"żadnych niepotrzebnych portów jako otwartych. Poniższa tabela zawiera "
+"przegląd dostępnych kontroli, w tym to, czy system przeszedł pomyślnie "
+"przeprowadzone kontrole. Pokazano także poziom ryzyka i uzasadnienie "
+"zidentyfikowania problemu. Poziom ryzyka może być inny w zależności od "
+"konkretnego środowiska."
+
+#: reports/report_types/name_server_report/report.html
+msgid "Name server compliance"
+msgstr "Zgodność serwera nazw"
+
+#: reports/report_types/name_server_report/report.html
+msgid "DNSSEC Present"
+msgstr "DNSSEC Obecny"
+
+#: reports/report_types/name_server_report/report.html
+msgid "name servers compliant"
+msgstr "zgodne z serwerami nazw"
+
+#: reports/report_types/name_server_report/report.html
+msgid "Valid DNSSEC"
+msgstr "Ważne DNSSEC"
+
+#: reports/report_types/name_server_report/report.html
+#: reports/report_types/web_system_report/report.html
+msgid "No unnecessary ports open"
+msgstr "Żadne niepotrzebne porty nie są otwarte"
+
+#: reports/report_types/name_server_report/report.html
+msgid "No nameservers have been found on this system."
+msgstr "W tym systemie nie znaleziono żadnych serwerów nazw."
+
+#: reports/report_types/name_server_report/report.py
+msgid "Name Server Report"
+msgstr "Raport serwera nazw"
+
+#: reports/report_types/name_server_report/report.py
+msgid "Name Server Report checks name servers on basic security standards."
+msgstr ""
+"Raport serwera nazw sprawdza serwery nazw pod kątem podstawowych standardów "
+"bezpieczeństwa."
+
+#: reports/report_types/open_ports_report/report.html
+msgid ""
+"The Open Ports Report provides an overview of the open ports identified on a"
+" system. The ports that are marked as <b>bold</b> were identified by direct "
+"scans performed by OpenKAT (such as nmap). Ports that are not marked in bold"
+" were identified through external services and/or scans (such as Shodan). "
+"Scans with the same hostnames, ports and IPs are merged."
+msgstr ""
+"Raport otwartych portów zawiera przegląd otwartych portów zidentyfikowanych "
+"w systemie. Porty oznaczone jako <b>pogrubione</b> zostały zidentyfikowane "
+"poprzez bezpośrednie skanowanie wykonane przez OpenKAT (takie jak nmap). "
+"Porty, które nie są zaznaczone pogrubioną czcionką, zostały zidentyfikowane "
+"za pomocą usług zewnętrznych i/lub skanów (takich jak Shodan). Skanowania z "
+"tymi samymi nazwami hostów, portami i IPs są łączone."
+
+#: reports/report_types/open_ports_report/report.html
+msgid "Overview of open ports found for the scanned assets"
+msgstr "Przegląd otwartych portów znalezionych dla zeskanowanych zasobów"
+
+#: reports/report_types/open_ports_report/report.html
+#: reports/report_types/systems_report/report.html
+msgid "IP address"
+msgstr "Adres IP"
+
+#: reports/report_types/open_ports_report/report.html
+msgid "Hostnames"
+msgstr "Nazwy hostów"
+
+#: reports/report_types/open_ports_report/report.html
+msgid "Direct scan"
+msgstr "Bezpośrednie skanowanie"
+
+#: reports/report_types/open_ports_report/report.py
+msgid "Open Ports Report"
+msgstr "Otwórz raport portów"
+
+#: reports/report_types/open_ports_report/report.py
+msgid "Find open ports of IP addresses"
+msgstr "Znajdź otwarte porty adresów IP"
+
+#: reports/report_types/rpki_report/report.html
+msgid ""
+"This section contains basic security information about Resource Public Key "
+"Infrastructure (RPKI). If your web server employs RPKI for its IP addresses "
+"and associated nameservers, then it enhances visitor protection against "
+"misconfigurations and malicious route intercepts through verified route "
+"announcements, ensuring reliable server access and secure internet traffic."
+msgstr ""
+"Ta sekcja zawiera podstawowe informacje dotyczące bezpieczeństwa dotyczące "
+"infrastruktury klucza publicznego zasobów (RPKI). Jeśli Twój serwer "
+"internetowy wykorzystuje RPKI dla swoich adresów IP i powiązanych serwerów "
+"nazw, zwiększa ochronę odwiedzających przed błędnymi konfiguracjami i "
+"złośliwym przechwytywaniem tras poprzez zweryfikowane ogłoszenia o trasach, "
+"zapewniając niezawodny dostęp do serwera i bezpieczny ruch internetowy."
+
+#: reports/report_types/rpki_report/report.html
+msgid ""
+"The RPKI Report shows if an RPKI route announcement was available for the "
+"system and if this announcement is not expired."
+msgstr ""
+"Raport RPKI pokazuje, czy w systemie dostępny był komunikat o trasie RPKI i "
+"czy ogłoszenie to nie wygasło."
+
+#: reports/report_types/rpki_report/report.html
+msgid "RPKI compliance"
+msgstr "Zgodność RPKI"
+
+#: reports/report_types/rpki_report/report.html
+msgid "RPKI Available"
+msgstr "RPKI Dostępne"
+
+#: reports/report_types/rpki_report/report.html
+msgid "RPKI valid"
+msgstr "RPKI ważny"
+
+#: reports/report_types/rpki_report/report.html
+msgid "RPKI record is not valid."
+msgstr "Rekord RPKI jest nieprawidłowy."
+
+#: reports/report_types/rpki_report/report.html
+msgid "RPKI record does not exist."
+msgstr "Rekord RPKI nie istnieje."
+
+#: reports/report_types/rpki_report/report.html
+#: reports/report_types/safe_connections_report/report.html
+msgid "No IPs have been found on this system."
+msgstr "W tym systemie nie znaleziono IPs."
+
+#: reports/report_types/rpki_report/report.py
+msgid "RPKI Report"
+msgstr "RPKI Raport"
+
+#: reports/report_types/rpki_report/report.py
+msgid ""
+"Shows whether the IP is covered by a valid RPKI ROA. For a hostname it shows"
+" the IP addresses and whether they are covered by a valid RPKI ROA."
+msgstr ""
+"Pokazuje, czy IP jest objęte prawidłowym RPKI ROA. W przypadku nazwy hosta "
+"pokazuje adresy IP i czy są one objęte prawidłowym RPKI ROA."
+
+#: reports/report_types/safe_connections_report/report.html
+msgid ""
+"The Safe Connections report provides an overview of the performed checks "
+"with regard to encrypted communication channels such as HTTPS. The table "
+"below gives an overview of the available checks including whether the system"
+" passed the performed checks. The risk level and reasoning as to why an "
+"issue was identified are shown too. The risk level may be different for your"
+" specific environment."
+msgstr ""
+"Raport Bezpieczne połączenia zawiera przegląd przeprowadzonych kontroli w "
+"zakresie szyfrowanych kanałów komunikacji, takich jak HTTPS. Poniższa tabela"
+" zawiera przegląd dostępnych kontroli, w tym to, czy system przeszedł "
+"pomyślnie przeprowadzone kontrole. Pokazano także poziom ryzyka i "
+"uzasadnienie zidentyfikowania problemu. Poziom ryzyka może być inny w "
+"zależności od konkretnego środowiska."
+
+#: reports/report_types/safe_connections_report/report.html
+msgid "Safe connections compliance"
+msgstr "Zgodność z bezpiecznymi połączeniami"
+
+#: reports/report_types/safe_connections_report/report.py
+msgid "Safe Connections Report"
+msgstr "Raport bezpiecznych połączeń"
+
+#: reports/report_types/safe_connections_report/report.py
+msgid "Shows whether the IPService contains safe ciphers."
+msgstr "Pokazuje, czy usługa IPService zawiera bezpieczne szyfry."
+
+#: reports/report_types/systems_report/report.html
+msgid ""
+"The System Report provides an overview of the system types (types of similar"
+" services) that were identified for each system. The following system types "
+"can be identified: DNS servers, Web servers, Mail servers and those "
+"classified as 'Other' servers. Each hostname and/or IP address is given one "
+"or more system types depending on the identified ports and services. The "
+"table below gives an overview of these results."
+msgstr ""
+"Raport systemowy zawiera przegląd typów systemów (rodzajów podobnych usług) "
+"zidentyfikowanych dla każdego systemu. Można zidentyfikować następujące typy"
+" systemów: serwery DNS, serwery WWW, serwery pocztowe oraz serwery "
+"sklasyfikowane jako „Inne”. Każdej nazwie hosta i/lub adresowi IP przypisany"
+" jest jeden lub więcej typów systemu, w zależności od zidentyfikowanych "
+"portów i usług. Poniższa tabela zawiera przegląd tych wyników."
+
+#: reports/report_types/systems_report/report.html
+msgid "Selected assets"
+msgstr "Wybrane aktywa"
+
+#: reports/report_types/systems_report/report.html
+msgid "No system types have been identified on this system."
+msgstr "W tym systemie nie zidentyfikowano żadnych typów systemów."
+
+#: reports/report_types/systems_report/report.py
+msgid "System Report"
+msgstr "Raport systemowy"
+
+#: reports/report_types/systems_report/report.py
+msgid "Combine IP addresses, hostnames and services into systems."
+msgstr "Połącz IP adresy, nazwy hostów i usługi w systemy."
+
+#: reports/report_types/tls_report/report.html
+msgid ""
+"The TLS Report shows which TLS protocols and ciphers were identified on the "
+"host for the provided port."
+msgstr ""
+"Raport TLS pokazuje, które TLS protokoły i szyfry zostały zidentyfikowane na"
+" hoście dla podanego portu."
+
+#: reports/report_types/tls_report/report.html
+msgid ""
+"The table below provides an overview of the identified TLS protocols and "
+"ciphers, including a status suggestion."
+msgstr ""
+"Poniższa tabela zawiera przegląd zidentyfikowanych TLS protokołów i szyfrów,"
+" łącznie z sugestią dotyczącą statusu."
+
+#: reports/report_types/tls_report/report.html
+msgid "Ciphers"
+msgstr "Szyfry"
+
+#: reports/report_types/tls_report/report.html
+msgid "Protocol"
+msgstr "Protokół"
+
+#: reports/report_types/tls_report/report.html
+msgid "Encryption Algorithm"
+msgstr "Algorytm szyfrowania"
+
+#: reports/report_types/tls_report/report.html
+msgid "Bits"
+msgstr "Bity"
+
+#: reports/report_types/tls_report/report.html
+msgid "Key Size"
+msgstr "Rozmiar klucza"
+
+#: reports/report_types/tls_report/report.html
+#: rocky/templates/organizations/organization_list.html
+#: rocky/templates/organizations/organization_settings.html
+msgid "Code"
+msgstr "Kod"
+
+#: reports/report_types/tls_report/report.html
+msgid "Phase out"
+msgstr "Wycofanie się"
+
+#: reports/report_types/tls_report/report.html
+msgid "Good"
+msgstr "Dobry"
+
+#: reports/report_types/tls_report/report.html
+msgid ""
+"No ciphers were found for this combination of IP address, port and service."
+msgstr "Nie znaleziono szyfrów dla tej kombinacji adresu IP, portu i usługi."
+
+#: reports/report_types/tls_report/report.html
+msgid ""
+"The list below gives an overview of the findings based on the identified TLS"
+" protocols and ciphers. This includes the reasoning why the cipher or "
+"protocol is marked as a finding."
+msgstr ""
+"Poniższa lista zawiera przegląd ustaleń na podstawie zidentyfikowanych TLS "
+"protokołów i szyfrów. Obejmuje to uzasadnienie, dlaczego szyfr lub protokół "
+"jest oznaczony jako wynik."
+
+#: reports/report_types/tls_report/report.py
+msgid "TLS Report"
+msgstr "TLS Raport"
+
+#: reports/report_types/tls_report/report.py
+msgid ""
+"TLS Report assesses the security of data encryption and transmission "
+"protocols."
+msgstr ""
+"TLS Raport ocenia bezpieczeństwo szyfrowania danych i protokołów transmisji."
+
+#: reports/report_types/vulnerability_report/report.html
+msgid "No vulnerabilities have been found on this system."
+msgstr "W tym systemie nie znaleziono żadnych luk."
+
+#: reports/report_types/vulnerability_report/report.html
+msgid ""
+"The Vulnerability Report provides an overview of all identified CVE "
+"vulnerabilities that were identified on the selected systems. For each CVE "
+"the table shows the CVE scoring, the number of occurrences, and the CVE "
+"details."
+msgstr ""
+"Raport o lukach zawiera przegląd wszystkich zidentyfikowanych CVE luk w "
+"zabezpieczeniach, które zostały zidentyfikowane w wybranych systemach. Dla "
+"każdego CVE tabela pokazuje punktację CVE, liczbę wystąpień i szczegóły CVE."
+
+#: reports/report_types/vulnerability_report/report.html
+msgid "vulnerabilities on this system"
+msgstr "luk w tym systemie"
+
+#: reports/report_types/vulnerability_report/report.html
+msgid "Advice"
+msgstr "Rada"
+
+#: reports/report_types/vulnerability_report/report.py
+msgid "Vulnerability Report"
+msgstr "Raport o lukach w zabezpieczeniach"
+
+#: reports/report_types/vulnerability_report/report.py
+msgid "Vulnerabilities found are grouped for each system."
+msgstr "Wykryte luki są pogrupowane dla każdego systemu."
+
+#: reports/report_types/vulnerability_report/report.py
+msgid "First seen"
+msgstr "Pierwszy raz widziany"
+
+#: reports/report_types/vulnerability_report/report.py
+msgid "Last seen"
+msgstr "Ostatnio widziany"
+
+#: reports/report_types/vulnerability_report/report.py
+msgid "Evidence"
+msgstr "Dowód"
+
+#: reports/report_types/web_system_report/report.html
+msgid ""
+"The Web System Report provides an overview of various web server checks that"
+" were performed against the scanned system(s). For each performed check the "
+"table below shows whether or not the server is compliant with the checks. A "
+"description of why this compliant check failed is also shown, including an "
+"general risk level. The risk level may be different for your specific "
+"environment."
+msgstr ""
+"Raport systemu sieciowego zawiera przegląd różnych kontroli serwera "
+"sieciowego przeprowadzonych w odniesieniu do przeskanowanych systemów. Dla "
+"każdej przeprowadzonej kontroli poniższa tabela pokazuje, czy serwer spełnia"
+" wymagania kontroli. Wyświetlany jest również opis przyczyny niepowodzenia "
+"kontroli zgodności, w tym ogólny poziom ryzyka. Poziom ryzyka może być inny "
+"w zależności od konkretnego środowiska."
+
+#: reports/report_types/web_system_report/report.html
+msgid "Web system compliance"
+msgstr "Zgodność systemu internetowego"
+
+#: reports/report_types/web_system_report/report.html
+msgid "CSP Present"
+msgstr "CSP Obecny"
+
+#: reports/report_types/web_system_report/report.html
+msgid "webservers compliant"
+msgstr "zgodne z serwerami internetowymi"
+
+#: reports/report_types/web_system_report/report.html
+msgid "Secure CSP Header"
+msgstr "Bezpieczny nagłówek CSP"
+
+#: reports/report_types/web_system_report/report.html
+msgid "Redirects HTTP to HTTPS"
+msgstr "Przekierowuje HTTP do HTTPS"
+
+#: reports/report_types/web_system_report/report.html
+msgid "Offers HTTPS"
+msgstr "Oferty HTTPS"
+
+#: reports/report_types/web_system_report/report.html
+msgid "Has a Security.txt"
+msgstr "Zawiera plik Security.txt"
+
+#: reports/report_types/web_system_report/report.html
+msgid "Has a certificate"
+msgstr "Posiada certyfikat"
+
+#: reports/report_types/web_system_report/report.html
+msgid "Certificate is valid"
+msgstr "Certyfikat jest ważny"
+
+#: reports/report_types/web_system_report/report.html
+msgid "Certificate is not expiring soon"
+msgstr "Certyfikat nie wygasa szybko"
+
+#: reports/report_types/web_system_report/report.html
+msgid "No webservers have been found on this system."
+msgstr "W tym systemie nie znaleziono żadnych serwerów internetowych."
+
+#: reports/report_types/web_system_report/report.py
+msgid "Web System Report"
+msgstr "Raport dotyczący systemu internetowego"
+
+#: reports/report_types/web_system_report/report.py
+msgid "Web System Reports check web systems on basic security standards."
+msgstr ""
+"Raporty systemu sieciowego sprawdzają systemy sieciowe pod kątem "
+"podstawowych standardów bezpieczeństwa."
+
+#: reports/templates/partials/export_report_settings.html
+msgid "Report schedule"
+msgstr "Harmonogram raportów"
+
+#: reports/templates/partials/export_report_settings.html
+msgid ""
+"When scheduling your report, you have two options. You can either choose to "
+"generate it just once now, or set it to run automatically at regular "
+"intervals, like daily, weekly, or monthly. If you need the report just for a"
+" single occasion, select the one-time option."
+msgstr ""
+"Planując raport, masz dwie możliwości. Możesz wygenerować go teraz tylko raz"
+" lub ustawić automatyczne uruchamianie w regularnych odstępach czasu, np. "
+"codziennie, co tydzień lub co miesiąc. Jeśli potrzebujesz raportu tylko na "
+"jedną okazję, wybierz opcję jednorazową."
+
+#: reports/templates/partials/export_report_settings.html
+#: reports/templates/report_overview/report_history_table.html
+msgid "Report name"
+msgstr "Nazwa raportu"
+
+#: reports/templates/partials/export_report_settings.html
+#, python-format, python-brace-format
+msgid ""
+"When generating reports, it is possible to give the report a name. The name "
+"can be static or dynamic. The default format for a report is '${report_type}"
+" for ${oois_count} objects'. These placeholders automatically adapt based on"
+" the report details. This format could for example return 'Aggregate Report "
+"for 15 objects'. Another placeholder that can be used is '${ooi}', which "
+"will show the name of the object when there is only one object. You can also"
+" customize the name by adding prefixes, suffixes, or other formats like "
+"'%%W' for the week number, using options from <a "
+"href=\"https://strftime.org/\" target=\"_blank\" rel=\"noopener\">Python "
+"strftime code</a>."
+msgstr ""
+"Podczas generowania raportów istnieje możliwość nadania raportowi nazwy. "
+"Nazwa może być statyczna lub dynamiczna. Domyślny format raportu to "
+"'${report_type} dla ${oois_count} obiektów'. Te symbole zastępcze "
+"dostosowują się automatycznie na podstawie szczegółów raportu. Ten format "
+"może na przykład zwrócić „Raport zbiorczy dla 15 obiektów”. Innym symbolem "
+"zastępczym, którego można użyć, jest '${ooi}', który pokaże nazwę obiektu, "
+"jeśli istnieje tylko jeden obiekt. Możesz także dostosować nazwę, dodając "
+"przedrostki, przyrostki lub inne formaty, takie jak „%%W” dla numeru "
+"tygodnia, korzystając z opcji z <a href=\"https://strftime.org/\" "
+"target=\"_blank\" rel=\"noopener\">Python strftime code</a>."
+
+#: reports/templates/partials/export_report_settings.html
+#: reports/templates/partials/generate_report_header.html
+#: reports/templates/partials/new_report_action_button.html
+#: reports/views/generate_report.py
+msgid "Generate report"
+msgstr "Wygeneruj raport"
+
+#: reports/templates/partials/generate_report_header.html
+msgid "To generate an aggregate report, complete the following steps."
+msgstr "Aby wygenerować raport zbiorczy, wykonaj następujące kroki."
+
+#: reports/templates/partials/generate_report_header.html
+msgid "To generate a multi report, complete the following steps."
+msgstr "Aby wygenerować raport wieloraportowy, wykonaj następujące kroki."
+
+#: reports/templates/partials/generate_report_header.html
+msgid "To generate separate report(s), complete the following steps."
+msgstr "Aby wygenerować osobne raporty, wykonaj następujące kroki."
+
+#: reports/templates/partials/generate_report_sidemenu.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Table of contents"
+msgstr "Spis treści"
+
+#: reports/templates/partials/new_report_action_button.html
+msgid "Actions for creating a new report"
+msgstr "Działania związane z utworzeniem nowego raportu"
+
+#: reports/templates/partials/new_report_action_button.html
+msgid "Separate report(s)"
+msgstr "Oddzielne raporty"
+
+#: reports/templates/partials/new_report_action_button.html
+#: reports/views/aggregate_report.py
+msgid "Aggregate report"
+msgstr "Raport zbiorczy"
+
+#: reports/templates/partials/new_report_action_button.html
+#: reports/views/multi_report.py
+msgid "Multi report"
+msgstr "Raport wielokrotny"
+
+#: reports/templates/partials/plugin_overview_table.html
+#: reports/templates/partials/report_sidemenu.html
+#: rocky/templates/oois/ooi_page_tabs.html
+msgid "Overview"
+msgstr "Przegląd"
+
+#: reports/templates/partials/plugin_overview_table.html
+msgid "Plugin overview table"
+msgstr "Tabela przeglądu wtyczek"
+
+#: reports/templates/partials/plugin_overview_table.html
+#: reports/templates/partials/report_setup_scan.html
+msgid "Required plugins"
+msgstr "Wymagane wtyczki"
+
+#: reports/templates/partials/plugin_overview_table.html
+#: reports/templates/partials/report_setup_scan.html
+msgid "Suggested plugins"
+msgstr "Sugerowane wtyczki"
+
+#: reports/templates/partials/plugin_overview_table.html
+msgid "Action required"
+msgstr "Wymagane działanie"
+
+#: reports/templates/partials/plugin_overview_table.html
+msgid "Ready"
+msgstr "Gotowy"
+
+#: reports/templates/partials/report_findings_table.html
+msgid ""
+"This table provides an overview of the identified findings on the scanned "
+"systems. For each finding type it shows the risk level, the number of "
+"occurrences and the first known occurrence of the finding. The risk level "
+"may be different for your specific environment. The details can be seen when"
+" expanding a row. A description, the source, impact and recommendation of "
+"the finding can be found here. It also shows in which findings the finding "
+"type occurred."
+msgstr ""
+"Tabela ta zawiera przegląd ustaleń zidentyfikowanych w przeskanowanych "
+"systemach. Dla każdego typu ustalenia pokazany jest poziom ryzyka, liczba "
+"wystąpień i pierwsze znane wystąpienie ustalenia. Poziom ryzyka może być "
+"inny w zależności od konkretnego środowiska. Szczegóły można zobaczyć "
+"podczas rozwijania wiersza. Opis, źródło, wpływ i zalecenia dotyczące "
+"ustalenia można znaleźć tutaj. Pokazuje także, w jakich ustaleniach wystąpił"
+" dany typ ustalenia."
+
+#: reports/templates/partials/report_findings_table.html
+msgid "First known occurrence"
+msgstr "Pierwsze znane zjawisko"
+
+#: reports/templates/partials/report_findings_table.html
+msgid "Open in report"
+msgstr "Otwórz w raporcie"
+
+#: reports/templates/partials/report_findings_table.html
+msgid ""
+"No critical and high findings have been identified for this organization."
+msgstr ""
+"W przypadku tej organizacji nie stwierdzono żadnych krytycznych i wysokich "
+"ustaleń."
+
+#: reports/templates/partials/report_findings_table.html
+msgid "No findings have been identified for this organization."
+msgstr "Nie stwierdzono żadnych ustaleń w przypadku tej organizacji."
+
+#: reports/templates/partials/report_header.html
+msgid "Download as PDF"
+msgstr "Pobierz jako PDF"
+
+#: reports/templates/partials/report_header.html
+#: rocky/templates/partials/ooi_list_toolbar.html
+msgid "Download as JSON"
+msgstr "Pobierz jako JSON"
+
+#: reports/templates/partials/report_header.html
+msgid "Open asset reports"
+msgstr "Otwórz raporty o zasobach"
+
+#: reports/templates/partials/report_header.html
+msgid "This is the OpenKAT report for organization"
+msgstr "To jest raport OpenKAT dla organizacji"
+
+#: reports/templates/partials/report_header.html
+msgid ""
+"All selected report types for the selected objects are displayed one below "
+"the other."
+msgstr ""
+"Wszystkie wybrane typy raportów dla wybranych obiektów są wyświetlane jeden "
+"pod drugim."
+
+#: reports/templates/partials/report_header.html
+msgid "Created with data from:"
+msgstr "Utworzono na podstawie danych z:"
+
+#: reports/templates/partials/report_header.html
+msgid "Created on:"
+msgstr "Utworzono:"
+
+#: reports/templates/partials/report_header.html
+msgid "Created from recipe:"
+msgstr "Utworzono z przepisu:"
+
+#: reports/templates/partials/report_header.html
+msgid "Recipe created by:"
+msgstr "Przepis stworzony przez:"
+
+#: reports/templates/partials/report_header.html
+#, python-format
+msgid "This sector contains %(length)s scanned organizations."
+msgstr "Ten sektor zawiera %(length)s przeskanowane organizacje."
+
+#: reports/templates/partials/report_header.html
+msgid "Of these organizations"
+msgstr "Z tych organizacji"
+
+#: reports/templates/partials/report_header.html
+msgid "organizations have tag"
+msgstr "organizacje mają tag"
+
+#: reports/templates/partials/report_header.html
+msgid "The basic security scores are around "
+msgstr "Podstawowe oceny bezpieczeństwa są w pobliżu"
+
+#: reports/templates/partials/report_header.html
+#, python-format
+msgid "A total of %(total)s critical vulnerabilities have been identified."
+msgstr "W sumie zidentyfikowano %(total)s krytyczne luki."
+
+#: reports/templates/partials/report_introduction.html
+msgid "Introduction"
+msgstr "Wstęp"
+
+#: reports/templates/partials/report_introduction.html
+msgid ""
+"This report gives an overview of the current state of security for your "
+"organisation for the selected date. The summary section provides an overview"
+" of the selected systems (objects), plugins and reports. This is followed "
+"with the findings for each report."
+msgstr ""
+"Raport ten zawiera przegląd aktualnego stanu bezpieczeństwa Twojej "
+"organizacji w wybranym terminie. Sekcja podsumowująca zawiera przegląd "
+"wybranych systemów (obiektów), wtyczek i raportów. Następnie przedstawiono "
+"ustalenia dotyczące każdego raportu."
+
+#: reports/templates/partials/report_names_form.html
+msgid "Report names:"
+msgstr "Nazwy raportów:"
+
+#: reports/templates/partials/report_names_form.html
+#: rocky/templates/forms/widgets/checkbox_group_table.html
+#: rocky/templates/oois/ooi_detail_add_related_object.html
+#: rocky/templates/partials/edit_ooi_clearance_level_modal.html
+#: rocky/templates/partials/form/field_input.html
+#: rocky/templates/partials/form/field_input_checkbox.html
+#: rocky/templates/partials/form/field_input_multiselect.html
+#: rocky/templates/partials/form/field_input_radio.html
+msgid "Required"
+msgstr "Wymagany"
+
+#: reports/templates/partials/report_names_form.html
+msgid "Add reference date"
+msgstr "Dodaj datę referencyjną"
+
+#: reports/templates/partials/report_names_form.html
+#: reports/templates/report_overview/modal_partials/rename_modal.html
+msgid "Reset"
+msgstr "Nastawić"
+
+#: reports/templates/partials/report_names_form.html
+msgid "No reference date"
+msgstr "Brak daty referencyjnej"
+
+#: reports/templates/partials/report_names_form.html
+msgid "Day"
+msgstr "Dzień"
+
+#: reports/templates/partials/report_names_form.html
+msgid "Week"
+msgstr "Tydzień"
+
+#: reports/templates/partials/report_names_form.html
+msgid "Month"
+msgstr "Miesiąc"
+
+#: reports/templates/partials/report_names_form.html
+msgid "Year"
+msgstr "Rok"
+
+#: reports/templates/partials/report_ooi_list.html
+msgid "Object selection"
+msgstr "Wybór obiektu"
+
+#: reports/templates/partials/report_ooi_list.html
+msgid ""
+"Select which objects you want to include in your report. You can either "
+"continue with a live set or you can select the objects manually from the "
+"table below."
+msgstr ""
+"Wybierz obiekty, które chcesz uwzględnić w swoim raporcie. Możesz albo "
+"kontynuować zestaw na żywo, albo wybrać obiekty ręcznie z poniższej tabeli."
+
+#: reports/templates/partials/report_ooi_list.html
+msgid ""
+"A live set is a set of objects based on the applied filters. Any object that"
+" matches this applied filter (now or in the future) will be used as input "
+"for the scheduled report. If your live set filter (e.g. 'hostnames' with 'L2"
+" clearance' that are 'declared') shows 2 hostnames that match the filter "
+"today, the scheduled report will run for those 2 hostnames. If you add 3 "
+"more hostnames tomorrow (with the same filter criteria), your next scheduled"
+" report will contain 5 hostnames. Your live set will update as you go."
+msgstr ""
+"Zestaw aktywny to zbiór obiektów bazujący na zastosowanych filtrach. Każdy "
+"obiekt pasujący do zastosowanego filtra (obecnie lub w przyszłości) zostanie"
+" użyty jako dane wejściowe dla zaplanowanego raportu. Jeśli Twój filtr "
+"aktywnego zestawu (np. „nazwy hostów” z „zadeklarowanym zezwoleniem L2”) "
+"pokazuje 2 nazwy hostów pasujące do filtra dzisiaj, zaplanowany raport "
+"zostanie wygenerowany dla tych 2 nazw hostów. Jeśli jutro dodasz jeszcze 3 "
+"nazwy hostów (z tymi samymi kryteriami filtrowania), Twój następny "
+"zaplanowany raport będzie zawierał 5 nazw hostów. Twój zestaw na żywo będzie"
+" aktualizowany na bieżąco."
+
+#: reports/templates/partials/report_ooi_list.html
+msgid ""
+"Based on the current dataset, your selected filters result in the following "
+"objects."
+msgstr ""
+"W oparciu o bieżący zbiór danych wybrane filtry dają w wyniku następujące "
+"obiekty."
+
+#: reports/templates/partials/report_ooi_list.html
+msgid "objects selected"
+msgstr "wybrane obiekty"
+
+#: reports/templates/partials/report_ooi_list.html
+msgid "Deselect all objects"
+msgstr "Odznacz wszystkie obiekty"
+
+#: reports/templates/partials/report_ooi_list.html
+#: rocky/templates/oois/ooi_list.html
+#, python-format
+msgid "Showing %(length)s of %(total)s objects"
+msgstr "Wyświetlanie %(length)s z %(total)s obiektów"
+
+#: reports/templates/partials/report_ooi_list.html
+#, python-format
+msgid "Select all %(total_oois)s object"
+msgid_plural "Select all %(total_oois)s objects"
+msgstr[0] "Wybierz cały obiekt %(total_oois)s"
+msgstr[1] "Wybierz wszystkie obiekty %(total_oois)s"
+msgstr[2] "Wybierz wszystkie obiekty %(total_oois)s"
+
+#: reports/templates/partials/report_ooi_list.html
+msgid "Object name"
+msgstr "Nazwa obiektu"
+
+#: reports/templates/partials/report_ooi_list.html
+msgid "Report(s) may be empty due to no objects in the selected filters."
+msgstr ""
+"Raport(y) może być pusty ze względu na brak obiektów w wybranych filtrach."
+
+#: reports/templates/partials/report_ooi_list.html
+msgid ""
+"Reports matching the selected filters will be empty at this moment in time. "
+"Future reports may contain data. It is still possible to generate the "
+"(potentially empty) report."
+msgstr ""
+"Raporty pasujące do wybranych filtrów będą w tym momencie puste. Przyszłe "
+"raporty mogą zawierać dane. Nadal możliwe jest wygenerowanie (potencjalnie "
+"pustego) raportu."
+
+#: reports/templates/partials/report_ooi_list.html
+msgid "Continue with live set"
+msgstr "Kontynuuj zestaw na żywo"
+
+#: reports/templates/partials/report_ooi_list.html
+#: reports/templates/partials/report_types_selection.html
+msgid "Continue with selection"
+msgstr "Kontynuuj wybór"
+
+#: reports/templates/partials/report_setup_scan.html
+#: reports/views/aggregate_report.py reports/views/generate_report.py
+#: reports/views/multi_report.py
+msgid "Configuration"
+msgstr "Konfiguracja"
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Set up the required plugins for this report."
+msgstr "Skonfiguruj wymagane wtyczki dla tego raportu."
+
+#: reports/templates/partials/report_setup_scan.html
+#: reports/templates/summary/selected_plugins.html
+msgid "Plugins"
+msgstr "Wtyczki"
+
+#: reports/templates/partials/report_setup_scan.html
+msgid ""
+"KAT will be able to generate a full report when all the required and "
+"suggested boefjes are enabled."
+msgstr ""
+"KAT będzie w stanie wygenerować pełny raport, gdy wszystkie wymagane i "
+"sugerowane boefje zostaną włączone."
+
+#: reports/templates/partials/report_setup_scan.html
+msgid ""
+"If you choose not to enable a plugin, the data that plugin would collect or "
+"produce will be left out of the report which will then be generated based on"
+" the available data collected by the enabled plugins."
+msgstr ""
+"Jeśli zdecydujesz się nie włączać wtyczki, dane, które wtyczka będzie "
+"zbierać lub generować, zostaną pominięte w raporcie, który zostanie "
+"następnie wygenerowany na podstawie dostępnych danych zebranych przez "
+"włączone wtyczki."
+
+#: reports/templates/partials/report_setup_scan.html
+msgid ""
+"Some plugins are mandatory as they are crucial for a report type. Reports "
+"that don't have their requirements met will be skipped."
+msgstr ""
+"Niektóre wtyczki są obowiązkowe, ponieważ mają kluczowe znaczenie dla typu "
+"raportu. Raporty, które nie spełniają wymagań, zostaną pominięte."
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Warning! Before you proceed read the following points:"
+msgstr "Ostrzeżenie! Zanim przejdziesz dalej, przeczytaj następujące punkty:"
+
+#: reports/templates/partials/report_setup_scan.html
+msgid ""
+"OpenKAT is designed to scan all known objects on a regular basis using the "
+"enabled plugins and set clearance levels. This means that scans will run "
+"automatically. Be patient; plugins may take some time before they have "
+"collected all their data. Enabling them just before report generation will "
+"likely result in inaccurate reports, as plugins have not finished collecting"
+" data."
+msgstr ""
+"OpenKAT przeznaczony jest do regularnego skanowania wszystkich znanych "
+"obiektów przy użyciu włączonych wtyczek i ustawiania poziomów dostępu. "
+"Oznacza to, że skanowanie będzie uruchamiane automatycznie. Bądź cierpliwy; "
+"wtyczki mogą zająć trochę czasu, zanim zgromadzą wszystkie swoje dane. "
+"Włączenie ich tuż przed wygenerowaniem raportu prawdopodobnie spowoduje "
+"powstanie niedokładnych raportów, ponieważ wtyczki nie zakończyły jeszcze "
+"zbierania danych."
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Good job! All required plugins are enabled."
+msgstr "Dobra robota! Wszystkie wymagane wtyczki są włączone."
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "This report type requires the following plugins to be enabled:"
+msgstr "Ten typ raportu wymaga włączenia następujących wtyczek:"
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Toggle all required plugins"
+msgstr "Przełącz wszystkie wymagane wtyczki"
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Show enabled plugins"
+msgstr "Pokaż włączone wtyczki"
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "There are no required plugins."
+msgstr "Nie ma wymaganych wtyczek."
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Good job! All suggested plugins are enabled."
+msgstr "Dobra robota! Wszystkie sugerowane wtyczki są włączone."
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "The following plugins are optional to generate the report:"
+msgstr "Następujące wtyczki są opcjonalne do generowania raportu:"
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Toggle all optional plugins"
+msgstr "Przełącz wszystkie opcjonalne wtyczki"
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Hide suggested plugins"
+msgstr "Ukryj sugerowane wtyczki"
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Show more suggested plugins"
+msgstr "Pokaż więcej sugerowanych wtyczek"
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "There are no optional plugins."
+msgstr "Nie ma opcjonalnych wtyczek."
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Enable selected plugins and continue"
+msgstr "Włącz wybrane wtyczki i kontynuuj"
+
+#: reports/templates/partials/report_severity_totals_table.html
+msgid ""
+"\n"
+"            This overview shows the total number of findings per\n"
+"            severity that have been identified for this organization.\n"
+"        "
+msgstr ""
+"\n"
+"Przegląd ten pokazuje całkowitą liczbę wyników przypadającą na jeden\n"
+"            dotkliwości, które zostały zidentyfikowane dla tej organizacji."
+
+#: reports/templates/partials/report_severity_totals_table.html
+msgid "Total per severity overview"
+msgstr "Łącznie według przeglądu ważności"
+
+#: reports/templates/partials/report_severity_totals_table.html
+msgid "Critical"
+msgstr "Krytyczny"
+
+#: reports/templates/partials/report_severity_totals_table.html
+msgid "High"
+msgstr "Wysoki"
+
+#: reports/templates/partials/report_severity_totals_table.html
+msgid "Medium"
+msgstr "Średni"
+
+#: reports/templates/partials/report_severity_totals_table.html
+msgid "Low"
+msgstr "Niski"
+
+#: reports/templates/partials/report_severity_totals_table.html
+#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+msgid "Pending"
+msgstr "Aż do"
+
+#: reports/templates/partials/report_severity_totals_table.html
+msgid "Unknown"
+msgstr "Nieznany"
+
+#: reports/templates/partials/report_severity_totals_table.html
+msgid "Total"
+msgstr "Całkowity"
+
+#: reports/templates/partials/report_sidemenu.html
+msgid "Selected Objects"
+msgstr "Wybrane obiekty"
+
+#: reports/templates/partials/report_sidemenu.html
+msgid "Selected Plugins"
+msgstr "Wybrane wtyczki"
+
+#: reports/templates/partials/report_sidemenu.html
+msgid "Used Config Objects"
+msgstr "Używane obiekty konfiguracyjne"
+
+#: reports/templates/partials/report_types_selection.html
+msgid "Choose report types"
+msgstr "Wybierz typy raportów"
+
+#: reports/templates/partials/report_types_selection.html
+msgid ""
+"Various types of reports, such as DNS reports and TLS reports, are essential"
+" for identifying vulnerabilities in different aspects of a system's "
+"security. DNS reports focus on domain name system configuration and "
+"potential weaknesses, while TLS reports assess the security of data "
+"encryption and transmission protocols, helping organizations pinpoint areas "
+"where security improvements are needed."
+msgstr ""
+"Różne typy raportów, takie jak raporty DNS i raporty TLS, są niezbędne do "
+"identyfikowania luk w różnych aspektach bezpieczeństwa systemu. Raporty DNS "
+"skupiają się na konfiguracji systemu nazw domen i potencjalnych słabych "
+"stronach, natomiast raporty TLS oceniają bezpieczeństwo szyfrowania danych i"
+" protokołów transmisji, pomagając organizacjom wskazać obszary, w których "
+"konieczna jest poprawa bezpieczeństwa."
+
+#: reports/templates/partials/report_types_selection.html
+#, python-format
+msgid "Selected object (%(total_oois)s)"
+msgid_plural "Selected objects (%(total_oois)s)"
+msgstr[0] "Wybrany obiekt (%(total_oois)s)"
+msgstr[1] "Wybrane obiekty (%(total_oois)s)"
+msgstr[2] "Wybrane obiekty (%(total_oois)s)"
+
+#: reports/templates/partials/report_types_selection.html
+#, python-format
+msgid ""
+"You have selected a live set in the previous step. Based on the current "
+"dataset, this live set results in %(total_oois)s objects."
+msgstr ""
+"W poprzednim kroku wybrałeś zestaw na żywo. W oparciu o bieżący zbiór "
+"danych, ten aktywny zestaw daje obiekty %(total_oois)s."
+
+#: reports/templates/partials/report_types_selection.html
+msgid "Applied filters:"
+msgstr "Zastosowane filtry:"
+
+#: reports/templates/partials/report_types_selection.html
+#, python-format
+msgid "You have selected %(total_oois)s object in the previous step."
+msgid_plural "You have selected %(total_oois)s objects in the previous step."
+msgstr[0] "W poprzednim kroku wybrałeś obiekt %(total_oois)s."
+msgstr[1] "W poprzednim kroku wybrałeś obiekty %(total_oois)s."
+msgstr[2] "W poprzednim kroku wybrałeś obiekty %(total_oois)s."
+
+#: reports/templates/partials/report_types_selection.html
+msgid "Change selection"
+msgstr "Zmień wybór"
+
+#: reports/templates/partials/report_types_selection.html
+msgid "Available report types"
+msgstr "Dostępne typy raportów"
+
+#: reports/templates/partials/report_types_selection.html
+msgid "All report types that are available for your selection."
+msgstr "Wszystkie typy raportów, które są dostępne do wyboru."
+
+#: reports/templates/partials/report_types_selection.html
+msgid "Toggle all report types"
+msgstr "Przełącz wszystkie typy raportów"
+
+#: reports/templates/partials/return_button.html
+#, python-format
+msgid "%(btn_text)s"
+msgstr "%(btn_text)s"
+
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/modal_partials/share_modal.html
+msgid "Delete the following report(s):"
+msgstr "Usuń następujące raporty:"
+
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/modal_partials/share_modal.html
+msgid ""
+"Deleted reports are removed in the view from the moment of deletion. The "
+"report can still be accessed on timestamps before the deletion. Only the "
+"report is removed from the view, not the data it is based on."
+msgstr ""
+"Usunięte raporty są usuwane w widoku od momentu usunięcia. Dostęp do raportu"
+" będzie nadal możliwy według znaczników czasu sprzed usunięcia. Z widoku "
+"zostanie usunięty tylko raport, a nie dane, na których się opiera."
+
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/modal_partials/share_modal.html
+msgid ""
+"It is still possible to generate a new report for same date. If the report "
+"is part of a combined report, it will remain available in the combined "
+"report."
+msgstr ""
+"Nadal istnieje możliwość wygenerowania nowego raportu na tę samą datę. Jeśli"
+" raport jest częścią raportu połączonego, pozostanie dostępny w raporcie "
+"połączonym."
+
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/modal_partials/rerun_modal.html
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+#: reports/templates/report_overview/subreports_table.html
+msgid "Reference date"
+msgstr "Data referencyjna"
+
+#: reports/templates/report_overview/modal_partials/enable_disable_schedule_modal.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Disable schedule"
+msgstr "Wyłącz harmonogram"
+
+#: reports/templates/report_overview/modal_partials/enable_disable_schedule_modal.html
+#, python-format
+msgid ""
+"Are you sure you want to disable the schedule for "
+"<strong>%(report_name)s</strong>? The recipe will still exist and the "
+"schedule can be enabled later on."
+msgstr ""
+"Czy na pewno chcesz wyłączyć harmonogram dla "
+"<strong>%(report_name)s</strong>? Przepis będzie nadal istniał, a "
+"harmonogram będzie można włączyć później."
+
+#: reports/templates/report_overview/modal_partials/rename_modal.html
+msgid "Rename the following report(s):"
+msgstr "Zmień nazwę następujących raportów:"
+
+#: reports/templates/report_overview/modal_partials/rename_modal.html
+#: reports/templates/report_overview/report_history_table.html
+msgid "Rename"
+msgstr "Przemianować"
+
+#: reports/templates/report_overview/modal_partials/rerun_modal.html
+msgid "Rerun the following report(s):"
+msgstr "Uruchom ponownie następujące raporty:"
+
+#: reports/templates/report_overview/modal_partials/rerun_modal.html
+msgid ""
+"By submitting you're generating the selected reports again, using the "
+"current data."
+msgstr ""
+"Przesyłając ponownie generujesz wybrane raporty, korzystając z aktualnych "
+"danych."
+
+#: reports/templates/report_overview/modal_partials/rerun_modal.html
+#: reports/templates/report_overview/report_history_table.html
+msgid "Rerun"
+msgstr "Ponowne odtworzenie"
+
+#: reports/templates/report_overview/report_history.html
+msgid "Reports history"
+msgstr "Historia raportów"
+
+#: reports/templates/report_overview/report_history.html
+msgid ""
+"On this page you can see all the reports that have been generated in the "
+"past. To create a new report, click the 'Generate Report' button."
+msgstr ""
+"Na tej stronie możesz zobaczyć wszystkie raporty, które zostały wygenerowane"
+" w przeszłości. Aby utworzyć nowy raport, kliknij przycisk „Generuj raport”."
+
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/report_overview/subreports.html
+#, python-format
+msgid "Showing %(length)s of %(total)s reports"
+msgstr "Wyświetlanie %(length)s z %(total)s raportów"
+
+#: reports/templates/report_overview/report_history_table.html
+#: rocky/templates/tasks/reports.html
+msgid "Reports:"
+msgstr "Raporty:"
+
+#: reports/templates/report_overview/report_history_table.html
+msgid "Shows parent report details"
+msgstr "Pokazuje szczegóły raportu nadrzędnego"
+
+#: reports/templates/report_overview/report_history_table.html
+msgid "Close asset report object details"
+msgstr "Zamknij szczegóły obiektu raportu o zasobach"
+
+#: reports/templates/report_overview/report_history_table.html
+msgid "Open asset report object details"
+msgstr "Otwórz szczegóły obiektu raportu o zasobach"
+
+#: reports/templates/report_overview/report_history_table.html
+msgid "Asset reports details"
+msgstr "Szczegóły raportów o zasobach"
+
+#: reports/templates/report_overview/report_history_table.html
+#, python-format
+msgid ""
+"This report consists of %(counter)s asset report with the following report "
+"type and object:"
+msgid_plural ""
+"This report consists of %(counter)s asset reports with the following report "
+"types and objects:"
+msgstr[0] ""
+"Ten raport składa się z %(counter)s raportu o zasobach z następującym typem "
+"raportu i obiektem:"
+msgstr[1] ""
+"Ten raport składa się z raportów o zasobach %(counter)s z następującymi "
+"typami raportów i obiektami:"
+msgstr[2] ""
+"Ten raport składa się z raportów o zasobach %(counter)s z następującymi "
+"typami raportów i obiektami:"
+
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/report_overview/subreports_header.html
+#: reports/templates/report_overview/subreports_table.html
+#: reports/views/report_overview.py
+msgid "Asset reports"
+msgstr "Raporty dotyczące zasobów"
+
+#: reports/templates/report_overview/report_history_table.html
+msgid "Shows asset report details"
+msgstr "Pokazuje szczegóły raportu o zasobach"
+
+#: reports/templates/report_overview/report_history_table.html
+msgid "View all asset reports"
+msgstr "Wyświetl wszystkie raporty o zasobach"
+
+#: reports/templates/report_overview/report_history_table.html
+msgid "No reports have been generated yet."
+msgstr "Nie wygenerowano jeszcze żadnych raportów."
+
+#: reports/templates/report_overview/report_overview_header.html
+#: reports/views/base.py rocky/templates/header.html
+#: rocky/templates/tasks/partials/tab_navigation.html
+#: rocky/templates/tasks/reports.html rocky/views/tasks.py
+msgid "Reports"
+msgstr "Raporty"
+
+#: reports/templates/report_overview/report_overview_header.html
+msgid "An overview of reports that are scheduled or have been generated."
+msgstr "Przegląd raportów, które są zaplanowane lub zostały wygenerowane."
+
+#: reports/templates/report_overview/report_overview_navigation.html
+msgid "Scheduled"
+msgstr "Zaplanowany"
+
+#: reports/templates/report_overview/report_overview_navigation.html
+msgid "History"
+msgstr "Historia"
+
+#: reports/templates/report_overview/scheduled_reports.html
+msgid "Scheduled reports"
+msgstr "Zaplanowane raporty"
+
+#: reports/templates/report_overview/scheduled_reports.html
+msgid ""
+"On this page you can see all the reports that are or have been scheduled. To"
+" schedule a report, select a start date and recurrence while generating a "
+"report."
+msgstr ""
+"Na tej stronie możesz zobaczyć wszystkie raporty, które są lub zostały "
+"zaplanowane. Aby zaplanować raport, podczas generowania raportu wybierz datę"
+" początkową i częstotliwość."
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+#, python-format
+msgid "Showing %(length)s of %(total)s schedules"
+msgstr "Wyświetlanie %(length)s z %(total)s harmonogramów"
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Scheduled reports:"
+msgstr "Zaplanowane raporty:"
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Scheduled for"
+msgstr "Zaplanowane na"
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Schedule status"
+msgstr "Stan harmonogramu"
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Once"
+msgstr "Raz"
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Recent reports"
+msgstr "Najnowsze raporty"
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Scheduled Reports:"
+msgstr "Zaplanowane raporty:"
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Show report details"
+msgstr "Pokaż szczegóły raportu"
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "objects"
+msgstr "obiekty"
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Enable schedule"
+msgstr "Włącz harmonogram"
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "No scheduled reports have been generated yet."
+msgstr "Nie wygenerowano jeszcze żadnych zaplanowanych raportów."
+
+#: reports/templates/report_overview/subreports_header.html
+msgid "Back to Reports History"
+msgstr "Powrót do historii raportów"
+
+#: reports/templates/report_overview/subreports_header.html
+msgid "An overview of all underlying reports of"
+msgstr "Przegląd wszystkich raportów bazowych"
+
+#: reports/templates/report_overview/subreports_header.html
+#: reports/templates/report_overview/subreports_table.html
+msgid "Shows report details"
+msgstr "Pokazuje szczegóły raportu"
+
+#: reports/templates/report_overview/subreports_table.html
+#: rocky/templates/tasks/boefjes.html
+#: rocky/templates/tasks/plugin_detail_task_list.html
+msgid "Input Object"
+msgstr "Obiekt wejściowy"
+
+#: reports/templates/report_schedules/delete_recipe_modal.html
+msgid "Delete report recipe"
+msgstr "Usuń przepis raportu"
+
+#: reports/templates/report_schedules/delete_recipe_modal.html
+#, python-format
+msgid "Are you sure you want to delete report recipe \"%(name)s\"?"
+msgstr "Czy na pewno chcesz usunąć przepis raportu „%(name)s”?"
+
+#: reports/templates/report_schedules/delete_recipe_modal.html
+msgid ""
+"Deleting this report recipe means it will be permanently deleted. It will "
+"not be possible anymore to see or enable the schedule. You will find "
+"previously generated reports in the report history tab."
+msgstr ""
+"Usunięcie tego przepisu raportu oznacza, że ​​zostanie on trwale usunięty. "
+"Nie będzie już możliwe wyświetlenie ani włączenie harmonogramu. W zakładce "
+"historia raportów znajdziesz wcześniej wygenerowane raporty."
+
+#: reports/templates/summary/report_asset_overview.html
+msgid ""
+"The objects listed in the table below were used to generate this report. For"
+" each object in the table it additionally shows the clearance level and "
+"whether or not the object was added by a user ('Declared') or indirectly "
+"identified through another service or system ('Inherited')."
+msgstr ""
+"Do wygenerowania tego raportu wykorzystano obiekty wymienione w poniższej "
+"tabeli. Dla każdego obiektu w tabeli dodatkowo pokazany jest poziom "
+"uprawnień oraz to, czy obiekt został dodany przez użytkownika („Zgłoszony”),"
+" czy też pośrednio zidentyfikowany poprzez inną usługę lub system "
+"(„Odziedziczony”)."
+
+#: reports/templates/summary/report_asset_overview.html
+msgid "No objects found."
+msgstr "Nie znaleziono żadnych obiektów."
+
+#: reports/templates/summary/report_asset_overview.html
+msgid ""
+"The table below shows which reports were chosen to generate this report, "
+"including a report description."
+msgstr ""
+"Poniższa tabela pokazuje, które raporty zostały wybrane do wygenerowania "
+"tego raportu, wraz z opisem raportu."
+
+#: reports/templates/summary/report_asset_overview.html
+msgid "No report types found."
+msgstr "Nie znaleziono typów raportów."
+
+#: reports/templates/summary/selected_plugins.html
+msgid ""
+"The table below shows all required or optional plugins for the selected "
+"reports."
+msgstr ""
+"Poniższa tabela przedstawia wszystkie wymagane lub opcjonalne wtyczki dla "
+"wybranych raportów."
+
+#: reports/templates/summary/selected_plugins.html
+msgid "Required and optional plugins"
+msgstr "Wtyczki wymagane i opcjonalne"
+
+#: reports/templates/summary/selected_plugins.html
+msgid "Plugin enabled"
+msgstr "Wtyczka włączona"
+
+#: reports/templates/summary/selected_plugins.html
+msgid "Plugin options"
+msgstr "Opcje wtyczek"
+
+#: reports/templates/summary/selected_plugins.html
+msgid "Plugin scan level"
+msgstr "Poziom skanowania wtyczki"
+
+#: reports/templates/summary/selected_plugins.html
+msgid "Enabled."
+msgstr "Włączony."
+
+#: reports/templates/summary/selected_plugins.html
+msgid "required"
+msgstr "wymagany"
+
+#: reports/templates/summary/selected_plugins.html
+msgid "optional"
+msgstr "fakultatywny"
+
+#: reports/templates/summary/selected_plugins.html
+msgid "Plugin extra info"
+msgstr "Dodatkowe informacje o wtyczce"
+
+#: reports/templates/summary/selected_plugins.html
+msgid ""
+"There are no required or optional plugins needed for the selected report "
+"types."
+msgstr "Dla wybranych typów raportów nie są wymagane ani opcjonalne wtyczki."
+
+#: reports/views/aggregate_report.py reports/views/generate_report.py
+#: reports/views/multi_report.py
+msgid "Select objects"
+msgstr "Wybierz obiekty"
+
+#: reports/views/aggregate_report.py reports/views/generate_report.py
+#: reports/views/multi_report.py
+msgid "Select report types"
+msgstr "Wybierz typy raportów"
+
+#: reports/views/aggregate_report.py reports/views/generate_report.py
+#: reports/views/multi_report.py
+msgid "Export setup"
+msgstr "Eksportuj konfigurację"
+
+#: reports/views/aggregate_report.py reports/views/generate_report.py
+msgid "Save report"
+msgstr "Zapisz raport"
+
+#: reports/views/aggregate_report.py reports/views/generate_report.py
+msgid "You do not have the required permissions to enable plugins."
+msgstr "Nie masz wymaganych uprawnień, aby włączyć wtyczki."
+
+#: reports/views/base.py
+msgid "Select at least one OOI to proceed."
+msgstr "Wybierz co najmniej jeden OOI, aby kontynuować."
+
+#: reports/views/base.py
+msgid "Select at least one report type to proceed."
+msgstr "Aby kontynuować, wybierz co najmniej jeden typ raportu."
+
+#: reports/views/mixins.py
+msgid ""
+"No data could be found for %(report_types). Object(s) did not exist on "
+"%(date)s."
+msgstr ""
+"Nie można znaleźć danych dla %(typy_raportów). Obiekt(y) nie istniał w dniu "
+"%(date)s."
+
+#: reports/views/multi_report.py
+msgid "View report"
+msgstr "Zobacz raport"
+
+#: reports/views/report_overview.py
+msgid "Not enough permissions"
+msgstr "Za mało uprawnień"
+
+#: reports/views/report_overview.py
+msgid "Recipe '{}' deleted successfully"
+msgstr "Przepis „{}” został pomyślnie usunięty"
+
+#: reports/views/report_overview.py
+msgid "Recipe not found."
+msgstr "Nie znaleziono przepisu."
+
+#: reports/views/report_overview.py
+msgid "No schedule or recipe selected"
+msgstr "Nie wybrano harmonogramu ani przepisu"
+
+#: reports/views/report_overview.py
+msgid ""
+"Schedule disabled successfully. '{}' will not be generated automatically "
+"until the schedule is enabled again."
+msgstr ""
+"Harmonogram został wyłączony pomyślnie. „{}” nie zostanie wygenerowany "
+"automatycznie, dopóki harmonogram nie zostanie ponownie włączony."
+
+#: reports/views/report_overview.py
+msgid ""
+"Schedule enabled successfully. '{}' will be generated according to schedule."
+msgstr ""
+"Harmonogram został pomyślnie włączony. '{}' zostanie wygenerowane zgodnie z "
+"harmonogramem."
+
+#: reports/views/report_overview.py
+msgid "An unexpected error occurred, please check logs for more info."
+msgstr ""
+"Wystąpił nieoczekiwany błąd. Sprawdź dzienniki, aby uzyskać więcej "
+"informacji."
+
+#: reports/views/report_overview.py
+msgid "Other OOI type selected than Report"
+msgstr "Wybrano inny typ OOI niż Raport"
+
+#: reports/views/report_overview.py
+msgid "Deletion successful."
+msgstr "Usunięcie powiodło się."
+
+#: reports/views/report_overview.py
+msgid ""
+"Multi organization reports cannot be rescheduled. It consists of imported "
+"data from different organizations and is not based on newly generated data."
+msgstr ""
+"Nie można przełożyć harmonogramu raportów obejmujących wiele organizacji. "
+"Składa się z danych zaimportowanych z różnych organizacji i nie opiera się "
+"na nowo wygenerowanych danych."
+
+#: reports/views/report_overview.py
+msgid ""
+"Rerun successful. It may take a moment before the new report has been "
+"generated."
+msgstr ""
+"Ponowne uruchomienie pomyślne. Wygenerowanie nowego raportu może chwilę "
+"potrwać."
+
+#: reports/views/report_overview.py
+#, python-format
+msgid ""
+"Couldn't rerun %s, since the recipe for this report has been disabled or "
+"deleted."
+msgstr ""
+"Nie można ponownie uruchomić %s, ponieważ przepis dla tego raportu został "
+"wyłączony lub usunięty."
+
+#: reports/views/report_overview.py
+msgid "Renaming failed. Empty report name found."
+msgstr "Zmiana nazwy nie powiodła się. Znaleziono pustą nazwę raportu."
+
+#: reports/views/report_overview.py
+msgid "Report names and reports does not match."
+msgstr "Nazwy raportów i raporty nie są zgodne."
+
+#: reports/views/report_overview.py
+msgid "Reports successfully renamed."
+msgstr "Pomyślnie zmieniono nazwę raportów."
+
+#: reports/views/report_overview.py
+msgid "Report {} could not be renamed."
+msgstr "Nie można zmienić nazwy raportu {}."
+
+#: reports/views/view_helpers.py
+msgid "1: Select objects"
+msgstr "1: Wybierz obiekty"
+
+#: reports/views/view_helpers.py
+msgid "2: Choose report types"
+msgstr "2: Wybierz typy raportów"
+
+#: reports/views/view_helpers.py
+msgid "3: Configuration"
+msgstr "3: Konfiguracja"
+
+#: reports/views/view_helpers.py
+msgid "4: Export setup"
+msgstr "4: Eksportuj konfigurację"
+
+#: reports/views/view_helpers.py
+msgid "3: Export setup"
+msgstr "3: Eksportuj konfigurację"
+
+#: tools/forms/base.py
+msgid "Date"
+msgstr "Data"
+
+#: tools/forms/boefje.py
+msgid "For example: -sTU --top-ports 1000"
+msgstr "Na przykład: -sTU --top-ports 1000"
+
+#: tools/forms/boefje.py
+msgid "JSON Schema"
+msgstr "JSON Schemat"
+
+#: tools/forms/boefje.py
+msgid "Input object type"
+msgstr "Typ obiektu wejściowego"
+
+#: tools/forms/boefje.py
+msgid "Output mime types"
+msgstr "Wyjściowe typy MIME"
+
+#: tools/forms/boefje.py
+msgid "Scan type"
+msgstr "Typ skanowania"
+
+#: tools/forms/boefje.py
+msgid "Interval amount"
+msgstr "Kwota interwału"
+
+#: tools/forms/boefje.py
+msgid ""
+"Specify the scanning interval for this Boefje. The default is 24 hours. For "
+"example: 5 minutes will let the Boefje scan every 5 minutes."
+msgstr ""
+"Określ interwał skanowania dla tego Boefje. Wartość domyślna to 24 godziny. "
+"Na przykład: 5 minut pozwoli Boefje skanować co 5 minut."
+
+#: tools/forms/boefje.py
+msgid "Interval frequency"
+msgstr "Częstotliwość interwałowa"
+
+#: tools/forms/boefje.py
+msgid "Object creation/change"
+msgstr "Tworzenie/zmiana obiektu"
+
+#: tools/forms/boefje.py
+msgid ""
+"Choose weather the Boefje should run after creating and/or changing an "
+"object. "
+msgstr ""
+"Wybierz pogodę, w której Boefje ma działać po utworzeniu i/lub zmianie "
+"obiektu."
+
+#: tools/forms/finding_type.py
+msgid "KAT-ID"
+msgstr "KAT-ID"
+
+#: tools/forms/finding_type.py
+msgid "Unique ID within OpenKAT, for this type"
+msgstr "Unikalny identyfikator w obrębie OpenKAT dla tego typu"
+
+#: tools/forms/finding_type.py
+msgid "Title"
+msgstr "Tytuł"
+
+#: tools/forms/finding_type.py
+msgid "Give the finding type a fitting title"
+msgstr "Nadaj typowi wyniku pasujący tytuł"
+
+#: tools/forms/finding_type.py
+msgid "Describe the finding type"
+msgstr "Opisz typ wyniku"
+
+#: tools/forms/finding_type.py
+msgid "Risk"
+msgstr "Ryzyko"
+
+#: tools/forms/finding_type.py
+msgid "Solution"
+msgstr "Rozwiązanie"
+
+#: tools/forms/finding_type.py
+msgid "How can this be solved?"
+msgstr "Jak można to rozwiązać?"
+
+#: tools/forms/finding_type.py
+msgid "Describe how this type of finding can be solved"
+msgstr "Opisz, jak można rozwiązać tego typu ustalenia"
+
+#: tools/forms/finding_type.py
+msgid "References"
+msgstr "Referencje"
+
+#: tools/forms/finding_type.py
+msgid "Please give some references on the solution"
+msgstr "Proszę o jakieś odniesienia do rozwiązania"
+
+#: tools/forms/finding_type.py
+msgid "Please give sources and references on the suggested solution"
+msgstr ""
+"Proszę o podanie źródeł i referencji na temat sugerowanego rozwiązania"
+
+#: tools/forms/finding_type.py
+msgid "Impact description"
+msgstr "Opis wpływu"
+
+#: tools/forms/finding_type.py
+msgid "Describe the solutions impact"
+msgstr "Opisz wpływ rozwiązań"
+
+#: tools/forms/finding_type.py
+msgid "Solution chance"
+msgstr "Szansa na rozwiązanie"
+
+#: tools/forms/finding_type.py
+msgid "Solution impact"
+msgstr "Wpływ rozwiązania"
+
+#: tools/forms/finding_type.py
+msgid "Solution effort"
+msgstr "Wysiłek rozwiązania"
+
+#: tools/forms/finding_type.py
+msgid "ID should start with "
+msgstr "Identyfikator powinien zaczynać się od"
+
+#: tools/forms/finding_type.py
+msgid "Finding type already exists"
+msgstr "Typ wyszukiwania już istnieje"
+
+#: tools/forms/finding_type.py
+msgid "Click to select one of the available options"
+msgstr "Kliknij, aby wybrać jedną z dostępnych opcji"
+
+#: tools/forms/finding_type.py
+#: rocky/templates/partials/finding_occurrence_definition_list.html
+msgid "Proof"
+msgstr "Dowód"
+
+#: tools/forms/finding_type.py
+msgid "Provide evidence of your finding"
+msgstr "Przedstaw dowód swojego ustalenia"
+
+#: tools/forms/finding_type.py
+msgid "Describe your finding"
+msgstr "Opisz swoje odkrycie"
+
+#: tools/forms/finding_type.py
+msgid "Reproduce finding"
+msgstr "Odtwórz znalezisko"
+
+#: tools/forms/finding_type.py
+msgid "Please explain how to reproduce your finding"
+msgstr "Proszę wyjaśnić, jak odtworzyć swoje ustalenia"
+
+#: tools/forms/finding_type.py tools/forms/upload_raw.py
+msgid "Date/Time (UTC)"
+msgstr "Data/godzina (UTC)"
+
+#: tools/forms/finding_type.py tools/forms/upload_raw.py
+msgid "Doc! I'm from the future, I'm here to take you back!"
+msgstr ""
+"Doktorze! Jestem z przyszłości, jestem tu, żeby cię zabrać z powrotem!"
+
+#: tools/forms/finding_type.py
+msgid "OOI doesn't exist"
+msgstr "OOI nie istnieje"
+
+#: tools/forms/findings.py
+msgid "Show non-muted findings"
+msgstr "Pokaż niewyciszone wyniki"
+
+#: tools/forms/findings.py
+msgid "Show muted findings"
+msgstr "Pokaż wyciszone wyniki"
+
+#: tools/forms/findings.py
+msgid "Show muted and non-muted findings"
+msgstr "Pokaż wyciszone i niewyciszone wyniki"
+
+#: tools/forms/findings.py
+msgid "Filter by severity"
+msgstr "Filtruj według ważności"
+
+#: tools/forms/findings.py
+msgid "Filter by muted findings"
+msgstr "Filtruj według wyciszonych wyników"
+
+#: tools/forms/findings.py tools/forms/ooi_form.py tools/forms/scheduler.py
+msgid "Search"
+msgstr "Szukaj"
+
+#: tools/forms/findings.py
+msgid "Object ID contains (case sensitive)"
+msgstr "Identyfikator obiektu zawiera (wielkość liter ma znaczenie)"
+
+#: tools/forms/ooi.py
+msgid "Filter types"
+msgstr "Typy filtrów"
+
+#: tools/forms/ooi.py
+msgid "Clearance Level"
+msgstr "Poziom rozliczenia"
+
+#: tools/forms/ooi.py
+msgid "Next scan"
+msgstr "Następny skan"
+
+#: tools/forms/ooi.py
+msgid "Show objects that don't meet the Boefjes scan level."
+msgstr "Pokaż obiekty, które nie spełniają poziomu skanowania Boefjes."
+
+#: tools/forms/ooi.py
+msgid "Show Boefjes that exceed the objects clearance level."
+msgstr "Pokaż Boefjes, które przekraczają poziom prześwitu obiektów."
+
+#: tools/forms/ooi.py
+msgid ""
+"All the boefjes with a scan level below or equal to the clearance level will"
+" be allowed to scan this object."
+msgstr ""
+"Wszystkie boefje z poziomem skanowania niższym lub równym poziomowi "
+"zezwolenia będą mogły skanować ten obiekt."
+
+#: tools/forms/ooi.py
+msgid "Expires by (UTC)"
+msgstr "Wygasa do (UTC)"
+
+#: tools/forms/ooi_form.py
+msgid "option"
+msgstr "opcja"
+
+#: tools/forms/ooi_form.py
+#, python-brace-format
+msgid "Optionally choose a {option_label}"
+msgstr "Opcjonalnie wybierz {option_label}"
+
+#: tools/forms/ooi_form.py
+#, python-brace-format
+msgid "Please choose a {option_label}"
+msgstr "Proszę wybrać {option_label}"
+
+#: tools/forms/ooi_form.py
+msgid "Filter by clearance level"
+msgstr "Filtruj według poziomu luzu"
+
+#: tools/forms/ooi_form.py
+msgid "Filter by clearance type"
+msgstr "Filtruj według typu luzu"
+
+#: tools/forms/scheduler.py
+msgid "From"
+msgstr "Z"
+
+#: tools/forms/scheduler.py
+msgid "To"
+msgstr "Do"
+
+#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+msgid "Cancelled"
+msgstr "Odwołany"
+
+#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+msgid "Completed"
+msgstr "Zakończony"
+
+#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+msgid "Dispatched"
+msgstr "Wysłany"
+
+#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+msgid "Failed"
+msgstr "Przegrany"
+
+#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+msgid "Queued"
+msgstr "W kolejce"
+
+#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+msgid "Running"
+msgstr "Działanie"
+
+#: tools/forms/scheduler.py
+msgid "Search by object name"
+msgstr "Szukaj według nazwy obiektu"
+
+#: tools/forms/scheduler.py
+msgid "The selected date is in the future. Please select a different date."
+msgstr "Wybrana data przypada w przyszłości. Proszę wybrać inną datę."
+
+#: tools/forms/settings.py
+msgid "--- Show all ----"
+msgstr "--- Pokaż wszystko ----"
+
+#: tools/forms/settings.py
+msgid "recommendation"
+msgstr "zalecenie"
+
+#: tools/forms/settings.py
+msgid "low"
+msgstr "Niski"
+
+#: tools/forms/settings.py
+msgid "medium"
+msgstr "średni"
+
+#: tools/forms/settings.py
+msgid "high"
+msgstr "wysoki"
+
+#: tools/forms/settings.py
+msgid "very high"
+msgstr "bardzo wysoki"
+
+#: tools/forms/settings.py
+msgid "critical"
+msgstr "krytyczny"
+
+#: tools/forms/settings.py
+msgid "quickfix"
+msgstr "szybka poprawka"
+
+#: tools/forms/settings.py
+msgid "Declared"
+msgstr "Zdeklarowany"
+
+#: tools/forms/settings.py
+msgid "Inherited"
+msgstr "Dziedziczny"
+
+#: tools/forms/settings.py
+msgid "Empty"
+msgstr "Pusty"
+
+#: tools/forms/settings.py
+msgid "Add one finding type ID per line."
+msgstr "Dodaj jeden identyfikator typu wyniku w każdym wierszu."
+
+#: tools/forms/settings.py
+msgid "Add the date and time of your finding (UTC)"
+msgstr "Dodaj datę i godzinę znalezienia (UTC)"
+
+#: tools/forms/settings.py
+msgid "Add the date and time of when the raw file was generated (UTC)"
+msgstr "Dodaj datę i godzinę wygenerowania pliku raw (UTC)"
+
+#: tools/forms/settings.py
+msgid ""
+"OpenKAT stores a time indication with every observation, so it is possible "
+"to see the status of your network through time. Select a datetime to change "
+"the view to represent that moment in time."
+msgstr ""
+"OpenKAT przechowuje wskazanie czasu przy każdej obserwacji, dzięki czemu "
+"możliwe jest sprawdzenie stanu sieci w czasie. Wybierz datę i godzinę, aby "
+"zmienić widok reprezentujący ten moment w czasie."
+
+#: tools/forms/settings.py
+msgid ""
+"<p>The name of the Docker image. For example: "
+"<i>'ghcr.io/minvws/openkat/nmap'</i>. In OpenKAT, all Boefjes with the same "
+"container image will be seen as 'variants' and will be shown together on the"
+" Boefje detail page. </p> "
+msgstr ""
+"<p>Nazwa obrazu Dockera. Na przykład: <i>'ghcr.io/minvws/openkat/nmap'</i>. "
+"W OpenKAT wszystkie Boefjes z tym samym obrazem kontenera będą postrzegane "
+"jako „warianty” i będą wyświetlane razem na stronie szczegółów Boefje. </p>"
+
+#: tools/forms/settings.py
+msgid ""
+"A description of the Boefje explaining in short what it can do. This will "
+"both be displayed inside the KAT-alogus and on the Boefje details page."
+msgstr ""
+"Opis Boefje wyjaśniający w skrócie, co potrafi. Będą one wyświetlane zarówno"
+" wewnątrz KAT-alogus, jak i na stronie szczegółów Boefje."
+
+#: tools/forms/settings.py
+msgid ""
+"Select the object type(s) that your Boefje consumes. To select multiple "
+"objects, press and hold the 'ctrl'/'command' key and then click the items "
+"you want to select. "
+msgstr ""
+"Wybierz typy obiektów, z których korzysta Twój Boefje. Aby wybrać wiele "
+"obiektów, naciśnij i przytrzymaj klawisz „Ctrl”/„Command”, a następnie "
+"kliknij elementy, które chcesz wybrać."
+
+#: tools/forms/settings.py
+msgid ""
+"<p>If any other settings are needed for your Boefje, add these as a JSON "
+"Schema, otherwise, leave the field empty or 'null'.</p> <p> This JSON is "
+"used as the basis for a form for the user. When the user enables this Boefje"
+" they can get the option to give extra information. For example, it can "
+"contain an API key that the script requires.</p> <p>More information about "
+"what the schema.json file looks like can be found <a "
+"href='https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html'>"
+" here</a>.</p> "
+msgstr ""
+"<p>Jeśli dla Twojego Boefje potrzebne są inne ustawienia, dodaj je jako "
+"schemat JSON, w przeciwnym razie pozostaw pole puste lub 'null'.</p> <p> To "
+"JSON służy jako podstawa formularza dla użytkownika. Gdy użytkownik włączy "
+"tę opcję Boefje, będzie mógł uzyskać dodatkowe informacje. Przykładowo może "
+"zawierać klucz API wymagany przez skrypt.</p> <p>Więcej informacji o tym, "
+"jak wygląda plik schema.json znajdziesz <a "
+"href='https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html'>"
+" tutaj</a>.</p>"
+
+#: tools/forms/settings.py
+msgid ""
+"<p>Add a set of mime types that are produced by this Boefje, separated by "
+"commas. For example: <i>'text/html'</i>, <i>'image/jpeg'</i> or "
+"<i>'boefje/{boefje-id}'</i></p> <p>These output mime types will be shown on "
+"the Boefje detail page as information for other users. </p> "
+msgstr ""
+"<p>Dodaj zestaw typów MIME generowanych przez ten Boefje, oddzielonych "
+"przecinkami. Na przykład: <i>'text/html'</i>, <i>'image/jpeg'</i> lub "
+"<i>'boefje/{boefje-id}'</i></p> <p>Te wyjściowe typy MIME będą być "
+"wyświetlane na stronie szczegółów Boefje jako informacja dla innych "
+"użytkowników. </p>"
+
+#: tools/forms/settings.py
+msgid ""
+"<p>Select a clearance level for your Boefje. For more information about the "
+"different clearance levels please check the <a "
+"href='https://docs.openkat.nl/manual/usermanual.html#scan-levels-clearance-"
+"indemnities'> documentation</a>.</p> "
+msgstr ""
+"<p>Wybierz poziom uprawnień dla swojego Boefje. Więcej informacji na temat "
+"różnych poziomów zezwolenia można znaleźć w dokumentacji <a "
+"href='https://docs.openkat.nl/manual/usermanual.html#scan-levels-clearance-"
+"indemnities'></a>.</p>"
+
+#: tools/forms/settings.py
+msgid ""
+"Choose when this Boefje will scan objects. It can run on a given interval or"
+" it can run every time an object has been created or changed. "
+msgstr ""
+"Wybierz, kiedy Boefje będzie skanować obiekty. Może działać w określonym "
+"przedziale czasu lub może działać za każdym razem, gdy obiekt zostanie "
+"utworzony lub zmieniony."
+
+#: tools/forms/settings.py
+msgid "Depth of the tree."
+msgstr "Głębokość drzewa."
+
+#: tools/forms/upload_csv.py
+msgid "Only CSV file supported"
+msgstr "Obsługiwany jest tylko plik CSV"
+
+#: tools/forms/upload_csv.py
+msgid "File could not be decoded"
+msgstr "Nie można zdekodować pliku"
+
+#: tools/forms/upload_csv.py
+msgid "No file selected"
+msgstr "Nie wybrano pliku"
+
+#: tools/forms/upload_csv.py
+msgid "The uploaded file is empty."
+msgstr "Przesłany plik jest pusty."
+
+#: tools/forms/upload_csv.py
+msgid "The number of columns do not meet the requirements."
+msgstr "Liczba kolumn nie spełnia wymagań."
+
+#: tools/forms/upload_csv.py
+msgid "OOI Type in CSV does not meet the criteria."
+msgstr "OOI Wpisz CSV nie spełnia kryteriów."
+
+#: tools/forms/upload_csv.py
+msgid "An error has occurred during the parsing of the csv file:"
+msgstr "Wystąpił błąd podczas analizowania pliku csv:"
+
+#: tools/forms/upload_csv.py
+msgid "Upload CSV file"
+msgstr "Prześlij plik CSV"
+
+#: tools/forms/upload_csv.py
+msgid "Only accepts CSV file."
+msgstr "Akceptuje tylko plik CSV."
+
+#: tools/forms/upload_oois.py rocky/templates/partials/explanations.html
+msgid "Object Type"
+msgstr "Typ obiektu"
+
+#: tools/forms/upload_oois.py
+msgid "Choose a type of which objects are added."
+msgstr "Wybierz typ dodawanych obiektów."
+
+#: tools/forms/upload_raw.py
+msgid "Mime types"
+msgstr "Typy mimów"
+
+#: tools/forms/upload_raw.py
+msgid ""
+"<p>Add a set of mime types, separated by commas, for "
+"example:</p><p><i>\"text/html, image/jpeg\"</i> or <i>\"boefje/dns-"
+"records\"</i>.</p><p>Mime types are used to match the correct normalizer to "
+"a raw file. When the mime type \"boefje/dns-records\" is added, the "
+"normalizer expects the raw file to contain dns scan information.</p>"
+msgstr ""
+"<p>Dodaj zestaw typów MIME oddzielonych przecinkami, na "
+"przykład:</p><p><i>\"text/html, image/jpeg\"</i> lub <i>\"boefje/dns-"
+"records\"</i>.</p><p>Typy MIME służą do dopasowania prawidłowego "
+"normalizatora do nieprzetworzonego pliku. Po dodaniu typu MIME „boefje/dns-"
+"records” normalizator oczekuje, że surowy plik będzie zawierał informacje o "
+"skanie dns.</p>"
+
+#: tools/forms/upload_raw.py rocky/templates/partials/ooi_list_toolbar.html
+#: rocky/templates/upload_raw.html
+msgid "Upload raw file"
+msgstr "Prześlij surowy plik"
+
+#: tools/forms/upload_raw.py
+msgid "Input or Scan OOI"
+msgstr "Wprowadź lub skanuj OOI"
+
+#: tools/forms/upload_raw.py
+msgid "Click to select one of the available options, or type one yourself"
+msgstr ""
+"Kliknij, aby wybrać jedną z dostępnych opcji, lub wpisz ją samodzielnie"
+
+#: tools/forms/upload_raw.py
+msgid "OOI doesn't exist, try another valid time"
+msgstr "OOI nie istnieje, spróbuj inny prawidłowy czas"
+
+#: tools/models.py
+msgid ""
+"A short code containing only lower-case unicode letters, numbers, hyphens or"
+" underscores that will be used in URLs and paths."
+msgstr ""
+"Krótki kod zawierający tylko małe litery Unicode, cyfry, łączniki i "
+"podkreślenia, który będzie używany w URLs i ścieżkach."
+
+#: tools/models.py
+msgid ""
+"This organization code is reserved by OpenKAT and cannot be used. Choose "
+"another organization code."
+msgstr ""
+"Ten kod organizacji jest zastrzeżony przez OpenKAT i nie można go użyć. "
+"Wybierz inny kod organizacji."
+
+#: tools/models.py
+msgid "new"
+msgstr "nowy"
+
+#: tools/templatetags/ooi_extra.py
+msgid "Unknown user"
+msgstr "Nieznany użytkownik"
+
+#: tools/view_helpers.py rocky/templates/header.html
+#: rocky/templates/organizations/organization_member_list.html
+#: rocky/views/organization_member_edit.py
+msgid "Members"
+msgstr "Członkowie"
+
+#: rocky/forms.py
+msgid "Current status"
+msgstr "Aktualny stan"
+
+#: rocky/forms.py rocky/templates/organizations/organization_member_list.html
+msgid "Active"
+msgstr "Aktywny"
+
+#: rocky/forms.py rocky/templates/organizations/organization_member_list.html
+msgid "New"
+msgstr "Nowy"
+
+#: rocky/forms.py
+msgid "Account status"
+msgstr "Stan konta"
+
+#: rocky/forms.py
+msgid "Not blocked"
+msgstr "Nie zablokowane"
+
+#: rocky/messaging.py
+msgid ""
+"You have trusted this member with a clearance level of L{}. This member "
+"needs at least a clearance level of L{} in order to do a proper onboarding. "
+"Edit this member and change the clearance level if necessary."
+msgstr ""
+"Zaufałeś temu członkowi z poziomem uprawnień L{}. Aby móc przeprowadzić "
+"prawidłowe wdrożenie, ten członek potrzebuje co najmniej poziomu uprawnień "
+"L{}. Edytuj ten element i w razie potrzeby zmień poziom uprawnień."
+
+#: rocky/paginator.py
+msgid "That page number is not an integer"
+msgstr "Numer strony nie jest liczbą całkowitą"
+
+#: rocky/paginator.py
+msgid "That page number is less than 1"
+msgstr "Numer tej strony jest mniejszy niż 1"
+
+#: rocky/paginator.py
+msgid "That page contains no results"
+msgstr "Ta strona nie zawiera żadnych wyników"
+
+#: rocky/scheduler.py
+msgid ""
+"The Scheduler has an unexpected error. Check the Scheduler logs for further "
+"details."
+msgstr ""
+"W harmonogramie wystąpił nieoczekiwany błąd. Więcej szczegółów można znaleźć"
+" w dziennikach programu planującego."
+
+#: rocky/scheduler.py
+msgid "Could not connect to Scheduler. Service is possibly down."
+msgstr ""
+"Nie można połączyć się z Harmonogramem. Usługa prawdopodobnie nie działa."
+
+#: rocky/scheduler.py
+msgid "Your request could not be validated."
+msgstr "Nie można zweryfikować Twojego żądania."
+
+#: rocky/scheduler.py
+msgid "Task could not be found."
+msgstr "Nie udało się znaleźć zadania."
+
+#: rocky/scheduler.py
+msgid ""
+"Scheduler is receiving too many requests. Increase SCHEDULER_PQ_MAXSIZE or "
+"wait for task to finish."
+msgstr ""
+"Harmonogram otrzymuje zbyt wiele żądań. Zwiększ SCHEDULER_PQ_MAXSIZE lub "
+"poczekaj na zakończenie zadania."
+
+#: rocky/scheduler.py
+msgid "Bad request. Your request could not be interpreted by the Scheduler."
+msgstr ""
+"Zła prośba. Twoja prośba nie mogła zostać zinterpretowana przez "
+"Harmonogramu."
+
+#: rocky/scheduler.py
+msgid "The Scheduler has received a conflict. Your task is already in queue."
+msgstr "Harmonogram odebrał konflikt. Twoje zadanie jest już w kolejce."
+
+#: rocky/scheduler.py
+msgid "A HTTPError occurred. See Scheduler logs for more info."
+msgstr ""
+"Wystąpił błąd HTTP. Aby uzyskać więcej informacji, zobacz dzienniki "
+"harmonogramu."
+
+#: rocky/scheduler.py
+msgid "Schedule list: "
+msgstr "Lista harmonogramów:"
+
+#: rocky/scheduler.py
+msgid "Task list: "
+msgstr "Lista zadań:"
+
+#: rocky/settings.py
+msgid "Blue light"
+msgstr "Niebieskie światło"
+
+#: rocky/settings.py
+msgid "Blue medium"
+msgstr "Niebieski średni"
+
+#: rocky/settings.py
+msgid "Blue dark"
+msgstr "Niebieski ciemny"
+
+#: rocky/settings.py
+msgid "Green light"
+msgstr "Zielone światło"
+
+#: rocky/settings.py
+msgid "Green medium"
+msgstr "Zielony średni"
+
+#: rocky/settings.py
+msgid "Green dark"
+msgstr "Zielony ciemny"
+
+#: rocky/settings.py
+msgid "Yellow light"
+msgstr "Żółte światło"
+
+#: rocky/settings.py
+msgid "Yellow medium"
+msgstr "Żółty średni"
+
+#: rocky/settings.py
+msgid "Yellow dark"
+msgstr "Żółty ciemny"
+
+#: rocky/settings.py
+msgid "Orange light"
+msgstr "Pomarańczowe światło"
+
+#: rocky/settings.py
+msgid "Orange medium"
+msgstr "Pomarańczowy średni"
+
+#: rocky/settings.py
+msgid "Orange dark"
+msgstr "Pomarańczowy ciemny"
+
+#: rocky/settings.py
+msgid "Red light"
+msgstr "Czerwone światło"
+
+#: rocky/settings.py
+msgid "Red medium"
+msgstr "Czerwony średni"
+
+#: rocky/settings.py
+msgid "Red dark"
+msgstr "Czerwony ciemny"
+
+#: rocky/settings.py
+msgid "Violet light"
+msgstr "Fioletowe światło"
+
+#: rocky/settings.py
+msgid "Violet medium"
+msgstr "Fioletowy środek"
+
+#: rocky/settings.py
+msgid "Violet dark"
+msgstr "Fioletowy ciemny"
+
+#: rocky/settings.py
+msgid "Plain"
+msgstr "Zwykły"
+
+#: rocky/settings.py
+msgid "Solid"
+msgstr "Solidny"
+
+#: rocky/settings.py
+msgid "Dashed"
+msgstr "Przerywana"
+
+#: rocky/settings.py
+msgid "Dotted"
+msgstr "Kropkowany"
+
+#: rocky/templates/403.html
+msgid "Error code 403: Unauthorized"
+msgstr "Kod błędu 403: Nieautoryzowany"
+
+#: rocky/templates/403.html
+msgid "Your account is not authorized to access this page or organization."
+msgstr ""
+"Twoje konto nie ma uprawnień dostępu do tej strony lub tej organizacji."
+
+#: rocky/templates/403.html
+msgid "Please contact your system administrator."
+msgstr "Skontaktuj się z administratorem systemu."
+
+#: rocky/templates/403.html rocky/templates/404.html
+msgid "You may want to go back to the"
+msgstr "Może zechcesz wrócić do"
+
+#: rocky/templates/403.html rocky/templates/404.html
+msgid "Crisis Room"
+msgstr "Pokój kryzysowy"
+
+#: rocky/templates/404.html
+msgid "Error code 404: Page not found"
+msgstr "Kod błędu 404: Nie znaleziono strony"
+
+#: rocky/templates/404.html
+msgid ""
+"The page you wanted to see or the file you wanted to view was not found."
+msgstr ""
+"Strona, którą chciałeś wyświetlić lub plik, który chciałeś wyświetlić, nie "
+"został znaleziony."
+
+#: rocky/templates/admin/base.html
+msgid "Skip to main content"
+msgstr "Przejdź do głównej treści"
+
+#: rocky/templates/admin/base.html
+msgid "Welcome,"
+msgstr "Powitanie,"
+
+#: rocky/templates/admin/base.html
+msgid "View site"
+msgstr "Zobacz witrynę"
+
+#: rocky/templates/admin/base.html
+msgid "Documentation"
+msgstr "Dokumentacja"
+
+#: rocky/templates/admin/base.html
+msgid "Change password"
+msgstr "Zmień hasło"
+
+#: rocky/templates/admin/base.html
+msgid "Log out"
+msgstr "Wyloguj się"
+
+#: rocky/templates/admin/base.html rocky/templates/header.html
+msgid "Breadcrumbs"
+msgstr "Bułka tarta"
+
+#: rocky/templates/admin/base.html rocky/templates/admin/change_form.html
+#: rocky/templates/admin/change_list.html
+#: rocky/templates/admin/delete_confirmation.html
+#: rocky/templates/admin/delete_selected_confirmation.html
+msgid "Home"
+msgstr "Dom"
+
+#: rocky/templates/admin/change_form.html
+#, python-format
+msgid "Add %(name)s"
+msgstr "Dodaj %(name)s"
+
+#: rocky/templates/admin/change_form.html
+#: rocky/templates/admin/change_list.html
+msgid "Please correct the error below."
+msgid_plural "Please correct the errors below."
+msgstr[0] "Popraw poniższy błąd."
+msgstr[1] "Popraw poniższe błędy."
+msgstr[2] "Popraw poniższe błędy."
+
+#: rocky/templates/admin/change_list.html
+msgid "Filter"
+msgstr "Filtr"
+
+#: rocky/templates/admin/change_list.html
+msgid "Hide counts"
+msgstr "Ukryj liczby"
+
+#: rocky/templates/admin/change_list.html
+msgid "Show counts"
+msgstr "Pokaż liczniki"
+
+#: rocky/templates/admin/change_list.html
+msgid "Clear all filters"
+msgstr "Wyczyść wszystkie filtry"
+
+#: rocky/templates/admin/delete_confirmation.html
+#, python-format
+msgid ""
+"Deleting the %(object_name)s '%(escaped_object)s' would result in deleting "
+"related objects, but your account doesn't have permission to delete the "
+"following types of objects"
+msgstr ""
+"Usunięcie %(object_name)s '%(escaped_object)s' spowodowałoby usunięcie "
+"powiązanych obiektów, ale Twoje konto nie ma uprawnień do usuwania "
+"następujących typów obiektów"
+
+#: rocky/templates/admin/delete_confirmation.html
+#, python-format
+msgid ""
+"Deleting the %(object_name)s '%(escaped_object)s' would require deleting the"
+" following protected related objects"
+msgstr ""
+"Usunięcie %(object_name)s '%(escaped_object)s' wymagałoby usunięcia "
+"następujących chronionych obiektów powiązanych"
+
+#: rocky/templates/admin/delete_confirmation.html
+#, python-format
+msgid ""
+"Are you sure you want to delete the %(object_name)s \"%(escaped_object)s\"? "
+"All of the following related items will be deleted"
+msgstr ""
+"Czy na pewno chcesz usunąć %(object_name)s \"%(escaped_object)s\"? Wszystkie"
+" poniższe powiązane elementy zostaną usunięte"
+
+#: rocky/templates/admin/delete_confirmation.html
+#: rocky/templates/admin/delete_selected_confirmation.html
+msgid "Yes, I’m sure"
+msgstr "Tak, jestem pewien"
+
+#: rocky/templates/admin/delete_confirmation.html
+#: rocky/templates/admin/delete_selected_confirmation.html
+msgid "No, take me back"
+msgstr "Nie, zabierz mnie z powrotem"
+
+#: rocky/templates/admin/delete_selected_confirmation.html
+msgid "Delete multiple objects"
+msgstr "Usuń wiele obiektów"
+
+#: rocky/templates/admin/delete_selected_confirmation.html
+#, python-format
+msgid ""
+"Deleting the selected %(objects_name)s would result in deleting related "
+"objects, but your account doesn't have permission to delete the following "
+"types of objects"
+msgstr ""
+"Usunięcie wybranego %(objects_name)s spowoduje usunięcie powiązanych "
+"obiektów, ale Twoje konto nie ma uprawnień do usuwania następujących typów "
+"obiektów"
+
+#: rocky/templates/admin/delete_selected_confirmation.html
+#, python-format
+msgid ""
+"Deleting the selected %(objects_name)s would require deleting the following "
+"protected related objects"
+msgstr ""
+"Usunięcie wybranego %(objects_name)s wymagałoby usunięcia następujących "
+"chronionych obiektów powiązanych"
+
+#: rocky/templates/admin/delete_selected_confirmation.html
+#, python-format
+msgid ""
+"Are you sure you want to delete the selected %(objects_name)s? All of the "
+"following objects and their related items will be deleted"
+msgstr ""
+"Czy na pewno chcesz usunąć wybrane %(objects_name)s? Wszystkie poniższe "
+"obiekty i powiązane z nimi elementy zostaną usunięte"
+
+#: rocky/templates/admin/popup_response.html
+msgid "Popup closing…"
+msgstr "Zamykanie wyskakującego okienka…"
+
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
+msgid "Close menu"
+msgstr "Zamknij menu"
+
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
+msgid "Main navigation"
+msgstr "Główna nawigacja"
+
+#: rocky/templates/dashboard_client.html
+msgid "Indemnifications"
+msgstr "Odszkodowania"
+
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html
+#: rocky/templates/partials/secondary-menu.html
+msgid "Logout"
+msgstr "Wyloguj się"
+
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html
+msgid "Welcome"
+msgstr "Powitanie"
+
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html
+msgid "User overview"
+msgstr "Przegląd użytkowników"
+
+#: rocky/templates/dashboard_redteam.html
+#: rocky/templates/partials/notifications_block.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid "warning"
+msgstr "ostrzeżenie"
+
+#: rocky/templates/dashboard_redteam.html
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+#: rocky/templates/partials/notifications_block.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid "Warning:"
+msgstr "Ostrzeżenie:"
+
+#: rocky/templates/dashboard_redteam.html
+msgid "Organization code missing"
+msgstr "Brak kodu organizacji"
+
+#: rocky/templates/finding_type_add.html
+#: rocky/templates/partials/findings_list_toolbar.html
+#: rocky/views/finding_type_add.py
+msgid "Add finding type"
+msgstr "Dodaj typ wyniku"
+
+#: rocky/templates/finding_type_add.html
+msgid "Finding Type"
+msgstr "Typ znalezienia"
+
+#: rocky/templates/findings/finding_add.html
+#: rocky/templates/oois/ooi_detail_findings_list.html
+#: rocky/templates/oois/ooi_findings.html
+#: rocky/templates/partials/findings_list_toolbar.html
+#: rocky/views/finding_add.py
+msgid "Add finding"
+msgstr "Dodaj znalezisko"
+
+#: rocky/templates/findings/finding_list.html
+msgid "Findings "
+msgstr "Ustalenia"
+
+#: rocky/templates/findings/finding_list.html
+#, python-format
+msgid ""
+"An overview of all findings OpenKAT found for organization "
+"<strong>%(organization_name)s</strong>. Each finding relates to an object. "
+"Click a finding for additional information."
+msgstr ""
+"Przegląd wszystkich wyników OpenKAT znalezionych dla organizacji "
+"<strong>%(organization_name)s</strong>. Każde znalezisko odnosi się do "
+"obiektu. Kliknij wynik, aby uzyskać dodatkowe informacje."
+
+#: rocky/templates/findings/finding_list.html
+#, python-format
+msgid "Showing %(length)s of %(total)s findings"
+msgstr "Wyświetlanie %(length)s z %(total)s wyników"
+
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/partials/mute_findings_modal.html
+msgid "Mute findings"
+msgstr "Wycisz ustalenia"
+
+#: rocky/templates/findings/finding_list.html
+msgid "Unmute findings"
+msgstr "Wyłącz wyciszenie wyników"
+
+#: rocky/templates/findings/findings_filter.html
+#: rocky/templates/partials/elements/ooi_list_settings_form.html
+#: rocky/templates/tasks/partials/task_filter.html
+msgid "Set filters"
+msgstr "Ustaw filtry"
+
+#: rocky/templates/findings/findings_filter.html
+#: rocky/templates/partials/elements/ooi_list_settings_form.html
+#: rocky/templates/tasks/partials/task_filter.html
+msgid "Clear filters"
+msgstr "Wyczyść filtry"
+
+#: rocky/templates/footer.html rocky/views/privacy_statement.py
+msgid "Privacy Statement"
+msgstr "Oświadczenie o ochronie prywatności"
+
+#: rocky/templates/forms/json_schema_form.html
+msgid "Fill out this form to answer the Question (again):"
+msgstr "Wypełnij ten formularz, aby odpowiedzieć na pytanie (ponownie):"
+
+#: rocky/templates/graph-d3.html
+msgid ""
+"Click a circle to collapse / expand the tree, click the text to view the "
+"tree from that OOI and hover over the text to see details."
+msgstr ""
+"Kliknij okrąg, aby zwinąć/rozwinąć drzewo, kliknij tekst, aby wyświetlić "
+"drzewo z tego OOI i najedź kursorem na tekst, aby zobaczyć szczegóły."
+
+#: rocky/templates/graph-d3.html
+msgid "Tree graph"
+msgstr "Wykres drzewa"
+
+#: rocky/templates/header.html
+msgid "Menu"
+msgstr "Menu"
+
+#: rocky/templates/header.html
+msgid "OpenKAT logo, go to the homepage of OpenKAT"
+msgstr "logo OpenKAT, przejdź do strony głównej OpenKAT"
+
+#: rocky/templates/header.html rocky/templates/tasks/ooi_detail_task_list.html
+#: rocky/templates/tasks/partials/tasks_overview_header.html
+#: rocky/templates/tasks/plugin_detail_task_list.html
+#: rocky/views/task_detail.py rocky/views/tasks.py
+msgid "Tasks"
+msgstr "Zadania"
+
+#: rocky/templates/health.html
+msgid "Health Checks"
+msgstr "Kontrole stanu zdrowia"
+
+#: rocky/templates/health.html
+msgid "Health checks"
+msgstr "Kontrole stanu zdrowia"
+
+#: rocky/templates/health.html
+msgid "Additional"
+msgstr "Dodatkowy"
+
+#: rocky/templates/indemnification_present.html
+msgid "Indemnification"
+msgstr "Odszkodowanie"
+
+#: rocky/templates/indemnification_present.html
+msgid ""
+"Indemnification on the organization present. You may now add objects and "
+"start scans."
+msgstr ""
+"Zabezpieczenie od obecnej organizacji. Możesz teraz dodawać obiekty i "
+"rozpoczynać skanowanie."
+
+#: rocky/templates/indemnification_present.html
+msgid "Go to Objects"
+msgstr "Przejdź do Obiektów"
+
+#: rocky/templates/indemnification_present.html
+msgid "Go to"
+msgstr "Idź do"
+
+#: rocky/templates/landing_page.html
+msgid "Welcome to OpenKAT"
+msgstr "Witamy w OpenKAT"
+
+#: rocky/templates/landing_page.html
+msgid "Kwetsbaarheden Analyse Tool"
+msgstr "Narzędzie analityczne Kwetsbaarheden"
+
+#: rocky/templates/landing_page.html
+msgid "What is OpenKAT?"
+msgstr "Co to jest OpenKAT?"
+
+#: rocky/templates/landing_page.html
+msgid ""
+"OpenKAT is a vulnerability analysis tool. An Open Source-project developed "
+"by the Ministry of Health, Welfare and Sport to make your and our world "
+"safer."
+msgstr ""
+"OpenKAT to narzędzie do analizy podatności. Projekt Open Source opracowany "
+"przez Ministerstwo Zdrowia, Opieki Społecznej i Sportu, aby uczynić Twój i "
+"nasz świat bezpieczniejszym."
+
+#: rocky/templates/landing_page.html
+msgid "OpenKAT sees"
+msgstr "OpenKAT widzi"
+
+#: rocky/templates/landing_page.html
+msgid ""
+"Dozens of tools are integrated in OpenKAT to view the world (digital and "
+"analog)."
+msgstr ""
+"W OpenKAT zintegrowanych jest dziesiątki narzędzi umożliwiających oglądanie "
+"świata (cyfrowego i analogowego)."
+
+#: rocky/templates/landing_page.html
+msgid "Our motto is therefore: I see, I see, what you do not see."
+msgstr "Naszą dewizą jest zatem: Widzę, widzę, czego Ty nie widzisz."
+
+#: rocky/templates/landing_page.html
+msgid "OpenKAT knows"
+msgstr "OpenKAT wie"
+
+#: rocky/templates/landing_page.html
+msgid ""
+"OpenKAT does not forget (just like that), and can be queried without "
+"scanning again. Also about a historical situation."
+msgstr ""
+"OpenKAT nie zapomina (tak po prostu) i można go sprawdzić bez ponownego "
+"skanowania. Także o sytuacji historycznej."
+
+#: rocky/templates/landing_page.html
+msgid "OpenKAT is secure"
+msgstr "OpenKAT jest bezpieczny"
+
+#: rocky/templates/landing_page.html
+msgid ""
+"Forensically secured storage of evidence is one of the basic ingredients of "
+"OpenKAT."
+msgstr ""
+"Zabezpieczone kryminalistycznie przechowywanie dowodów jest jednym z "
+"podstawowych składników OpenKAT."
+
+#: rocky/templates/landing_page.html
+msgid "OpenKAT is sweet"
+msgstr "OpenKAT jest słodki"
+
+#: rocky/templates/landing_page.html
+msgid ""
+"OpenKAT thinks about privacy, and stores what is necessary, within the rules"
+" of your organization and the law."
+msgstr ""
+"OpenKAT myśli o prywatności i przechowuje to, co konieczne, w ramach zasad "
+"obowiązujących w Twojej organizacji i prawa."
+
+#: rocky/templates/landing_page.html
+msgid "A wide playing field"
+msgstr "Szerokie pole do gry"
+
+#: rocky/templates/landing_page.html
+msgid ""
+"OpenKAT makes a copy of the actual reality by means of the integrated tools."
+" Within this copy you can search for answers to countless security and "
+"policy questions. Expected and unexpected changes in the world are made "
+"visible, and where necessary reported or made known directly to the right "
+"people."
+msgstr ""
+"OpenKAT tworzy kopię rzeczywistej rzeczywistości za pomocą zintegrowanych "
+"narzędzi. W tej kopii możesz szukać odpowiedzi na niezliczone pytania "
+"dotyczące bezpieczeństwa i zasad. Oczekiwane i nieoczekiwane zmiany na "
+"świecie są widoczne, a w razie potrzeby zgłaszane lub udostępniane "
+"bezpośrednio właściwym osobom."
+
+#: rocky/templates/legal/privacy_statement.html
+msgid "OpenKAT Privacy Statement"
+msgstr "OpenKAT Oświadczenie o ochronie prywatności"
+
+#: rocky/templates/legal/privacy_statement.html
+msgid ""
+"OpenKAT is dedicated to protecting the confidentiality and privacy of "
+"information entrusted to it. As part of this fundamental obligation, OpenKAT"
+" is committed to the appropriate protection and use of personal information "
+"(sometimes referred to as \"personal data\", \"personally identifiable "
+"information\" or \"PII\") that has been collected online."
+msgstr ""
+"OpenKAT dba o ochronę poufności i prywatności powierzonych jej informacji. W"
+" ramach tego podstawowego obowiązku firma OpenKAT zobowiązuje się do "
+"odpowiedniej ochrony i wykorzystania danych osobowych (czasami nazywanych "
+"„danymi osobowymi”, „informacjami umożliwiającymi identyfikację” lub „PII”) "
+"zebranych online."
+
+#: rocky/templates/oois/error.html
+msgid "Object List"
+msgstr "Lista obiektów"
+
+#: rocky/templates/oois/error.html
+msgid "An error occurred. Please contact a system administrator."
+msgstr "Wystąpił błąd. Skontaktuj się z administratorem systemu."
+
+#: rocky/templates/oois/ooi_add.html
+#, python-format
+msgid "Add a %(display_type)s"
+msgstr "Dodaj %(display_type)s"
+
+#: rocky/templates/oois/ooi_add.html
+msgid ""
+"Here you can add the asset of the client. Findings can be added to these in "
+"the findings page."
+msgstr ""
+"Tutaj możesz dodać zasób klienta. Wyniki można dodać do nich na stronie "
+"wyników."
+
+#: rocky/templates/oois/ooi_add.html
+#, python-format
+msgid "Add %(display_type)s"
+msgstr "Dodaj %(display_type)s"
+
+#: rocky/templates/oois/ooi_add_type_select.html
+#: rocky/templates/oois/ooi_detail_add_related_object.html
+#: rocky/templates/partials/elements/ooi_add_type_select_form.html
+#: rocky/templates/partials/ooi_list_toolbar.html rocky/views/ooi_add.py
+msgid "Add object"
+msgstr "Dodaj obiekt"
+
+#: rocky/templates/oois/ooi_add_type_select.html
+msgid "Select the type of object you want to create."
+msgstr "Wybierz typ obiektu, który chcesz utworzyć."
+
+#: rocky/templates/oois/ooi_delete.html
+#, python-format
+msgid "Delete %(primary_key)s"
+msgstr "Usuń %(primary_key)s"
+
+#: rocky/templates/oois/ooi_delete.html
+msgid "Are you sure?"
+msgstr "Czy jesteś pewien?"
+
+#: rocky/templates/oois/ooi_delete.html
+#, python-format
+msgid "Here you can delete the %(display_type)s."
+msgstr "Tutaj możesz usunąć %(display_type)s."
+
+#: rocky/templates/oois/ooi_delete.html
+msgid "To be deleted object(s)"
+msgstr "Obiekt(y) do usunięcia"
+
+#: rocky/templates/oois/ooi_delete.html
+#: rocky/templates/partials/elements/ooi_tree_condensed_table.html
+msgid "Key"
+msgstr "Klawisz"
+
+#: rocky/templates/oois/ooi_delete.html
+#: rocky/templates/partials/ooi_detail_toolbar.html
+#, python-format
+msgid "Delete %(display_type)s"
+msgstr "Usuń %(display_type)s"
+
+#: rocky/templates/oois/ooi_delete.html
+msgid "Deletion not possible for types: KATFindingType and CVEFindingType"
+msgstr "Usunięcie nie jest możliwe dla typów: KATFindingType i CVEFindingType"
+
+#: rocky/templates/oois/ooi_detail.html
+msgid "using boefjes"
+msgstr "za pomocą boefjes"
+
+#: rocky/templates/oois/ooi_detail.html
+#: rocky/templates/organizations/organization_settings.html
+msgid "indemnification warning"
+msgstr "ostrzeżenie dotyczące odszkodowania"
+
+#: rocky/templates/oois/ooi_detail.html
+#, python-format
+msgid ""
+"<strong>Warning:</strong> There is no indemnification for this organization."
+" Go to the <a href=\"%(organization_settings)s\">organization settings "
+"page</a> to add one."
+msgstr ""
+"<strong>Ostrzeżenie:</strong> Ta organizacja nie jest objęta żadnym "
+"zabezpieczeniem. Przejdź do <a href=\"%(organization_settings)s\">strony "
+"ustawień organizacji</a>, aby ją dodać."
+
+#: rocky/templates/oois/ooi_detail.html
+msgid "Permission warning"
+msgstr "Ostrzeżenie dotyczące pozwolenia"
+
+#: rocky/templates/oois/ooi_detail.html
+msgid ""
+"<strong>Warning:</strong> You don't have the proper permission at the "
+"organizational level to scan objects. Contact your administrator."
+msgstr ""
+"<strong>Ostrzeżenie:</strong> Nie masz odpowiednich uprawnień na poziomie "
+"organizacji do skanowania obiektów. Skontaktuj się ze swoim administratorem."
+
+#: rocky/templates/oois/ooi_detail.html
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Scan warning"
+msgstr "Ostrzeżenie o skanowaniu"
+
+#: rocky/templates/oois/ooi_detail.html
+#, python-format
+msgid ""
+"<strong>Warning:</strong> You are not allowed to scan this OOI. Your maximum"
+" clearance level is %(member_clearance_level)s and this OOI has level "
+"%(boefje_scan_level)s. Go to your <a href=\"%(account_details)s\">account "
+"details</a> to manage your clearance level."
+msgstr ""
+"<strong>Ostrzeżenie:</strong> Nie masz uprawnień do skanowania tego OOI. "
+"Twój maksymalny poziom uprawnień to %(member_clearance_level)s, a ten OOI ma"
+" poziom %(boefje_scan_level)s. Przejdź do <a "
+"href=\"%(account_details)s\">szczegółów konta</a>, aby zarządzać poziomem "
+"uprawnień."
+
+#: rocky/templates/oois/ooi_detail.html rocky/templates/scan.html
+msgid "Boefjes overview"
+msgstr "Przegląd Boefjes"
+
+#: rocky/templates/oois/ooi_detail.html
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+#: rocky/templates/scan.html rocky/templates/tasks/boefjes.html
+#: rocky/templates/tasks/normalizers.html
+msgid "Boefje"
+msgstr "Boefje"
+
+#: rocky/templates/oois/ooi_detail.html rocky/templates/scan.html
+msgid "Scan profile"
+msgstr "Skanuj profil"
+
+#: rocky/templates/oois/ooi_detail.html
+msgid "Unable to start scan. See the warning for more details."
+msgstr ""
+"Nie można rozpocząć skanowania. Więcej szczegółów znajdziesz w ostrzeżeniu."
+
+#: rocky/templates/oois/ooi_detail.html
+msgid "Start scan"
+msgstr "Rozpocznij skanowanie"
+
+#: rocky/templates/oois/ooi_detail.html
+msgid "There are no boefjes enabled to scan an OOI of type"
+msgstr "Brak boefjes obsługujących skanowanie typu OOI"
+
+#: rocky/templates/oois/ooi_detail.html
+msgid "See"
+msgstr "Widzieć"
+
+#: rocky/templates/oois/ooi_detail.html
+msgid "to find and enable boefjes that can scan within the current level."
+msgstr ""
+"aby znaleźć i włączyć boefje, które mogą skanować w obrębie bieżącego "
+"poziomu."
+
+#: rocky/templates/oois/ooi_detail_add_related_object.html
+#: rocky/templates/partials/ooi_detail_related_object.html
+msgid "Add related object"
+msgstr "Dodaj powiązany obiekt"
+
+#: rocky/templates/oois/ooi_detail_add_related_object.html
+#: rocky/templates/oois/ooi_detail_object.html
+msgid "Object details"
+msgstr "Szczegóły obiektu"
+
+#: rocky/templates/oois/ooi_detail_add_related_object.html
+#: rocky/templates/partials/elements/ooi_add_type_select_form.html
+msgid "Object type"
+msgstr "Typ obiektu"
+
+#: rocky/templates/oois/ooi_detail_add_related_object.html
+#: rocky/templates/partials/elements/ooi_add_type_select_form.html
+msgid "Choose an object type to add"
+msgstr "Wybierz typ obiektu do dodania"
+
+#: rocky/templates/oois/ooi_detail_add_related_object.html
+#: rocky/templates/partials/elements/ooi_add_type_select_form.html
+msgid "Select an object type to add."
+msgstr "Wybierz typ obiektu do dodania."
+
+#: rocky/templates/oois/ooi_detail_findings_list.html
+msgid "Overview of findings for"
+msgstr "Przegląd ustaleń dla"
+
+#: rocky/templates/oois/ooi_detail_findings_list.html
+msgid "Score"
+msgstr "Wynik"
+
+#: rocky/templates/oois/ooi_detail_findings_list.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid "Finding details"
+msgstr "Znalezienie szczegółów"
+
+#: rocky/templates/oois/ooi_detail_findings_overview.html
+msgid "Overview of the number of findings and their severity found on"
+msgstr "Przegląd liczby stwierdzonych ustaleń i ich wagi"
+
+#: rocky/templates/oois/ooi_detail_findings_overview.html
+msgid ""
+"Findings can occur multiple times. To give better insight the following "
+"table shows the number of unique findings found as well as the number of "
+"occurrences."
+msgstr ""
+"Wyniki mogą wystąpić wielokrotnie. Aby zapewnić lepszy wgląd, poniższa "
+"tabela pokazuje liczbę znalezionych unikalnych wyników, a także liczbę "
+"wystąpień."
+
+#: rocky/templates/oois/ooi_detail_findings_overview.html
+msgid "See finding details"
+msgstr "Zobacz szczegóły wyszukiwania"
+
+#: rocky/templates/oois/ooi_detail_findings_overview.html
+msgid "Total findings"
+msgstr "Łączne ustalenia"
+
+#: rocky/templates/oois/ooi_detail_object.html
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Inactive"
+msgstr "Nieaktywny"
+
+#: rocky/templates/oois/ooi_detail_origins_declarations.html
+msgid "Declarations"
+msgstr "Deklaracje"
+
+#: rocky/templates/oois/ooi_detail_origins_inference.html
+msgid "Inferred by"
+msgstr "Wywnioskowane przez"
+
+#: rocky/templates/oois/ooi_detail_origins_inference.html
+msgid "Bit"
+msgstr "Fragment"
+
+#: rocky/templates/oois/ooi_detail_origins_inference.html
+msgid "Parameters"
+msgstr "Parametry"
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+msgid "Last observed by"
+msgstr "Ostatnio obserwowany przez"
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+msgid "Task ID"
+msgstr "Identyfikator zadania"
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+msgid "When"
+msgstr "Gdy"
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+#: rocky/templates/tasks/normalizers.html
+msgid "Normalizer"
+msgstr "Normalizer"
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+msgid "This scan was manually created."
+msgstr "Ten skan został utworzony ręcznie."
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+msgid "The boefje has since been deleted or disabled."
+msgstr "Od tego czasu boefje zostało usunięte lub wyłączone."
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+msgid "No Raw file could be found, this might point to an error in OpenKAT"
+msgstr "Nie znaleziono pliku Raw, może to wskazywać na błąd w OpenKAT"
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Warning"
+msgstr "Ostrzeżenie"
+
+#: rocky/templates/oois/ooi_edit.html
+#, python-format
+msgid "Edit %(type)s: %(ooi_human_readable)s"
+msgstr "Edytuj %(type)s: %(ooi_human_readable)s"
+
+#: rocky/templates/oois/ooi_edit.html
+msgid "Primary key fields cannot be edited."
+msgstr "Pola klucza podstawowego nie mogą być edytowane."
+
+#: rocky/templates/oois/ooi_edit.html
+#, python-format
+msgid "Save %(display_type)s"
+msgstr "Zapisz %(display_type)s"
+
+#: rocky/templates/oois/ooi_findings.html
+msgid "Currently no findings have been identified for OOI"
+msgstr "Obecnie nie zidentyfikowano żadnych wyników dla OOI"
+
+#: rocky/templates/oois/ooi_list.html
+#, python-format
+msgid ""
+"An overview of objects found for organization "
+"<strong>%(organization_name)s</strong>. Objects can be added manually or by "
+"running Boefjes. Click an object for additional information."
+msgstr ""
+"Przegląd znalezionych obiektów dla organizacji "
+"<strong>%(organization_name)s</strong>. Obiekty można dodawać ręcznie lub "
+"uruchamiając Boefjes. Kliknij obiekt, aby uzyskać dodatkowe informacje."
+
+#: rocky/templates/oois/ooi_list.html
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Edit clearance level"
+msgstr "Edytuj poziom zezwolenia"
+
+#: rocky/templates/oois/ooi_mute_finding.html
+msgid "Mute finding:"
+msgstr "Wycisz znalezienie:"
+
+#: rocky/templates/oois/ooi_mute_finding.html
+msgid "Give a reason below why you want to mute this finding."
+msgstr "Podaj poniżej powód, dla którego chcesz zignorować to ustalenie."
+
+#: rocky/templates/oois/ooi_mute_finding.html
+#: rocky/templates/partials/mute_findings_modal.html
+#: rocky/templates/partials/ooi_detail_toolbar.html
+msgid "Mute finding"
+msgstr "Wycisz znalezienie"
+
+#: rocky/templates/oois/ooi_mute_finding.html
+msgid "Mute"
+msgstr "Niemy"
+
+#: rocky/templates/oois/ooi_page_tabs.html
+msgid "List of views for OOI"
+msgstr "Lista wyświetleń dla OOI"
+
+#: rocky/templates/oois/ooi_past_due_warning.html
+msgid "This object is past due"
+msgstr "Ten obiekt jest przeterminowany"
+
+#: rocky/templates/oois/ooi_past_due_warning.html
+msgid "This object is past due and has been deleted"
+msgstr "Obiekt ten jest przeterminowany i został usunięty"
+
+#: rocky/templates/oois/ooi_past_due_warning.html
+msgid ""
+"This object is past due. You are viewing the object state in a past state."
+msgstr ""
+"Ten obiekt jest przeterminowany. Oglądasz stan obiektu w stanie przeszłym."
+
+#: rocky/templates/oois/ooi_past_due_warning.html
+msgid ""
+"You will not be able to add Findings or other OOI's to past due objects."
+msgstr ""
+"Nie będziesz mógł dodawać Wyników ani innych OOI do obiektów zaległych."
+
+#: rocky/templates/oois/ooi_past_due_warning.html
+#: rocky/templates/partials/hyperlink_ooi_id.html
+#, python-format
+msgid "Show details for %(name)s"
+msgstr "Pokaż szczegóły dla %(name)s"
+
+#: rocky/templates/oois/ooi_past_due_warning.html
+msgid "View the current state"
+msgstr "Zobacz aktualny stan"
+
+#: rocky/templates/oois/ooi_past_due_warning.html
+msgid ""
+"You will not be able to add Findings or other OOI's, this object has been "
+"deleted and is no longer available."
+msgstr ""
+"Nie będziesz mógł dodać Wyników ani innych OOI, ten obiekt został usunięty i"
+" nie jest już dostępny."
+
+#: rocky/templates/oois/ooi_summary.html
+msgid "Summary for"
+msgstr "Podsumowanie dla"
+
+#: rocky/templates/oois/ooi_summary.html
+msgid "Below you can see findings that were found for"
+msgstr "Poniżej możesz zobaczyć znalezione wyniki"
+
+#: rocky/templates/oois/ooi_summary.html
+msgid "and direct  children of this"
+msgstr "i kieruj w tym dzieci"
+
+#: rocky/templates/oois/ooi_summary.html
+msgid "This"
+msgstr "Ten"
+
+#: rocky/templates/oois/ooi_summary.html
+msgid "tree view"
+msgstr "widok na drzewo"
+
+#: rocky/templates/oois/ooi_summary.html
+msgid "of the"
+msgstr "z"
+
+#: rocky/templates/oois/ooi_summary.html
+msgid "shows the same objects."
+msgstr "pokazuje te same obiekty."
+
+#: rocky/templates/organizations/organization_add.html
+msgid ""
+"Please enter the following organization details. These details can be edited"
+" within the organization page within OpenKAT when necessary."
+msgstr ""
+"Proszę wprowadzić następujące dane organizacyjne. W razie potrzeby szczegóły"
+" te można edytować na stronie organizacji w ciągu OpenKAT."
+
+#: rocky/templates/organizations/organization_edit.html
+msgid "Edit organization"
+msgstr "Edytuj organizację"
+
+#: rocky/templates/organizations/organization_edit.html
+msgid "Save organization"
+msgstr "Zapisz organizację"
+
+#: rocky/templates/organizations/organization_list.html
+msgid "An overview of all organizations you are a member of."
+msgstr "Przegląd wszystkich organizacji, których jesteś członkiem."
+
+#: rocky/templates/organizations/organization_list.html
+msgid "Add new organization"
+msgstr "Dodaj nową organizację"
+
+#: rocky/templates/organizations/organization_list.html
+#, python-format
+msgid ""
+"\n"
+"                            Showing %(total)s organizations\n"
+"                        "
+msgstr ""
+"\n"
+"Wyświetlanie organizacji %(total)s"
+
+#: rocky/templates/organizations/organization_list.html
+msgid "Organization overview:"
+msgstr "Przegląd organizacji:"
+
+#: rocky/templates/organizations/organization_list.html
+#: rocky/templates/organizations/organization_settings.html
+msgid "Tags"
+msgstr "Tagi"
+
+#: rocky/templates/organizations/organization_list.html
+msgid "There were no organizations found for your user account"
+msgstr "Nie znaleziono organizacji dla Twojego konta użytkownika"
+
+#: rocky/templates/organizations/organization_list.html
+msgid "Actions to perform for all of your organizations."
+msgstr "Działania do wykonania dla wszystkich organizacji."
+
+#: rocky/templates/organizations/organization_list.html
+#: rocky/templates/organizations/organization_settings.html
+msgid "Rerun all bits"
+msgstr "Uruchom ponownie wszystkie bity"
+
+#: rocky/templates/organizations/organization_member_add.html
+msgid "Change account type"
+msgstr "Zmień typ konta"
+
+#: rocky/templates/organizations/organization_member_add_header.html
+#: rocky/views/organization_member_add.py
+msgid "Add member"
+msgstr "Dodaj członka"
+
+#: rocky/templates/organizations/organization_member_add_header.html
+#, python-format
+msgid ""
+"Creating a new member of organization <strong>%(organization)s</strong>. For"
+" detailed information about the different account types, check the <a "
+"href=\"https://docs.openkat.nl/basics/users-and-organisations.html#users\" "
+"target=\"_blank\" rel=\"noopener\">documentation</a>."
+msgstr ""
+"Tworzenie nowego członka organizacji <strong>%(organization)s</strong>. Aby "
+"uzyskać szczegółowe informacje na temat różnych typów kont, sprawdź <a "
+"href=\"https://docs.openkat.nl/basics/users-and-organisations.html#users\" "
+"target=\"_blank\" rel=\"noopener\">dokumentację</a>."
+
+#: rocky/templates/organizations/organization_member_edit.html
+#: rocky/views/organization_member_edit.py
+msgid "Edit member"
+msgstr "Edytuj członka"
+
+#: rocky/templates/organizations/organization_member_edit.html
+msgid "Save member"
+msgstr "Zapisz członka"
+
+#: rocky/templates/organizations/organization_member_list.html
+#, python-format
+msgid "An overview of members of <strong>%(organization_name)s</strong>."
+msgstr "Przegląd członków <strong>%(organization_name)s</strong>."
+
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Add member(s)"
+msgstr "Dodaj członków"
+
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Manually"
+msgstr "Ręcznie"
+
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Upload a CSV"
+msgstr "Prześlij plik CSV"
+
+#: rocky/templates/organizations/organization_member_list.html
+#, python-format
+msgid ""
+"\n"
+"                        Showing %(total)s members\n"
+"                    "
+msgstr ""
+"\n"
+"Wyświetlanie %(total)s członków"
+
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Member overview:"
+msgstr "Przegląd członków:"
+
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Role"
+msgstr "Rola"
+
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Assigned clearance level"
+msgstr "Przypisany poziom zezwolenia"
+
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Super user"
+msgstr "Super użytkownik"
+
+#: rocky/templates/organizations/organization_member_upload.html
+#: rocky/views/organization_member_add.py
+msgid "Add members"
+msgstr "Dodaj członków"
+
+#: rocky/templates/organizations/organization_member_upload.html
+#, python-format
+msgid ""
+"To upload multiple members at once, you can upload a CSV file or you can <a "
+"href=\"%(download_url)s\">download the template</a>."
+msgstr ""
+"Aby przesłać wielu członków jednocześnie, możesz przesłać plik CSV lub <a "
+"href=\"%(download_url)s\">pobrać szablon</a>."
+
+#: rocky/templates/organizations/organization_member_upload.html
+msgid ""
+"To create a custom CSV file, make sure it meets the following criteria:"
+msgstr ""
+"Aby utworzyć niestandardowy plik CSV, upewnij się, że spełnia on następujące"
+" kryteria:"
+
+#: rocky/templates/organizations/organization_member_upload.html
+msgid "Upload"
+msgstr "Wgrywać"
+
+#: rocky/templates/organizations/organization_settings.html
+#, python-format
+msgid ""
+"An overview of general information and settings for "
+"<strong>%(organization_name)s</strong>."
+msgstr ""
+"Przegląd ogólnych informacji i ustawień dla "
+"<strong>%(organization_name)s</strong>."
+
+#: rocky/templates/organizations/organization_settings.html
+msgid ""
+"<strong>Warning:</strong> Indemnification is not set for this organization."
+msgstr ""
+"<strong>Ostrzeżenie:</strong> Dla tej organizacji nie ustawiono "
+"zabezpieczenia."
+
+#: rocky/templates/organizations/organization_settings.html
+#: rocky/views/indemnification_add.py
+msgid "Add indemnification"
+msgstr "Dodaj odszkodowanie"
+
+#: rocky/templates/partials/current_config.html
+msgid "Current configuration"
+msgstr "Aktualna konfiguracja"
+
+#: rocky/templates/partials/delete_ooi_modal.html
+msgid "Delete objects"
+msgstr "Usuń obiekty"
+
+#: rocky/templates/partials/delete_ooi_modal.html
+msgid ""
+"Are you sure you want to delete all the selected objects? The history of the"
+" deleted objects will still be available."
+msgstr ""
+"Czy na pewno chcesz usunąć wszystkie zaznaczone obiekty? Historia usuniętych"
+" obiektów będzie nadal dostępna."
+
+#: rocky/templates/partials/edit_ooi_clearance_level_modal.html
+msgid "Edit clearance level settings"
+msgstr "Edytuj ustawienia poziomu zezwolenia"
+
+#: rocky/templates/partials/edit_ooi_clearance_level_modal.html
+msgid "You are editing clearance level of all the selected objects."
+msgstr "Edytujesz poziom luzu wszystkich wybranych obiektów."
+
+#: rocky/templates/partials/edit_ooi_clearance_level_modal.html
+msgid "Switching between declare and inherit"
+msgstr "Przełączanie pomiędzy deklaracją i dziedziczeniem"
+
+#: rocky/templates/partials/edit_ooi_clearance_level_modal.html
+msgid ""
+"Clearance levels can be automatically inherited or you can manually declare "
+"the clearance level for an object. Switching to inherit clearance level will"
+" also recalculate the clearance levels of objects that inherit from these "
+"clearance levels."
+msgstr ""
+"Poziomy zezwolenia mogą być dziedziczone automatycznie lub można ręcznie "
+"zadeklarować poziom zezwolenia dla obiektu. Przełączenie na dziedziczenie "
+"poziomu uprawnień spowoduje również ponowne obliczenie poziomów uprawnień "
+"obiektów, które dziedziczą z tych poziomów uprawnień."
+
+#: rocky/templates/partials/elements/ooi_detail_settings.html
+msgid "Observed at"
+msgstr "Zaobserwowano o godz"
+
+#: rocky/templates/partials/elements/ooi_detail_settings.html
+#: rocky/templates/partials/elements/ooi_report_settings.html
+msgid "Show settings"
+msgstr "Pokaż ustawienia"
+
+#: rocky/templates/partials/elements/ooi_detail_settings.html
+#: rocky/templates/partials/elements/ooi_report_settings.html
+msgid "Hide settings"
+msgstr "Ukryj ustawienia"
+
+#: rocky/templates/partials/elements/ooi_list_settings_form.html
+msgid "Toggle all OOI types"
+msgstr "Przełącz wszystkie typy OOI"
+
+#: rocky/templates/partials/elements/ooi_tree_condensed_table.html
+msgid "Children"
+msgstr "Dzieci"
+
+#: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
+#, python-format
+msgid "Show details for %(object_id)s, with %(child_count)s children."
+msgstr "Pokaż szczegóły dla %(object_id)s z dziećmi %(child_count)s."
+
+#: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
+#, python-format
+msgid ""
+"Show tree for %(object_id)s with only children of type %(object_ooi_type)s"
+msgstr ""
+"Pokaż drzewo dla %(object_id)s zawierające tylko dzieci typu "
+"%(object_ooi_type)s"
+
+#: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
+#, python-format
+msgid "Unfold %(object_id)s with %(child_count)s children"
+msgstr "Rozwiń %(object_id)s z %(child_count)s dziećmi"
+
+#: rocky/templates/partials/elements/ooi_tree_table.html
+msgid "go to:"
+msgstr "przejdź do:"
+
+#: rocky/templates/partials/elements/ooi_tree_table.html
+msgid "Go to detailpage"
+msgstr "Przejdź do strony szczegółów"
+
+#: rocky/templates/partials/elements/ooi_tree_table.html
+msgid "detail"
+msgstr "szczegół"
+
+#: rocky/templates/partials/elements/ooi_tree_table.html
+msgid "Go to tree view"
+msgstr "Przejdź do widoku drzewa"
+
+#: rocky/templates/partials/elements/ooi_tree_table.html
+msgid "tree"
+msgstr "drzewo"
+
+#: rocky/templates/partials/elements/ooi_tree_table.html
+msgid "Go to graph view"
+msgstr "Przejdź do widoku wykresu"
+
+#: rocky/templates/partials/elements/ooi_tree_table.html
+msgid "graph"
+msgstr "wykres"
+
+#: rocky/templates/partials/explanations.html
+msgid "Clearance level inheritance"
+msgstr "Dziedziczenie poziomu uprawnień"
+
+#: rocky/templates/partials/explanations.html
+msgid "OOI"
+msgstr "OOI"
+
+#: rocky/templates/partials/explanations.html
+msgid "This OOI"
+msgstr "To OOI"
+
+#: rocky/templates/partials/explanations.html
+msgid "Origin"
+msgstr "Pochodzenie"
+
+#: rocky/templates/partials/explanations.html
+msgid "declared"
+msgstr "zdeklarowany"
+
+#: rocky/templates/partials/explanations.html
+msgid "inherited from ↓"
+msgstr "odziedziczone od ↓"
+
+#: rocky/templates/partials/explanations.html
+msgid "Show clearance level inheritance"
+msgstr "Pokaż dziedziczenie poziomu uprawnień"
+
+#: rocky/templates/partials/finding_occurrence_definition_list.html
+msgid "Reproduction"
+msgstr "Reprodukcja"
+
+#: rocky/templates/partials/form/checkbox_group_table_form.html
+msgid "Please enable plugin to start scanning."
+msgstr "Włącz wtyczkę, aby rozpocząć skanowanie."
+
+#: rocky/templates/partials/form/field_input.html
+msgid "Not set"
+msgstr "Nie ustawiono"
+
+#: rocky/templates/partials/form/field_input.html
+msgid "Forgot email"
+msgstr "Zapomniałem e-maila"
+
+#: rocky/templates/partials/form/field_input.html
+msgid "Forgot password"
+msgstr "Zapomniałem hasła"
+
+#: rocky/templates/partials/form/field_input_errors.html
+#: rocky/templates/partials/notifications_block.html
+msgid "error"
+msgstr "błąd"
+
+#: rocky/templates/partials/form/field_input_errors.html
+#: rocky/templates/partials/form/form_errors.html
+#: rocky/templates/partials/notifications_block.html
+msgid "Error:"
+msgstr "Błąd:"
+
+#: rocky/templates/partials/form/field_input_help_text.html
+msgid "Open explanation"
+msgstr "Otwarte wyjaśnienie"
+
+#: rocky/templates/partials/form/field_input_help_text.html
+msgid "Close explanation"
+msgstr "Zamknij wyjaśnienie"
+
+#: rocky/templates/partials/form/field_input_help_text.html
+#: rocky/templates/partials/notifications_block.html
+#: rocky/templates/two_factor/core/login.html
+msgid "Explanation:"
+msgstr "Wyjaśnienie:"
+
+#: rocky/templates/partials/form/indemnification_add_form.html
+msgid ""
+"Performing security scans against assets is generally only allowed if you "
+"have permission to scan those assets. Certain scans might also have a "
+"negative impact on (your) assets. Therefore it is important to know and be "
+"aware of the impact of security scans."
+msgstr ""
+"Wykonywanie skanów bezpieczeństwa zasobów jest zazwyczaj dozwolone tylko "
+"wtedy, gdy masz pozwolenie na skanowanie tych zasobów. Niektóre skany mogą "
+"mieć również negatywny wpływ na (Twoje) zasoby. Dlatego ważne jest, aby znać"
+" i mieć świadomość wpływu skanowań bezpieczeństwa."
+
+#: rocky/templates/partials/form/indemnification_add_form.html
+msgid ""
+"An organization indemnification is required before you can use OpenKAT. With"
+" the indemnification you declare that you, as a person, can be held "
+"accountable."
+msgstr ""
+"Aby móc korzystać z OpenKAT, wymagane jest zabezpieczenie organizacji. "
+"Poprzez zabezpieczenie oświadczasz, że jako osoba możesz zostać pociągnięty "
+"do odpowiedzialności."
+
+#: rocky/templates/partials/form/indemnification_add_form.html
+msgid "Set an indemnification"
+msgstr "Ustal odszkodowanie"
+
+#: rocky/templates/partials/hyperlink_ooi_type.html
+#, python-format
+msgid "Only show objects of type %(type)s"
+msgstr "Pokazuj tylko obiekty typu %(type)s"
+
+#: rocky/templates/partials/list_filters.html
+msgid "Hide filter options"
+msgstr "Ukryj opcje filtrów"
+
+#: rocky/templates/partials/list_filters.html
+msgid "Show filter options"
+msgstr "Pokaż opcje filtrów"
+
+#: rocky/templates/partials/list_paginator.html
+msgid "List pagination"
+msgstr "Paginacja listy"
+
+#: rocky/templates/partials/list_paginator.html
+msgid "Previous Page"
+msgstr "Poprzednia strona"
+
+#: rocky/templates/partials/list_paginator.html
+msgid "Previous"
+msgstr "Poprzedni"
+
+#: rocky/templates/partials/list_paginator.html
+msgid "Five Pages Back"
+msgstr "Pięć stron wstecz"
+
+#: rocky/templates/partials/list_paginator.html
+#: rocky/templates/partials/pagination.html
+msgid "Page"
+msgstr "Strona"
+
+#: rocky/templates/partials/list_paginator.html
+msgid "Current"
+msgstr "Aktualny"
+
+#: rocky/templates/partials/list_paginator.html
+msgid "Five Pages Forward"
+msgstr "Pięć stron dalej"
+
+#: rocky/templates/partials/list_paginator.html
+msgid "Next Page"
+msgstr "Następna strona"
+
+#: rocky/templates/partials/list_paginator.html
+msgid "Next"
+msgstr "Następny"
+
+#: rocky/templates/partials/mute_findings_modal.html
+msgid "You are muting the selected findings."
+msgstr "Wyciszasz wybrane wyniki."
+
+#: rocky/templates/partials/mute_findings_modal.html
+msgid "Reason:"
+msgstr "Powód:"
+
+#: rocky/templates/partials/mute_findings_modal.html
+msgid "Expires by (UTC):"
+msgstr "Wygasa do (UTC):"
+
+#: rocky/templates/partials/notifications_block.html
+msgid "Confirmation:"
+msgstr "Potwierdzenie:"
+
+#: rocky/templates/partials/ooi_detail_related_object.html
+msgid "No related object known for"
+msgstr "Nie jest znany żaden powiązany obiekt"
+
+#: rocky/templates/partials/ooi_detail_toolbar.html
+msgid "Generate Report"
+msgstr "Wygeneruj raport"
+
+#: rocky/templates/partials/ooi_detail_toolbar.html
+#, python-format
+msgid "Edit %(display_type)s"
+msgstr "Edytuj %(display_type)s"
+
+#: rocky/templates/partials/ooi_head.html
+msgid "Data from:"
+msgstr "Dane z:"
+
+#: rocky/templates/partials/ooi_head.html
+msgid "(Now)"
+msgstr "(Teraz)"
+
+#: rocky/templates/partials/ooi_list_toolbar.html
+msgid "Scan for objects"
+msgstr "Skanuj w poszukiwaniu obiektów"
+
+#: rocky/templates/partials/ooi_list_toolbar.html
+#: rocky/templates/upload_csv.html rocky/views/upload_csv.py
+msgid "Upload CSV"
+msgstr "Prześlij CSV"
+
+#: rocky/templates/partials/ooi_list_toolbar.html
+msgid "Export"
+msgstr "Eksport"
+
+#: rocky/templates/partials/ooi_list_toolbar.html
+msgid "Download as CSV"
+msgstr "Pobierz jako CSV"
+
+#: rocky/templates/partials/ooi_report_findings_block.html
+#, python-format
+msgid "%(total)s findings on %(name)s"
+msgstr "Wyniki %(total)s w dniu %(name)s"
+
+#: rocky/templates/partials/ooi_report_findings_block_table.html
+#, python-format
+msgid "Findings for %(type)s %(name)s on %(observed_at)s:"
+msgstr "Wyniki dla %(type)s %(name)s w dniu %(observed_at)s:"
+
+#: rocky/templates/partials/ooi_report_findings_block_table.html
+msgid "Open finding details"
+msgstr "Otwórz szczegóły znalezienia"
+
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+#, python-format
+msgid "Details of %(object_id)s"
+msgstr "Szczegóły %(object_id)s"
+
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid ""
+"The severity of this findingtype has not (yet) been determined by the data "
+"source. This situation requires manual investigation of the severity."
+msgstr ""
+"Źródło danych nie określiło (jeszcze) wagi tego rodzaju ustalenia. Ta "
+"sytuacja wymaga ręcznego zbadania powagi."
+
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid "Total occurrences"
+msgstr "Całkowita liczba wystąpień"
+
+#: rocky/templates/partials/ooi_tree_toolbar_bottom.html
+msgid "Tree - dense view"
+msgstr "Drzewo - gęsty widok"
+
+#: rocky/templates/partials/ooi_tree_toolbar_bottom.html
+msgid "Tree - table view"
+msgstr "Drzewo - widok tabeli"
+
+#: rocky/templates/partials/organization_member_list_filters.html
+msgid "Update List"
+msgstr "Aktualizuj listę"
+
+#: rocky/templates/partials/organization_properties_table.html
+msgid "Organization name"
+msgstr "Nazwa organizacji"
+
+#: rocky/templates/partials/organization_properties_table.html
+msgid "Organization code"
+msgstr "Kod organizacji"
+
+#: rocky/templates/partials/organizations_menu_dropdown.html
+msgid "Select organization"
+msgstr "Wybierz organizację"
+
+#: rocky/templates/partials/organizations_menu_dropdown.html
+msgid "All organizations"
+msgstr "Wszystkie organizacje"
+
+#: rocky/templates/partials/page-meta.html
+msgid "Logged in as:"
+msgstr "Zalogowałem się jako:"
+
+#: rocky/templates/partials/pagination.html
+msgid "of"
+msgstr "z"
+
+#: rocky/templates/partials/pagination.html
+msgid "first"
+msgstr "Pierwszy"
+
+#: rocky/templates/partials/pagination.html
+msgid "previous"
+msgstr "poprzedni"
+
+#: rocky/templates/partials/pagination.html
+msgid "next"
+msgstr "Następny"
+
+#: rocky/templates/partials/pagination.html
+msgid "last"
+msgstr "ostatni"
+
+#: rocky/templates/partials/secondary-menu.html
+msgid "User navigation"
+msgstr "Nawigacja użytkownika"
+
+#: rocky/templates/partials/secondary-menu.html
+msgid "Close user navigation"
+msgstr "Zamknij nawigację użytkownika"
+
+#: rocky/templates/partials/secondary-menu.html
+msgid "My organizations"
+msgstr "Moje organizacje"
+
+#: rocky/templates/partials/secondary-menu.html
+msgid "Profile"
+msgstr "Profil"
+
+#: rocky/templates/partials/skip-to-content.html
+msgid "Go to content"
+msgstr "Przejdź do treści"
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid ""
+"The clearance level determines the level of boefje scans allowed on this "
+"object. An object inherits its clearance level from neighbouring objects. "
+"This means that the clearance level might stay the same, increase or "
+"decrease, depending on other declared clearance levels."
+msgstr ""
+"Poziom zezwolenia określa poziom skanów boefje dozwolonych dla tego obiektu."
+" Obiekt dziedziczy poziom odstępu od obiektów sąsiadujących. Oznacza to, że "
+"poziom dopuszczenia może pozostać taki sam, wzrosnąć lub zmniejszyć, w "
+"zależności od innych zadeklarowanych poziomów dopuszczenia."
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Empty clearance level explanation"
+msgstr "Wyjaśnienie poziomu luzu pustego"
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Empty:"
+msgstr "Pusty:"
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid ""
+"This object has a clearance level of \"empty\". This means that this object "
+"has no clearance level."
+msgstr ""
+"Ten obiekt ma poziom zezwolenia „pusty”. Oznacza to, że obiekt ten nie ma "
+"poziomu zezwolenia."
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Indemnification warning"
+msgstr "Ostrzeżenie dotyczące odszkodowania"
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Indemnification is not set for this organization."
+msgstr "Dla tej organizacji nie przewidziano zabezpieczenia."
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Go to the"
+msgstr "Idź do"
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "organization settings page"
+msgstr "stronę ustawień organizacji"
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "to add one."
+msgstr "aby dodać jeden."
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Set clearance level warning"
+msgstr "Ustaw ostrzeżenie o poziomie luzu"
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid ""
+"You don't have permissions to set the clearance level. Contact your "
+"administrator."
+msgstr ""
+"Nie masz uprawnień, aby ustawić poziom uprawnień. Skontaktuj się ze swoim "
+"administratorem."
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+#, python-format
+msgid ""
+"You are not allowed to set the clearance level of this OOI. Your maximum "
+"clearance level is %(member_clearance_level)s and this OOI has level "
+"%(boefje_scan_level)s."
+msgstr ""
+"Nie możesz ustawić poziomu zezwolenia dla tego OOI. Twój maksymalny poziom "
+"uprawnień to %(member_clearance_level)s, a ten OOI ma poziom "
+"%(boefje_scan_level)s."
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Go to your"
+msgstr "Idź do swojego"
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "account details"
+msgstr "szczegóły konta"
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "to manage your clearance level."
+msgstr "aby zarządzać poziomem uprawnień."
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Current clearance level"
+msgstr "Aktualny poziom uprawnień"
+
+#: rocky/templates/tasks/boefje_task_detail.html
+msgid ""
+"An overview of the boefje task, the input OOI and the RAW data it generated."
+msgstr ""
+"Przegląd zadania boefje, danych wejściowych OOI i wygenerowanych przez nie "
+"danych RAW."
+
+#: rocky/templates/tasks/boefje_task_detail.html
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Download meta and raw data"
+msgstr "Pobierz meta i surowe dane"
+
+#: rocky/templates/tasks/boefje_task_detail.html
+msgid "Download meta data"
+msgstr "Pobierz metadane"
+
+#: rocky/templates/tasks/boefje_task_detail.html
+msgid "Input object"
+msgstr "Obiekt wejściowy"
+
+#: rocky/templates/tasks/boefjes.html
+msgid "There are no tasks for boefjes."
+msgstr "Nie ma zadań dla boefjes."
+
+#: rocky/templates/tasks/boefjes.html
+msgid "List of tasks for boefjes."
+msgstr "Lista zadań dla boefjesa."
+
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/reports.html
+msgid "Organization Code"
+msgstr "Kod organizacji"
+
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
+#: rocky/templates/tasks/ooi_detail_task_list.html
+#: rocky/templates/tasks/plugin_detail_task_list.html
+msgid "Created date"
+msgstr "Data utworzenia"
+
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
+#: rocky/templates/tasks/reports.html
+msgid "Modified date"
+msgstr "Zmodyfikowana data"
+
+#: rocky/templates/tasks/normalizers.html
+msgid "There are no tasks for normalizers."
+msgstr "Nie ma zadań dla normalizatorów."
+
+#: rocky/templates/tasks/normalizers.html
+msgid "List of tasks for normalizers."
+msgstr "Lista zadań dla normalizatorów."
+
+#: rocky/templates/tasks/normalizers.html
+msgid "Boefje input OOI"
+msgstr "Boefje wejście OOI"
+
+#: rocky/templates/tasks/normalizers.html
+msgid "Manually added"
+msgstr "Dodano ręcznie"
+
+#: rocky/templates/tasks/ooi_detail_task_list.html
+msgid "There have been no tasks."
+msgstr "Nie było żadnych zadań."
+
+#: rocky/templates/tasks/partials/stats.html
+msgid "Task statistics - Last 24 hours"
+msgstr "Statystyki zadań - Ostatnie 24 godziny"
+
+#: rocky/templates/tasks/partials/stats.html
+msgid "All times in UTC, blocks of 1 hour."
+msgstr "Wszystkie czasy w UTC, bloki po 1 godzinie."
+
+#: rocky/templates/tasks/partials/stats.html
+msgid "Timeslot"
+msgstr "Szczelina czasowa"
+
+#: rocky/templates/tasks/partials/stats.html
+msgid "Could not load stats, Scheduler error."
+msgstr "Nie można załadować statystyk, błąd harmonogramu."
+
+#: rocky/templates/tasks/partials/tab_navigation.html
+msgid "List of tasks"
+msgstr "Lista zadań"
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Loading..."
+msgstr "Załadunek..."
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Yielded objects"
+msgstr "Otrzymane obiekty"
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Yielded raw files"
+msgstr "Otrzymane surowe pliki"
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Reschedule"
+msgstr "Zmień termin"
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Download task data"
+msgstr "Pobierz dane zadania"
+
+#: rocky/templates/tasks/partials/tasks_overview_header.html
+#, python-format
+msgid ""
+"An overview of the tasks for <strong>%(organization)s</strong>. Tasks are "
+"divided in Boefjes, Normalizers and Reports. Boefjes scan objects and "
+"Normalizers dispatch on the output mime-type. Additionally, there is a "
+"Report tasks. This task aggregates and presents findings from both Boefjes "
+"and Normalizers."
+msgstr ""
+"Przegląd zadań dla <strong>%(organization)s</strong>. Zadania podzielone są "
+"na Boefjes, Normalizers i Raporty. Boefjes skanuj obiekty i Normalizers "
+"wysyłaj na wyjściowy typ MIME. Dodatkowo istnieje Raport zadań. To zadanie "
+"agreguje i prezentuje wyniki zarówno z Boefjes, jak i Normalizers."
+
+#: rocky/templates/tasks/plugin_detail_task_list.html
+msgid "There are no tasks for"
+msgstr "Nie ma zadań dot"
+
+#: rocky/templates/tasks/plugin_detail_task_list.html
+msgid "List of tasks for"
+msgstr "Lista zadań dot"
+
+#: rocky/templates/tasks/reports.html
+msgid "There are no tasks for reports."
+msgstr "Brak zadań dla raportów."
+
+#: rocky/templates/tasks/reports.html
+msgid "List of tasks for reports."
+msgstr "Lista zadań dla raportów."
+
+#: rocky/templates/tasks/reports.html
+msgid "Recipe ID"
+msgstr "Identyfikator przepisu"
+
+#: rocky/templates/two_factor/_wizard_actions.html
+msgid "Log in"
+msgstr "Zaloguj się"
+
+#: rocky/templates/two_factor/_wizard_actions.html
+msgid "Authenticate"
+msgstr "Uwierzytelniać"
+
+#: rocky/templates/two_factor/core/backup_tokens.html
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Backup Tokens"
+msgstr "Tokeny zapasowe"
+
+#: rocky/templates/two_factor/core/backup_tokens.html
+msgid ""
+"Backup tokens can be used when your primary and backup phone numbers aren't "
+"available. The backup tokens below can be used for login verification. If "
+"you've used up all your backup tokens, you can generate a new set of backup "
+"tokens. Only the backup tokens shown below will be valid."
+msgstr ""
+"Tokenów zapasowych można używać, gdy podstawowy i zapasowy numer telefonu "
+"nie są dostępne. Poniższe tokeny zapasowe mogą zostać użyte do weryfikacji "
+"logowania. Jeśli wykorzystałeś wszystkie tokeny zapasowe, możesz wygenerować"
+" nowy zestaw tokenów zapasowych. Tylko tokeny zapasowe pokazane poniżej będą"
+" ważne."
+
+#: rocky/templates/two_factor/core/backup_tokens.html
+msgid "Print these tokens and keep them somewhere safe."
+msgstr "Wydrukuj te żetony i przechowuj je w bezpiecznym miejscu."
+
+#: rocky/templates/two_factor/core/backup_tokens.html
+msgid "You don't have any backup codes yet."
+msgstr "Nie masz jeszcze żadnych kodów zapasowych."
+
+#: rocky/templates/two_factor/core/backup_tokens.html
+msgid "Generate Tokens"
+msgstr "Generuj tokeny"
+
+#: rocky/templates/two_factor/core/backup_tokens.html
+#: rocky/templates/two_factor/core/setup_complete.html
+msgid "Back to Account Security"
+msgstr "Powrót do Bezpieczeństwo konta"
+
+#: rocky/templates/two_factor/core/login.html
+msgid "You are logged in."
+msgstr "Jesteś zalogowany."
+
+#: rocky/templates/two_factor/core/login.html
+msgid "Two factor authentication is enabled for your account."
+msgstr "Na Twoim koncie włączone jest uwierzytelnianie dwuskładnikowe."
+
+#: rocky/templates/two_factor/core/login.html
+msgid ""
+"Two factor authentication is not enabled for your account. Enable it to "
+"continue."
+msgstr ""
+"Na Twoim koncie nie jest włączone uwierzytelnianie dwuskładnikowe. Włącz, "
+"aby kontynuować."
+
+#: rocky/templates/two_factor/core/login.html
+msgid "Setup two factor authentication"
+msgstr "Skonfiguruj uwierzytelnianie dwuskładnikowe"
+
+#: rocky/templates/two_factor/core/login.html
+msgid "Credentials"
+msgstr "Referencje"
+
+#: rocky/templates/two_factor/core/login.html
+msgid ""
+"Use this form for entering backup tokens for logging in. These tokens have "
+"been generated for you to print and keep safe. Please enter one of these "
+"backup tokens to login to your account."
+msgstr ""
+"Użyj tego formularza, aby wprowadzić tokeny zapasowe do logowania. Tokeny te"
+" zostały wygenerowane, abyś mógł je wydrukować i zachować w bezpiecznym "
+"miejscu. Aby zalogować się na swoje konto, wprowadź jeden z tych tokenów "
+"zapasowych."
+
+#: rocky/templates/two_factor/core/login.html
+msgid "As a last resort, you can use a backup token:"
+msgstr "W ostateczności możesz skorzystać z tokena zapasowego:"
+
+#: rocky/templates/two_factor/core/login.html
+msgid "Use Backup Token"
+msgstr "Użyj tokena zapasowego"
+
+#: rocky/templates/two_factor/core/otp_required.html
+msgid "Permission Denied"
+msgstr "Odmowa pozwolenia"
+
+#: rocky/templates/two_factor/core/otp_required.html
+msgid ""
+"The page you requested, enforces users to verify using two-factor "
+"authentication for security reasons. You need to enable these security "
+"features in order to access this page."
+msgstr ""
+"Strona, o którą prosiłeś, ze względów bezpieczeństwa wymusza na "
+"użytkownikach weryfikację przy użyciu uwierzytelniania dwuskładnikowego. Aby"
+" uzyskać dostęp do tej strony, musisz włączyć te funkcje zabezpieczeń."
+
+#: rocky/templates/two_factor/core/otp_required.html
+#: rocky/templates/two_factor/profile/profile.html
+msgid ""
+"Two-factor authentication is not enabled for your account. Enable two-factor"
+" authentication for enhanced account security."
+msgstr ""
+"Uwierzytelnianie dwuskładnikowe nie jest włączone dla Twojego konta. Włącz "
+"uwierzytelnianie dwuskładnikowe, aby zwiększyć bezpieczeństwo konta."
+
+#: rocky/templates/two_factor/core/otp_required.html
+#: rocky/templates/two_factor/core/setup.html
+#: rocky/templates/two_factor/core/setup_complete.html
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Enable Two-Factor Authentication"
+msgstr "Włącz uwierzytelnianie dwuskładnikowe"
+
+#: rocky/templates/two_factor/core/phone_register.html
+msgid "Add Backup Phone"
+msgstr "Dodaj telefon zapasowy"
+
+#: rocky/templates/two_factor/core/phone_register.html
+msgid ""
+"You'll be adding a backup phone number to your account. This number will be "
+"used if your primary method of registration is not available."
+msgstr ""
+"Do swojego konta dodasz zapasowy numer telefonu. Numer ten zostanie użyty, "
+"jeśli podstawowa metoda rejestracji nie będzie dostępna."
+
+#: rocky/templates/two_factor/core/phone_register.html
+msgid ""
+"We've sent a token to your phone number. Please enter the token you've "
+"received."
+msgstr "Wysłaliśmy token na Twój numer telefonu. Wpisz otrzymany token."
+
+#: rocky/templates/two_factor/core/setup.html
+msgid ""
+"To start using a token generator, please use your smartphone to scan the QR "
+"code below or use the setup key. For example, use GoogleAuthenticator. Then,"
+" enter the token generated by the app."
+msgstr ""
+"Aby rozpocząć korzystanie z generatora tokenów, zeskanuj poniższy kod QR "
+"swoim smartfonem lub użyj klucza konfiguracyjnego. Na przykład użyj "
+"GoogleAuthenticator. Następnie wprowadź token wygenerowany przez aplikację."
+
+#: rocky/templates/two_factor/core/setup.html
+msgid "QR code"
+msgstr "Kod QR"
+
+#: rocky/templates/two_factor/core/setup.html
+msgid "Setup key"
+msgstr "Klucz konfiguracyjny"
+
+#: rocky/templates/two_factor/core/setup.html
+msgid ""
+"The secret key is a 32 characters representation of the QR code. There are 2"
+" options to setup the two factor authtentication. You can scan the QR code "
+"above or you can insert this key using the secret key option of the "
+"authenticator app."
+msgstr ""
+"Tajny klucz to 32-znakowa reprezentacja kodu QR. Istnieją 2 opcje "
+"konfiguracji uwierzytelniania dwuskładnikowego. Możesz zeskanować powyższy "
+"kod QR lub wprowadzić ten klucz, korzystając z opcji tajnego klucza w "
+"aplikacji uwierzytelniającej."
+
+#: rocky/templates/two_factor/core/setup_complete.html
+msgid ""
+"Congratulations, you've successfully enabled two-factor authentication."
+msgstr "Gratulacje, pomyślnie włączyłeś uwierzytelnianie dwuskładnikowe."
+
+#: rocky/templates/two_factor/core/setup_complete.html
+msgid "Start using OpenKAT"
+msgstr "Zacznij używać OpenKAT"
+
+#: rocky/templates/two_factor/core/setup_complete.html
+msgid ""
+"However, it might happen that you don't have access to your primary token "
+"device. To enable account recovery, add a phone number."
+msgstr ""
+"Może się jednak zdarzyć, że nie będziesz mieć dostępu do swojego głównego "
+"urządzenia tokena. Aby umożliwić odzyskanie konta, dodaj numer telefonu."
+
+#: rocky/templates/two_factor/core/setup_complete.html
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Add Phone Number"
+msgstr "Dodaj numer telefonu"
+
+#: rocky/templates/two_factor/profile/disable.html
+msgid "Disable Two-factor Authentication"
+msgstr "Wyłącz uwierzytelnianie dwuskładnikowe"
+
+#: rocky/templates/two_factor/profile/disable.html
+msgid ""
+"You are about to disable two-factor authentication. This weakens your "
+"account security, are you sure?"
+msgstr ""
+"Zamierzasz wyłączyć uwierzytelnianie dwuskładnikowe. Osłabia to "
+"bezpieczeństwo Twojego konta, jesteś pewien?"
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Account Security"
+msgstr "Bezpieczeństwo konta"
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Tokens will be generated by your token generator."
+msgstr "Tokeny zostaną wygenerowane przez Twój generator tokenów."
+
+#: rocky/templates/two_factor/profile/profile.html
+#, python-format
+msgid "Primary method: %(primary)s"
+msgstr "Metoda podstawowa: %(primary)s"
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Tokens will be generated by your YubiKey."
+msgstr "Tokeny zostaną wygenerowane przez Twój YubiKey."
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Backup Phone Numbers"
+msgstr "Zapasowe numery telefonów"
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid ""
+"If your primary method is not available, we are able to send backup tokens "
+"to the phone numbers listed below."
+msgstr ""
+"Jeśli Twoja podstawowa metoda nie jest dostępna, jesteśmy w stanie wysłać "
+"tokeny zapasowe na numery telefonów wymienione poniżej."
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Unregister"
+msgstr "Wyrejestruj się"
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid ""
+"If you don't have any device with you, you can access your account using "
+"backup tokens."
+msgstr ""
+"Jeśli nie masz przy sobie żadnego urządzenia, możesz uzyskać dostęp do "
+"swojego konta za pomocą tokenów zapasowych."
+
+#: rocky/templates/two_factor/profile/profile.html
+#, python-format
+msgid "You have only one backup token remaining."
+msgid_plural "You have %(counter)s backup tokens remaining."
+msgstr[0] "Pozostał Ci tylko jeden token zapasowy."
+msgstr[1] "Pozostało Ci %(counter)s tokenów zapasowych."
+msgstr[2] "Pozostało Ci %(counter)s tokenów zapasowych."
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Show Codes"
+msgstr "Pokaż kody"
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Disable Two-Factor Authentication"
+msgstr "Wyłącz uwierzytelnianie dwuskładnikowe"
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid ""
+"However we strongly discourage you to do so, you can also disable two-factor"
+" authentication for your account."
+msgstr ""
+"Jednak zdecydowanie odradzamy to robić, możesz także wyłączyć "
+"uwierzytelnianie dwuskładnikowe dla swojego konta."
+
+#: rocky/templates/two_factor/twilio/sms_message.html
+#, python-format
+msgid "Your OTP token is %(token)s"
+msgstr "Twój token OTP to %(token)s"
+
+#: rocky/templates/upload_csv.html
+msgid "Automate the creation of multiple objects by uploading a CSV file."
+msgstr "Zautomatyzuj tworzenie wielu obiektów, przesyłając plik CSV."
+
+#: rocky/templates/upload_csv.html
+msgid "These are the criteria for CSV upload:"
+msgstr "Oto kryteria przesyłania CSV:"
+
+#: rocky/templates/upload_raw.html
+msgid "Automate the creation of multiple objects by uploading a raw file."
+msgstr "Zautomatyzuj tworzenie wielu obiektów, przesyłając surowy plik."
+
+#: rocky/templates/upload_raw.html
+msgid ""
+"An input OOI can be selected for the normalizer to attach newly yielded OOIs"
+" to. If no input OOI was used for the raw file, a placeholder ExternalScan "
+"OOI can be used. ExternalScan OOIs can be created from the objects page. "
+"When a new version of the raw file is generated, the same ExternalScan OOI "
+"should be chosen to ensure that old results are overwritten."
+msgstr ""
+"Można wybrać wejście OOI dla normalizatora, do którego dołączy nowo uzyskany"
+" OOIs. Jeśli dla pliku nieprzetworzonego nie użyto żadnych danych "
+"wejściowych OOI, można użyć obiektu zastępczego externalScan OOI. Zewnętrzny"
+" skan OOIs można utworzyć ze strony obiektów. Kiedy generowana jest nowa "
+"wersja pliku surowego, należy wybrać ten sam plik OutsideScan OOI, aby mieć "
+"pewność, że stare wyniki zostaną nadpisane."
+
+#: rocky/templates/upload_raw.html rocky/views/upload_raw.py
+msgid "Upload raw"
+msgstr "Prześlij surowe"
+
+#: rocky/views/bytes_raw.py
+msgid "Getting raw data failed."
+msgstr "Pobieranie nieprzetworzonych danych nie powiodło się."
+
+#: rocky/views/bytes_raw.py
+msgid "The task does not have any raw data."
+msgstr "Zadanie nie zawiera żadnych surowych danych."
+
+#: rocky/views/finding_list.py rocky/views/ooi_list.py
+msgid "Unknown action."
+msgstr "Nieznana akcja."
+
+#: rocky/views/health.py
+msgid "Beautified"
+msgstr "Upiększony"
+
+#: rocky/views/indemnification_add.py
+msgid "Indemnification successfully set."
+msgstr "Zabezpieczenie zostało pomyślnie ustalone."
+
+#: rocky/views/mixins.py
+msgid "The selected date is in the future."
+msgstr "Wybrana data przypada w przyszłości."
+
+#: rocky/views/mixins.py
+msgid "Can not parse date, falling back to show current date."
+msgstr "Nie można przeanalizować daty, cofając się do bieżącej daty."
+
+#: rocky/views/mixins.py
+#, python-format
+msgid "Could not load origins for OOI: %s from octopoes"
+msgstr "Nie można załadować źródeł dla OOI: %s z ośmiornic"
+
+#: rocky/views/mixins.py
+msgid "Could not load normalizer metas from bytes"
+msgstr "Nie można załadować meta normalizatora z bajtów"
+
+#: rocky/views/mixins.py
+#, python-format
+msgid "Could not load boefje %s from katalogus"
+msgstr "Nie można załadować boefje %s z katalogów"
+
+#: rocky/views/mixins.py
+msgid "You do not have the permission to add items to a dashboard."
+msgstr "Nie masz uprawnień do dodawania elementów do pulpitu nawigacyjnego."
+
+#: rocky/views/mixins.py
+msgid "Dashboard item has been added."
+msgstr "Dodano element panelu kontrolnego."
+
+#: rocky/views/ooi_add.py
+#, python-format
+msgid "Add %(ooi_type)s"
+msgstr "Dodaj %(ooi_type)s"
+
+#: rocky/views/ooi_detail.py
+msgid ""
+"Cannot set clearance level. It must be provided and must be a valid number."
+msgstr ""
+"Nie można ustawić poziomu luzu. Należy go podać i musi to być ważny numer."
+
+#: rocky/views/ooi_detail.py
+msgid "Only Question OOIs can be answered."
+msgstr "Można odpowiedzieć tylko na pytanie OOIs."
+
+#: rocky/views/ooi_detail.py
+msgid "Question has been answered."
+msgstr "Odpowiedź na pytanie została udzielona."
+
+#: rocky/views/ooi_detail_related_object.py
+msgid " (as "
+msgstr "(Jak"
+
+#: rocky/views/ooi_findings.py
+msgid "Object findings"
+msgstr "Ustalenia obiektu"
+
+#: rocky/views/ooi_list.py
+msgid "No OOIs selected."
+msgstr "Nie wybrano OOIs."
+
+#: rocky/views/ooi_list.py
+#, python-format
+msgid ""
+"Could not raise clearance levels to L%s. Indemnification not present at "
+"organization %s."
+msgstr ""
+"Nie można podnieść poziomów uprawnień do L%s. Brak zabezpieczenia w "
+"organizacji %s."
+
+#: rocky/views/ooi_list.py
+#, python-format
+msgid ""
+"Could not raise clearance level to L%s. You were trusted a clearance level "
+"of L%s. Contact your administrator to receive a higher clearance."
+msgstr ""
+"Nie można podnieść poziomu zezwolenia do L%s. Zaufano Ci na poziomie "
+"uprawnień L%s. Skontaktuj się z administratorem, aby otrzymać wyższe "
+"zezwolenie."
+
+#: rocky/views/ooi_list.py
+#, python-format
+msgid ""
+"Could not raise clearance level to L%s. You acknowledged a clearance level "
+"of L%s. Please accept the clearance level below to proceed."
+msgstr ""
+"Nie można podnieść poziomu zezwolenia do L%s. Zatwierdziłeś poziom "
+"zezwolenia L%s. Aby kontynuować, zaakceptuj poniższy poziom uprawnień."
+
+#: rocky/views/ooi_list.py
+msgid "An error occurred while saving clearance levels."
+msgstr "Wystąpił błąd podczas zapisywania poziomów dopuszczenia."
+
+#: rocky/views/ooi_list.py
+msgid "One of the OOI's doesn't exist"
+msgstr "Jeden z OOI nie istnieje"
+
+#: rocky/views/ooi_list.py
+#, python-format
+msgid "Successfully set scan profile to %s for %d OOIs."
+msgstr "Pomyślnie ustaw profil skanowania na %s dla %d OOIs."
+
+#: rocky/views/ooi_list.py
+msgid "An error occurred while setting clearance levels to inherit."
+msgstr "Wystąpił błąd podczas ustawiania dziedziczonych poziomów uprawnień."
+
+#: rocky/views/ooi_list.py
+msgid ""
+"An error occurred while setting clearance levels to inherit: one of the OOIs"
+" doesn't exist."
+msgstr ""
+"Wystąpił błąd podczas ustawiania poziomów uprawnień do dziedziczenia: jeden "
+"z OOIs nie istnieje."
+
+#: rocky/views/ooi_list.py
+#, python-format
+msgid "Successfully set %d OOI(s) clearance level to inherit."
+msgstr "Pomyślnie ustawiono %d OOI(s) poziom uprawnień do dziedziczenia."
+
+#: rocky/views/ooi_list.py
+msgid "An error occurred while deleting oois."
+msgstr "Wystąpił błąd podczas usuwania oois."
+
+#: rocky/views/ooi_list.py
+msgid "An error occurred while deleting OOIs: one of the OOIs doesn't exist."
+msgstr "Wystąpił błąd podczas usuwania OOIs: jeden z OOIs nie istnieje."
+
+#: rocky/views/ooi_list.py
+#, python-format
+msgid ""
+"Successfully deleted %d ooi(s). Note: Bits can recreate objects "
+"automatically."
+msgstr ""
+"Pomyślnie usunięto %d ooi(s). Uwaga: Bity mogą automatycznie odtwarzać "
+"obiekty."
+
+#: rocky/views/ooi_mute.py
+msgid "Please select at least one finding."
+msgstr "Proszę wybrać co najmniej jedno ustalenie."
+
+#: rocky/views/ooi_mute.py
+msgid "Finding(s) successfully unmuted."
+msgstr "Pomyślnie wyłączono wyciszenie wyników."
+
+#: rocky/views/ooi_mute.py
+msgid "Finding(s) successfully muted."
+msgstr "Wyniki zostały pomyślnie wyciszone."
+
+#: rocky/views/ooi_tree.py
+msgid "Tree Visualisation"
+msgstr "Wizualizacja drzewa"
+
+#: rocky/views/ooi_tree.py
+msgid "Graph Visualisation"
+msgstr "Wizualizacja wykresu"
+
+#: rocky/views/ooi_view.py
+msgid "Observed_at: "
+msgstr "Zaobserwowane_w:"
+
+#: rocky/views/ooi_view.py
+msgid "OOI types: "
+msgstr "OOI typy:"
+
+#: rocky/views/ooi_view.py
+msgid "Clearance level: "
+msgstr "Poziom rozliczenia:"
+
+#: rocky/views/ooi_view.py
+msgid "Clearance type: "
+msgstr "Rodzaj rozliczenia:"
+
+#: rocky/views/ooi_view.py
+msgid "Searching for: "
+msgstr "Wyszukiwanie:"
+
+#: rocky/views/organization_add.py
+msgid "Setup"
+msgstr "Organizować coś"
+
+#: rocky/views/organization_add.py
+msgid "Organization added successfully."
+msgstr "Organizacja została dodana pomyślnie."
+
+#: rocky/views/organization_add.py
+msgid "You are not allowed to add organizations."
+msgstr "Nie możesz dodawać organizacji."
+
+#: rocky/views/organization_edit.py
+#, python-format
+msgid "Organization %s successfully updated."
+msgstr "Organizacja %s została pomyślnie zaktualizowana."
+
+#: rocky/views/organization_member_add.py
+msgid "Add column titles, followed by each object on a new line."
+msgstr "Dodaj tytuły kolumn, a następnie każdy obiekt w nowym wierszu."
+
+#: rocky/views/organization_member_add.py
+msgid "The columns are: "
+msgstr "Kolumny to:"
+
+#: rocky/views/organization_member_add.py
+msgid "Clearance levels should be between -1 and 4."
+msgstr "Poziomy prześwitu powinny mieścić się w przedziale od -1 do 4."
+
+#: rocky/views/organization_member_add.py
+msgid "Account type can be one of: "
+msgstr "Typ konta może być jednym z:"
+
+#: rocky/views/organization_member_add.py
+msgid "Member added successfully."
+msgstr "Pomyślnie dodano członka."
+
+#: rocky/views/organization_member_add.py
+msgid "The csv file is missing required columns"
+msgstr "W pliku CSV brakuje wymaganych kolumn"
+
+#: rocky/views/organization_member_add.py
+#, python-brace-format
+msgid "Invalid account type: '{account_type}'"
+msgstr "Nieprawidłowy typ konta: '{account_type}'"
+
+#: rocky/views/organization_member_add.py
+#, python-brace-format
+msgid "Invalid data for: '{email}'"
+msgstr "Nieprawidłowe dane dla: '{email}'"
+
+#: rocky/views/organization_member_add.py
+#, python-brace-format
+msgid "Invalid email address: '{email}'"
+msgstr "Nieprawidłowy adres e-mail: '{email}'"
+
+#: rocky/views/organization_member_add.py
+msgid "Successfully processed users from csv."
+msgstr "Pomyślnie przetworzono użytkowników z pliku CSV."
+
+#: rocky/views/organization_member_add.py
+msgid "Error parsing the csv file. Please verify its contents."
+msgstr "Błąd podczas analizowania pliku CSV. Proszę sprawdzić jego zawartość."
+
+#: rocky/views/organization_member_edit.py
+#, python-format
+msgid "Member %s successfully updated."
+msgstr "Pomyślnie zaktualizowano członka %s."
+
+#: rocky/views/organization_member_edit.py
+#, python-format
+msgid ""
+"The updated trusted clearance level of L%s is lower then the member's "
+"acknowledged clearance level of L%s. This member only has clearance for "
+"level L%s. For this reason the acknowledged clearance level has been set at "
+"the same level as trusted clearance level."
+msgstr ""
+"Zaktualizowany poziom zaufania zaufanego L%s jest niższy niż zatwierdzony "
+"poziom zezwolenia członka wynoszący L%s. Ten członek ma uprawnienia tylko na"
+" poziomie L%s. Z tego powodu potwierdzony poziom dopuszczenia został "
+"ustalony na tym samym poziomie, co zaufany poziom dopuszczenia."
+
+#: rocky/views/organization_member_edit.py
+msgid ""
+"You have trusted this member with a higher trusted level than member "
+"acknowledged. Member must first accept this level to use it."
+msgstr ""
+"Zaufałeś temu członkowi na wyższym poziomie zaufania niż zatwierdzony przez "
+"członka. Aby móc z niego skorzystać, użytkownik musi najpierw zaakceptować "
+"ten poziom."
+
+#: rocky/views/organization_member_list.py
+#, python-format
+msgid "Blocked member %s successfully."
+msgstr "Pomyślnie zablokowano członka %s."
+
+#: rocky/views/organization_member_list.py
+#, python-format
+msgid "Unblocked member %s successfully."
+msgstr "Pomyślnie odblokowano członka %s."
+
+#: rocky/views/organization_settings.py
+#, python-brace-format
+msgid "Recalculated {number_of_bits} bits. Duration: {duration}"
+msgstr "Przeliczono {number_of_bits} bitów. Czas trwania: {duration}"
+
+#: rocky/views/page_actions.py
+msgid "Could not process your request, action required."
+msgstr "Nie można przetworzyć żądania. Wymagane jest podjęcie działania."
+
+#: rocky/views/scan_profile.py
+msgid ""
+"Cannot set clearance level. The clearance type must be inherited or "
+"declared."
+msgstr ""
+"Nie można ustawić poziomu luzu. Typ zezwolenia musi być dziedziczony lub "
+"zadeklarowany."
+
+#: rocky/views/scans.py
+msgid "Scans"
+msgstr "Skany"
+
+#: rocky/views/scheduler.py
+msgid "Your report has been scheduled."
+msgstr "Twój raport został zaplanowany."
+
+#: rocky/views/scheduler.py
+msgid ""
+"Your task is scheduled and will soon be started in the background. Results "
+"will be added to the object list when they are in. It may take some time, a "
+"refresh of the page may be needed to show the results."
+msgstr ""
+"Twoje zadanie zostało zaplanowane i wkrótce zostanie uruchomione w tle. "
+"Wyniki zostaną dodane do listy obiektów po ich wprowadzeniu. Może to zająć "
+"trochę czasu, może być konieczne odświeżenie strony, aby wyświetlić wyniki."
+
+#: rocky/views/tasks.py
+#, python-brace-format
+msgid "Fetching tasks failed: no connection with scheduler: {error}"
+msgstr ""
+"Pobieranie zadań nie powiodło się: brak połączenia z harmonogramem: {error}"
+
+#: rocky/views/tasks.py
+msgid "All Tasks"
+msgstr "Wszystkie zadania"
+
+#: rocky/views/upload_csv.py
+msgid "Add column titles. Followed by each object on a new line."
+msgstr "Dodaj tytuły kolumn. Po każdym obiekcie w nowej linii."
+
+#: rocky/views/upload_csv.py
+msgid ""
+"For URL object type, a column 'raw' with URL values is required, starting "
+"with http:// or https://, optionally a second column 'network' is supported "
+msgstr ""
+"Dla typu obiektu URL wymagana jest kolumna 'surowa' zawierająca wartości URL"
+" zaczynająca się od http:// lub https://, opcjonalnie obsługiwana jest druga"
+" kolumna 'network'"
+
+#: rocky/views/upload_csv.py
+msgid ""
+"For Hostname object type, a column with 'name' values is required, "
+"optionally a second column 'network' is supported "
+msgstr ""
+"W przypadku obiektu typu Hostname wymagana jest kolumna z wartościami "
+"„nazwa”, opcjonalnie obsługiwana jest druga kolumna „sieć”."
+
+#: rocky/views/upload_csv.py
+msgid ""
+"For IPAddressV4 and IPAddressV6 object types, a column of 'address' is "
+"required, optionally a second column 'network' is supported "
+msgstr ""
+"Dla typów obiektów IPAddressV4 i IPAddressV6 wymagana jest kolumna „adres”, "
+"opcjonalnie obsługiwana jest druga kolumna „sieć”"
+
+#: rocky/views/upload_csv.py
+msgid ""
+"Clearance levels can be controlled by a column 'clearance' taking numerical "
+"values 0, 1, 2, 3, and 4 for the corresponding clearance level (other values"
+" are ignored) "
+msgstr ""
+"Poziomy zezwolenia można kontrolować za pomocą kolumny „prześwit”, "
+"przyjmując wartości liczbowe 0, 1, 2, 3 i 4 dla odpowiedniego poziomu "
+"zezwolenia (inne wartości są ignorowane)"
+
+#: rocky/views/upload_csv.py
+msgid "Object(s) could not be created for row number(s): "
+msgstr "Nie można utworzyć obiektów dla numerów wierszy:"
+
+#: rocky/views/upload_csv.py
+msgid "Object(s) successfully added."
+msgstr "Obiekt(y) pomyślnie dodano."
+
+#: rocky/views/upload_raw.py
+#, python-format
+msgid "Raw file could not be uploaded to Bytes: status code %d"
+msgstr "Nie można przesłać surowego pliku do Bytes: kod stanu %d"
+
+#: rocky/views/upload_raw.py
+#, python-format
+msgid "Raw file could not be uploaded to Bytes: %s"
+msgstr "Nie można przesłać surowego pliku do Bytes: %s"
+
+#: rocky/views/upload_raw.py
+msgid "Raw file successfully added."
+msgstr "Pomyślnie dodano plik surowy."
+
+#, fuzzy
+#~ msgid "Findings @ "
+#~ msgstr "Diskubrimentu"
+
+#~ msgid "Clearance level has been set"
+#~ msgstr "Nivel di autorisashon a ser poni"
+
+#~ msgid "Add URL"
+#~ msgstr "Añadi URL"
+
+#~ msgid ""
+#~ "Boefjes that has a scan level below or equal to the clearance level, is "
+#~ "permitted to scan an object."
+#~ msgstr ""
+#~ "Boefjes ku tin un nivél di skan mas abou of parew ku e nivél di "
+#~ "autorisashon, tin pèrmit pa skan un opheto."
+
+#~ msgid "Delete object(s)"
+#~ msgstr "Kita opheto(nan)"
+
+#~ msgid "Set clearance level to inherit"
+#~ msgstr "Pone nivél di autorisashon na heredá"
+
+#~ msgid "Set clearance level for:"
+#~ msgstr "Pone nivél di autorisashon pa:"
+
+#~ msgid "Setting the scan level from \\"
+#~ msgstr "Ajustando e nivel di skan for di \\"
+
+#~ msgid "You are about to set the clearance level from \\"
+#~ msgstr "Bo ta na e punto di pone e nivél di autorisashon for di \\"
+
+#~ msgid "Yes, set to inherit"
+#~ msgstr "Si, poné na heredá"
+
+#, python-format
+#~ msgid "Successfully set scan profile to %s for %d oois."
+#~ msgstr "Ku exito a pone profil di skén pa %s pa %d oois."
+
+#, python-format
+#~ msgid "Successfully set %d ooi(s) clearance level to inherit."
+#~ msgstr "Éksito den ajustá %d OOI(s) nivel di autorisashon pa heredá."
+
+#~ msgid "An error occurred while deleting oois: one of the OOIs doesn't exist."
+#~ msgstr ""
+#~ "Un error a sosodé durante e eliminashon di OOI nan: un di e OOI nan no ta "
+#~ "eksistí."
+
+#, python-brace-format
+#~ msgid "Can not reset scan level. Scan level of {ooi_name} not declared"
+#~ msgstr "No por resèt nivél di skan. Nivél di skan òf {ooi_name} no ta deklará"
+
+#~ msgid "The Email must be set"
+#~ msgstr "E email adrès mester wordu yena"
+
+#~ msgid "E-mail address"
+#~ msgstr "Email adrès"
+
+#~ msgid ""
+#~ "Dozens of tools are integrated in OpenKAT to view the world (digital and "
+#~ "analog). <br> Our motto is therefore: I see, I see, what you do not see."
+#~ msgstr ""
+#~ "Dosen di hermentnan ta integrá den OpenKAT pa mira e mundu (digital i "
+#~ "anoloog). <br>Nos lema ta: Mi ta mira, mi ta mira loke bo no ta mira."
+
+#~ msgid "E-mail"
+#~ msgstr "E-korreo"
+
+#, python-brace-format
+#~ msgid "A unique code of {code_length} characters."
+#~ msgstr "Un codigo uniko di {code_length} letras."
+
+#~ msgid ""
+#~ "I declare that OpenKAT may scan the assets of my organization and that I "
+#~ "have permission to scan these assets. I am aware of the implications a scan "
+#~ "with a higher scan level brings on my systems."
+#~ msgstr ""
+#~ "Mi ta deklara ku OpenKAT por skan e propiedatnan di mi organisashon i ku mi "
+#~ "tin pèrmit pa skan e propiedatnan aki. Mi ta konsiente di e implikashonnan "
+#~ "un skan ku nivel di skan haltu tin riba mi sistemanan."
+
+#~ msgid ""
+#~ "I declare that I am authorized to give this indemnification within my "
+#~ "organization. I have the experience and knowledge to know what the "
+#~ "consequences might be and can be held responsible for them."
+#~ msgstr ""
+#~ "Mi ta deklará ku mi tin autorisashon pa duna e indemnisashon aki den mi "
+#~ "organisashon. Mi tin e eksperensia i konosementu pa sa e konsekensianan i mi"
+#~ " por ta responsabel pa nan."
+
+#~ msgid "Register"
+#~ msgstr "Registrá"
+
+#~ msgid "Create a new account for your organization"
+#~ msgstr "Krea un account nobo pa bo organisashon"
+
+#~ msgid ""
+#~ "All user  accounts are part of an organization. So if you’re new and your "
+#~ "company is also new to OpenKAT you can register here to create a OpenKAT "
+#~ "account for your company including an admin account for you. If you like a "
+#~ "user account that is connected to an already existing organization within "
+#~ "OpenKAT you can ask the admin to create an account for you."
+#~ msgstr ""
+#~ "Tur account ta parti di un organisashon. Kèmèn si bo ta nobo i bo kompania "
+#~ "tambe ta nobo na OpenKAT bo por registrá akinan pa krea un OpenKAT account "
+#~ "pa bo kompania inkluéndo un admin account pa bo. Si bo ke un account ku ta "
+#~ "konekta ku un organisashon ku ta èksisti kaba na KAT bo por puntra e admin "
+#~ "pa krea un account pa bo."
+
+#~ msgid "How does OpenKAT work"
+#~ msgstr "Kon OpenKAT ta functiona?"
+
+#~ msgid ""
+#~ "OpenKAT is able to give insight into security risks on your online objects. "
+#~ "For example, your websites, mailservers or online data. OpenKAT uses scans "
+#~ "to find and assess the area's that might be at risk and reports these back "
+#~ "to you. As a user you decide which insight you would like and OpenKAT guides"
+#~ " you to through the process. During this introduction you will be guided "
+#~ "through the steps to create a report."
+#~ msgstr ""
+#~ "OpenKAT tin e posibilidàt di duna informashon mas detaya den riésgonan di "
+#~ "siguridát di bo online ophetonan. Por ehempel, bo websites, mailservers òf "
+#~ "online data. OpenKAT ta úza scans pa enkontra i asertà areanan ku por kore "
+#~ "riésgo i rapòrta esaki bèk na abo. Komo kliente bo ta skohè ki informashon "
+#~ "bo ke i OpenKAT ta guiá'bu dor di e proceso Durante e introdukshon aki bo lo"
+#~ " wòrdu guiá dor di e stapnan pa traha un rapòrt."
+
+#~ msgid "OpenKAT setup"
+#~ msgstr "OpenKAT setup"
+
+#~ msgid ""
+#~ "Please enter the following organization details. These details can be edited"
+#~ " within the organization page within OpenKAT when necessary. Adding a new "
+#~ "organization requires a new database."
+#~ msgstr ""
+#~ "Por fabor pone e detayenan di e siguiente organisashon. E detayenan aki por "
+#~ "wordu editá den e página di organisashon den OpenKAT si ta nesesario. Agregá"
+#~ " un organisashon nobo ta requeri un base di datos nobo."
+
+#~ msgid "Account setup"
+#~ msgstr "Account setup"
+
+#~ msgid "Organization setup with separate accounts:"
+#~ msgstr "Konfigurá organisashon ku accountnan separá:"
+
+#~ msgid ""
+#~ "Within OpenKAT it is possible to create separate user accounts with the "
+#~ "specific roles. Each with their own functionalities and permissions. This is"
+#~ " useful when multiple people will be working with the same OpenKAT-setup. "
+#~ "You can choose to create the separate accounts during this introduction or "
+#~ "when you’re ready from the OpenKAT users page."
+#~ msgstr ""
+#~ "Den OpenKAT ta posibel pa krea accountnan separá ku e ròlnan specìfiko kada "
+#~ "un ku nan mes functionalidat ì pèrmitnan. Esaki ta útil ora mayoria hende ke"
+#~ " traha ku e mesun OpenKAT-setup. Bo por skohé pa krea e accountnan separá "
+#~ "durante e introdukshon aki of ora bo ta kla."
+
+#~ msgid "Single account setup:"
+#~ msgstr "Setup account pa mi mes:"
+
+#~ msgid ""
+#~ "Alternatively it is also an option to run OpenKAT from a single user "
+#~ "account. Which is useful when you are the only user in the account. You will"
+#~ " be able to access the functionality of the different roles from your "
+#~ "account. You can always add additional user accounts If you’re team expands "
+#~ "in the future."
+#~ msgstr ""
+#~ "Alternativamente tambe ta un opshón pa huza OpenKAT for di un solo account. "
+#~ "Ku ta útil si bo ta e úniko usadó di e account. Bo lo por tin e posibilidát "
+#~ "pa tin accesso na functionalidatnan di e diferente ròlnan for di bo account."
+#~ " Abo por semper añadi accountnan adishonál si bo tìm expandé den futuro."
+
+#~ msgid "Create separate accounts"
+#~ msgstr "Krea accountnan separá"
+
+#~ msgid "Continue with this account, onboard me!"
+#~ msgstr "Sigi ku e account aki, abòrdami!"
+
+#~ msgid "Users"
+#~ msgstr "Usarionan"
+
+#~ msgid ""
+#~ "Within OpenKAT there are three types of user accounts. Each has its own "
+#~ "functions."
+#~ msgstr ""
+#~ "Den OpenKAT tin trés diferente tipo di user accounts. Kada ún tin su mes "
+#~ "funkshón."
+
+#~ msgid "Admin"
+#~ msgstr "Admin"
+
+#~ msgid ""
+#~ "Each organization must have an admin. The admin can create and manage user "
+#~ "accounts as well as organization details."
+#~ msgstr ""
+#~ "Kada organisashon mester tin un admin. E admin por krea i manehá accountnan "
+#~ "pa usudonan i tambe detayes di organisashon."
+
+#~ msgid "Red teamer"
+#~ msgstr "Tìm kòrá"
+
+#~ msgid "A red teamer account can run scans and generate reports."
+#~ msgstr "Un account pa tìm kòrá por start scans òf generá rapòrtnan."
+
+#~ msgid "Client account"
+#~ msgstr "Account pa kliénte"
+
+#~ msgid "A client account can access reports."
+#~ msgstr "Un account pa kliénte por tin accesso na rapòrtnan."
+
+#~ msgid ""
+#~ "Each organization requires at least one admin and one red teamer account to "
+#~ "function. This introduction will guide you through the setup of both. After "
+#~ "that you can choose to add a client account as well."
+#~ msgstr ""
+#~ "Kada organisashon ta requerì sikiera ún admin ì ún tìm kòrá account pa "
+#~ "functioná. É introdukshon aki ta guiabu pa setup tur dós. Despues ku bo por "
+#~ "skohé pa añadi ún account pa kliénte tambe."
+
+#~ msgid "Let's add accounts"
+#~ msgstr "Laga nos añadi accounts"
+
+#~ msgid "Admin account setup"
+#~ msgstr "Account setup pa admin"
+
+#~ msgid "Admin details"
+#~ msgstr "Admin detayes"
+
+#~ msgid "Skip this step"
+#~ msgstr "Salta e stèp aki"
+
+#~ msgid "Go back to previous step"
+#~ msgstr "Bai bèk na e stèp anterior"
+
+#~ msgid "Red teamer account setup"
+#~ msgstr "Setup account pa tìm kòrà"
+
+#~ msgid "Red teamer details"
+#~ msgstr "Tìm kòrà detayes"
+
+#~ msgid "Client account setup (optional)"
+#~ msgstr "Setup account pa kliénte (opcionàl)"
+
+#~ msgid ""
+#~ "A client account can access reports. Adding a client account to the "
+#~ "organization is optional."
+#~ msgstr ""
+#~ "Un account pa kliénte por tin accesso na rapòrtnan. Añadi un account pa "
+#~ "kliénte na e organisashon ta optionàl."
+
+#~ msgid "User details"
+#~ msgstr "Usario detayes"
+
+#~ msgid "Finish organization setup"
+#~ msgstr "Finalisá setup organisashon"
+
+#~ msgid ""
+#~ "OpenKAT is the \"Kwetsbaarheden Analyse Tool\" (Vulnerabilities Analysis "
+#~ "Tool). An Open-Source-project developed by the Ministry of Health, Welfare "
+#~ "and Sport to make your and our world a safer place."
+#~ msgstr ""
+#~ "OpenKAT ta e \"Kwetsbaarheden Analyse Tool\" (tool pa hasi análisis di "
+#~ "bulerabilidat). Un proyekto Open Source desaroyá pa Ministerio di Salú "
+#~ "Públiko, Salú i Deporte pa hasi nos mundu un lugar mas sigur pa bo i nos."
+
+#~ msgid ""
+#~ "OpenKAT is able to give insight into security risks on your online objects. "
+#~ "For example, your websites, mailservers or online data."
+#~ msgstr ""
+#~ "OpenKAT tin e abilidát di duna revelashon di riésgonan di siguridát di bo "
+#~ "online ophetonan. Por ehèmpel, bo website nan, mailservers òf online data."
+
+#~ msgid ""
+#~ "OpenKAT uses plugins to find and assess the area's that might be at risk and"
+#~ " reports these back to you. Each plugin has its own skillset which could be "
+#~ "scanning, normalizing or analyzing data. As a user you decide which areas "
+#~ "you would like to monitor or scan and which insight you would like to "
+#~ "receive."
+#~ msgstr ""
+#~ "OpenKAT ta huza plugins pa deskubrì i evalúa e areanan ku por ta un riésgo i"
+#~ " rapòrta esaki bèk na bo. Kada plugin tin nan mes sèt di abilidát ku por ta "
+#~ "scan, nòrmalisá òf analisá data. Komo usario bo ta disidì kwa area bo tin "
+#~ "gana di monitoriá òf skan i tambe ki tipo di revelashon bo tin gana di "
+#~ "recibí."
+
+#~ msgid ""
+#~ "Within OpenKAT you can view the insights as well as all the data OpenKAT has"
+#~ " found. You can choose to browse through the data or view reports."
+#~ msgstr ""
+#~ "Den OpenKAT bo por mira e insights i tambe tur data ku KAT a deskubrì. Bo "
+#~ "por skohé pa buska den e data òf wak rapòrt nan."
+
+#~ msgid ""
+#~ "During this introduction you will be guided through the steps to create a "
+#~ "report."
+#~ msgstr ""
+#~ "Durante e introdukshon aki bo lo wordu guiá dor di e stap nan pa krea un "
+#~ "rapòrt."
+
+#~ msgid "OpenKAT introduction"
+#~ msgstr "OpenKAT introdukshon"
+
+#~ msgid "Choose a report - Introduction"
+#~ msgstr "Skohé un rapòrt - Introduskhon"
+
+#~ msgid ""
+#~ "Reports within OpenKAT contain an overview of the scanned objects, issues "
+#~ "found within them and known security risks that the object might be "
+#~ "vulnerable to. Each report gives a high overview of the state of the object "
+#~ "as well as detailed information on what OpenKAT found and possible "
+#~ "solutions."
+#~ msgstr ""
+#~ "Rapòrtnan den OpenKAT ta kontene un lista di ophetonan di skan, problemanan "
+#~ "haña serka nan i riesgo di siguridat nan ku e opheto por ta vulnerabel na "
+#~ "dje. Kada rapòrt ta duna un lista prioritá di e estado di e opheto i tambe "
+#~ "informashon detaya di tur loke KAT a enkontra i solushonanan posibel."
+
+#~ msgid ""
+#~ "OpenKAT can scan and analyze by using plugins. Each plugin has it's unique "
+#~ "skillset and will collect specific data or give specific insights. You "
+#~ "manage the plugins within your account which let's OpenKAT know which "
+#~ "plugins to run and on which objects or areas."
+#~ msgstr ""
+#~ "OpenKAT por skan i analisá dor di huza plugins. Kada plugin tin nan mas sèt "
+#~ "di skills uniko i lo kolekta data spesifiko of duna mas informashon "
+#~ "spesifiko. Bo ta maneha plugins den bo account ku ta laga OpenKAT sa kwa "
+#~ "plugins mester huza riba kwa opheto òf areanan."
+
+#~ msgid "Generating a report"
+#~ msgstr "Generándo un rapport"
+
+#~ msgid ""
+#~ "When you choose a report type OpenKAT will guide you through the setup. "
+#~ "OpenKAT will ask the necessary questions based on the input the report "
+#~ "needs, as well as asks for permission to run plugins that you haven’t "
+#~ "enabled yet but are needed to collect or analyze the data."
+#~ msgstr ""
+#~ "Ora bo selektá un tipo di informe, OpenKAT lo guia bo den e ajuste. OpenKAT "
+#~ "lo hasi e preguntanan necesario basá riba e entrada ku e informe ta "
+#~ "nesesitá, tambe lo pidi permiso pa eksekutá plug-innan ku ainda bo no a "
+#~ "habilidá, pero ku ta nesesario pa kolektá òf analisá e datonan."
+
+#~ msgid ""
+#~ "You can also choose to look at the collected data directly or generate your "
+#~ "own report by selecting and running plugins on objects of your choice. "
+#~ "OpenKAT will present the results."
+#~ msgstr ""
+#~ "Bo por tambe skohé pa mira e data kolekta direktamente òf genera bo mes "
+#~ "rapòrt dor di selekta i start plugins riba ophetonan si bo eskoho. OpenKAT "
+#~ "lo presentabu ku e resultadonan."
+
+#~ msgid "Permission"
+#~ msgstr "Permiso Nenga"
+
+#~ msgid ""
+#~ "Plugins can be provided by OpenKAT but they can also come from the "
+#~ "community. Before a plugin can run, you need to give it permission by "
+#~ "enabling it."
+#~ msgstr ""
+#~ "Plugins ta bin di OpenKAT pero nan tambe por bini dor di e komunidát. Promé "
+#~ "un plugin por wordu huza, bo mester dunele pèrmiso dor di activé"
+
+#~ msgid ""
+#~ "When you generate a report. OpenKAT will let you know which plugins it "
+#~ "requires or suggests so you can choose to enable them."
+#~ msgstr ""
+#~ "Ora bo genera un rapòrt. OpenKAT ta lagabu sa kwa plugins e mester òf "
+#~ "duna'bu sugerencias pa skohé kwa pa activá."
+
+#~ msgid "Let's choose a report"
+#~ msgstr "Ban skohé un rapòrt"
+
+#~ msgid "Choose a report - Type"
+#~ msgstr "Skohé un rapòrt - Tipo"
+
+#~ msgid ""
+#~ "When you start to generate this report. OpenKAT will guide you through the "
+#~ "necessary steps."
+#~ msgstr ""
+#~ "Ora bo kuminsa generá e rapòrt aki. OpenKAT lo guiá'bu dor di e stapnan "
+#~ "necesario."
+
+#~ msgid "Setup scan"
+#~ msgstr "Setup skan"
+
+#~ msgid "Let OpenKAT know what object to scan"
+#~ msgstr "Laga OpenKAT sa kwa opheto e tinku skan"
+
+#~ msgid ""
+#~ "Plugins scan and analyze objects. OpenKAT needs to know which object(s) you "
+#~ "would like to scan and analyze for the DNS-report. So it can tell you which "
+#~ "plugins are available for the chosen object."
+#~ msgstr ""
+#~ "Plug-innan skan i analisá objektonan. OpenKAT mester sa kua objèkto(s) bo "
+#~ "kier skan i analisá pa e informe DNS. Asina ku por bisa bo ku kuál plug-"
+#~ "innan ta disponibel pa e objèkto selektá."
+
+#~ msgid "Understanding objects"
+#~ msgstr "Kompronde ophetonan"
+
+#~ msgid "Creating, adding and editing objects"
+#~ msgstr "Kreando, añadiando i editá ophetonan"
+
+#~ msgid ""
+#~ "Within OpenKAT you can view, add and edit objects from the organization’s "
+#~ "object page."
+#~ msgstr ""
+#~ "Den OpenKAT bo por mira, añadi i editá ophetonan di e organisashon su page "
+#~ "di opheto."
+
+#~ msgid ""
+#~ "Let’s add an object to scan for the DNS-Report. For this introduction we "
+#~ "suggest adding a URL."
+#~ msgstr ""
+#~ "Ban añadi un opheto pa skan pa traha e DNS-rapòrt. Pa e introdukshon aki nos"
+#~ " ta sugerí añadi un URL."
+
+#~ msgid "Create your first object, a URL by filling out the form below."
+#~ msgstr "Krea bo promé opheto, un URL dor di yena e formulario abou."
+
+#~ msgid ""
+#~ "Additional details and examples can be found by pressing on the help button "
+#~ "next to the input field."
+#~ msgstr ""
+#~ "Detayesnan i ehempelnan adishonal bo por haña dor di primi e help botón "
+#~ "banda di e vèld."
+
+#~ msgid "Dependencies"
+#~ msgstr "Dependesianan"
+
+#~ msgid ""
+#~ "The additional objects that OpenKAT created will be added to your object "
+#~ "list as separate objects. If OpenKAT can’t add them automatically it will "
+#~ "guide you through the process of creating them manually."
+#~ msgstr ""
+#~ "E ophetonan adishonal ku OpenKAT á krea lo wordu agregá na e lista di opehto"
+#~ " komo ophetonan separá. Si OpenKAT no por agregá esakinan automatikamente e "
+#~ "ta guia'bu dor di e processo pa kreanan manualmente."
+
+#~ msgid ""
+#~ "Based on the url you provided OpenKAT added the necessary additional objects"
+#~ " to create a url object."
+#~ msgstr ""
+#~ "Basá riba e URL ku bo a duna, OpenKAT a agrega e ophetonan adishonal "
+#~ "necesario pa krea un opheto di URL."
+
+#~ msgid "URL"
+#~ msgstr "URL"
+
+#~ msgid "Path"
+#~ msgstr "Routa"
+
+#~ msgid "Hostname"
+#~ msgstr "Hostname"
+
+#~ msgid "scheme"
+#~ msgstr "programa"
+
+#~ msgid "Network"
+#~ msgstr "Nètwèrk"
+
+#~ msgid "Start scanning"
+#~ msgstr "Start skan"
+
+#~ msgid "OpenKAT Introduction"
+#~ msgstr "OpenKAT Introdukshon"
+
+#~ msgid "Setup scan - OOI clearance for"
+#~ msgstr "Sètup skan- OOI autorisashon pa"
+
+#~ msgid ""
+#~ "Some scans are lightweight while others might be a bit more aggressive with "
+#~ "their scanning. OpenKAT requires you to set a clearance level for each "
+#~ "object to prevent you from unintentionally running aggressive scans. For "
+#~ "example you might have the right to run any type of scan on your own server "
+#~ "but you probably don’t have the right to do so for objects owned by other "
+#~ "people of companies."
+#~ msgstr ""
+#~ "Algun skan ta ligero, i otro por ta un tiki mas agresivo den nan skaneo. "
+#~ "OpenKAT ta requeri bo pa ajustá un nivel di autorisashon pa kada opheto pa "
+#~ "evitá ku b'a sende skan agresivo sin intenshón. Por ehèmpel, bo por tin e "
+#~ "derechi pa skan kualkier tipo di opheto riba bo propio server, pero "
+#~ "probabelmente bo no tin e derechi pa hasi meskos ku ophetonan ku ta "
+#~ "pertenese na otro personanan of kompanianan."
+
+#~ msgid "How to know required clearance level"
+#~ msgstr "Kon pa sa nivél di autorisashon requerí"
+
+#~ msgid ""
+#~ "Each plugin that scans will have a scan intensity score. The intensity of "
+#~ "the scan must be equal to or below the clearance level you set for your "
+#~ "object. If the scan has an intensity level that is too high, OpenKAT will "
+#~ "notify you before running it. Visually clearance levels and intensity scores"
+#~ " are indicated with little cat paws."
+#~ msgstr ""
+#~ "Kada plug-in ku skan ta tin un puntu di intensidat di skaneo. E intensidat "
+#~ "di e skaneo mester ta igual òf mas abou ku e nivel di autorisashon ku bo a "
+#~ "ajustá pa bo opheto. Si e skaneo tin un nivel di intensidat ku ta hopi "
+#~ "haltu, OpenKAT lo notifiká bo promé di eksekutá e skaneo. Visualmente, "
+#~ "nivelnan di autorisashon i punto di intensidat ta indiká ku patanan di "
+#~ "pushi."
+
+#~ msgid ""
+#~ "This scan has a scan intensity score of 1, requiring a level 1 clearance "
+#~ "level to be run. This means that the scan does not touch the object itself, "
+#~ "but only searches for information about the object."
+#~ msgstr ""
+#~ "E skan tin un score di nivél di intensidat di 1, ku ta requerí nivél 1 di "
+#~ "autorisashon pa start. Esaki ta nifika ku e skan no ta mishi ku e opheto "
+#~ "riba su mes, pero solamente ta buska informashon tokante e opheto."
+
+#~ msgid ""
+#~ "An example of a more aggressive scan. Which has a scan intensity score of 3."
+#~ " Meaning it requires at least a level 3 clearance level to be set on your "
+#~ "object."
+#~ msgstr ""
+#~ "Un ehèmpel di un skaneo mas agresivo. Ku tin un puntu di intensidat di "
+#~ "skaneo di 3. Esaki ta nifiká ku mester tin por lo menos un nivel di "
+#~ "autorisashon di 3 pa wordu ajustá riba bo opheto."
+
+#~ msgid "Acknowledge clearance level"
+#~ msgstr "Rekonosé nivel di autorisashon"
+
+#~ msgid "Setup scan - Set clearance level for"
+#~ msgstr "Sètup skan- Pone nivel di autorisashon pa"
+
+#, python-format
+#~ msgid ""
+#~ "After creating a new object OpenKAT will ask you to set a clearance level. "
+#~ "On the object detail page you can always change the clearance level. For the"
+#~ " onboarding we will suggest to set the clearance level to "
+#~ "L%(dns_report_least_clearance_level)s."
+#~ msgstr ""
+#~ "Despues di krea un opheto nobo, OpenKAT lo puntra bo pa pone un nivel di "
+#~ "autorisashon. Na e página di detaye di e opheto, bo por kambia e nivel di "
+#~ "autorisashon semper. Pa e proceso di onboarding nos lo sugeri pa pone e "
+#~ "nivel di autorisashon na L%(dns_report_least_clearance_level)s."
+
+#~ msgid "Setup scan - Enable plugins"
+#~ msgstr "Configurá skan - Aktivá plugins"
+
+#~ msgid "Plugins introduction"
+#~ msgstr "Plugins su introduskhon"
+
+#~ msgid ""
+#~ "OpenKAT uses plugins to scan, check and analyze. Each plugin will bring a "
+#~ "specific skillset that will help to generate your report. There are three "
+#~ "types of plugins."
+#~ msgstr ""
+#~ "OpenKAT ta huza plugins pa scan, check i analisá. Kada plugin ta trese un "
+#~ "abilidát specifikó ku lo juda pa generá bo rapòrt. Tin tres tipo di plugins."
+
+#~ msgid ""
+#~ "Scan objects for data. Each boefje has a scan intensity score to prevent "
+#~ "invasive scanning on objects where you don’t have the clearance to do so."
+#~ msgstr ""
+#~ "Skèn ophetonan pa data. Kada boefje tin un intesidát score pa skan pa "
+#~ "prevení scannan invasivo riba opheto kaminda bo no tin autorisashon pa hasi "
+#~ "esaki."
+
+#~ msgid ""
+#~ "Check the data for specific objects and add these object to your object "
+#~ "list."
+#~ msgstr ""
+#~ "Chèk e data pa ophetonan specifikó i añadi e ophetonan aki na bo lista di "
+#~ "opheto."
+
+#~ msgid "Analyze the available data to come to insights and conclusions."
+#~ msgstr "Analisá e data disponibel pa yega na konklushonnan i perspectivanan."
+
+#~ msgid ""
+#~ "OpenKAT will be able to generate a full report when all the required and "
+#~ "suggested plugins are enabled. If you choose not to give a plugin permission"
+#~ " to run, the data that plugin would collect or produce will be left out of "
+#~ "the report which will then be generated based on the available data "
+#~ "collected by the enabled plugins. Below are the suggested and required "
+#~ "plugins for this report."
+#~ msgstr ""
+#~ "OpenKAT ta dispuesto pa generá un fúl rapòrt ora tur e plugins nan requerí i"
+#~ " sugerá ta aktivá. Si bo skohé pa no duna un plugin pèrmiso  pa start, e "
+#~ "data ku e plugin lo mester kolektá òf produsí lo wordu saka for di e rapòrt "
+#~ "ku lo generá a base di e data ku tin disponibel kolektá pa e plugins aktivo."
+#~ " Abou bo por mira e plugins nan ku ta requerí pa e rapòrt aki."
+
+#~ msgid "Let’s setup your scan by enabling the plugins of your choice below."
+#~ msgstr "Laga nos ban setup e skan dor di aktivá e plugins di bo eskoho abou."
+
+#~ msgid ""
+#~ "The enabled boefjes are collecting the data needed to generate the DNS-"
+#~ "report. This may take some time based on the type of scans and the number of"
+#~ " objects found. For the current scan we expect boefjes to take about 3 "
+#~ "minutes."
+#~ msgstr ""
+#~ "E Boefjes nan aktivá ta bezig ta kolektando e data necesario pa generá e "
+#~ "DNS-rapòrt. Esaki ta bai tuma tempu a base di e tipo di scannan i e kantidát"
+#~ " di ophetonan enkontrá."
+
+#~ msgid ""
+#~ "During this introduction we ask you to wait till the scan is ready. After "
+#~ "which you can view the report."
+#~ msgstr ""
+#~ "Durante e introdukshon aki nos ta pidibu pa warda te ora e skan kaba. "
+#~ "Despues bo por mira e rapòrt."
+
+#~ msgid ""
+#~ "After the onboarding, boefjes run in the background. This enables you to use"
+#~ " OpenKAT in the meantime without waiting for scans to finish. When you would"
+#~ " like to see the status of a scan you can open the \"tasks\" page."
+#~ msgstr ""
+#~ "Despues di e onboarding, boefjes nan ta sigi den background. Esaki ta pone "
+#~ "ku bo por uza OpenKAT mientras tantu sin mester warda te ora e skannan kaba."
+#~ " Kaminda bo lo por ke mira e status di un skan bo por habri e pagina di "
+#~ "\"tarea\". "
+
+#~ msgid "Open my DNS-report"
+#~ msgstr "Habri mi DNS-rapòrt"
+
+#~ msgid "1: Introduction"
+#~ msgstr "Introdukshon"
+
+#~ msgid "2: Choose a report"
+#~ msgstr "Skohé un rapòrt"
+
+#~ msgid "3: Setup scan"
+#~ msgstr "Setup scan"
+
+#~ msgid "4: Open report"
+#~ msgstr "Habri rapòrt"
+
+#~ msgid "3: Indemnification"
+#~ msgstr "3: Indemnizashon"
+
+#~ msgid "4: Account setup"
+#~ msgstr "4: Account setup"
+
+#~ msgid "OpenKAT Setup"
+#~ msgstr "OpenKAT Setup"
+
+#, python-brace-format
+#~ msgid "{name} successfully created."
+#~ msgstr "{name} a wòrdu krea ku èksito."
+
+#~ msgid "The name of the organisation"
+#~ msgstr "E nòmber di e organisashon"
+
+#~ msgid ""
+#~ "A slug containing only lower-case unicode letters, numbers, hyphens or "
+#~ "underscores that will be used in URLs and paths"
+#~ msgstr ""
+#~ "Un slug ta kontene solamente lower-case unicode letras, numbernan, hyphens "
+#~ "òf underscores ku lo wordu huza den URLs i paths"
+
+#~ msgid ""
+#~ "Before you're able to add assets to OpenKAT and to assign clearance levels, "
+#~ "you have to give indemnification on the organization and declare that you as"
+#~ " a person can be held accountable."
+#~ msgstr ""
+#~ "Prome ku bo por añadi propiedatnan na OpenKAT i pone nivelnan di "
+#~ "authorisashon, bo mester duna indemnizashon na e organisashon i deklara ku "
+#~ "abo komo persona por wordu pone responsabel."
+
+#~ msgid "Register an indemnification"
+#~ msgstr "Registrá un indemnizashon"
+
+#~ msgid "Add Finding"
+#~ msgstr "Añadí Diskubrimentu"
+
+#~ msgid "Mute Findings"
+#~ msgstr "Muta Diskubrimentu"
+
+#~ msgid "Mute Finding"
+#~ msgstr "Muta diskubrimentu"
+
+#~ msgid "Account Type"
+#~ msgstr "Tipo di account"
+
+#~ msgid "Every member of OpenKAT must be part of an account type."
+#~ msgstr "Kada miembro di OpenKAT mester ta parti di un tipo di kuenta."
+
+#~ msgid "Source OOI"
+#~ msgstr "Orígen OOI"
+
+#~ msgid "Manual creation"
+#~ msgstr "Kreashon manual"
+
+#~ msgid " member account setup"
+#~ msgstr " konfigurashon di kuenta di miembro"
+
+#~ msgid "Member details"
+#~ msgstr "Detayes di miembro"
+
+#~ msgid "Member account type setup"
+#~ msgstr "Konfigurashon di tipo di kuenta di miembro"
+
+#~ msgid "Choose an account type for this new member."
+#~ msgstr "Selekshoná un tipo di kuenta pa e miembro nobo aki."
+
+#~ msgid "Account type details"
+#~ msgstr "Detayenan di tipo di kuenta"
+
+#~ msgid "Upload a csv file with members for organisation"
+#~ msgstr "Subi un archivo csv ku miembronan pa e organisashon"
+
+#~ msgid "Download the template"
+#~ msgstr "Download e template"
+
+#~ msgid "or create a csv file with the following criteria"
+#~ msgstr "òf krea un archivo csv ku e kriterionan sigiente"
+
+#~ msgid "Shown status types"
+#~ msgstr "Muestra di tiponan di status"
+
+#~ msgid "Blocked status"
+#~ msgstr "Status blòkiá"
+
+#~ msgid "Type select"
+#~ msgstr "Selektá tipo"
+
+#~ msgid "Add Account Type"
+#~ msgstr "Añadi Tipo di account"
+
+#~ msgid "Add Member"
+#~ msgstr "Añadí miembro"
+
+#~ msgid ""
+#~ "An overview of the top 10 most severe findings OpenKAT found. Check the "
+#~ "detail section for additional severity information."
+#~ msgstr ""
+#~ "Un bista general di e 10 diskubrimentunan mas serio ku OpenKAT a haña. Chèk "
+#~ "den seccion di detaye pa informashon adishonal tokante severidat."
+
+#~ msgid "Top 10 most severe Findings"
+#~ msgstr "Top 10 di e diskubrimentunan mas serio."
+
+#~ msgid "Showing "
+#~ msgstr "Mustra "
+
+#~ msgid "findings"
+#~ msgstr "diskubrimentunan"
+
+#~ msgid "Finding type:"
+#~ msgstr "Tipo di diskubrimentu:"
+
+#~ msgid "OOI type:"
+#~ msgstr "Tipo di opheto"
+
+#~ msgid "Source OOI:"
+#~ msgstr "Orígen OOI:"
+
+#~ msgid "KAT-alogus Settings"
+#~ msgstr "KAT-alogus Settings"
+
+#~ msgid ""
+#~ "There are currently no settings defined. Add settings at plugin detail page."
+#~ msgstr ""
+#~ "Na e momentonan aki no tin settings pone. Añadi settings na e página detaya "
+#~ "di plugin."
+
+#, python-format
+#~ msgid ""
+#~ "These are the findings of a OpenKAT-analysis (%(observed_at)s). Click a "
+#~ "finding for more detailed information about the issue, its origin, severity "
+#~ "and possible solutions."
+#~ msgstr ""
+#~ "Esakinan ta e resultadonan di un OpenKAT-analysis riba %(observed_at)s. "
+#~ "Click un resultadopa mas informashon detayá tokante e problema, su orígen, "
+#~ "severidat i posibel solushonnan."
+
+#~ msgid "DNS Tree"
+#~ msgstr "DNS Mapa"
+
+#~ msgid "Total findings:"
+#~ msgstr "Totál diskubrimentu:"
+
+#~ msgid "An overview of"
+#~ msgstr "Resúmen di resultado"
+
+#~ msgid "object type"
+#~ msgstr "tipo di opheto"
+
+#~ msgid ""
+#~ "This shows general information and its related objects. It also gives the "
+#~ "possibility to add additional related objects, or to scan for them."
+#~ msgstr ""
+#~ "Esaki ta mustra informashon general i e ophetonan relashoná. Tambe ta brinda"
+#~ " e posibilidat pa agrega ophetonan relashoná adishonal, òf pa skan pa nan."
+
+#~ msgid "Unique"
+#~ msgstr "Úniko"
+
+#~ msgid "There are no tasks for boefjes"
+#~ msgstr "No tin tareanan pa boefjes"
+
+#~ msgid "List of tasks for boefjes"
+#~ msgstr "Lista di tareanan pa boefjes"
+
+#~ msgid "There are no tasks for normalizers"
+#~ msgstr "No tin tareanan pa normalizers"
+
+#~ msgid "List of tasks for normalizers"
+#~ msgstr "Lista di tareanan pa normalizers"
+
+#~ msgid "Your password must contain at least the following:"
+#~ msgstr "Bo password mester kontené por lo menos lo siguinte:"
+
+#~ msgid " special characters such as: "
+#~ msgstr " karakternan speshal manera: "
+
+#~ msgid ""
+#~ "Failed to get list of findings for organization {}, check server logs for "
+#~ "more details."
+#~ msgstr ""
+#~ "No por a optené lista di diskubrimentu pa e organisashon {}, kontrolá "
+#~ "registro di servidor pa detayenan mas."
+
+#~ msgid ""
+#~ "An overview of all (critical) findings OpenKAT found. Check the detail "
+#~ "section for additional severity information."
+#~ msgstr ""
+#~ "Un relato general di tur diskubrimentu (krítiko) ku OpenKAT a enkontrá. Chèk"
+#~ " e sekshon detayá pa informashon addishonal severo."
+
+#~ msgid "Total Findings"
+#~ msgstr "Diskubrimentu Totál"
+
+#~ msgid " Finding Details"
+#~ msgstr "Detayes di diskubrimentu"
+
+#~ msgid "Top critical organizations"
+#~ msgstr "Top organisashonnan krítiko"
+
+#~ msgid "Critical findings"
+#~ msgstr "Diskubrimentu Kritiko"
+
+#~ msgid "Critical Findings"
+#~ msgstr "Diskubrimentu Kritiko"
+
+#~ msgid "this field is required"
+#~ msgstr "E vèld aki ta obligatorio"
+
+#~ msgid "This field is required"
+#~ msgstr "E vèld aki ta obligatorio"
+
+#~ msgid ""
+#~ "\n"
+#~ "                            You don't have any clearance to scan objects.<br>\n"
+#~ "                            Get in contact with the admin to give you the necessary clearance level.\n"
+#~ "                        "
+#~ msgstr ""
+#~ "\n"
+#~ " Bo no tin ningun nivel di autorisashon pa skan ophetonan.<br>\n"
+#~ " Tuma kontakto ku e administradó pa duna bo e nivel di autorisashon nesesario.\n"
+#~ " "
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "        Use the form below to clone the settings from <i>%(current_organization)s</i> to the selected organization.\n"
+#~ "        This includes both the KAT-alogus settings as well as enabled and disabled plugins.\n"
+#~ "      "
+#~ msgstr ""
+#~ "\n"
+#~ " Uza e formulario abou pa kopia e konfigurashon di <i>%(current_organization)s</i> pa e organisashon selektá.\n"
+#~ " Esaki ta inkluí tanto e konfigurashonnan di KAT-alogus manera tambe e plug-innan aktivá i desaktivá.\n"
+#~ "      "
+
+#~ msgid ""
+#~ "\n"
+#~ "                            Plugin available\n"
+#~ "                        "
+#~ msgid_plural ""
+#~ "\n"
+#~ "                            Plugins available\n"
+#~ "                        "
+#~ msgstr[0] ""
+#~ "\n"
+#~ "                        Plug-in disponibel\n"
+#~ "                        "
+#~ msgstr[1] ""
+#~ "\n"
+#~ "                        Plug-ins disponibel\n"
+#~ "                      "
+
+#~ msgid ""
+#~ "\n"
+#~ "            Add setting\n"
+#~ "          "
+#~ msgid_plural ""
+#~ "\n"
+#~ "            Add settings\n"
+#~ "          "
+#~ msgstr[0] ""
+#~ "\n"
+#~ "            Añadi configurashon\n"
+#~ "          "
+#~ msgstr[1] ""
+#~ "\n"
+#~ "            Añadi configurashonnan\n"
+#~ "          "
+
+#~ msgid ""
+#~ "\n"
+#~ "            Setting\n"
+#~ "          "
+#~ msgid_plural ""
+#~ "\n"
+#~ "            Settings\n"
+#~ "          "
+#~ msgstr[0] ""
+#~ "\n"
+#~ "            Configurashon\n"
+#~ "          "
+#~ msgstr[1] ""
+#~ "\n"
+#~ "            Configurashonnan\n"
+#~ "          "
+
+#~ msgid ""
+#~ "\n"
+#~ "                  Add setting and enable boefje\n"
+#~ "                "
+#~ msgid_plural ""
+#~ "\n"
+#~ "                  Add settings and enable boefje\n"
+#~ "                "
+#~ msgstr[0] ""
+#~ "\n"
+#~ "                        Pone setting i sende boefje\n"
+#~ "                        "
+#~ msgstr[1] ""
+#~ "\n"
+#~ "                        Pone settings i sende boefje\n"
+#~ "                      "
+
+#~ msgid ""
+#~ "\n"
+#~ "                    OpenKAT has a permission system that allows administrators to\n"
+#~ "                    configure which users can set a certain clearance level. The will make sure\n"
+#~ "                    that only users that are trusted can start the more aggressive scans.\n"
+#~ "                "
+#~ msgstr ""
+#~ "\n"
+#~ "OpenKAT tin un sistema di permiso ku ta laga administratornan\n"
+#~ "configure kua usuarionan por pone un nivel di autorisashon determiná. Esaki lo segurá\n"
+#~ "ku solamente usuarionan ku ta konfiable por inisiá e skaneonan mas agresivo.\n"
+#~ " "
+
+#~ msgid ""
+#~ "\n"
+#~ "                    Before a member is granted the ability to set clearance levels on an object,\n"
+#~ "                    they must first acknowledge and accept the clearance level set by the administrators.\n"
+#~ "                    The maximum scanning level permitted for a member is aligned with the trusted clearance level.\n"
+#~ "                    By acknowledging the trusted clearance level, this member formally agrees to abide by\n"
+#~ "                    this permission and gains the capability to perform scans only up to this trusted clearance level.\n"
+#~ "                    This two-step process ensures that the member operates within authorized boundaries.\n"
+#~ "                "
+#~ msgstr ""
+#~ "\n"
+#~ "Promé ku un miembro ta otorgá e habilidat pa pone nivelnan di autorisashon riba un opheto,\n"
+#~ "promé nan mester reconosé i aseptá e nivel di autorisashon poni pa e administratornan.\n"
+#~ "E nivel máksimo di skaneo permití pa un miembro ta aliná ku e nivel di autorisashon konfiable.\n"
+#~ "Pa reconosé e nivel di autorisashon konfiable, e miembro aki formalmente ta akordá pa kumpli ku\n"
+#~ "e permiso aki i ta haña e kapasidat pa realizá skaneonan solamente te na e nivel di autorisashon konfiable aki.\n"
+#~ "E proheso di dos pason aki ta garantisá ku e miembro ta operá den fronteranan autorisá.\n"
+#~ " "
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "                                Unfortunately you cannot continue the onboarding. </br>\n"
+#~ "                                Your administrator has trusted you with a clearance level of <strong>L%(tcl)s</strong>.</br>\n"
+#~ "                                You need at least a clearance level of <strong>L%(dns_report_least_clearance_level)s</strong> to scan <strong>%(ooi)s</strong></br>\n"
+#~ "                                Contact your administrator to receive a higher clearance.\n"
+#~ "                            "
+#~ msgstr ""
+#~ "\n"
+#~ " Desafortunadamente bo no por sigui ku e proceso di onboarding. </br>\n"
+#~ " Bo administrator a konfia bo ku un nivel di autorisashon di <strong>L%(tcl)s</strong>.</br>\n"
+#~ " Bo mester tin almenos un nivel di autorisashon di <strong>L%(dns_report_least_clearance_level)s</strong> pa skaneá\n"
+#~ " <strong>%(ooi)s</strong></br>\n"
+#~ " Tuma kontakto ku bo administrator pa risibí un nivel di autorisashon mas haltu.\n"
+#~ " "
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "                            Your administrator has trusted you with a clearance level of <strong>L%(tcl)s</strong>.</br>\n"
+#~ "                            You must first accept this clearance level to continue.\n"
+#~ "                            "
+#~ msgstr ""
+#~ "\n"
+#~ " Bo administrator a konfia bo ku un nivel di autorisashon di <strong>L%(tcl)s</strong>.</br>\n"
+#~ " Promé bo mester aseptá e nivel di autorisashon aki pa por sigui.\n"
+#~ " "
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "                            Accept level L%(tcl)s clearance and responsibility\n"
+#~ "                        "
+#~ msgstr ""
+#~ "\n"
+#~ "Aseptá nivel di autorisashon L%(tcl)s i responsabilidat\n"
+#~ "                        "
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "                            Your administrator has <strong>trusted</strong> you with a clearance level of <strong>L%(tcl)s</strong>.</br>\n"
+#~ "                            You have also <strong>acknowledged</strong> to use this clearance level of <strong>L%(acl)s</strong>.\n"
+#~ "                            "
+#~ msgstr ""
+#~ "\n"
+#~ " Bo administrator a <strong>konfia</strong> bo ku un nivel di autorisashon di <strong>L%(tcl)s</strong>.</br>\n"
+#~ " Bo tambe a <strong>rekonosé</strong> pa usa e nivel di autorisashon aki di <strong>L%(acl)s</strong>.\n"
+#~ " "
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "                            <strong>Warning:</strong>\n"
+#~ "                            Indemnification is not set for this organization.\n"
+#~ "                            Go to the <a href=\"%(organization_settings)s\">organization settings page</a> to add one.\n"
+#~ "                        "
+#~ msgstr ""
+#~ "\n"
+#~ " <strong>Advertensia:</strong>\n"
+#~ " Indemnisashon no ta ajustá pa e organisashon aki.\n"
+#~ " Bishitá e <a href=\"%(organization_settings)s\">página di ajuste di organisashon</a> pa agregá un.\n"
+#~ "                        "
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "                    An overview of \"%(organization_name)s\" its members.\n"
+#~ "                "
+#~ msgstr ""
+#~ "\n"
+#~ " Un bista general di e miembronan di \"%(organization_name)s\".\n"
+#~ "                "
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "            An overview of \"%(organization_name)s\". This shows general information and its settings.\n"
+#~ "          "
+#~ msgstr ""
+#~ "\n"
+#~ " Un bista general di \"%(organization_name)s\". Esaki ta mustra informashon general i su ajustenan.\n"
+#~ "          "
+
+#~ msgid ""
+#~ "\n"
+#~ "              <strong>Warning:</strong>\n"
+#~ "              Indemnification is not set for this organization.\n"
+#~ "            "
+#~ msgstr ""
+#~ "\n"
+#~ " <strong>Advertensia:</strong>\n"
+#~ " Indemnisashon no ta ajustá pa e organisashon aki.\n"
+#~ "            "
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "              This means that this object will be scanned by Boefjes with scan level\n"
+#~ "              %(scan_level)s and lower. Setting the clearance level from “declared”\n"
+#~ "              to “inherit” means that this object will inherit its level from neighbouring\n"
+#~ "              objects. This means that the clearance level might stay the same, increase,\n"
+#~ "              or decrease depending on other declared clearance levels. Clearance levels\n"
+#~ "              of objects that inherit from this clearance level will also be recalculated.\n"
+#~ "            "
+#~ msgstr ""
+#~ "\n"
+#~ "              Esaki ta nifiká ku e opheto aki lo wordu di skan dor di Boefjes ku nivél di skan\n"
+#~ "              %(scan_level)s i mas abou. Pone e nivél di autorisashon for di deklará\n"
+#~ "              na “heredá” ta nifiká ku e opheto aki lo heredá su nivél for di ophetonan den bisindario.\n"
+#~ "              Esaki ta nifiká ku e nivél di autorisashon por keda meskos, subi,\n"
+#~ "              òf baha depende di e otro nivél di autorisashonnan. Nivél di autorisashonnan\n"
+#~ "              di ophetonan ku ta heredá for di e nivél di autorisashon tambe lo wordu rekalkulá.\n"
+#~ "            "
+
+#~ msgid ""
+#~ "\n"
+#~ "                This object has a clearance level of \"L0\". This means that this object will not be scanned by any Boefje until that\n"
+#~ "                Boefje is run manually for this object again. Objects with a clearance level higher than \"L0\" will be scanned automatically by Boefjes with\n"
+#~ "                corresponding scan levels.\n"
+#~ "            "
+#~ msgstr ""
+#~ "\n"
+#~ "                E opheto aki tin un nivel di authorisashon di \"L0\". Esaki ta nifika ku e opheto aki no por wòrdu di skan dor di ningun Boefje te ora\n"
+#~ "                e Boefje aki ta wordu di skan manualmente atrobe pe e opheto. Ophetonan ku un nivel di authorisashon mas haltu ku \"L0\" ta wòrdu di skan automatikamente dor di Boefjes ku\n"
+#~ "                nivelnan di skan korespondiente.\n"
+#~ "            "
+
+#~ msgid "Download PDF"
+#~ msgstr "Download PDF"
+
+#~ msgid "There are no boefjes available within the current clearance level of"
+#~ msgstr "No tin boefjes disponibel den e nivel di authorisashon di"
+
+#~ msgid "Or if you have the authorization, upgrade the clearance level of"
+#~ msgstr "Òf si bo tin authorisashon, subi e nivel di authorisason di"
+
+#~ msgid "Accounts"
+#~ msgstr "Habri detayes"
+
+#~ msgid "Currently there are no findings for OOI"
+#~ msgstr "Aktualmente no a diskubri nada pa OOI"
+
+#~ msgid "Select your language"
+#~ msgstr "Selekshoná bo idioma"
+
+#, python-format
+#~ msgid ""
+#~ "Current language is %(current_language)s. Choose your preferred language."
+#~ msgstr "Idioma aktual ta %(current_language)s. Escoge bo idioma preferí."
+
+#, python-format
+#~ msgid "Findings report for %(name)s"
+#~ msgstr "Rapport di resultadonan pa %(name)s"
+
+#, python-format
+#~ msgid ""
+#~ "These are the findings of a OpenKAT-analysis on %(observed_at)s. Click a "
+#~ "finding for more detailed information about the issue, its origin, severity "
+#~ "and possible solutions."
+#~ msgstr ""
+#~ "Esakinan ta e resultadonan di un OpenKAT-analysis riba %(observed_at)s. "
+#~ "Click un resultadopa mas informashon detayá tokante e problema, su orígen, "
+#~ "severidat i posibel solushonnan."
+
+#, python-format
+#~ msgid "A report for %(name)s wasn't found."
+#~ msgstr "Un rapport pa %(name)s no por a wordu haña."
+
+#, python-format
+#~ msgid ""
+#~ "Perhaps it never was, perhaps it just didn't exist on %(observed_at)s <br> "
+#~ "Try some other dates!"
+#~ msgstr ""
+#~ "Probablemente e no tabata, probablemente e nunka a eksistí riba "
+#~ "%(observed_at)s<br> Purba algun otro fechanan!"
+
+#~ msgid "You can't generate a report for an OOI on a date in the future."
+#~ msgstr "Bo no por generà un rapòrt pa un OOI ku un fecha den futuro."
+
+#~ msgid "Findings report"
+#~ msgstr "Rapòrt di diskubrimentu"
+
+#~ msgid "Generating report failed. See Keiko logs for more information."
+#~ msgstr ""
+#~ "Falamentu den generashon di rapòrt. Wak Keiko logs pa mas informashon."
+
+#~ msgid ""
+#~ "Timeout reached generating report. See Keiko logs for more information."
+#~ msgstr ""
+#~ "Tempo di espera a yega na su fin den generashon di rapòrt. Wak e Keiko logs "
+#~ "pa mas informashon."
+
+#~ msgid ""
+#~ "Boefjes gather factual information, such as by calling an external scanning "
+#~ "tool like nmap or using a database like shodan."
+#~ msgstr ""
+#~ "Boefjes ta reuni informashon faktuál, huzando tools manera nmap òf usando un"
+#~ " base di datos manera shodan."
+
+#~ msgid " Details"
+#~ msgstr "Detayes"
+
+#~ msgid "Action"
+#~ msgstr "Akshon"
+
+#~ msgid "Unset"
+#~ msgstr "Bashi"
+
+#~ msgid "Failed fetching settings for {}. Is the Katalogus up?"
+#~ msgstr "No por a enkontra e ajustamentunan pa {}. Katalogus ta disponibel?"
+
+#~ msgid "Before enabling, please set the required settings for '{}'."
+#~ msgstr "Promé ku aktivá, por fabor pone e ajustamentunan necesario pa '{}'."
+
+#~ msgid "Currently filtered on:"
+#~ msgstr "Aktuálmente filtrá riba:"
+
+#~ msgid "Object tree"
+#~ msgstr "Mapa di opheto"
+
+#~ msgid "Please select an OOI to start scan."
+#~ msgstr "Por fabor, selekshoná un OOI pa kuminsá skan."
+
+#~ msgid "Task queue is full, please try again later."
+#~ msgstr "Lista di trabou ta yen, por fabor purba atrobe mas laat."
+
+#~ msgid "Task is invalid."
+#~ msgstr "Tarea ta inbalido"
+
+#~ msgid "Task already queued."
+#~ msgstr "Tarea ta pone kla kaba."
+
+#~ msgid "Observed by"
+#~ msgstr "Obserbá pa"
+
+#~ msgid "Select status"
+#~ msgstr "Selektá status"
+
+#~ msgid "Success"
+#~ msgstr "Èxito"
+
+#~ msgid "No scans found for this object."
+#~ msgstr "Ningun skan enkontra pa e opheto."
+
+#~ msgid "all"
+#~ msgstr "tur"
+
+#~ msgid "Fetching tasks failed: no connection with scheduler"
+#~ msgstr "No por haña tarea: no tin konekshon ku scheduler"
+
+#~ msgid "Latest plugin settings:"
+#~ msgstr "Reciente plugin settings:"
+
+#~ msgid "Overview of settings:"
+#~ msgstr "Relato di settings:"
+
+#~ msgid "For this tutorial we suggest a DNS-report to get you started."
+#~ msgstr "Pa a tutoriál aki nos ta sugerí un DNS-rapòrt pa kuminsa ku ne."
+
+#~ msgid "DNS report"
+#~ msgstr "DNS Rapòrt"
+
+#~ msgid "User overview:"
+#~ msgstr "Resúmen di kliente:"
+
+#~ msgid "Boefjes overview:"
+#~ msgstr "Relato general di Boefjes:"
+
+#~ msgid ""
+#~ "Within OpenKAT you can view reports for each of your current objects. For "
+#~ "specific reports you can choose one of the available report types and "
+#~ "generate a report. Such as a pen-test, a DNS-report or a mail report to give"
+#~ " some examples."
+#~ msgstr ""
+#~ "Den OpenKAT bo por mira rapòrtnan pa kada un di bo ophetonan. Pa rapòrtnan "
+#~ "specifikó bo por skohé un di e tipo rapòrtnan obtenibel i generá un rapòrt. "
+#~ "Manera un pen-test, un DNS-rapòrt òf un mail rapòrt pa duna algun ehempel."
+
+#~ msgid ""
+#~ "A lot of things can be an object within the scope of OpenKAT. For example a "
+#~ "mailserver, an ip-address, a URL, a DNS record, a hostname or a network to "
+#~ "name a few.  While these objects can be related to each other they are all "
+#~ "objects within OpenKAT that can be scanned to gain valuable insight."
+#~ msgstr ""
+#~ "Hopi kos por ta un opheto den di e alkanse di OpenKAT. Por ehempel un "
+#~ "mailserver, un ip-adrès, un URL, un DNS record, un hostname òf un netwèrk pa"
+#~ " nombra un par. Mientras tantu e ophetonan aki por ta relatá na otro nan tur"
+#~ " ta ophetonan den di OpenKAT ku por wordu di skan pa haña informashon "
+#~ "balioso."
+
+#~ msgid ""
+#~ "Most objects have dependencies on the existence of other objects. For "
+#~ "example a URL needs to be connected to a network, hostname, fqdn (fully "
+#~ "qualified domain name) and ip-address. OpenKAT collects these additional "
+#~ "object automatically when possible. By running plugins to collect or extract"
+#~ " this data."
+#~ msgstr ""
+#~ "Mayoria ophetonan tin dependesianan riba e exsistencia di otro ophetonan. "
+#~ "Por ehempel un URL mester ta konektá ku un nètwèrk, hostname, fqdn (fúl "
+#~ "kwalifiká nòmber di domèin) i ip-adrès. OpenKAT ta kolektá e ophetonan "
+#~ "adishonal automatikamente si ta posibel. Dor di start plugins pa kolektá òf "
+#~ "extrahé data."
+
+#~ msgid "Risk score:"
+#~ msgstr "Puntuashon di riesgo:"
+
+#~ msgid "Permission to set OOI clearance levels "
+#~ msgstr "Pèrmit pa pone nivél di autorisashonnan pa OOI "
+
+#~ msgid "You have currently accepted clearance up to level "
+#~ msgstr "Bo aktualmente a aseptá e nivel di autorisashon te na nivel "
+
+#~ msgid ""
+#~ "If you don’t remember the email address connected to your account, contact: "
+#~ msgstr ""
+#~ "Si bo no ta kòrda e email adrès konektá ku bo account, tuma kontákto ku: "
+
+#~ msgid "Publisher"
+#~ msgstr "Editora"
+
+#~ msgid "You don't have permission to enable "
+#~ msgstr "Bo no tin permiso pa aktivá "
+
+#, fuzzy
+#~ msgid ""
+#~ "<span>Warning scan level:</span> Scanning OOI's with a lower clearance level"
+#~ " will result in OpenKAT increasing the clearance level on that OOI, not only"
+#~ " for this scan but from now on out, until it manually gets set to something "
+#~ "else again. This means that all other enabled Boefjes will use this higher "
+#~ "clearance level aswel."
+#~ msgstr ""
+#~ "\n"
+#~ "          <span>Advertensia nivel di skan:</span>\n"
+#~ "          Skèn OOI's ku nivel di authorisashon mas abou lo resulta ku OpenKAT mester subi e nivel di authorisashon pa e OOI,\n"
+#~ "          no solamente pa e skan aki for di awor i adelante, te ora manualmente e wordu pone na algu otro atrobe.\n"
+#~ "          Esaki ta nifika ku tur otro Boefjes aktivo lo huza e nivel di authorisashon  aki tambe.\n"
+#~ "        "
+
+#~ msgid "Reason"
+#~ msgstr "Motibu"
+
+#~ msgid "Overview of findings for "
+#~ msgstr "Reprodusí búskeda"
+
+#~ msgid "Error"
+#~ msgstr "Error"
+
+#~ msgid "Explanation"
+#~ msgstr "Deklarashon"
+
+#~ msgid "Here, an indemnification can be given on behalf of your organization"
+#~ msgstr "Akinan, un indemnizashon por wordu duna p’e organisashon"
+
+#~ msgid "Confirmation"
+#~ msgstr "Indemnizashon"
+
+#~ msgid "No related objects added to "
+#~ msgstr "Ningún ophetonan relatá añadi na"
+
+#~ msgid "Use the button below to add a related object. "
+#~ msgstr "Huza e botón abou pa añadi un opheto relatá. "
+
+#~ msgid "Logged in as"
+#~ msgstr "Logged in komo"
+
+#, python-format
+#~ msgid ""
+#~ "Could not raise clearance level of %s to L%s.                             "
+#~ "Indemnification not present at organization %s."
+#~ msgstr ""
+#~ "No por subi e nivel di autorisashon di %s pa L%s. Indemnisashon no ta "
+#~ "presente na organisashon %s."
+
+#~ msgid "DNS Zone"
+#~ msgstr "Zona DNS"
+
+#~ msgid ""
+#~ "OpenKAT added the following required object to your object list to complete "
+#~ "your request: {}"
+#~ msgstr ""
+#~ "OpenKAT a añadi e siguinte opheton na bo lista di ophetonan pa kompleta bo "
+#~ "petishon: {}"
+
+#, python-format
+#~ msgid ""
+#~ "Could not raise clearance level of %s to L%s.                 "
+#~ "Indemnification not present at organization %s."
+#~ msgstr ""
+#~ "No por a subi e nivel di autorisashon di %s pa L%s. Indemnisashon no ta "
+#~ "presente pa organisashon %s."
+
+#~ msgid ""
+#~ "Not all required boefjes are selected. Please select all required boefjes."
+#~ msgstr ""
+#~ "No tur boefjes necesario ta selektá. Por fabor selektá tur boefjes "
+#~ "necesario."
+
+#, python-format
+#~ msgid ""
+#~ "Could not raise clearance level of %s to L%s.                         "
+#~ "Indemnification not present at organization %s."
+#~ msgstr ""
+#~ "No por a subi e nivel di autorisashon di %s pa L%s. Indemnisashon no ta "
+#~ "presente pa organisashon %s."
+
+#, python-format
+#~ msgid ""
+#~ "Could not raise clearance level of %s to L%s. You acknowledged a clearance "
+#~ "level of L%s. Please accept the clearance level below to proceed."
+#~ msgstr ""
+#~ "No por a subi e nivel di autorisashon di %s pa L%s. Bo a rekonosé un nivel "
+#~ "di autorisashon di L%s. Por fabor, akseptá e nivel di autorisashon mas abou "
+#~ "pa por sigui."
+
+#~ msgid "Choose a valid level"
+#~ msgstr "Skohé un nivél balido"
+
+#, python-format
+#~ msgid "Raw file could not be uploaded to Bytes: status code %s"
+#~ msgstr "No por a subi e arkivo na Bytes: status code %s"
+
+#~ msgid "Failure mode"
+#~ msgstr "Failure mode"
+
+#~ msgid "Frequency Level"
+#~ msgstr "Nivél di frequensidat"
+
+#~ msgid "Detectability Level"
+#~ msgstr "Nivél di detectabilidat"
+
+#~ msgid "Effect(s)"
+#~ msgstr "Efekto"
+
+#~ msgid "Describe in one sentence what type of failure mode you are creating."
+#~ msgstr "Deskribi den un sentencia ki tipo di failure mode bo ta kreando."
+
+#~ msgid "Describe the failure mode in details."
+#~ msgstr "Reprodusí búskeda"
+
+#~ msgid ""
+#~ "From 1 to 5, how often does this failure mode occurs. 1: Almost unthinkable "
+#~ "and 5: occurs daily."
+#~ msgstr ""
+#~ "Di 1 te 5, kwantu biaha e failure mode aki ta occurí. 1: Kasi imposibeli 5: "
+#~ "occurí diariamente."
+
+#~ msgid ""
+#~ "Is this failure mode easy detectable? Give it a score from 1 to 5. 1: always"
+#~ " detectable and 5: almost undetectable."
+#~ msgstr ""
+#~ "E failure mode aki por wordu detektá fasil? Duné un score for di 1 te 5. 1: "
+#~ "semper detektábel i 5: kasi imposibel."
+
+#~ msgid "Describe the type of failure mode"
+#~ msgstr "Deskribi e tipo di failure mode"
+
+#~ msgid "explanation-failure-mode"
+#~ msgstr "splikashon-failure-mode"
+
+#~ msgid "Describe in more detail what the failure mode is about."
+#~ msgstr "Deskribi mas detayá kiko e failure mode aki ta."
+
+#~ msgid "explanation-description"
+#~ msgstr "splikashon-diskripshon"
+
+#~ msgid "explanation-frequency-level"
+#~ msgstr "splikashon-nivel-di-freqeuncia"
+
+#~ msgid "explanation-detectability_level"
+#~ msgstr "splikashon-nivel-detektebilidat"
+
+#~ msgid "You must at least set a failure mode."
+#~ msgstr "Bo mester por lo menos pone un failure mode."
+
+#~ msgid "Choose a frequency level."
+#~ msgstr "Nivél di frequensidat"
+
+#~ msgid "Choose a detectability level."
+#~ msgstr "Nivél di detectabilidat"
+
+#~ msgid "Choose at least one effect."
+#~ msgstr "Skohé por lo menos ùn efekto"
+
+#~ msgid "Affected Department"
+#~ msgstr "Departamentu afektá"
+
+#~ msgid "Affected Objects"
+#~ msgstr "Ophetonan afektá"
+
+#~ msgid "Choose a failure mode which applies to "
+#~ msgstr "Skohé un failure mode ku ta aplika na "
+
+#~ msgid "When this failure mode occurs, which department is affected?"
+#~ msgstr "Ora a failure mode aki occurí, kwa departamentu ta afekta?"
+
+#~ msgid "Which objects does this failure mode affect when it occurs?"
+#~ msgstr "Kwa opheto e failure mode aki ta afekta ora e occurí?"
+
+#~ msgid "explanation-affected-ooi-type"
+#~ msgstr "splikashon-tipo-di-ooi-afekta"
+
+#~ msgid "Effect"
+#~ msgstr "Efekto"
+
+#~ msgid "Severity Level"
+#~ msgstr "Nivél di severedat"
+
+#~ msgid "Name a possible effect of any type of failure mode that can occur."
+#~ msgstr "Duna un ehempel di un posibel efekto di e failre mode aki."
+
+#~ msgid ""
+#~ "Describe the severity of this effect ex. 1: not severe and 5: catastrophic"
+#~ msgstr ""
+#~ "Diskribi e seviridat di e efekto aki, por ehempel 1: no severo i 5: "
+#~ "katastrófiko"
+
+#~ msgid "Describe a possible effect for FMEA"
+#~ msgstr "Deskibri un posibel efekto pa FMEA"
+
+#~ msgid "explanation-effect"
+#~ msgstr "splikashon-efekto"
+
+#~ msgid "explanation-severity-level"
+#~ msgstr "splikashon-nivel-severo"
+
+#~ msgid "The effect is required."
+#~ msgstr "E vak aki ta obligatorio"
+
+#~ msgid "This effect already exists."
+#~ msgstr "E organisashon aki ta eksistí kaba"
+
+#~ msgid "Choose a severity level."
+#~ msgstr "Nivel di rísiko"
+
+#~ msgid "Finances"
+#~ msgstr "Finansiasnan"
+
+#~ msgid "Marketing"
+#~ msgstr "Marketing"
+
+#~ msgid "Human Resources"
+#~ msgstr "Human Resources"
+
+#~ msgid "Research & Development"
+#~ msgstr "Research & Development"
+
+#~ msgid "Administration"
+#~ msgstr "Indemnizashon"
+
+#~ msgid "Level 1: Not Severe"
+#~ msgstr "Nivèl 1: No Severo"
+
+#~ msgid "Level 2: Harmful"
+#~ msgstr "Nivel 2: Dañoso"
+
+#~ msgid "Level 3: Severe"
+#~ msgstr "Nivel 3: Severo"
+
+#~ msgid "Level 4: Very Harmful"
+#~ msgstr "Nivel 4: Hopi Dañoso"
+
+#~ msgid "Level 5: Catastrophic"
+#~ msgstr "Nivel 5: Katastrófiko"
+
+#~ msgid ""
+#~ "Level 1: Very Rare. Incident (almost) never occurs, almost unthinkable."
+#~ msgstr ""
+#~ "Nivel 1: Hopi Straño. Insidente (kasi) nunka ta okuri, kasi inpensabel."
+
+#~ msgid "Level 2: Rare. Incidents occur less than once a year (3-5)."
+#~ msgstr "Nivel 2: Straño. Insidente ta okuri menos ku un biaha pa aña (3-5)."
+
+#~ msgid "Level 3: Occurs. Incidents occur several times a year."
+#~ msgstr "Nivel 3: Ta okuri, Insidente ta okuri par di biaha pa aña."
+
+#~ msgid "Level 4: Regularly. Incidents occur weekly."
+#~ msgstr "Nivel 4: Regularmente. Insidente ta pasa tur siman."
+
+#~ msgid "Level 5: Frequent. Incidents occur daily."
+#~ msgstr "Nivel 5: Frquente. Incidente ta pasa tur dia."
+
+#~ msgid ""
+#~ "Level 1: Always Detectable. Incident (almost) never occurs, almost "
+#~ "unthinkable."
+#~ msgstr ""
+#~ "Nivel 1: Semper Detektabel. Insidente (kasi) nunka ta okuri, kasi imposibel."
+
+#~ msgid ""
+#~ "Level 2: Usually Detectable. Incidents occur less than once a year (3-5)."
+#~ msgstr ""
+#~ "Nivel 2: Normalmente Dektetabel. Insidente ta okuri menos ku un biaha pa aña"
+#~ " (3-5)."
+
+#~ msgid "Level 3: Detectable. Failure mode is detectable with effort."
+#~ msgstr "Nivel 3: Detektabel. Faillure mode ta detektabel ku eksfuerzo."
+
+#~ msgid "Level 4: Poorly Detectable. Detecting the failure mode is difficult."
+#~ msgstr "Nivel 4: Malu Detectabel. Detektá e failure mode ta difícil."
+
+#~ msgid ""
+#~ "Level 5: Almost Undetectable. Failure mode detection is very difficult or "
+#~ "nearly impossible."
+#~ msgstr ""
+#~ "Nivel 5: Pobremente Detektabel. Faillure mode detekshon ta hopi difisil òf "
+#~ "kasi imposibel."
+
+#~ msgid "Failure modes"
+#~ msgstr "Failure modes"
+
+#~ msgid "Failure Mode Affected Objects"
+#~ msgstr "Failure Mode Ophetonan afektá"
+
+#~ msgid "FMEA Departments Heatmap:"
+#~ msgstr "Departamento di FMEA Heatmap:"
+
+#~ msgid "No data to build heatmap"
+#~ msgstr "Ningun data pa kontruí heatmap "
+
+#~ msgid "Failure mode affected object table:"
+#~ msgstr "Failure mode tabèl di opheto afektá "
+
+#~ msgid "Affected Object"
+#~ msgstr "Ophetonan afektá"
+
+#~ msgid "Failure mode affected objects cannot be found."
+#~ msgstr "No por decodifica e archivo"
+
+#~ msgid "Define which objects are affected for a failure mode"
+#~ msgstr "Defini kwa ophetonan ta afekta pa un failure mode"
+
+#~ msgid "Failure mode affected objects"
+#~ msgstr "No por decódifica e archivo"
+
+#~ msgid "Save"
+#~ msgstr "Warda"
+
+#~ msgid "No failure mode yet defined."
+#~ msgstr "Ningun failure mode ahinda defini"
+
+#~ msgid "To add affected objects to a failure mode, first create one."
+#~ msgstr "Pa agregá ophetonan afektá na un failure mode, krea un prome."
+
+#~ msgid "Create failure mode"
+#~ msgstr "Krea failure mode"
+
+#~ msgid "Failure mode affected objects table:"
+#~ msgstr "Failure mode tabèl di ophetonan afekta:"
+
+#~ msgid "No failure mode affected objects yet defined."
+#~ msgstr "Ningun failure mode ophetonan afekta ahinda defini."
+
+#~ msgid "Create failure mode Affected Objects"
+#~ msgstr "Reprodusí búskeda"
+
+#~ msgid "Departments failure modes"
+#~ msgstr "Failure modes departamentonan"
+
+#~ msgid "Failure modes and affected departments table:"
+#~ msgstr "Failure modes i tabèl di departamentonan afekta:"
+
+#~ msgid "Failure Mode"
+#~ msgstr "Failure Mode"
+
+#~ msgid "Affected Departments"
+#~ msgstr "Departementonan Afektá"
+
+#~ msgid "Nothing found."
+#~ msgstr "Nada enkontra."
+
+#~ msgid "Failure mode properties"
+#~ msgstr "No por decodifica e archivo"
+
+#~ msgid "Properties"
+#~ msgstr "Karakteristikanan"
+
+#~ msgid "Risk class"
+#~ msgstr "Nivel di rísiko"
+
+#~ msgid "Frequency level"
+#~ msgstr "Nivel di frequensidat"
+
+#~ msgid "Detectability level"
+#~ msgstr "Nivel di detektabilidat"
+
+#~ msgid ""
+#~ "\n"
+#~ "                        Effect and severity level\n"
+#~ "                        "
+#~ msgid_plural ""
+#~ "\n"
+#~ "                        Effects and severity levels\n"
+#~ "                      "
+#~ msgstr[0] ""
+#~ "\n"
+#~ "                        Nivel di efekto i severidat\n"
+#~ "                        "
+#~ msgstr[1] ""
+#~ "\n"
+#~ "                        Nivel di efektonan i severidatnan\n"
+#~ "                      "
+
+#~ msgid "Failure mode effect"
+#~ msgstr "No por decodifica e archivo"
+
+#~ msgid "Failure mode effect properties"
+#~ msgstr "No por decodifica e archivo"
+
+#~ msgid "FMEA effect and severity"
+#~ msgstr "FMEA efekto i seviridat"
+
+#~ msgid "FMEA effect"
+#~ msgstr "FMEA efekto"
+
+#~ msgid "Failure mode effects table:"
+#~ msgstr "Tabèl di Efektonan di Modo di Falla"
+
+#~ msgid "Severity level"
+#~ msgstr "Nivel di rísiko"
+
+#~ msgid "No failure mode effect yet defined."
+#~ msgstr "No por decodifica e archivo"
+
+#~ msgid "Create a failure mode effect"
+#~ msgstr "Reprodusí búskeda"
+
+#~ msgid "Create a new failure mode"
+#~ msgstr "Krea un failure mode nobo"
+
+#~ msgid "Failure mode and effects"
+#~ msgstr "No por decodifica e archivo"
+
+#~ msgid "No failure mode effects created."
+#~ msgstr "No por decodifica e archivo"
+
+#~ msgid ""
+#~ "First create failure mode effects which can be added later to a failure "
+#~ "mode."
+#~ msgstr ""
+#~ "Prome krea efektonan di failure mode pa despues añadi esaki na un failure "
+#~ "mode."
+
+#~ msgid "Create failure mode effects"
+#~ msgstr "Reprodusí búskeda"
+
+#~ msgid "Failure mode table:"
+#~ msgstr "Tabèl di failure mode:"
+
+#~ msgid "Risk Class"
+#~ msgstr "Nivel di rísiko"
+
+#~ msgid "Sluit details"
+#~ msgstr "Habri detayes"
+
+#~ msgid "Description:"
+#~ msgstr "Deklarashon"
+
+#~ msgid "Frequency level:"
+#~ msgstr "Nivel di frequencidat:"
+
+#~ msgid "Detectability level:"
+#~ msgstr "Nivel di detektabilidat"
+
+#~ msgid ""
+#~ "\n"
+#~ "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\tEffect and severity level\n"
+#~ "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t"
+#~ msgid_plural ""
+#~ "\n"
+#~ "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\tEffects and severity levels\n"
+#~ "\t\t\t\t\t\t\t\t\t\t\t\t\t\t"
+#~ msgstr[0] ""
+#~ "\n"
+#~ "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\tNivel di efekto i severidat\n"
+#~ "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t"
+#~ msgstr[1] ""
+#~ "\n"
+#~ "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\tNivel di efektonan i severidatnan\n"
+#~ "\t\t\t\t\t\t\t\t\t\t\t\t\t\t"
+
+#~ msgid "Failure mode report"
+#~ msgstr "No por decodifica e archivo"
+
+#~ msgid "Failure mode: "
+#~ msgstr "No por decodifica e archivo"
+
+#~ msgid "Severity: "
+#~ msgstr "Seviridat:"
+
+#~ msgid "Detectability: "
+#~ msgstr "Detektabilidat"
+
+#~ msgid "Frequency: "
+#~ msgstr "Frequencia: "
+
+#~ msgid "Effect: "
+#~ msgstr "Efekto: "
+
+#~ msgid "Description: "
+#~ msgstr "Deklarashon: "
+
+#~ msgid "Affected Departments: "
+#~ msgstr "Departamentonan afekta: "
+
+#~ msgid "Affected OOI's: "
+#~ msgstr "OOI's afekta:"
+
+#~ msgid "Report cannot be viewed, failure mode not found."
+#~ msgstr "Rapòrt no por wordu mira, no por haña failure mode."
+
+#~ msgid "FMEA introduction"
+#~ msgstr "FMEA introdukshon"
+
+#~ msgid ""
+#~ "FMEA (failure mode and effective analysis) is a step-by-step approach for "
+#~ "collecting knowledge about possible points of failure in a design, "
+#~ "manufacturing process, product or service."
+#~ msgstr ""
+#~ "FMEA (failure mode and effective analysis) ta un enfoque paso a paso pa "
+#~ "kolekta konosimentu tokante puntonan posibel di fayo den un diseño, proseso "
+#~ "fabriká, produkto òf servicio."
+
+#~ msgid ""
+#~ "Failure mode (FM) refers to the way in which something might break down and "
+#~ "includes potential errors that may occur, especially errors that may affect "
+#~ "a system. Effective analysis (EA) involves deciphering the consequences of "
+#~ "those break downs by making sure that all failures can be detected, "
+#~ "determining how frequently a failure might occur and identifying which "
+#~ "potential failures should be prioritized."
+#~ msgstr ""
+#~ "Failure mode (FM) ta referi na e manera kaminda algu por posibelmente kibra "
+#~ "i inkluí errornan potenshal ku por okuri, speshalmente errornan ku por "
+#~ "afektá un sistema. Effective analysis (EA) ta envolvi den buska e "
+#~ "konsekuensiasnan di loke por kibra dor di detekta tur failure modes, "
+#~ "determiná kon frequente failure modes ta okuri i identifiká kwa failure "
+#~ "modes mester wordu prioritisa."
+
+#~ msgid "Create affected objects of a failure mode"
+#~ msgstr "Kreá ophetonan afektá di un failure mode"
+
+#~ msgid "View all failure modes"
+#~ msgstr "Mustrami tur failue modes"
+
+#~ msgid "View all failure mode effects"
+#~ msgstr "Mustrami tur efektonan di failure mode"
+
+#~ msgid "View all affected objects for a failure modes"
+#~ msgstr "Mustrami tur ophetonan afektá pa failure modes"
+
+#~ msgid "Heatmap"
+#~ msgstr "Mapa kayente"
+
+#~ msgid "--- Select an option ----"
+#~ msgstr "-- Selecta un opcion --"
+
+#~ msgid "Failure mode affected objects successfully created."
+#~ msgstr "Failure mode i ophetonan afektá a wòrdu kreá ku èksito."
+
+#~ msgid "Create"
+#~ msgstr "Kreá"
+
+#~ msgid "Treeobjects successfully added."
+#~ msgstr "Mapa di ophetonan añadi ku èxito."
+
+#~ msgid "Please select a department or ooi."
+#~ msgstr "Por fabor selekta un departamentu òf ooi."
+
+#~ msgid "Failure mode successfully created."
+#~ msgstr "Failure mode a wòrdu kreá ku èksito."
+
+#~ msgid "Failure mode effect successfully created."
+#~ msgstr "Failure mode a wòrdu kreá ku èksito."
+
+#~ msgid "FMEA"
+#~ msgstr "FMEA"
+
+#~ msgid "Failure mode effects"
+#~ msgstr "Efektonan di failure mode"
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "                            \"Withdraw acceptance of level L%(acl)s clearance and responsibility\"\n"
+#~ "                    "
+#~ msgstr ""
+#~ "\n"
+#~ "\"Retirá aseptashon di nivel di autorisashon L%(acl)s i responsabilidat\"\n"
+#~ " "
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "                        \"Accept level L%(tcl)s clearance and responsibility\"\n"
+#~ "                    "
+#~ msgstr ""
+#~ "\n"
+#~ "\"Aseptá nivel di autorisashon L%(tcl)s i responsabilidat\"\n"
+#~ " "
+
+#~ msgid ""
+#~ "\n"
+#~ "                  Add setting\n"
+#~ "                "
+#~ msgid_plural ""
+#~ "\n"
+#~ "                  Add settings\n"
+#~ "                "
+#~ msgstr[0] ""
+#~ "\n"
+#~ "                        Añadi setting\n"
+#~ "                        "
+#~ msgstr[1] ""
+#~ "\n"
+#~ "                        Añadi settings\n"
+#~ "                      "
+
+#~ msgid "Organization code(s) for raw does not exist in our database"
+#~ msgstr "Codigo di organisashon den e CSV no ta èksisti den nos database"
+
+#~ msgid "Scan OOI"
+#~ msgstr "Skèn OOI"
+
+#~ msgid "Selected OOIs:"
+#~ msgstr "OOI's selektá:"
+
+#~ msgid "Session has terminated, please select OOIs again."
+#~ msgstr "Seshon a wòrdu tèrminá. Por fabor selekta OOIs dinobo."
+
+#~ msgid "Could not connect to Bytes. Service is possibly down"
+#~ msgstr "No por konektá ku Bytes. Servicio ta down"
+
+#~ msgid "Could not connect to Octopoes. Service is possibly down"
+#~ msgstr "No por konektá ku Octopoes. Servicio ta down"
+
+#~ msgid "Could not connect to Scheduler. Service is possibly down"
+#~ msgstr "No por konektá ku Scheduler. Servicio ta down"
+
+#~ msgid "Rocky will not function properly. Not all services are healthy."
+#~ msgstr "Rocky no lo functiona mane debe ser. No tur servicio ta saludabel."
+
+#~ msgid "Failure"
+#~ msgstr "Failure"
+
+#~ msgid "Task details not found."
+#~ msgstr "Detayes di tarea no por wordu haña."
+
+#~ msgid "This name we will use to communicate with you."
+#~ msgstr "E nomber aki nos lo huza pa komuniká ku bo."
+
+#~ msgid "What do we call you?"
+#~ msgstr "Kon nos por jama'bu?"
+
+#~ msgid "Enter your email address."
+#~ msgstr "Yena bo email adres"
+
+#~ msgid "Choose your super secret password"
+#~ msgstr "Skohé bo password super sekreto"
+
+#~ msgid "Enter your new password"
+#~ msgstr "Yena bo password nobo"
+
+#~ msgid "Repeat your new password"
+#~ msgstr "Ripiti bo password nobo"
+
+#~ msgid "Confirm your new password"
+#~ msgstr "Konfirmá bo password nobo"
+
+#~ msgid "List of tasks for "
+#~ msgstr "Lista di tareanan pa "
+
+#~ msgid "No input OOI"
+#~ msgstr "No tin entrada OOI"
+
+#~ msgid ""
+#~ "Can not parse observed_at parameter, falling back to showing current object"
+#~ msgstr ""
+#~ "No por parse e parametro observed_at, regresando na munstra e opheto aktual"
+
+#~ msgid "Scanning successfully scheduled."
+#~ msgstr "Skèn a start ku èxito."

--- a/rocky/rocky/settings.py
+++ b/rocky/rocky/settings.py
@@ -336,12 +336,22 @@ LOCALE_PATHS = (BASE_DIR / "rocky/locale",)
 EXTRA_LANG_INFO = {
     "pap": {"bidi": False, "code": "pap", "name": "Papiamentu", "name_local": "Papiamentu"},
     "en@pirate": {"bidi": False, "code": "en@pirate", "name": "English (Pirate)", "name_local": "English (Pirate)"},
+    "la": {"bidi": False, "code": "la", "name": "Latin", "name_local": "Latina"},
 }
 LANG_INFO = locale.LANG_INFO.copy()
 LANG_INFO.update(EXTRA_LANG_INFO)
 locale.LANG_INFO = LANG_INFO
 
-LANGUAGES = [("en", "en"), ("nl", "nl"), ("pap", "pap"), ("it", "it"), ("fy", "fy")]
+LANGUAGES = [
+    ("en", "en"),
+    ("nl", "nl"),
+    ("pap", "pap"),
+    ("it", "it"),
+    ("fy", "fy"),
+    ("pl", "pl"),
+    ("id", "id"),
+    ("la", "la"),
+]
 
 if env.bool("PIRATE", False):
     LANGUAGE_CODE = "en@pirate"


### PR DESCRIPTION
## Summary
- add Polish, Indonesian, and Latin Django translation catalogs
- register the new languages in Rocky settings
- fill the new catalogs using machine translation with protected placeholders and OpenKAT domain terms

## Validation
- msgfmt --statistics --check rocky/rocky/locale/pl/LC_MESSAGES/django.po
- msgfmt --statistics --check rocky/rocky/locale/id/LC_MESSAGES/django.po
- msgfmt --statistics --check rocky/rocky/locale/la/LC_MESSAGES/django.po
- python3 -m py_compile rocky/rocky/settings.py

Note: these translations were machine-assisted and should be reviewed by Polish, Indonesian, and Latin reviewers before release.