### PR TITLE
Add Polish language

### DIFF
--- a/rocky/rocky/locale/pl/LC_MESSAGES/django.po
+++ b/rocky/rocky/locale/pl/LC_MESSAGES/django.po
@@ -2,10 +2,9 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 #
-#: reports/forms.py
 msgid ""
 msgstr ""
-"Project-Id-Version: OpenKAT\n"
+"Project-Id-Version: Polish (OpenKAT)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-03-28 14:22+0000\n"
 "PO-Revision-Date: 2026-07-15 00:00+0000\n"
@@ -19,11 +18,11 @@ msgstr ""
 
 #: account/admin.py
 msgid "Permissions"
-msgstr ""
+msgstr "Uprawnienia"
 
 #: account/admin.py
 msgid "Important dates"
-msgstr ""
+msgstr "Ważne daty"
 
 #: account/forms/account_setup.py crisis_room/forms.py
 #: katalogus/templates/katalogus_settings.html
@@ -42,94 +41,94 @@ msgstr ""
 #: rocky/templates/organizations/organization_settings.html
 #: rocky/templates/partials/ooi_detail_related_object.html
 msgid "Name"
-msgstr ""
+msgstr "Nazwa"
 
 #: account/forms/account_setup.py
 msgid "The name that will be used in order to communicate."
-msgstr ""
+msgstr "Imię, które będzie używane do komunikacji."
 
 #: account/forms/account_setup.py
 msgid "Please provide username"
-msgstr ""
+msgstr "Proszę podać nazwę użytkownika"
 
 #: account/forms/account_setup.py
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Email"
-msgstr ""
+msgstr "E-mail"
 
 #: account/forms/account_setup.py
 msgid "Enter an email address."
-msgstr ""
+msgstr "Wpisz adres e-mail."
 
 #: account/forms/account_setup.py
 msgid "Password"
-msgstr ""
+msgstr "Hasło"
 
 #: account/forms/account_setup.py
 msgid "Choose a super secret password"
-msgstr ""
+msgstr "Wybierz super tajne hasło"
 
 #: account/forms/account_setup.py
 msgid "Choose another email."
-msgstr ""
+msgstr "Wybierz inny adres e-mail."
 
 #: account/forms/account_setup.py tools/forms/settings.py
 msgid "--- Please select one of the available options ----"
-msgstr ""
+msgstr "--- Proszę wybrać jedną z dostępnych opcji ----"
 
 #: account/forms/account_setup.py
 msgid "Account type"
-msgstr ""
+msgstr "Typ konta"
 
 #: account/forms/account_setup.py
 msgid "Please select an account type to proceed."
-msgstr ""
+msgstr "Aby kontynuować, wybierz typ konta."
 
 #: account/forms/account_setup.py
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 msgid "Trusted clearance level"
-msgstr ""
+msgstr "Zaufany poziom uprawnień"
 
 #: account/forms/account_setup.py
 msgid "Select a clearance level you trust this member with."
-msgstr ""
+msgstr "Wybierz poziom uprawnień, którym ufasz temu członkowi."
 
 #: account/forms/account_setup.py onboarding/forms.py tools/forms/ooi.py
 msgid "Please select a clearance level to proceed."
-msgstr ""
+msgstr "Aby kontynuować, wybierz poziom uprawnień."
 
 #: account/forms/account_setup.py tools/models.py
 msgid "The name of the organization."
-msgstr ""
+msgstr "Nazwa organizacji."
 
 #: account/forms/account_setup.py
 msgid "explanation-organization-name"
-msgstr ""
+msgstr "wyjaśnienie-nazwa-organizacji"
 
 #: account/forms/account_setup.py
 #, python-brace-format
 msgid "A unique code of maximum {code_length} characters in length."
-msgstr ""
+msgstr "Unikalny kod o maksymalnej długości znaków {code_length}."
 
 #: account/forms/account_setup.py
 msgid "explanation-organization-code"
-msgstr ""
+msgstr "kod-wyjaśnienia-organizacji"
 
 #: account/forms/account_setup.py
 msgid "Organization name is required to proceed."
-msgstr ""
+msgstr "Aby kontynuować, wymagana jest nazwa organizacji."
 
 #: account/forms/account_setup.py
 msgid "Choose another organization."
-msgstr ""
+msgstr "Wybierz inną organizację."
 
 #: account/forms/account_setup.py
 msgid "Organization code is required to proceed."
-msgstr ""
+msgstr "Aby kontynuować, wymagany jest kod organizacji."
 
 #: account/forms/account_setup.py
 msgid "Choose another code for your organization."
-msgstr ""
+msgstr "Wybierz inny kod dla swojej organizacji."
 
 #: account/forms/account_setup.py
 msgid ""
@@ -137,6 +136,9 @@ msgid ""
 "have permission to scan these assets. I am aware of the implications a scan "
 "(with a higher scan level) brings on my systems."
 msgstr ""
+"Oświadczam, że OpenKAT może skanować aktywa mojej organizacji i że posiadam "
+"pozwolenie na skanowanie tych aktywów. Jestem świadomy konsekwencji, jakie "
+"skanowanie (z wyższym poziomem skanowania) niesie dla moich systemów."
 
 #: account/forms/account_setup.py
 msgid ""
@@ -144,123 +146,134 @@ msgid ""
 "organization. I have the experience and knowledge to know what the "
 "consequences might be and can be held responsible for them."
 msgstr ""
+"Oświadczam, że jestem upoważniony do udzielenia tego zabezpieczenia w "
+"imieniu mojej organizacji. Mam doświadczenie i wiedzę, aby wiedzieć, jakie "
+"mogą być konsekwencje, i mogę ponieść za nie odpowiedzialność."
 
 #: account/forms/account_setup.py
 msgid "Trusted to change Clearance Levels."
-msgstr ""
+msgstr "Zaufany, jeśli chodzi o zmianę poziomów zezwoleń."
 
 #: account/forms/account_setup.py
 msgid "Acknowledged to change Clearance Levels."
-msgstr ""
+msgstr "Potwierdzono zmianę poziomów zezwoleń."
 
 #: account/forms/account_setup.py rocky/forms.py
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Blocked"
-msgstr ""
+msgstr "Zablokowany"
 
 #: account/forms/account_setup.py
 msgid ""
 "Set the members status to blocked, so they don't have access to the "
 "organization anymore."
 msgstr ""
+"Ustaw status członków na zablokowanych, aby nie mieli już dostępu do "
+"organizacji."
 
 #: account/forms/account_setup.py
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Accepted clearance level"
-msgstr ""
+msgstr "Akceptowany poziom zezwolenia"
 
 #: account/forms/account_setup.py
 msgid "Enter tags separated by comma."
-msgstr ""
+msgstr "Wprowadź tagi oddzielone przecinkami."
 
 #: account/forms/account_setup.py
 msgid "The two password fields didn’t match."
-msgstr ""
+msgstr "Obydwa pola hasła nie pasują do siebie."
 
 #: account/forms/account_setup.py
 msgid "New password"
-msgstr ""
+msgstr "Nowe hasło"
 
 #: account/forms/account_setup.py
 msgid "Enter a new password"
-msgstr ""
+msgstr "Wprowadź nowe hasło"
 
 #: account/forms/account_setup.py
 msgid "New password confirmation"
-msgstr ""
+msgstr "Potwierdzenie nowego hasła"
 
 #: account/forms/account_setup.py
 msgid "Repeat the new password"
-msgstr ""
+msgstr "Powtórz nowe hasło"
 
 #: account/forms/account_setup.py
 msgid "Confirm the new password"
-msgstr ""
+msgstr "Potwierdź nowe hasło"
 
 #: account/forms/login.py
 msgid "Please enter a correct email address and password."
-msgstr ""
+msgstr "Proszę podać poprawny adres e-mail i hasło."
 
 #: account/forms/login.py
 msgid "This account is inactive."
-msgstr ""
+msgstr "To konto jest nieaktywne."
 
 #: account/forms/login.py
 msgid "Insert the email you registered with or got at OpenKAT installation."
 msgstr ""
+"Wpisz adres e-mail, na który zarejestrowałeś się lub otrzymałeś podczas "
+"instalacji OpenKAT."
 
 #: account/forms/organization.py
 msgid "Organization is required."
-msgstr ""
+msgstr "Wymagana jest organizacja."
 
 #: account/forms/organization.py tools/view_helpers.py
 #: rocky/templates/dashboard_redteam.html
 #: rocky/templates/organizations/organization_list.html
 #: rocky/views/organization_add.py
 msgid "Organizations"
-msgstr ""
+msgstr "Organizacje"
 
 #: account/forms/organization.py
 msgid "The organization from which to clone settings."
-msgstr ""
+msgstr "Organizacja, z której mają być klonowane ustawienia."
 
 #: account/forms/password_reset.py account/templates/account_detail.html
 msgid "Email address"
-msgstr ""
+msgstr "Adres e-mail"
 
 #: account/forms/password_reset.py
 msgid "A reset link will be sent to this email"
-msgstr ""
+msgstr "Na ten e-mail zostanie wysłany link resetujący"
 
 #: account/forms/password_reset.py
 msgid "The email address connected to your OpenKAT-account"
-msgstr ""
+msgstr "Adres e-mail powiązany z Twoim kontem OpenKAT"
 
 #: account/forms/token.py
 msgid ""
 "Insert the token generated by the authenticator app to setup the two factor "
 "authentication."
 msgstr ""
+"Włóż token wygenerowany przez aplikację uwierzytelniającą, aby skonfigurować"
+" uwierzytelnianie dwuskładnikowe."
 
 #: account/forms/token.py
 msgid "Insert the token generated by your token authenticator app."
-msgstr ""
+msgstr "Włóż token wygenerowany przez aplikację uwierzytelniającą token."
 
 #: account/forms/token.py
 msgid "Backup token"
-msgstr ""
+msgstr "Token zapasowy"
 
 #: account/mixins.py
 msgid "Clearance level has been set."
-msgstr ""
+msgstr "Poziom zezwolenia został ustawiony."
 
 #: account/mixins.py
 #, python-format
 msgid ""
-"Could not raise clearance level of %s to L%s. Indemnification not present at "
-"organization %s."
+"Could not raise clearance level of %s to L%s. Indemnification not present at"
+" organization %s."
 msgstr ""
+"Nie można podnieść poziomu zezwolenia %s do L%s. Odszkodowanie nie występuje"
+" w organizacji %s."
 
 #: account/mixins.py
 #, python-format
@@ -268,6 +281,9 @@ msgid ""
 "Could not raise clearance level of %s to L%s. You were trusted a clearance "
 "level of L%s. Contact your administrator to receive a higher clearance."
 msgstr ""
+"Nie można podnieść poziomu zezwolenia %s do L%s. Zaufano Ci na poziomie "
+"uprawnień L%s. Skontaktuj się z administratorem, aby otrzymać wyższe "
+"zezwolenie."
 
 #: account/mixins.py
 #, python-format
@@ -276,170 +292,186 @@ msgid ""
 "level of L%s. Please accept the clearance level first on your profile page "
 "to proceed."
 msgstr ""
+"Nie można podnieść poziomu zezwolenia %s do L%s. Potwierdziłeś poziom "
+"zezwolenia L%s. Aby kontynuować, najpierw zaakceptuj poziom uprawnień na "
+"stronie profilu."
 
 #: account/models.py
 msgid "The email must be set"
-msgstr ""
+msgstr "Adres e-mail musi być ustawiony"
 
 #: account/models.py
 msgid "Superuser must have is_staff=True."
-msgstr ""
+msgstr "Superużytkownik musi mieć is_staff=True."
 
 #: account/models.py
 msgid "Superuser must have is_superuser=True."
-msgstr ""
+msgstr "Superużytkownik musi mieć wartość is_superuser=True."
 
 #: account/models.py
 msgid "full name"
-msgstr ""
+msgstr "pełne imię i nazwisko"
 
 #: account/models.py
 msgid "email"
-msgstr ""
+msgstr "e-mail"
 
 #: account/models.py
 msgid "staff status"
-msgstr ""
+msgstr "stan personelu"
 
 #: account/models.py
 msgid "Designates whether the user can log into this admin site."
 msgstr ""
+"Określa, czy użytkownik może zalogować się do tej witryny administracyjnej."
 
 #: account/models.py tools/models.py
 msgid "active"
-msgstr ""
+msgstr "aktywny"
 
 #: account/models.py
 msgid ""
 "Designates whether this user should be treated as active. Unselect this "
 "instead of deleting accounts."
 msgstr ""
+"Określa, czy ten użytkownik powinien być traktowany jako aktywny. Odznacz tę"
+" opcję zamiast usuwać konta."
 
 #: account/models.py
 msgid "date joined"
-msgstr ""
+msgstr "data dołączenia"
 
 #: account/models.py
 msgid "The clearance level of the user for all organizations."
-msgstr ""
+msgstr "Poziom uprawnień użytkownika dla wszystkich organizacji."
 
 #: account/models.py
 msgid "name"
-msgstr ""
+msgstr "nazwa"
 
 #: account/templates/account_detail.html account/views/account.py
 msgid "Account details"
-msgstr ""
+msgstr "Szczegóły konta"
 
 #: account/templates/account_detail.html account/templates/password_reset.html
 #: account/views/password_reset.py
 msgid "Reset password"
-msgstr ""
+msgstr "Zresetuj hasło"
 
 #: account/templates/account_detail.html
 msgid "Full name"
-msgstr ""
+msgstr "Pełne imię i nazwisko"
 
 #: account/templates/account_detail.html
 msgid "Member type"
-msgstr ""
+msgstr "Typ członka"
 
 #: account/templates/account_detail.html
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: rocky/templates/tasks/normalizers.html
 msgid "Organization"
-msgstr ""
+msgstr "Organizacja"
 
 #: account/templates/account_detail.html
 msgid "Permission to set OOI clearance levels"
-msgstr ""
+msgstr "Zezwolenie na ustawienie poziomów luzu OOI"
 
 #: account/templates/account_detail.html
 msgid "OOI clearance"
-msgstr ""
+msgstr "Luz OOI"
 
 #: account/templates/account_detail.html
 msgid "You don't have any clearance to scan objects."
-msgstr ""
+msgstr "Nie masz uprawnień do skanowania obiektów."
 
 #: account/templates/account_detail.html
 msgid ""
 "Get in contact with the admin to give you the necessary clearance level."
 msgstr ""
+"Skontaktuj się z administratorem, aby uzyskać niezbędny poziom uprawnień."
 
 #: account/templates/account_detail.html
 msgid "You have currently accepted clearance up to level"
-msgstr ""
+msgstr "Obecnie zaakceptowałeś zezwolenie do poziomu"
 
 #: account/templates/account_detail.html
 msgid "Explanation OOI Clearance"
-msgstr ""
+msgstr "Objaśnienie OOI Luz"
 
 #: account/templates/account_detail.html
 msgid ""
 "You can withdraw this at anytime you like, but know that you won't be able "
 "to change clearance levels anymore when you do."
 msgstr ""
+"Możesz to wycofać w dowolnym momencie, ale pamiętaj, że nie będziesz już "
+"mógł zmienić poziomu zezwolenia, gdy to zrobisz."
 
 #: account/templates/account_detail.html
 #, python-format
 msgid "Withdraw L%(acl)s clearance and responsibility"
-msgstr ""
+msgstr "Cofnij zezwolenie i odpowiedzialność L%(acl)s"
 
 #: account/templates/account_detail.html
 msgid "Explanation OOI clearance"
-msgstr ""
+msgstr "Objaśnienie Luz OOI"
 
 #: account/templates/account_detail.html
 #, python-format
 msgid ""
 "You are granted clearance for level L%(tcl)s by your admin. Before you can "
 "change OOI clearance levels up to this level, you need to accept this "
-"permission. Remember: <strong>with great power comes great responsibility.</"
-"strong>"
+"permission. Remember: <strong>with great power comes great "
+"responsibility.</strong>"
 msgstr ""
+"Otrzymałeś zezwolenie na poziom L%(tcl)s od swojego administratora. Zanim "
+"będziesz mógł zmienić poziomy uprawnień OOI aż do tego poziomu, musisz "
+"zaakceptować to uprawnienie. Pamiętaj: <strong> z wielką mocą wiąże się "
+"wielka odpowiedzialność.</strong>"
 
 #: account/templates/account_detail.html
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 #, python-format
 msgid "Accept level L%(tcl)s clearance and responsibility"
-msgstr ""
+msgstr "Zaakceptuj uprawnienia i odpowiedzialność na poziomie L%(tcl)s"
 
 #: account/templates/password_reset.html
 msgid "Use the form below to reset your password."
-msgstr ""
+msgstr "Skorzystaj z poniższego formularza, aby zresetować hasło."
 
 #: account/templates/password_reset.html
 #: account/templates/password_reset_confirm.html
 msgid "Send"
-msgstr ""
+msgstr "Wysłać"
 
 #: account/templates/password_reset.html
 #: account/templates/password_reset_confirm.html
 msgid "Back"
-msgstr ""
+msgstr "Z powrotem"
 
 #: account/templates/password_reset_confirm.html
 msgid "Confirm reset password"
-msgstr ""
+msgstr "Potwierdź resetowanie hasła"
 
 #: account/templates/password_reset_confirm.html
 msgid "Use the form below to confirm resetting your password"
 msgstr ""
+"Skorzystaj z poniższego formularza, aby potwierdzić zresetowanie hasła"
 
 #: account/templates/password_reset_confirm.html
 msgid "Confirm password"
-msgstr ""
+msgstr "Potwierdź hasło"
 
 #: account/templates/password_reset_confirm.html
 msgid "The link is invalid"
-msgstr ""
+msgstr "Link jest nieprawidłowy"
 
 #: account/templates/password_reset_confirm.html
 msgid ""
 "The password reset link was invalid, possibly because it has already been "
 "used.  Please request a new password reset."
 msgstr ""
+"Link do resetowania hasła był nieprawidłowy, prawdopodobnie dlatego, że "
+"został już użyty.  Poproś o zresetowanie nowego hasła."
 
 #: account/templates/password_reset_email.html
 #, python-format
@@ -447,55 +479,59 @@ msgid ""
 "You're receiving this email because you requested a password reset for your "
 "user account at %(site_name)s."
 msgstr ""
+"Otrzymujesz tego e-maila, ponieważ poprosiłeś o zresetowanie hasła do "
+"swojego konta użytkownika pod adresem %(site_name)s."
 
 #: account/templates/password_reset_email.html
 #: account/templates/registration_email.html
 msgid "Please go to the following page and choose a new password:"
-msgstr ""
+msgstr "Przejdź na następującą stronę i wybierz nowe hasło:"
 
 #: account/templates/password_reset_email.html
 #: account/templates/registration_email.html
 msgid "Sincerely,"
-msgstr ""
+msgstr "Z poważaniem,"
 
 #: account/templates/password_reset_email.html
 #: account/templates/registration_email.html
 msgid "The OpenKAT team"
-msgstr ""
+msgstr "Zespół OpenKAT"
 
 #: account/templates/password_reset_subject.txt
 #, python-format
 msgid "Password reset on %(site_name)s"
-msgstr ""
+msgstr "Resetowanie hasła w %(site_name)s"
 
 #: account/templates/recover_email.html account/views/recover_email.py
 msgid "Recover email address"
-msgstr ""
+msgstr "Odzyskaj adres e-mail"
 
 #: account/templates/recover_email.html
 msgid "Information on how to recover your connected email address"
-msgstr ""
+msgstr "Informacje o tym, jak odzyskać połączony adres e-mail"
 
 #: account/templates/recover_email.html
 msgid "Forgotten email address?"
-msgstr ""
+msgstr "Zapomniałeś adresu e-mail?"
 
 #: account/templates/recover_email.html
 msgid ""
 "If you don’t remember the email address connected to your account, contact:"
 msgstr ""
+"Jeśli nie pamiętasz adresu e-mail powiązanego z Twoim kontem, skontaktuj się"
+" z:"
 
 #: account/templates/recover_email.html
 msgid "Please contact the system administrator."
-msgstr ""
+msgstr "Skontaktuj się z administratorem systemu."
 
 #: account/templates/recover_email.html
 msgid "Back to login"
-msgstr ""
+msgstr "Powrót do logowania"
 
 #: account/templates/recover_email.html
 msgid "Back to Home"
-msgstr ""
+msgstr "Powrót do domu"
 
 #: account/templates/registration_email.html
 #, python-format
@@ -503,73 +539,80 @@ msgid ""
 "Welcome to OpenKAT. You're receiving this email because you have been added "
 "to organization \"%(organization)s\" at %(site_name)s."
 msgstr ""
+"Witamy w OpenKAT. Otrzymujesz tego e-maila, ponieważ dodano Cię do "
+"organizacji „%(organization)s” pod adresem %(site_name)s."
 
 #: account/templates/registration_subject.txt
 #, python-format
 msgid "Verify OpenKAT account on %(site_name)s"
-msgstr ""
+msgstr "Zweryfikuj konto OpenKAT na %(site_name)s"
 
 #: account/validators.py
 msgid ""
 "Your password must contain at least the following but longer passwords are "
 "recommended:"
 msgstr ""
+"Twoje hasło musi zawierać co najmniej następujące elementy, ale zalecane są "
+"dłuższe hasła:"
 
 #: account/validators.py
 msgid " characters"
-msgstr ""
+msgstr "pismo"
 
 #: account/validators.py
 msgid " digits"
-msgstr ""
+msgstr "cyfry"
 
 #: account/validators.py
 msgid " letters"
-msgstr ""
+msgstr "beletrystyka"
 
 #: account/validators.py
 msgid ""
 " special characters such as: {str(validators.get('special_characters',''))}"
 msgstr ""
+"znaki specjalne, takie jak: {str(validators.get('special_characters',''))}"
 
 #: account/validators.py
 msgid " lower case letters"
-msgstr ""
+msgstr "małe litery"
 
 #: account/validators.py
 msgid " upper case letters"
-msgstr ""
+msgstr "wielkie litery"
 
 #: account/views/login.py
 msgid "Your session has timed out. Please login again."
-msgstr ""
+msgstr "Twoja sesja wygasła. Proszę zalogować się ponownie."
 
 #: account/views/login.py rocky/templates/header.html
 msgid "OpenKAT"
-msgstr ""
+msgstr "OpenKAT"
 
 #: account/views/login.py account/views/password_reset.py
 #: account/views/recover_email.py rocky/templates/partials/secondary-menu.html
 #: rocky/templates/two_factor/core/login.html
 msgid "Login"
-msgstr ""
+msgstr "Logowanie"
 
 #: account/views/login.py
 msgid "Two factor authentication"
-msgstr ""
+msgstr "Uwierzytelnianie dwuskładnikowe"
 
 #: account/views/password_reset.py
 msgid "We couldn't send a password reset link. Contact "
-msgstr ""
+msgstr "Nie mogliśmy wysłać linku do resetowania hasła. Kontakt"
 
 #: account/views/password_reset.py
 msgid ""
 "We couldn't send a password reset link. Contact your system administrator."
 msgstr ""
+"Nie mogliśmy wysłać linku do resetowania hasła. Skontaktuj się z "
+"administratorem systemu."
 
 #: components/modal/template.html
 msgid "Close modal"
-msgstr ""
+msgstr "Zamknij moduł"
 
 #: components/modal/template.html
 #: crisis_room/templates/partials/delete_dashboard_item_modal.html
@@ -592,146 +635,155 @@ msgstr ""
 #: rocky/templates/partials/mute_findings_modal.html
 #: rocky/templates/two_factor/_wizard_actions.html
 msgid "Cancel"
-msgstr ""
+msgstr "Anulować"
 
 #: crisis_room/forms.py
 msgid "Title on dashboard"
-msgstr ""
+msgstr "Tytuł na desce rozdzielczej"
 
 #: crisis_room/forms.py
 msgid "Dashboard item size"
-msgstr ""
+msgstr "Rozmiar elementu pulpitu nawigacyjnego"
 
 #: crisis_room/forms.py
 msgid "Full width"
-msgstr ""
+msgstr "Pełna szerokość"
 
 #: crisis_room/forms.py
 msgid "Half width"
-msgstr ""
+msgstr "Połowa szerokości"
 
 #: crisis_room/forms.py
 msgid "An item with that name already exists. Try a different title."
-msgstr ""
+msgstr "Element o tej nazwie już istnieje. Wypróbuj inny tytuł."
 
 #: crisis_room/forms.py
 msgid "An error occurred while adding dashboard item."
-msgstr ""
+msgstr "Wystąpił błąd podczas dodawania elementu pulpitu nawigacyjnego."
 
 #: crisis_room/forms.py
 msgid "Number of rows in list"
-msgstr ""
+msgstr "Liczba wierszy na liście"
 
 #: crisis_room/forms.py
 msgid "List sorting by"
-msgstr ""
+msgstr "Sortowanie listy według"
 
 #: crisis_room/forms.py
 msgid "Type (A-Z)"
-msgstr ""
+msgstr "Typ (A-Z)"
 
 #: crisis_room/forms.py
 msgid "Type (Z-A)"
-msgstr ""
+msgstr "Typ (Z-A)"
 
 #: crisis_room/forms.py
 msgid "Clearance level (Low-High)"
-msgstr ""
+msgstr "Poziom luzu (niski-wysoki)"
 
 #: crisis_room/forms.py
 msgid "Clearance level (High-Low)"
-msgstr ""
+msgstr "Poziom luzu (wysoki-niski)"
 
 #: crisis_room/forms.py
 msgid "Show table columns"
-msgstr ""
+msgstr "Pokaż kolumny tabeli"
 
 #: crisis_room/forms.py
 msgid "Severity (Low-High)"
-msgstr ""
+msgstr "Dotkliwość (niska-wysoka)"
 
 #: crisis_room/forms.py
 msgid "Severity (High-Low)"
-msgstr ""
+msgstr "Dotkliwość (wysoka-niska)"
 
 #: crisis_room/forms.py
 msgid "Finding (A-Z)"
-msgstr ""
+msgstr "Znalezienie (A-Z)"
 
 #: crisis_room/forms.py
 msgid "Finding (Z-A)"
-msgstr ""
+msgstr "Znalezienie (Z-A)"
 
 #: crisis_room/models.py
 msgid "Findings Dashboard"
-msgstr ""
+msgstr "Panel wyników"
 
 #: crisis_room/models.py
 msgid ""
-"Where on the dashboard do you want to show the data? Position {} is the most "
-"top level and the max position is {}."
+"Where on the dashboard do you want to show the data? Position {} is the most"
+" top level and the max position is {}."
 msgstr ""
+"Gdzie na dashboardzie chcesz pokazać dane? Pozycja {} to najwyższy poziom, a"
+" maksymalna pozycja to {}."
 
 #: crisis_room/models.py
 msgid "Will be displayed on the general crisis room, for all organizations."
 msgstr ""
+"Zostanie wywieszony w ogólnym pokoju kryzysowym dla wszystkich organizacji."
 
 #: crisis_room/models.py
 msgid "Will be displayed on a single organization dashboard"
-msgstr ""
+msgstr "Będą wyświetlane na panelu kontrolnym pojedynczej organizacji"
 
 #: crisis_room/models.py
 msgid "Will be displayed on the findings dashboard for all organizations"
-msgstr ""
+msgstr "Zostaną wyświetlone na panelu wyników dla wszystkich organizacji"
 
 #: crisis_room/models.py
 msgid "Can change position up or down of a dashboard item."
 msgstr ""
+"Może zmieniać położenie elementu na desce rozdzielczej w górę lub w dół."
 
 #: crisis_room/models.py
 msgid "You have to choose between a recipe or a query, but not both."
 msgstr ""
+"Musisz wybrać pomiędzy przepisem a zapytaniem, ale nie jednym i drugim."
 
 #: crisis_room/models.py
 msgid "You have set a query and not where it is from. Also set the source."
-msgstr ""
+msgstr "Ustawiłeś zapytanie, a nie skąd ono pochodzi. Ustaw także źródło."
 
 #: crisis_room/models.py
 msgid ""
 "DashboardItem must contain at least a 'recipe' or a 'source' with a 'query'."
 msgstr ""
+"DashboardItem musi zawierać co najmniej „przepis” lub „źródło” z "
+"„zapytaniem”."
 
 #: crisis_room/models.py
 msgid "Max dashboard items reached."
-msgstr ""
+msgstr "Osiągnięto maksymalną liczbę elementów panelu."
 
 #: crisis_room/templates/crisis_room.html
 #: crisis_room/templates/organization_crisis_room.html
 #: rocky/templates/header.html
 msgid "Crisis room"
-msgstr ""
+msgstr "Pokój kryzysowy"
 
 #: crisis_room/templates/crisis_room.html
 msgid "Crisis room overview for all organizations."
-msgstr ""
+msgstr "Przegląd pokoju kryzysowego dla wszystkich organizacji."
 
 #: crisis_room/templates/crisis_room_dashboards.html
 msgid "Dashboards"
-msgstr ""
+msgstr "Pulpity nawigacyjne"
 
 #: crisis_room/templates/crisis_room_dashboards.html
 msgid ""
 "On this page you can see an overview of the dashboards for all "
 "organizations. **More context can be written here**"
 msgstr ""
+"Na tej stronie możesz zobaczyć przegląd dashboardów dla wszystkich "
+"organizacji. **Więcej kontekstu można napisać tutaj**"
 
 #: crisis_room/templates/crisis_room_dashboards.html
 msgid "dashboards"
-msgstr ""
+msgstr "pulpity nawigacyjne"
 
 #: crisis_room/templates/crisis_room_dashboards.html
 msgid "There are no dashboards to display."
-msgstr ""
+msgstr "Brak pulpitów nawigacyjnych do wyświetlenia."
 
 #: crisis_room/templates/crisis_room_findings.html
 #: crisis_room/templates/partials/crisis_room_findings_table.html
@@ -739,31 +791,38 @@ msgstr ""
 #: reports/templates/partials/report_findings_table.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Findings overview"
-msgstr ""
+msgstr "Przegląd wyników"
 
 #: crisis_room/templates/crisis_room_findings.html
 msgid ""
 "\n"
-"                            This overview shows the total number of findings "
-"per\n"
-"                            severity that have been identified for all "
-"organizations.\n"
-"                            This data is based on the latest Crisis Room "
-"Findings Report\n"
+"                            This overview shows the total number of findings per\n"
+"                            severity that have been identified for all organizations.\n"
+"                            This data is based on the latest Crisis Room Findings Report\n"
 "                            of each organization.\n"
 "                        "
 msgstr ""
+"\n"
+"Przegląd ten pokazuje całkowitą liczbę wyników przypadającą na jeden\n"
+"                            dotkliwości, które zostały zidentyfikowane dla wszystkich organizacji.\n"
+"                            Dane te opierają się na najnowszym raporcie Crisis Room Findings Report\n"
+"                            każdej organizacji."
 
 #: crisis_room/templates/crisis_room_findings.html
 msgid "Findings per organization"
-msgstr ""
+msgstr "Wyniki według organizacji"
 
 #: crisis_room/templates/crisis_room_findings.html
 msgid ""
 "This table shows the findings that have been identified for each "
-"organization, sorted by the finding types and grouped by organizations. This "
-"data is based on the latest Crisis Room Findings Report of each organization."
+"organization, sorted by the finding types and grouped by organizations. This"
+" data is based on the latest Crisis Room Findings Report of each "
+"organization."
 msgstr ""
+"W poniższej tabeli przedstawiono ustalenia zidentyfikowane dla każdej "
+"organizacji, posortowane według typów ustaleń i pogrupowane według "
+"organizacji. Dane te opierają się na najnowszym raporcie z ustaleń Crisis "
+"Room Findings Report każdej organizacji."
 
 #: crisis_room/templates/crisis_room_findings.html
 #: reports/report_types/findings_report/report.html
@@ -771,17 +830,21 @@ msgid ""
 "No findings have been identified yet. As soon as they have been identified, "
 "they will be shown on this page."
 msgstr ""
+"Nie zidentyfikowano jeszcze żadnych ustaleń. Gdy tylko zostaną "
+"zidentyfikowane, zostaną wyświetlone na tej stronie."
 
 #: crisis_room/templates/crisis_room_findings.html
 msgid ""
 "There are no organizations yet. After creating an organization, the "
 "identified findings will be shown here."
 msgstr ""
+"Nie ma jeszcze żadnych organizacji. Po utworzeniu organizacji "
+"zidentyfikowane ustalenia zostaną tutaj pokazane."
 
 #: crisis_room/templates/crisis_room_header.html
 #: crisis_room/templates/organization_crisis_room_header.html
 msgid "Crisis room navigation"
-msgstr ""
+msgstr "Nawigacja po pokoju kryzysowym"
 
 #: crisis_room/templates/crisis_room_header.html
 #: crisis_room/templates/partials/new_dashboard_item_action_button.html
@@ -797,8 +860,8 @@ msgstr ""
 #: reports/report_types/web_system_report/report.html
 #: reports/templates/partials/report_findings_table.html
 #: reports/templates/partials/report_sidemenu.html
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
-#: rocky/templates/header.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
 #: rocky/templates/oois/ooi_detail_findings_list.html
 #: rocky/templates/oois/ooi_detail_findings_overview.html
 #: rocky/templates/oois/ooi_page_tabs.html
@@ -807,84 +870,88 @@ msgstr ""
 #: rocky/views/finding_list.py rocky/views/finding_type_add.py
 #: rocky/views/ooi_view.py
 msgid "Findings"
-msgstr ""
+msgstr "Ustalenia"
 
 #: crisis_room/templates/organization_crisis_room.html
 msgid "Options for dashboard"
-msgstr ""
+msgstr "Opcje pulpitu nawigacyjnego"
 
 #: crisis_room/templates/organization_crisis_room.html
 msgid "Show all descriptions"
-msgstr ""
+msgstr "Pokaż wszystkie opisy"
 
 #: crisis_room/templates/organization_crisis_room.html
 msgid "Hide all descriptions"
-msgstr ""
+msgstr "Ukryj wszystkie opisy"
 
 #: crisis_room/templates/organization_crisis_room.html
 #: crisis_room/templates/partials/delete_dashboard_modal.html
 msgid "Delete dashboard"
-msgstr ""
+msgstr "Usuń pulpit nawigacyjny"
 
 #: crisis_room/templates/organization_crisis_room.html
 msgid ""
 "There are no dashboards yet. Click on \"Add dashboard\" to create a new "
 "dashboard."
 msgstr ""
+"Nie ma jeszcze żadnych dashboardów. Kliknij „Dodaj pulpit nawigacyjny”, aby "
+"utworzyć nowy pulpit nawigacyjny."
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 #: katalogus/templates/partials/objects_to_scan.html
 #: rocky/templates/forms/widgets/checkbox_group_table.html
 #: rocky/templates/oois/ooi_list.html
 msgid "Object list"
-msgstr ""
+msgstr "Lista obiektów"
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid "Finding list"
-msgstr ""
+msgstr "Lista znalezisk"
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 #: crisis_room/templates/partials/new_dashboard_item_action_button.html
 msgid "Report section"
-msgstr ""
+msgstr "Sekcja raportu"
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid "There are no dashboard items added yet."
-msgstr ""
+msgstr "Nie dodano jeszcze żadnych elementów panelu."
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid ""
-"You can add dashboard items via the filters on the objects and findings page "
-"or you can add a report section."
+"You can add dashboard items via the filters on the objects and findings page"
+" or you can add a report section."
 msgstr ""
+"Możesz dodać elementy panelu za pomocą filtrów na stronie obiektów i "
+"wniosków lub możesz dodać sekcję raportu."
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid "Add objects"
-msgstr ""
+msgstr "Dodaj obiekty"
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid "Add findings"
-msgstr ""
+msgstr "Dodaj ustalenia"
 
 #: crisis_room/templates/organization_crisis_room_dashboard_items.html
 msgid "Add report section"
-msgstr ""
+msgstr "Dodaj sekcję raportu"
 
 #: crisis_room/templates/organization_crisis_room_header.html
 #: crisis_room/templates/partials/new_dashboard_modal.html
 msgid "Add dashboard"
-msgstr ""
+msgstr "Dodaj pulpit nawigacyjny"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid "Findings per organization overview"
-msgstr ""
+msgstr "Przegląd wyników według organizacji"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: reports/templates/partials/report_findings_table.html
 #: reports/templates/partials/report_severity_totals_table.html
 #: tools/forms/finding_type.py
 msgid "Finding types"
-msgstr ""
+msgstr "Znajdowanie typów"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: reports/report_types/dns_report/report.html
@@ -895,15 +962,15 @@ msgstr ""
 #: rocky/templates/partials/ooi_report_findings_block_table.html
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "Occurrences"
-msgstr ""
+msgstr "Zdarzenia"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid "Highest risk level"
-msgstr ""
+msgstr "Najwyższy poziom ryzyka"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid "Critical finding types"
-msgstr ""
+msgstr "Krytyczne typy wyników"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
@@ -917,7 +984,7 @@ msgstr ""
 #: rocky/templates/tasks/ooi_detail_task_list.html
 #: rocky/templates/tasks/plugin_detail_task_list.html
 msgid "Details"
-msgstr ""
+msgstr "Bliższe dane"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
@@ -932,7 +999,7 @@ msgstr ""
 #: rocky/templates/tasks/ooi_detail_task_list.html
 #: rocky/templates/tasks/plugin_detail_task_list.html
 msgid "Close details"
-msgstr ""
+msgstr "Zamknij szczegóły"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
@@ -947,67 +1014,75 @@ msgstr ""
 #: rocky/templates/tasks/ooi_detail_task_list.html
 #: rocky/templates/tasks/plugin_detail_task_list.html
 msgid "Open details"
-msgstr ""
+msgstr "Otwórz szczegóły"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid ""
-"This overview shows the total number of findings per severity that have been "
-"identified for this organization."
+"This overview shows the total number of findings per severity that have been"
+" identified for this organization."
 msgstr ""
+"Przegląd ten przedstawia całkowitą liczbę ustaleń według wagi "
+"zidentyfikowanych dla tej organizacji."
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: reports/report_types/findings_report/report.html
 msgid "Critical and high findings"
-msgstr ""
+msgstr "Krytyczne i wysokie ustalenia"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: reports/report_types/findings_report/report.html
 msgid ""
 "This table shows the top 25 critical and high findings that have been "
-"identified for this organization, grouped by finding types. A table with all "
-"the identified findings can be found in the Findings Report."
+"identified for this organization, grouped by finding types. A table with all"
+" the identified findings can be found in the Findings Report."
 msgstr ""
+"W poniższej tabeli przedstawiono 25 najważniejszych i najważniejszych "
+"ustaleń zidentyfikowanych dla tej organizacji, pogrupowanych według typów "
+"wyników. Tabela zawierająca wszystkie zidentyfikowane ustalenia znajduje się"
+" w Raporcie z ustaleń."
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid "No findings have been identified. Check report for more details."
 msgstr ""
+"Nie stwierdzono żadnych ustaleń. Sprawdź raport, aby uzyskać więcej "
+"szczegółów."
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 msgid "View findings report"
-msgstr ""
+msgstr "Zobacz raport z ustaleń"
 
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Edit report recipe"
-msgstr ""
+msgstr "Edytuj przepis na raport"
 
 #: crisis_room/templates/partials/dashboard_finding_list.html
 #, python-format
 msgid "Showing %(length)s findings"
-msgstr ""
+msgstr "Wyświetlanie wyników %(length)s"
 
 #: crisis_room/templates/partials/dashboard_finding_list.html
 msgid "Go to findings"
-msgstr ""
+msgstr "Przejdź do ustaleń"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
 msgid "Findings table "
-msgstr ""
+msgstr "Tabela ustaleń"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: crisis_room/templates/partials/dashboard_ooi_list_table.html
 #: rocky/templates/findings/finding_list.html
 #: rocky/templates/oois/ooi_list.html
 msgid "column headers with buttons are sortable"
-msgstr ""
+msgstr "nagłówki kolumn z przyciskami można sortować"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
 #, python-format
 msgid "Show details for %(finding)s"
-msgstr ""
+msgstr "Pokaż szczegóły %(finding)s"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
@@ -1016,7 +1091,7 @@ msgstr ""
 #: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
 #: rocky/views/mixins.py
 msgid "Tree"
-msgstr ""
+msgstr "Drzewo"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
@@ -1025,14 +1100,15 @@ msgstr ""
 #: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
 #: rocky/views/mixins.py
 msgid "Graph"
-msgstr ""
+msgstr "Wykres"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: reports/report_types/dns_report/report.html
 #: rocky/templates/oois/ooi_detail_findings_list.html
-#: rocky/templates/oois/ooi_detail_findings_overview.html rocky/views/mixins.py
+#: rocky/templates/oois/ooi_detail_findings_overview.html
+#: rocky/views/mixins.py
 msgid "Severity"
-msgstr ""
+msgstr "Powaga"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: reports/report_types/dns_report/report.html
@@ -1040,45 +1116,45 @@ msgstr ""
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 #: rocky/views/mixins.py
 msgid "Finding"
-msgstr ""
+msgstr "Odkrycie"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
 #: rocky/templates/partials/ooi_report_findings_block_table.html
 msgid "Finding type"
-msgstr ""
+msgstr "Znalezienie typu"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
 #, python-format
 msgid "Show details for %(finding_type)s"
-msgstr ""
+msgstr "Pokaż szczegóły %(finding_type)s"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
 msgid "OOI type"
-msgstr ""
+msgstr "Typ OOI"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
 #, python-format
 msgid "Show %(ooi_type)s objects"
-msgstr ""
+msgstr "Pokaż obiekty %(ooi_type)s"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/views/mixins.py
 msgid "Location"
-msgstr ""
+msgstr "Lokalizacja"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #, python-format
 msgid "Show details for %(ooi)s"
-msgstr ""
+msgstr "Pokaż szczegóły %(ooi)s"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: rocky/templates/findings/finding_list.html
 msgid "Risk score"
-msgstr ""
+msgstr "Ocena ryzyka"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: katalogus/templates/normalizer_detail.html
@@ -1089,9 +1165,10 @@ msgstr ""
 #: reports/templates/summary/report_asset_overview.html tools/forms/boefje.py
 #: tools/forms/finding_type.py rocky/templates/findings/finding_list.html
 #: rocky/templates/oois/ooi_detail.html
-#: rocky/templates/oois/ooi_detail_findings_list.html rocky/templates/scan.html
+#: rocky/templates/oois/ooi_detail_findings_list.html
+#: rocky/templates/scan.html
 msgid "Description"
-msgstr ""
+msgstr "Opis"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: reports/report_types/multi_organization_report/recommendations.html
@@ -1099,7 +1176,7 @@ msgstr ""
 #: reports/templates/partials/report_severity_totals_table.html
 #: rocky/templates/findings/finding_list.html
 msgid "Recommendation"
-msgstr ""
+msgstr "Zalecenie"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: reports/report_types/vulnerability_report/report.py
@@ -1109,61 +1186,61 @@ msgstr ""
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "Source"
-msgstr ""
+msgstr "Źródło"
 
 #: crisis_room/templates/partials/dashboard_finding_list_table.html
 #: reports/templates/partials/report_findings_table.html
 #: rocky/templates/findings/finding_list.html
 msgid "Impact"
-msgstr ""
+msgstr "Uderzenie"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Options for dashboard items"
-msgstr ""
+msgstr "Opcje elementów pulpitu nawigacyjnego"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Show description"
-msgstr ""
+msgstr "Pokaż opis"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Hide description"
-msgstr ""
+msgstr "Ukryj opis"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Position up"
-msgstr ""
+msgstr "Pozycja w górę"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Position down"
-msgstr ""
+msgstr "Pozycja w dół"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 msgid "Rerun report"
-msgstr ""
+msgstr "Uruchom ponownie raport"
 
 #: crisis_room/templates/partials/dashboard_item_action_button.html
 #: crisis_room/templates/partials/delete_dashboard_item_modal.html
 msgid "Delete item"
-msgstr ""
+msgstr "Usuń element"
 
 #: crisis_room/templates/partials/dashboard_ooi_list.html
 #, python-format
 msgid "Showing %(length)s objects"
-msgstr ""
+msgstr "Wyświetlanie obiektów %(length)s"
 
 #: crisis_room/templates/partials/dashboard_ooi_list.html
 msgid "Go to objects"
-msgstr ""
+msgstr "Przejdź do obiektów"
 
 #: crisis_room/templates/partials/dashboard_ooi_list_table.html
 #: rocky/templates/oois/ooi_list.html
 msgid "Objects "
-msgstr ""
+msgstr "Obiekty"
 
 #: crisis_room/templates/partials/delete_dashboard_item_modal.html
 #, python-format
 msgid "Are you sure you want to delete '%(name)s' from this dashboard?"
-msgstr ""
+msgstr "Czy na pewno chcesz usunąć „%(name)s” z tego pulpitu nawigacyjnego?"
 
 #: crisis_room/templates/partials/delete_dashboard_item_modal.html
 #: crisis_room/templates/partials/delete_dashboard_modal.html
@@ -1176,7 +1253,7 @@ msgstr ""
 #: rocky/templates/oois/ooi_list.html
 #: rocky/templates/partials/delete_ooi_modal.html rocky/views/ooi_delete.py
 msgid "Delete"
-msgstr ""
+msgstr "Usuwać"
 
 #: crisis_room/templates/partials/delete_dashboard_modal.html
 #, python-format
@@ -1184,14 +1261,16 @@ msgid ""
 "Are you sure you want to delete dashboard '%(dashboard)s'? All the items on "
 "the dashboard will be deleted as well."
 msgstr ""
+"Czy na pewno chcesz usunąć panel „%(dashboard)s”? Wszystkie elementy na "
+"pulpicie nawigacyjnym również zostaną usunięte."
 
 #: crisis_room/templates/partials/new_dashboard_item_action_button.html
 msgid "Actions for adding dashboard items"
-msgstr ""
+msgstr "Akcje dodawania elementów panelu kontrolnego"
 
 #: crisis_room/templates/partials/new_dashboard_item_action_button.html
 msgid "Add item"
-msgstr ""
+msgstr "Dodaj element"
 
 #: crisis_room/templates/partials/new_dashboard_item_action_button.html
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
@@ -1200,26 +1279,32 @@ msgstr ""
 #: reports/templates/summary/ooi_selection.html tools/forms/ooi.py
 #: tools/view_helpers.py rocky/templates/admin/delete_confirmation.html
 #: rocky/templates/admin/delete_selected_confirmation.html
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
-#: rocky/templates/header.html rocky/views/ooi_add.py rocky/views/ooi_list.py
-#: rocky/views/ooi_view.py rocky/views/upload_csv.py rocky/views/upload_raw.py
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
+#: rocky/views/ooi_add.py rocky/views/ooi_list.py rocky/views/ooi_view.py
+#: rocky/views/upload_csv.py rocky/views/upload_raw.py
 msgid "Objects"
-msgstr ""
+msgstr "Obiekty"
 
 #: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
 msgid "Add dashboard item"
-msgstr ""
+msgstr "Dodaj element pulpitu nawigacyjnego"
 
 #: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
 msgid ""
-"To  add a <strong>report section</strong>, go to the history page and open a "
-"report. Then go to the section that you want to add to your dashboard and "
-"press the options button next to the section name to create a dashboard item."
+"To  add a <strong>report section</strong>, go to the history page and open a"
+" report. Then go to the section that you want to add to your dashboard and "
+"press the options button next to the section name to create a dashboard "
+"item."
 msgstr ""
+"Aby dodać sekcję raportu <strong></strong>, przejdź do strony historii i "
+"otwórz raport. Następnie przejdź do sekcji, którą chcesz dodać do swojego "
+"dashboardu i naciśnij przycisk opcji obok nazwy sekcji, aby utworzyć element"
+" dashboardu."
 
 #: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
 msgid "Go to report history"
-msgstr ""
+msgstr "Przejdź do historii raportów"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #, python-format
@@ -1227,6 +1312,8 @@ msgid ""
 "\n"
 "    Add %(item_type)s to dashboard\n"
 msgstr ""
+"\n"
+"    Dodaj %(item_type)s do panelu\n"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #, python-format
@@ -1234,6 +1321,7 @@ msgid ""
 "Add these %(item_type)s with the selected filters to the dashboard of your "
 "choice."
 msgstr ""
+"Dodaj te %(item_type)s z wybranymi filtrami do wybranego panelu kontrolnego."
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
@@ -1244,61 +1332,71 @@ msgstr ""
 #: rocky/templates/partials/notifications_block.html
 #: rocky/templates/two_factor/core/login.html
 msgid "explanation"
-msgstr ""
+msgstr "wyjaśnienie"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid "You do not have a custom dashboard yet"
-msgstr ""
+msgstr "Nie masz jeszcze niestandardowego pulpitu nawigacyjnego"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #, python-format
 msgid ""
-"In order to add these %(item_type)s to a dashboard, you first need to create "
-"a dashboard. Please add a dashboard in the crisis room of your organization."
+"In order to add these %(item_type)s to a dashboard, you first need to create"
+" a dashboard. Please add a dashboard in the crisis room of your "
+"organization."
 msgstr ""
+"Aby dodać te %(item_type)s do dashboardu, musisz najpierw utworzyć "
+"dashboard. Dodaj dashboard w pokoju kryzysowym swojej organizacji."
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 #: rocky/templates/findings/finding_list.html
 #: rocky/templates/oois/ooi_list.html
 msgid "Add to dashboard"
-msgstr ""
+msgstr "Dodaj do panelu"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal.html
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid "Go to crisis room"
-msgstr ""
+msgstr "Idź do pokoju kryzysowego"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid "Add report section to dashboard"
-msgstr ""
+msgstr "Dodaj sekcję raportu do dashboardu"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid ""
-"In order to add this report section to a dashboard, you first need to create "
-"a dashboard. Please create a dashboard in the crisis room of your "
+"In order to add this report section to a dashboard, you first need to create"
+" a dashboard. Please create a dashboard in the crisis room of your "
 "organization."
 msgstr ""
+"Aby dodać tę sekcję raportu do dashboardu, musisz najpierw utworzyć "
+"dashboard. Utwórz dashboard w pokoju kryzysowym swojej organizacji."
 
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid "Report must be scheduled for dashboard items"
-msgstr ""
+msgstr "Raport musi być zaplanowany dla elementów pulpitu nawigacyjnego"
 
 #: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
 msgid ""
 "In order for dashboard information to be updated on a regular basis instead "
-"of showing static data, the report should be scheduled. The frequency of the "
-"schedules recurrence determines how fresh the data on the dashboard will be."
+"of showing static data, the report should be scheduled. The frequency of the"
+" schedules recurrence determines how fresh the data on the dashboard will "
+"be."
 msgstr ""
+"Aby informacje w dashboardzie były na bieżąco aktualizowane, zamiast "
+"pokazywać statyczne dane, należy zaplanować raport. Częstotliwość "
+"powtarzania harmonogramów decyduje o tym, jak świeże będą dane na "
+"dashboardzie."
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 msgid "Applied filters"
-msgstr ""
+msgstr "Zastosowane filtry"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 msgid "Object types"
-msgstr ""
+msgstr "Typy obiektów"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 #: katalogus/templates/change_clearance_level.html onboarding/forms.py
@@ -1306,16 +1404,17 @@ msgstr ""
 #: reports/templates/summary/ooi_selection.html tools/forms/boefje.py
 #: tools/forms/ooi.py rocky/templates/oois/ooi_page_tabs.html
 #: rocky/templates/partials/explanations.html
-#: rocky/templates/scan_profiles/scan_profile_detail.html rocky/views/mixins.py
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+#: rocky/views/mixins.py
 msgid "Clearance level"
-msgstr ""
+msgstr "Poziom rozliczenia"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 #: reports/templates/partials/report_ooi_list.html
 #: reports/templates/summary/ooi_selection.html tools/forms/ooi.py
 #: rocky/views/mixins.py
 msgid "Clearance type"
-msgstr ""
+msgstr "Rodzaj rozliczenia"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 #: reports/templates/report_overview/modal_partials/delete_modal.html
@@ -1323,86 +1422,89 @@ msgstr ""
 #: reports/templates/report_overview/report_history_table.html
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Input objects"
-msgstr ""
+msgstr "Obiekty wejściowe"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 msgid "Show all objects"
-msgstr ""
+msgstr "Pokaż wszystkie obiekty"
 
 #: crisis_room/templates/partials/report_dashboard_item_filter.html
 #: reports/templates/partials/report_types_selection.html
 msgid "No filters applied"
-msgstr ""
+msgstr "Nie zastosowano żadnych filtrów"
 
 #: crisis_room/templates/partials/report_section_action_button.html
 msgid "Add section to dashboard"
-msgstr ""
+msgstr "Dodaj sekcję do dashboardu"
 
 #: katalogus/client.py
 msgid ""
 "The KATalogus has an unexpected error. Check the logs for further details."
 msgstr ""
+"KATAlogus zawiera nieoczekiwany błąd. Sprawdź dzienniki, aby uzyskać więcej "
+"szczegółów."
 
 #: katalogus/client.py
 #, python-format
 msgid "An HTTP %d error occurred. Check logs for more info."
 msgstr ""
+"Wystąpił błąd HTTP %d. Sprawdź dzienniki, aby uzyskać więcej informacji."
 
 #: katalogus/client.py
 msgid "An HTTP error occurred. Check logs for more info."
-msgstr ""
+msgstr "Wystąpił błąd HTTP. Sprawdź dzienniki, aby uzyskać więcej informacji."
 
 #: katalogus/client.py
 msgid "Boefje with this name already exists."
-msgstr ""
+msgstr "Boefje o tej nazwie już istnieje."
 
 #: katalogus/client.py
 msgid "Boefje with this ID already exists."
-msgstr ""
+msgstr "Boefje o tym identyfikatorze już istnieje."
 
 #: katalogus/client.py
 msgid "Access to resource not allowed"
-msgstr ""
+msgstr "Dostęp do zasobu nie jest dozwolony"
 
 #: katalogus/client.py
 msgid "User is not allowed to see plugin settings"
-msgstr ""
+msgstr "Użytkownik nie ma dostępu do ustawień wtyczki"
 
 #: katalogus/client.py
 msgid "User is not allowed to set plugin settings"
-msgstr ""
+msgstr "Użytkownik nie może zmieniać ustawień wtyczki"
 
 #: katalogus/client.py
 msgid "User is not allowed to delete plugin settings"
-msgstr ""
+msgstr "Użytkownikowi nie wolno usuwać ustawień wtyczki"
 
 #: katalogus/client.py
 msgid "User is not allowed to view plugin settings"
-msgstr ""
+msgstr "Użytkownik nie ma uprawnień do przeglądania ustawień wtyczki"
 
 #: katalogus/client.py
 msgid "User is not allowed to access the other organization"
-msgstr ""
+msgstr "Użytkownik nie ma dostępu do innej organizacji"
 
 #: katalogus/client.py
 msgid "User is not allowed to enable plugins"
-msgstr ""
+msgstr "Użytkownik nie może włączać wtyczek"
 
 #: katalogus/client.py
 msgid "User is not allowed to disable plugins"
-msgstr ""
+msgstr "Użytkownikowi nie wolno wyłączać wtyczek"
 
 #: katalogus/client.py
 msgid "User is not allowed to create plugins"
-msgstr ""
+msgstr "Użytkownikowi nie wolno tworzyć wtyczek"
 
 #: katalogus/client.py
 msgid "User is not allowed to edit plugins"
-msgstr ""
+msgstr "Użytkownikowi nie wolno edytować wtyczek"
 
 #: katalogus/forms/katalogus_filter.py
 msgid "Show all"
-msgstr ""
+msgstr "Pokaż wszystko"
 
 #: katalogus/forms/katalogus_filter.py
 #: katalogus/templates/partials/enable_disable_plugin.html
@@ -1411,7 +1513,7 @@ msgstr ""
 #: reports/report_types/dns_report/report.html
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Enabled"
-msgstr ""
+msgstr "Włączony"
 
 #: katalogus/forms/katalogus_filter.py
 #: katalogus/templates/partials/enable_disable_plugin.html
@@ -1420,39 +1522,42 @@ msgstr ""
 #: reports/templates/report_overview/scheduled_reports_table.html
 #: reports/templates/summary/selected_plugins.html
 msgid "Disabled"
-msgstr ""
+msgstr "Wyłączony"
 
 #: katalogus/forms/katalogus_filter.py
 msgid "Enabled-Disabled"
-msgstr ""
+msgstr "Włączone-wyłączone"
 
 #: katalogus/forms/katalogus_filter.py
 msgid "Disabled-Enabled"
-msgstr ""
+msgstr "Wyłączone-włączone"
 
 #: katalogus/forms/katalogus_filter.py
 msgid "Filter options"
-msgstr ""
+msgstr "Opcje filtrowania"
 
 #: katalogus/forms/katalogus_filter.py
 msgid "Sorting options"
-msgstr ""
+msgstr "Opcje sortowania"
 
 #: katalogus/forms/plugin_settings.py
 msgid "This field is required."
-msgstr ""
+msgstr "To pole jest wymagane."
 
 #: katalogus/templates/about_plugins.html
 #: katalogus/templates/partials/plugins_navigation.html
 msgid "About plugins"
-msgstr ""
+msgstr "O wtyczkach"
 
 #: katalogus/templates/about_plugins.html katalogus/templates/katalogus.html
 msgid ""
-"Plugins gather data, objects and insight. Each plugin has its own focus area "
-"and strengths and may be able to work with other plugins to gain even more "
+"Plugins gather data, objects and insight. Each plugin has its own focus area"
+" and strengths and may be able to work with other plugins to gain even more "
 "insights."
 msgstr ""
+"Wtyczki gromadzą dane, obiekty i spostrzeżenia. Każda wtyczka ma swój własny"
+" obszar zainteresowań i mocne strony i może współpracować z innymi "
+"wtyczkami, aby uzyskać jeszcze więcej informacji."
 
 #: katalogus/templates/about_plugins.html katalogus/templates/boefjes.html
 msgid ""
@@ -1460,120 +1565,130 @@ msgid ""
 "issues, and give insight. Each boefje is a separate scan that can run on a "
 "selection of objects."
 msgstr ""
+"Boefjes służą do skanowania obiektów. Wykrywają luki w zabezpieczeniach, "
+"problemy związane z bezpieczeństwem i dają wgląd. Każde boefje to oddzielne "
+"skanowanie, które można uruchomić na wybranych obiektach."
 
 #: katalogus/templates/about_plugins.html katalogus/templates/normalizers.html
 msgid ""
 "Normalizers analyze the information and turn it into objects for the data "
 "model in Octopoes."
 msgstr ""
+"Normalizers analizuje informacje i przekształca je w obiekty dla modelu "
+"danych w Octopoes."
 
 #: katalogus/templates/about_plugins.html
 msgid ""
-"Bits are business rules that look for insight within the current dataset and "
-"search for specific insight and draw conclusions."
+"Bits are business rules that look for insight within the current dataset and"
+" search for specific insight and draw conclusions."
 msgstr ""
+"Bity to reguły biznesowe, które wyszukują wgląd w bieżący zbiór danych, "
+"szukają konkretnych informacji i wyciągają wnioski."
 
 #: katalogus/templates/boefje_detail.html
 #: katalogus/templates/partials/plugin_tile_modal.html
 #: katalogus/templates/plugin_container_image.html
 msgid "Scan level"
-msgstr ""
+msgstr "Poziom skanowania"
 
 #: katalogus/templates/boefje_detail.html
 #: katalogus/templates/normalizer_detail.html
 msgid "Consumes"
-msgstr ""
+msgstr "Konsumuje"
 
 #: katalogus/templates/boefje_detail.html
 #, python-format
 msgid "%(plugin_name)s is able to scan the following object types:"
-msgstr ""
+msgstr "%(plugin_name)s jest w stanie skanować następujące typy obiektów:"
 
 #: katalogus/templates/boefje_detail.html
 #: katalogus/templates/normalizer_detail.html
 #, python-format
 msgid "%(plugin_name)s does not need any input objects."
-msgstr ""
+msgstr "%(plugin_name)s nie potrzebuje żadnych obiektów wejściowych."
 
 #: katalogus/templates/boefje_detail.html
 #: katalogus/templates/normalizer_detail.html
 #: katalogus/templates/partials/plugin_tile_modal.html
 msgid "Produces"
-msgstr ""
+msgstr "Produkuje"
 
 #: katalogus/templates/boefje_detail.html
 #: katalogus/templates/normalizer_detail.html
 #: katalogus/templates/partials/plugin_tile_modal.html
 #, python-format
 msgid "%(plugin_name)s can produce the following output:"
-msgstr ""
+msgstr "%(plugin_name)s może generować następujące dane wyjściowe:"
 
 #: katalogus/templates/boefje_detail.html
 #, python-format
 msgid "%(plugin_name)s doesn't produce any output mime types."
-msgstr ""
+msgstr "%(plugin_name)s nie generuje żadnych wyjściowych typów MIME."
 
 #: katalogus/templates/boefje_setup.html
 msgid "Boefje variant setup"
-msgstr ""
+msgstr "Konfiguracja wariantu Boefje"
 
 #: katalogus/templates/boefje_setup.html
 #: rocky/templates/organizations/organization_member_list.html
 #: rocky/templates/organizations/organization_settings.html
 #: rocky/views/ooi_edit.py rocky/views/organization_edit.py
 msgid "Edit"
-msgstr ""
+msgstr "Redagować"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Boefje setup"
-msgstr ""
+msgstr "Konfiguracja Boefje"
 
 #: katalogus/templates/boefje_setup.html
 msgid ""
 "You can create a new Boefje. If you want more information on this, you can "
-"check out the <a href=\"https://docs.openkat.nl/developer_documentation/"
-"development_tutorial/creating_a_boefje.html\">documentation</a>."
+"check out the <a "
+"href=\"https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html\">documentation</a>."
 msgstr ""
+"Możesz utworzyć nowy Boefje. Jeśli chcesz uzyskać więcej informacji na ten "
+"temat, zapoznaj się z dokumentacją <a "
+"href=\"https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html\"></a>."
 
 #: katalogus/templates/boefje_setup.html
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 msgid "Save changes"
-msgstr ""
+msgstr "Zapisz zmiany"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Discard changes"
-msgstr ""
+msgstr "Odrzuć zmiany"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Create variant"
-msgstr ""
+msgstr "Utwórz wariant"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Discard variant"
-msgstr ""
+msgstr "Odrzuć wariant"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Create new Boefje"
-msgstr ""
+msgstr "Utwórz nowy Boefje"
 
 #: katalogus/templates/boefje_setup.html
 msgid "Discard new Boefje"
-msgstr ""
+msgstr "Wyrzuć nowy Boefje"
 
 #: katalogus/templates/boefjes.html
 msgid "Add Boefje"
-msgstr ""
+msgstr "Dodaj Boefje"
 
 #: katalogus/templates/boefjes.html katalogus/templates/katalogus.html
 #: katalogus/templates/normalizers.html
 msgid "available"
-msgstr ""
+msgstr "dostępny"
 
 #: katalogus/templates/change_clearance_level.html
 #: katalogus/templates/partials/objects_to_scan.html
 #: reports/templates/partials/report_setup_scan.html
 msgid "scan level warning"
-msgstr ""
+msgstr "ostrzeżenie o poziomie skanowania"
 
 #: katalogus/templates/change_clearance_level.html
 #, python-format
@@ -1581,10 +1696,12 @@ msgid ""
 "%(plugin_name)s will only scan objects with a corresponding clearance level "
 "of <strong>L%(scan_level)s</strong> or higher."
 msgstr ""
+"%(plugin_name)s będzie skanował tylko obiekty z odpowiednim poziomem "
+"zezwolenia <strong>L%(scan_level)s</strong> lub wyższym."
 
 #: katalogus/templates/change_clearance_level.html
 msgid "Scan object"
-msgstr ""
+msgstr "Zeskanuj obiekt"
 
 #: katalogus/templates/change_clearance_level.html
 #, python-format
@@ -1593,115 +1710,123 @@ msgid ""
 "be advised that by continuing you will declare a level %(scan_level)s on "
 "these objects."
 msgstr ""
+"Następujące obiekty nie zostały jeszcze dopuszczone do poziomu "
+"%(scan_level)s, informujemy, że kontynuując zadeklarujesz dla nich poziom "
+"%(scan_level)s."
 
 #: katalogus/templates/change_clearance_level.html
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/summary/report_asset_overview.html
 msgid "Selected objects"
-msgstr ""
+msgstr "Wybrane obiekty"
 
 #: katalogus/templates/change_clearance_level.html
 #: reports/templates/report_overview/report_history_table.html
 #: reports/templates/summary/ooi_selection.html rocky/views/mixins.py
 msgid "Object"
-msgstr ""
+msgstr "Obiekt"
 
 #: katalogus/templates/change_clearance_level.html
 msgid "Are you sure you want to scan anyways?"
-msgstr ""
+msgstr "Czy na pewno chcesz mimo to skanować?"
 
 #: katalogus/templates/change_clearance_level.html
 #: rocky/templates/oois/ooi_detail.html
 msgid "Scan"
-msgstr ""
+msgstr "Skandować"
 
 #: katalogus/templates/clone_settings.html
 #: katalogus/templates/confirmation_clone_settings.html
 msgid "Clone settings"
-msgstr ""
+msgstr "Ustawienia klonowania"
 
 #: katalogus/templates/clone_settings.html
 #, python-format
 msgid ""
 "Use the form below to clone the settings from "
-"<strong>%(current_organization)s</strong> to the selected organization. This "
-"includes both the KAT-alogus settings as well as enabled and disabled "
+"<strong>%(current_organization)s</strong> to the selected organization. This"
+" includes both the KAT-alogus settings as well as enabled and disabled "
 "plugins."
 msgstr ""
+"Skorzystaj z poniższego formularza, aby sklonować ustawienia "
+"<strong>%(current_organization)s</strong> do wybranej organizacji. Dotyczy "
+"to zarówno ustawień KAT-alogus, jak i włączonych i wyłączonych wtyczek."
 
 #: katalogus/templates/confirmation_clone_settings.html
 msgid "Clone"
-msgstr ""
+msgstr "Klon"
 
 #: katalogus/templates/katalogus.html
 msgid "All plugins"
-msgstr ""
+msgstr "Wszystkie wtyczki"
 
 #: katalogus/templates/katalogus_settings.html
 msgid "KAT-alogus settings"
-msgstr ""
+msgstr "Ustawienia KAT-alogusa"
 
 #: katalogus/templates/katalogus_settings.html
 msgid ""
 "There are currently no settings defined. Add settings at the plugin detail "
 "page."
 msgstr ""
+"Obecnie nie zdefiniowano żadnych ustawień. Dodaj ustawienia na stronie "
+"szczegółów wtyczki."
 
 #: katalogus/templates/katalogus_settings.html
 #: rocky/templates/two_factor/core/otp_required.html
 msgid "Go back"
-msgstr ""
+msgstr "Wracać"
 
 #: katalogus/templates/katalogus_settings.html
 msgid "This is an overview of the latest settings of all plugins."
-msgstr ""
+msgstr "To jest przegląd najnowszych ustawień wszystkich wtyczek."
 
 #: katalogus/templates/katalogus_settings.html
 msgid "Latest plugin settings"
-msgstr ""
+msgstr "Najnowsze ustawienia wtyczki"
 
 #: katalogus/templates/katalogus_settings.html
 #: rocky/templates/tasks/ooi_detail_task_list.html
 msgid "Plugin"
-msgstr ""
+msgstr "Wtyczka"
 
 #: katalogus/templates/katalogus_settings.html
 #: katalogus/templates/plugin_settings_list.html
 #: rocky/templates/oois/ooi_delete.html
 msgid "Value"
-msgstr ""
+msgstr "Wartość"
 
 #: katalogus/templates/normalizer_detail.html
 #, python-format
 msgid "%(plugin_name)s is able to process the following mime types:"
-msgstr ""
+msgstr "%(plugin_name)s może przetwarzać następujące typy MIME:"
 
 #: katalogus/templates/partials/boefje_tile.html
 msgid "This object type is required"
-msgstr ""
+msgstr "Ten typ obiektu jest wymagany"
 
 #: katalogus/templates/partials/boefje_tile.html
 msgid "Scan level:"
-msgstr ""
+msgstr "Poziom skanowania:"
 
 #: katalogus/templates/partials/boefje_tile.html
 msgid "Publisher:"
-msgstr ""
+msgstr "Wydawca:"
 
 #: katalogus/templates/partials/boefje_tile.html
 #: katalogus/templates/partials/plugin_tile.html
 #: katalogus/templates/partials/plugin_tile_modal.html
 msgid "See details"
-msgstr ""
+msgstr "Zobacz szczegóły"
 
 #: katalogus/templates/partials/enable_disable_plugin.html
 msgid "Enable"
-msgstr ""
+msgstr "Włączać"
 
 #: katalogus/templates/partials/enable_disable_plugin.html
 #: rocky/templates/two_factor/profile/disable.html
 msgid "Disable"
-msgstr ""
+msgstr "Wyłączyć"
 
 #: katalogus/templates/partials/katalogus_filter.html
 #: rocky/templates/findings/findings_filter.html
@@ -1709,7 +1834,7 @@ msgstr ""
 #: rocky/templates/partials/organization_member_list_filters.html
 #: rocky/templates/tasks/partials/task_filter.html
 msgid "Hide filters"
-msgstr ""
+msgstr "Ukryj filtry"
 
 #: katalogus/templates/partials/katalogus_filter.html
 #: rocky/templates/findings/findings_filter.html
@@ -1717,7 +1842,7 @@ msgstr ""
 #: rocky/templates/partials/organization_member_list_filters.html
 #: rocky/templates/tasks/partials/task_filter.html
 msgid "Show filters"
-msgstr ""
+msgstr "Pokaż filtry"
 
 #: katalogus/templates/partials/katalogus_filter.html
 #: rocky/templates/findings/findings_filter.html
@@ -1725,29 +1850,29 @@ msgstr ""
 #: rocky/templates/partials/organization_member_list_filters.html
 #: rocky/templates/tasks/partials/task_filter.html
 msgid "applied"
-msgstr ""
+msgstr "stosowany"
 
 #: katalogus/templates/partials/katalogus_filter.html
 msgid "Filter plugins"
-msgstr ""
+msgstr "Filtruj wtyczki"
 
 #: katalogus/templates/partials/katalogus_filter.html
 msgid "Clear filter"
-msgstr ""
+msgstr "Wyczyść filtr"
 
 #: katalogus/templates/partials/katalogus_header.html
 #: katalogus/views/change_clearance_level.py katalogus/views/katalogus.py
 #: katalogus/views/katalogus_settings.py katalogus/views/plugin_detail.py
 #: katalogus/views/plugin_settings_add.py
 #: katalogus/views/plugin_settings_delete.py
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
-#: rocky/templates/header.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
 msgid "KAT-alogus"
-msgstr ""
+msgstr "KAT-alogus"
 
 #: katalogus/templates/partials/katalogus_header.html
 msgid "An overview of all available plugins."
-msgstr ""
+msgstr "Przegląd wszystkich dostępnych wtyczek."
 
 #: katalogus/templates/partials/katalogus_header.html
 #: katalogus/templates/plugin_settings_list.html
@@ -1756,35 +1881,35 @@ msgstr ""
 #: rocky/templates/organizations/organization_list.html
 #: rocky/templates/organizations/organization_settings.html
 msgid "Settings"
-msgstr ""
+msgstr "Ustawienia"
 
 #: katalogus/templates/partials/katalogus_toolbar.html
 msgid "Gridview"
-msgstr ""
+msgstr "Widok siatki"
 
 #: katalogus/templates/partials/katalogus_toolbar.html
 msgid "Tableview"
-msgstr ""
+msgstr "Widok stołu"
 
 #: katalogus/templates/partials/modal_report_types.html
 msgid "Required for"
-msgstr ""
+msgstr "Wymagane dla"
 
 #: katalogus/templates/partials/modal_report_types.html
 msgid "report types"
-msgstr ""
+msgstr "typy raportów"
 
 #: katalogus/templates/partials/modal_report_types.html
 msgid "Report types for "
-msgstr ""
+msgstr "Typy raportów dla"
 
 #: katalogus/templates/partials/no_enabling_permission_message.html
 msgid "No permission to enable/disable plugins"
-msgstr ""
+msgstr "Brak uprawnień do włączania/wyłączania wtyczek"
 
 #: katalogus/templates/partials/no_enabling_permission_message.html
 msgid "Contact your administrator to request permission."
-msgstr ""
+msgstr "Skontaktuj się z administratorem, aby poprosić o pozwolenie."
 
 #: katalogus/templates/partials/objects_to_scan.html
 #, python-format
@@ -1795,10 +1920,15 @@ msgid ""
 "<strong>L%(scan_level)s</strong>. Use the filter to show OOI's with a lower "
 "clearance level."
 msgstr ""
+"Ten Boefje będzie skanował tylko obiekty z odpowiednim poziomem zezwolenia "
+"<strong>L%(scan_level)s</strong> lub wyższym. Boefje nie podlega żadnej "
+"odpowiedzialności za skanowanie OOI z niższym poziomem zezwolenia niż "
+"<strong>L%(scan_level)s</strong>. Użyj filtra, aby wyświetlić modele OOI z "
+"niższym poziomem luzu."
 
 #: katalogus/templates/partials/objects_to_scan.html
 msgid "Warning scan level:"
-msgstr ""
+msgstr "Poziom skanowania ostrzeżeń:"
 
 #: katalogus/templates/partials/objects_to_scan.html
 msgid ""
@@ -1807,6 +1937,10 @@ msgid ""
 "now on out, until it manually gets set to something else again. This means "
 "that all other enabled Boefjes will use this higher clearance level aswel."
 msgstr ""
+"Skanowanie OOI z niższym poziomem zezwolenia spowoduje, że OpenKAT zwiększy "
+"poziom zezwolenia na tym OOI, nie tylko dla tego skanowania, ale od teraz, "
+"aż do ponownego ręcznego ustawienia czegoś innego. Oznacza to, że wszystkie "
+"inne włączone Boefjes będą używać tego wyższego poziomu zezwolenia."
 
 #: katalogus/templates/partials/objects_to_scan.html
 #, python-format
@@ -1815,6 +1949,9 @@ msgid ""
 "Add objects with a complying clearance level, or alter the clearance level "
 "of existing objects."
 msgstr ""
+"Obecnie nie masz żadnych obiektów spełniających poziom skanowania %(name)s. "
+"Dodaj obiekty o odpowiednim poziomie prześwitu lub zmień poziom prześwitu "
+"istniejących obiektów."
 
 #: katalogus/templates/partials/objects_to_scan.html
 #, python-format
@@ -1822,59 +1959,62 @@ msgid ""
 "You currently don't have scannable objects for %(name)s. Add objects to use "
 "this Boefje. This Boefje is able to scan objects of the following types:"
 msgstr ""
+"Obecnie nie masz obiektów do skanowania dla %(name)s. Dodaj obiekty, aby "
+"używać tego Boefje. Ten Boefje jest w stanie skanować obiekty następujących "
+"typów:"
 
 #: katalogus/templates/partials/plugin_settings_required.html
 msgid "The form could not be initialized."
-msgstr ""
+msgstr "Nie można zainicjować formularza."
 
 #: katalogus/templates/partials/plugin_settings_required.html
 msgid "Required settings"
-msgstr ""
+msgstr "Wymagane ustawienia"
 
 #: katalogus/templates/partials/plugin_settings_required.html
 #: rocky/templates/partials/ooi_list_toolbar.html
 msgid "Add"
-msgstr ""
+msgstr "Dodać"
 
 #: katalogus/templates/partials/plugin_tile.html
 msgid "Required for:"
-msgstr ""
+msgstr "Wymagane dla:"
 
 #: katalogus/templates/partials/plugin_tile_modal.html
 msgid "Boefje details"
-msgstr ""
+msgstr "Szczegóły Boefje"
 
 #: katalogus/templates/partials/plugin_tile_modal.html reports/forms.py
 #: reports/templates/report_overview/report_history_table.html
 msgid "Report types"
-msgstr ""
+msgstr "Typy raportów"
 
 #: katalogus/templates/partials/plugin_tile_modal.html
 msgid "This boefje is required by the following report types."
-msgstr ""
+msgstr "To boefje jest wymagane w przypadku następujących typów raportów."
 
 #: katalogus/templates/partials/plugin_tile_modal.html
 msgid "Go to boefje detail page"
-msgstr ""
+msgstr "Przejdź do strony szczegółów boefje"
 
 #: katalogus/templates/partials/plugins.html
 msgid "Plugins overview:"
-msgstr ""
+msgstr "Przegląd wtyczek:"
 
 #: katalogus/templates/partials/plugins.html
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugin name"
-msgstr ""
+msgstr "Nazwa wtyczki"
 
 #: katalogus/templates/partials/plugins.html
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugin type"
-msgstr ""
+msgstr "Typ wtyczki"
 
 #: katalogus/templates/partials/plugins.html
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugin description"
-msgstr ""
+msgstr "Opis wtyczki"
 
 #: katalogus/templates/partials/plugins.html
 #: reports/templates/partials/report_header.html
@@ -1882,73 +2022,75 @@ msgstr ""
 #: rocky/templates/organizations/organization_list.html
 #: rocky/templates/organizations/organization_settings.html
 msgid "Actions"
-msgstr ""
+msgstr "Działania"
 
 #: katalogus/templates/partials/plugins.html
 msgid "Detail page"
-msgstr ""
+msgstr "Strona ze szczegółami"
 
 #: katalogus/templates/partials/plugins_navigation.html
 #: reports/templates/report_overview/report_overview_navigation.html
 msgid "Plugins Navigation"
-msgstr ""
+msgstr "Nawigacja po wtyczkach"
 
 #: katalogus/templates/partials/plugins_navigation.html
 #: rocky/templates/scan.html rocky/templates/tasks/boefjes.html
 #: rocky/templates/tasks/partials/tab_navigation.html rocky/views/tasks.py
 msgid "Boefjes"
-msgstr ""
+msgstr "Boefjes"
 
 #: katalogus/templates/partials/plugins_navigation.html
 #: rocky/templates/tasks/normalizers.html
 #: rocky/templates/tasks/partials/tab_navigation.html rocky/views/tasks.py
 msgid "Normalizers"
-msgstr ""
+msgstr "Normalizatory"
 
 #: katalogus/templates/partials/plugins_navigation.html
 #: tools/forms/scheduler.py
 msgid "All"
-msgstr ""
+msgstr "Wszystko"
 
 #: katalogus/templates/plugin_container_image.html tools/forms/boefje.py
 msgid "Container image"
-msgstr ""
+msgstr "Obraz kontenera"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "The container image for this Boefje is:"
-msgstr ""
+msgstr "Obraz kontenera dla tego Boefje to:"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Variants"
-msgstr ""
+msgstr "Warianty"
 
 #: katalogus/templates/plugin_container_image.html
 msgid ""
 "Boefje variants that use the same container image. For more information "
 "about Boefje variants you can read the documentation."
 msgstr ""
+"Warianty Boefje korzystające z tego samego obrazu kontenera. Więcej "
+"informacji na temat wariantów Boefje można znaleźć w dokumentacji."
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Add variant"
-msgstr ""
+msgstr "Dodaj wariant"
 
 #: katalogus/templates/plugin_container_image.html
 #: rocky/templates/partials/notifications_block.html
 msgid "confirmation"
-msgstr ""
+msgstr "potwierdzenie"
 
 #: katalogus/templates/plugin_container_image.html
 #, python-format
 msgid "Variant %(plugin.name)s created."
-msgstr ""
+msgstr "Utworzono wariant %(plugin.name)s."
 
 #: katalogus/templates/plugin_container_image.html
 msgid "The Boefje variant is successfully created and can now be used."
-msgstr ""
+msgstr "Wariant Boefje został pomyślnie utworzony i można go teraz używać."
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Overview of variants"
-msgstr ""
+msgstr "Przegląd wariantów"
 
 #: katalogus/templates/plugin_container_image.html
 #: reports/report_types/tls_report/report.html
@@ -1959,36 +2101,36 @@ msgstr ""
 #: rocky/templates/tasks/plugin_detail_task_list.html
 #: rocky/templates/tasks/reports.html
 msgid "Status"
-msgstr ""
+msgstr "Status"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Age"
-msgstr ""
+msgstr "Wiek"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Scan interval"
-msgstr ""
+msgstr "Interwał skanowania"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Run on"
-msgstr ""
+msgstr "Biegnij dalej"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "current"
-msgstr ""
+msgstr "aktualny"
 
 #: katalogus/templates/plugin_container_image.html
 #: reports/report_types/dns_report/report.html
 msgid "minutes"
-msgstr ""
+msgstr "protokół"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Default system scan frequency"
-msgstr ""
+msgstr "Domyślna częstotliwość skanowania systemu"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Boefje ID"
-msgstr ""
+msgstr "Identyfikator Boefje"
 
 #: katalogus/templates/plugin_container_image.html
 #: reports/templates/report_overview/modal_partials/delete_modal.html
@@ -1997,222 +2139,251 @@ msgstr ""
 #: reports/templates/report_overview/subreports_table.html
 #: rocky/templates/tasks/reports.html
 msgid "Creation date"
-msgstr ""
+msgstr "Data utworzenia"
 
 #: katalogus/templates/plugin_container_image.html tools/forms/boefje.py
 msgid "Arguments"
-msgstr ""
+msgstr "Argumenty"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "The following arguments are used for this Boefje variant:"
-msgstr ""
+msgstr "W przypadku tego wariantu Boefje używane są następujące argumenty:"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "There are no arguments used for this Boefje variant."
-msgstr ""
+msgstr "Dla tego wariantu Boefje nie zastosowano żadnych argumentów."
 
 #: katalogus/templates/plugin_container_image.html
 msgid "Edit variant"
-msgstr ""
+msgstr "Edytuj wariant"
 
 #: katalogus/templates/plugin_container_image.html
 msgid "This Boefje has no variants yet."
-msgstr ""
+msgstr "Ten Boefje nie ma jeszcze żadnych wariantów."
 
 #: katalogus/templates/plugin_container_image.html
 msgid ""
-"You can make a variant and change the arguments and JSON Schema to customize "
-"it to fit your needs."
+"You can make a variant and change the arguments and JSON Schema to customize"
+" it to fit your needs."
 msgstr ""
+"Możesz stworzyć wariant i zmienić argumenty oraz schemat JSON, aby "
+"dostosować go do swoich potrzeb."
 
 #: katalogus/templates/plugin_settings_add.html
 msgid "Add setting"
 msgid_plural "Add settings"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Dodaj ustawienie"
+msgstr[1] "Dodaj ustawienia"
+msgstr[2] "Dodaj ustawienia"
 
 #: katalogus/templates/plugin_settings_add.html
 msgid "Setting"
 msgid_plural "Settings"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Ustawienie"
+msgstr[1] "Ustawienia"
+msgstr[2] "Ustawienia"
 
 #: katalogus/templates/plugin_settings_add.html
 msgid "Add setting and enable boefje"
 msgid_plural "Add settings and enable boefje"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Dodaj ustawienie i włącz boefje"
+msgstr[1] "Dodaj ustawienia i włącz boefje"
+msgstr[2] "Dodaj ustawienia i włącz boefje"
 
 #: katalogus/templates/plugin_settings_delete.html
 msgid "Delete settings"
-msgstr ""
+msgstr "Usuń ustawienia"
 
 #: katalogus/templates/plugin_settings_delete.html
 #, python-format
 msgid ""
 "Are you sure you want to delete all settings for the plugin %(plugin_name)s?"
 msgstr ""
+"Czy na pewno chcesz usunąć wszystkie ustawienia wtyczki %(plugin_name)s?"
 
 #: katalogus/templates/plugin_settings_list.html
 msgid ""
-"In the table below the settings for this specific Boefje can be seen. Set or "
-"change the value of the variables by editing the settings."
+"In the table below the settings for this specific Boefje can be seen. Set or"
+" change the value of the variables by editing the settings."
 msgstr ""
+"W poniższej tabeli można zobaczyć ustawienia dla tego konkretnego Boefje. "
+"Ustaw lub zmień wartość zmiennych, edytując ustawienia."
 
 #: katalogus/templates/plugin_settings_list.html
 msgid "Configure Settings"
-msgstr ""
+msgstr "Skonfiguruj ustawienia"
 
 #: katalogus/templates/plugin_settings_list.html
 msgid "Overview of settings"
-msgstr ""
+msgstr "Przegląd ustawień"
 
 #: katalogus/templates/plugin_settings_list.html
 msgid "Variable"
-msgstr ""
+msgstr "Zmienny"
 
 #: katalogus/views/change_clearance_level.py
 msgid "Session has terminated, please select objects again."
-msgstr ""
+msgstr "Sesja została zakończona. Wybierz obiekty ponownie."
 
 #: katalogus/views/change_clearance_level.py
 msgid "Change clearance level"
-msgstr ""
+msgstr "Zmień poziom zezwolenia"
 
 #: katalogus/views/katalogus_settings.py
 msgid "Settings from {} to {} successfully cloned."
-msgstr ""
+msgstr "Ustawienia od {} do {} pomyślnie sklonowano."
 
 #: katalogus/views/katalogus_settings.py
 #: katalogus/views/plugin_settings_list.py
 msgid "Failed getting settings for boefje {}"
-msgstr ""
+msgstr "Nie udało się pobrać ustawień dla boefje {}"
 
 #: katalogus/views/mixins.py
 msgid ""
 "Getting information for plugin {} failed. Please check the KATalogus logs."
 msgstr ""
+"Pobieranie informacji o wtyczce {} nie powiodło się. Proszę sprawdzić logi "
+"KATalogus."
 
 #: katalogus/views/plugin_detail.py
 msgid ""
 "Some selected OOIs needs an increase of clearance level to perform scans. "
 "You do not have the permission to change clearance level."
 msgstr ""
+"Niektóre wybrane modele OOIs wymagają zwiększenia poziomu uprawnień w celu "
+"przeprowadzenia skanowania. Nie masz uprawnień do zmiany poziomu uprawnień."
 
 #: katalogus/views/plugin_enable_disable.py
 msgid "{} '{}' disabled."
-msgstr ""
+msgstr "{} '{}' wyłączony."
 
 #: katalogus/views/plugin_enable_disable.py
 msgid "{} '{}' enabled."
-msgstr ""
+msgstr "{} '{}' włączony."
 
 #: katalogus/views/plugin_enable_disable.py
 msgid ""
 "You have not acknowledged your clearance level. Go to your profile page to "
 "acknowledge your clearance level."
 msgstr ""
+"Nie potwierdziłeś swojego poziomu uprawnień. Przejdź do strony swojego "
+"profilu, aby potwierdzić swój poziom uprawnień."
 
 #: katalogus/views/plugin_enable_disable.py
 msgid ""
 "Your clearance level is not set. Go to your profile page to see your "
 "clearance or contact the administrator to set a clearance level."
 msgstr ""
+"Poziom uprawnień nie jest ustawiony. Przejdź do strony swojego profilu, aby "
+"zobaczyć swoje uprawnienia lub skontaktuj się z administratorem, aby ustawić"
+" poziom uprawnień."
 
 #: katalogus/views/plugin_enable_disable.py
 msgid ""
 "Your clearance level is L{}. Contact your administrator to get a higher "
 "clearance level."
 msgstr ""
+"Twój poziom uprawnień to L{}. Skontaktuj się z administratorem, aby uzyskać "
+"wyższy poziom uprawnień."
 
 #: katalogus/views/plugin_enable_disable.py
 msgid "To enable {} you need at least a clearance level of L{}. "
-msgstr ""
+msgstr "Aby włączyć {}, potrzebujesz co najmniej poziomu uprawnień L{}."
 
 #: katalogus/views/plugin_settings_add.py
 msgid "Trying to add settings to boefje without schema"
-msgstr ""
+msgstr "Próbuję dodać ustawienia do boefje bez schematu"
 
 #: katalogus/views/plugin_settings_add.py
 msgid "No changes to the settings added: no form data present"
-msgstr ""
+msgstr "Nie dodano żadnych zmian w ustawieniach: brak danych formularza"
 
 #: katalogus/views/plugin_settings_add.py
 msgid "Added settings for '{}'"
-msgstr ""
+msgstr "Dodano ustawienia dla „{}”"
 
 #: katalogus/views/plugin_settings_add.py
 msgid "Failed adding settings"
-msgstr ""
+msgstr "Nie udało się dodać ustawień"
 
 #: katalogus/views/plugin_settings_add.py
 msgid "Enabling {} failed"
-msgstr ""
+msgstr "Włączenie {} nie powiodło się"
 
 #: katalogus/views/plugin_settings_add.py
 msgid "Boefje '{}' enabled."
-msgstr ""
+msgstr "Boefje „{}” włączone."
 
 #: katalogus/views/plugin_settings_add.py
 msgid "Add settings"
-msgstr ""
+msgstr "Dodaj ustawienia"
 
 #: katalogus/views/plugin_settings_delete.py
 msgid "Settings for plugin {} successfully deleted."
-msgstr ""
+msgstr "Ustawienia wtyczki {} zostały pomyślnie usunięte."
 
 #: katalogus/views/plugin_settings_delete.py
 msgid "Plugin {} has no settings."
-msgstr ""
+msgstr "Wtyczka {} nie ma żadnych ustawień."
 
 #: katalogus/views/plugin_settings_delete.py
 msgid ""
 "Failed deleting Settings for plugin {}. Check the Katalogus logs for more "
 "info."
 msgstr ""
+"Nie udało się usunąć ustawień wtyczki {}. Więcej informacji znajdziesz w "
+"logach Katalogusa."
 
 #: onboarding/forms.py
 msgid ""
 "The clearance level determines how aggressive the object can be scanned by "
 "plugins. A higher clearance level means more aggressive scans are allowed."
 msgstr ""
+"Poziom zezwolenia określa, jak agresywnie obiekt może być skanowany przez "
+"wtyczki. Wyższy poziom zezwolenia oznacza, że ​​dozwolone są bardziej "
+"agresywne skany."
 
 #: onboarding/forms.py tools/forms/ooi.py
 msgid "explanation-clearance-level"
-msgstr ""
+msgstr "poziom wyjaśnienia"
 
 #: onboarding/forms.py
 msgid "Please enter a valid URL starting with 'http://' or 'https://'."
-msgstr ""
+msgstr "Wprowadź prawidłowy URL zaczynający się od 'http://' lub 'https://'."
 
 #: onboarding/templates/partials/onboarding_header.html
 msgid "Onboarding"
-msgstr ""
+msgstr "Proces wdrażania do firmy nowego pracownika"
 
 #: onboarding/templates/partials/step_1_introduction_text.html
 msgid "Welcome to OpenKAT!"
-msgstr ""
+msgstr "Witamy w OpenKAT!"
 
 #: onboarding/templates/partials/step_1_introduction_text.html
 msgid ""
-"Welcome to the onboarding of OpenKAT. We will walk you through some steps to "
-"set everything up."
+"Welcome to the onboarding of OpenKAT. We will walk you through some steps to"
+" set everything up."
 msgstr ""
+"Witamy na pokładzie OpenKAT. Przeprowadzimy Cię przez kilka kroków, aby "
+"wszystko skonfigurować."
 
 #: onboarding/templates/partials/step_1_introduction_text.html
 msgid ""
-"At the end of this onboarding you have added your first object, created your "
-"first DNS report and learned about some basic concepts used within OpenKAT."
+"At the end of this onboarding you have added your first object, created your"
+" first DNS report and learned about some basic concepts used within OpenKAT."
 msgstr ""
+"Pod koniec tego wdrożenia dodałeś swój pierwszy obiekt, stworzyłeś swój "
+"pierwszy raport DNS i poznałeś kilka podstawowych koncepcji używanych w "
+"OpenKAT."
 
 #: onboarding/templates/partials/step_1_introduction_text.html
 msgid "The full documentation for OpenKAT can be found at:"
-msgstr ""
+msgstr "Pełną dokumentację OpenKAT można znaleźć pod adresem:"
 
 #: onboarding/templates/partials/step_2_organization_text.html
 #: rocky/templates/organizations/organization_add.html
 msgid "Organization setup"
-msgstr ""
+msgstr "Konfiguracja organizacji"
 
 #: onboarding/templates/partials/step_2_organization_text.html
 msgid ""
@@ -2220,36 +2391,43 @@ msgid ""
 "be changed later in the interface. The organization code cannot be changed "
 "as this is used by the database."
 msgstr ""
+"Proszę wprowadzić następujące dane organizacyjne. Nazwę organizacji można "
+"zmienić później w interfejsie. Kodu organizacji nie można zmienić, ponieważ "
+"jest on używany przez bazę danych."
 
 #: onboarding/templates/step_10_report.html
 #: reports/report_types/concatenated_report/report.py
 msgid "Report"
-msgstr ""
+msgstr "Raport"
 
 #: onboarding/templates/step_10_report.html
 msgid "Boefjes are scanning"
-msgstr ""
+msgstr "Boefjes skanują"
 
 #: onboarding/templates/step_10_report.html
 msgid ""
 "The enabled Boefjes are running in the background to gather the data for "
 "your DNS Report. This may take a few minutes."
 msgstr ""
+"Włączone Boefjes działają w tle, aby zebrać dane do raportu DNS. Może to "
+"potrwać kilka minut."
 
 #: onboarding/templates/step_10_report.html
 msgid ""
 "In the meantime you can explore OpenKAT and view your DNS Report on the "
 "Reports page once it has been generated."
 msgstr ""
+"W międzyczasie możesz eksplorować OpenKAT i przeglądać raport DNS na stronie"
+" Raporty po jego wygenerowaniu."
 
 #: onboarding/templates/step_10_report.html
 msgid "Continue to OpenKAT"
-msgstr ""
+msgstr "Kontynuuj do OpenKAT"
 
 #: onboarding/templates/step_1_introduction_registration.html
 #: onboarding/templates/step_1a_introduction.html
 msgid "Let's get started"
-msgstr ""
+msgstr "Zacznijmy"
 
 #: onboarding/templates/step_2a_organization_setup.html
 #: onboarding/templates/step_2b_organization_update.html
@@ -2257,7 +2435,7 @@ msgstr ""
 #: rocky/templates/organizations/organization_settings.html
 #: rocky/templates/partials/organization_properties_table.html
 msgid "Organization details"
-msgstr ""
+msgstr "Szczegóły organizacji"
 
 #: onboarding/templates/step_2a_organization_setup.html
 #: rocky/templates/forms/json_schema_form.html
@@ -2269,54 +2447,65 @@ msgstr ""
 #: rocky/templates/partials/form/indemnification_add_form.html
 #: rocky/templates/two_factor/_wizard_actions.html
 msgid "Submit"
-msgstr ""
+msgstr "Składać"
 
 #: onboarding/templates/step_2b_organization_update.html
 msgid "Submit changes"
-msgstr ""
+msgstr "Prześlij zmiany"
 
 #: onboarding/templates/step_2b_organization_update.html
 #: onboarding/templates/step_3_indemnification_setup.html
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 #: onboarding/templates/step_7_clearance_level_introduction.html
 msgid "Continue"
-msgstr ""
+msgstr "Kontynuować"
 
 #: onboarding/templates/step_3_indemnification_setup.html
 msgid "Indemnification setup"
-msgstr ""
+msgstr "Konfiguracja zabezpieczenia"
 
 #: onboarding/templates/step_3_indemnification_setup.html
 msgid "Indemnification on the organization is already present."
-msgstr ""
+msgstr "Zabezpieczenie dla organizacji już istnieje."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 msgid "User clearance level"
-msgstr ""
+msgstr "Poziom uprawnień użytkownika"
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 msgid ""
-"The user clearance level specifies the maximum scan level for security scans "
-"and the maximum clearance level you can assign to objects (e.g. a URL)."
+"The user clearance level specifies the maximum scan level for security scans"
+" and the maximum clearance level you can assign to objects (e.g. a URL)."
 msgstr ""
+"Poziom uprawnień użytkownika określa maksymalny poziom uprawnień dla skanów "
+"bezpieczeństwa oraz maksymalny poziom uprawnień, jaki możesz przypisać do "
+"obiektów (np. URL)."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 msgid ""
 "The administrator assigns a maximum user clearance level to each user. This "
 "will make sure that only trusted users can start more aggressive scans."
 msgstr ""
+"Administrator przypisuje każdemu użytkownikowi maksymalny poziom uprawnień "
+"użytkownika. Dzięki temu tylko zaufani użytkownicy będą mogli rozpocząć "
+"bardziej agresywne skanowanie."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 msgid ""
 "A user must accept a clearance level, before they perform actions in "
 "OpenKAT. Here you may accept the maximum trusted clearance level, as "
-"assigned by your administrator. On your user settings page you can choose to "
-"lower your accepted clearance level after completing the onboarding."
+"assigned by your administrator. On your user settings page you can choose to"
+" lower your accepted clearance level after completing the onboarding."
 msgstr ""
+"Użytkownik musi zaakceptować poziom uprawnień, zanim podejmie działania w "
+"OpenKAT. Tutaj możesz zaakceptować maksymalny poziom zaufanego "
+"uwierzytelnienia przypisany przez administratora. Na stronie ustawień "
+"użytkownika możesz obniżyć akceptowany poziom uprawnień po zakończeniu "
+"wdrażania."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 msgid "What is my clearance level?"
-msgstr ""
+msgstr "Jaki jest mój poziom uprawnień?"
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 #, python-format
@@ -2328,6 +2517,12 @@ msgid ""
 "<strong>%(ooi)s</strong> </br> Contact your administrator to receive a "
 "higher clearance."
 msgstr ""
+"Niestety nie możesz kontynuować wdrażania. </br> Twój administrator "
+"powierzył Ci poziom uprawnień <strong>L%(tcl)s</strong>. </br> Do skanowania"
+" potrzebny jest co najmniej poziom uprawnień "
+"<strong>L%(dns_report_least_clearance_level)s</strong> "
+"<strong>%(ooi)s</strong> </br> Skontaktuj się z administratorem, aby "
+"otrzymać wyższe uprawnienia."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 #: onboarding/templates/step_5_add_scan_ooi.html
@@ -2337,7 +2532,7 @@ msgstr ""
 #: onboarding/templates/step_9_choose_report_type.html
 #: rocky/templates/partials/form/boefje_tiles_form.html
 msgid "Skip onboarding"
-msgstr ""
+msgstr "Pomiń wdrażanie"
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 #, python-format
@@ -2346,6 +2541,8 @@ msgid ""
 "<strong>L%(tcl)s</strong>. </br> You must first accept this clearance level "
 "to continue."
 msgstr ""
+"Twój administrator powierzył Ci poziom uprawnień <strong>L%(tcl)s</strong>. "
+"</br> Aby kontynuować, musisz najpierw zaakceptować ten poziom uprawnień."
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
 #, python-format
@@ -2353,10 +2550,12 @@ msgid ""
 "Your administrator has <strong>trusted</strong> you with a clearance level "
 "of <strong>L%(tcl)s</strong>."
 msgstr ""
+"Twój administrator nadał Ci <strong>trusted</strong> z poziomem uprawnień "
+"<strong>L%(tcl)s</strong>."
 
 #: onboarding/templates/step_5_add_scan_ooi.html
 msgid "Add an object"
-msgstr ""
+msgstr "Dodaj obiekt"
 
 #: onboarding/templates/step_5_add_scan_ooi.html
 msgid ""
@@ -2364,11 +2563,14 @@ msgid ""
 "URLs. In the onboarding we will add an URL object, such as our vulnerable "
 "OpenKAT website: https://mispo.es."
 msgstr ""
+"OpenKAT wykorzystuje różnego rodzaju obiekty, takie jak adresy IP, nazwy "
+"hostów i adresy URL. Podczas wdrażania dodamy obiekt URL, taki jak nasza "
+"podatna na ataki witryna internetowa OpenKAT: https://mispo.es."
 
 #: onboarding/templates/step_5_add_scan_ooi.html
 #: rocky/templates/partials/ooi_detail_related_object.html
 msgid "Related objects"
-msgstr ""
+msgstr "Powiązane obiekty"
 
 #: onboarding/templates/step_5_add_scan_ooi.html
 msgid ""
@@ -2378,22 +2580,31 @@ msgid ""
 "collects and adds these related objects by running scans. Objects can also "
 "be manually added."
 msgstr ""
+"Większość obiektów ma zależności od istnienia powiązanych obiektów. Na "
+"przykład URL musi być podłączony do sieci, nazwy hosta, fqdn (pełnej nazwy "
+"domeny) i adresu IP. Jeśli to możliwe, OpenKAT automatycznie zbiera i dodaje"
+" powiązane obiekty, uruchamiając skanowanie. Obiekty można także dodawać "
+"ręcznie."
 
 #: onboarding/templates/step_5_add_scan_ooi.html
 msgid "Create object"
-msgstr ""
+msgstr "Utwórz obiekt"
 
 #: onboarding/templates/step_6_set_clearance_level.html
 msgid "Set object clearance level"
-msgstr ""
+msgstr "Ustaw poziom prześwitu obiektu"
 
 #: onboarding/templates/step_6_set_clearance_level.html
 msgid ""
-"After creating a new object you can set a clearance level for this object. A "
-"clearance level determines how aggressive the object can be scanned. A "
+"After creating a new object you can set a clearance level for this object. A"
+" clearance level determines how aggressive the object can be scanned. A "
 "higher clearance level, means that more aggressive scans are allowed. "
 "Clearance levels can always be adjusted later on."
 msgstr ""
+"Po utworzeniu nowego obiektu możesz ustawić poziom zezwolenia dla tego "
+"obiektu. Poziom zezwolenia określa, jak agresywnie można skanować obiekt. "
+"Wyższy poziom zezwolenia oznacza, że ​​dozwolone są bardziej agresywne "
+"skany. Poziomy luzu można zawsze dostosować później."
 
 #: onboarding/templates/step_6_set_clearance_level.html
 #, python-format
@@ -2402,22 +2613,30 @@ msgid ""
 "L%(dns_report_least_clearance_level)s, meaning only informational scans are "
 "allowed."
 msgstr ""
+"Do wdrożenia używamy poziomu uprawnień "
+"L%(dns_report_least_clearance_level)s, co oznacza, że ​​dozwolone są tylko "
+"skany informacyjne."
 
 #: onboarding/templates/step_6_set_clearance_level.html
 msgid "Set clearance level"
-msgstr ""
+msgstr "Ustaw poziom luzu"
 
 #: onboarding/templates/step_7_clearance_level_introduction.html
 msgid "Plugin introduction"
-msgstr ""
+msgstr "Wprowadzenie do wtyczki"
 
 #: onboarding/templates/step_7_clearance_level_introduction.html
 msgid ""
 "OpenKAT uses plugins to scan your objects. Each plugin has a scan level to "
-"specify how aggressive the scan is. Plugins can only scan those objects with "
-"a clearance level that is equal to, or higher than the scan level of the "
+"specify how aggressive the scan is. Plugins can only scan those objects with"
+" a clearance level that is equal to, or higher than the scan level of the "
 "plugin. Plugin scan level are indicated by the number of cat paws."
 msgstr ""
+"OpenKAT wykorzystuje wtyczki do skanowania obiektów. Każda wtyczka ma poziom"
+" skanowania, który określa, jak agresywne jest skanowanie. Wtyczki mogą "
+"skanować tylko te obiekty z poziomem uprawnień równym lub wyższym od poziomu"
+" skanowania wtyczki. Poziom skanowania wtyczki jest wskazywany przez liczbę "
+"kocich łap."
 
 #: onboarding/templates/step_7_clearance_level_introduction.html
 msgid ""
@@ -2425,6 +2644,9 @@ msgid ""
 "performs non-intrusive scans which look for publicly available information. "
 "It scans objects with a clearance level of 1 or higher."
 msgstr ""
+"Wtyczka <strong>DNS Zone</strong> ma poziom skanowania 1, co oznacza, że "
+"​​wykonuje nieinwazyjne skanowanie w poszukiwaniu publicznie dostępnych "
+"informacji. Skanuje obiekty o poziomie prześwitu 1 lub wyższym."
 
 #: onboarding/templates/step_7_clearance_level_introduction.html
 msgid ""
@@ -2432,46 +2654,61 @@ msgid ""
 "more aggressive and could potentially break things. It scans objects with a "
 "clearance level of 3 or higher."
 msgstr ""
+"Wtyczka <strong>Fierce</strong> ma poziom skanowania 3, co oznacza, że "
+"​​jest bardziej agresywna i może potencjalnie coś zepsuć. Skanuje obiekty o "
+"poziomie prześwitu 3 lub wyższym."
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid "Enabling plugins and start scanning"
-msgstr ""
+msgstr "Włącz wtyczki i rozpocznij skanowanie"
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid ""
 "OpenKAT uses plugins to scan, check and analyze. There are three types of "
 "plugins."
 msgstr ""
+"OpenKAT wykorzystuje wtyczki do skanowania, sprawdzania i analizowania. "
+"Istnieją trzy typy wtyczek."
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid ""
 "The first plugin are <b>Boefjes</b>, which scan objects for data. These are "
 "security tools like nmap, LeakIX and WPscan. </p>"
 msgstr ""
+"Pierwsza wtyczka to <b>Boefjes</b>, która skanuje obiekty w poszukiwaniu "
+"danych. Są to narzędzia bezpieczeństwa, takie jak nmap, LeakIX i WPscan. "
+"</p>"
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid ""
-"The other two plugins are <b>Normalizers</b> and <b>Bits</b>, which are used "
-"to process the output of Boefjes. They can create findings and related "
+"The other two plugins are <b>Normalizers</b> and <b>Bits</b>, which are used"
+" to process the output of Boefjes. They can create findings and related "
 "objects. Bits are also used to create organization specific findings, based "
 "on policy requirements. </p>"
 msgstr ""
+"Pozostałe dwie wtyczki to <b>Normalizers</b> i <b>Bits</b>, które służą do "
+"przetwarzania danych wyjściowych Boefjes. Mogą tworzyć znaleziska i "
+"powiązane obiekty. Bity są również wykorzystywane do tworzenia wniosków "
+"specyficznych dla organizacji, w oparciu o wymagania polityczne. </p>"
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid ""
 "For the onboarding we will enable the Boefjes shown below. Once enabled "
-"these Boefjes gather publicly available information on suitable objects with "
-"a clearance level of 1 or higher. Normalizers and Bits are enabled by "
+"these Boefjes gather publicly available information on suitable objects with"
+" a clearance level of 1 or higher. Normalizers and Bits are enabled by "
 "default."
 msgstr ""
+"Na potrzeby wdrożenia włączymy pokazany poniżej Boefjes. Po włączeniu "
+"Boefjes zbierają publicznie dostępne informacje o odpowiednich obiektach z "
+"poziomem dostępu 1 lub wyższym. Normalizers i Bitsy są domyślnie włączone."
 
 #: onboarding/templates/step_8_setup_scan_select_plugins.html
 msgid "Enable and continue"
-msgstr ""
+msgstr "Włącz i kontynuuj"
 
 #: onboarding/templates/step_9_choose_report_type.html
 msgid "Generate a report"
-msgstr ""
+msgstr "Wygeneruj raport"
 
 #: onboarding/templates/step_9_choose_report_type.html
 msgid ""
@@ -2479,79 +2716,85 @@ msgid ""
 "can generate different types of reports in OpenKAT. Each report may require "
 "one or more plugins that provide the input for the report."
 msgstr ""
+"Raporty można wykorzystać do uzyskania większej wiedzy na temat zasobów "
+"organizacji. W OpenKAT możesz generować różne typy raportów. Każdy raport "
+"może wymagać jednej lub większej liczby wtyczek zapewniających dane "
+"wejściowe do raportu."
 
 #: onboarding/templates/step_9_choose_report_type.html
 msgid ""
 "For the onboarding we will generate a DNS report for your added URL. In the "
 "previous step you enabled the required plugins for this report."
 msgstr ""
+"Na potrzeby wdrożenia wygenerujemy raport DNS dla dodanego URL. W poprzednim"
+" kroku włączyłeś wymagane wtyczki dla tego raportu."
 
 #: onboarding/templates/step_9_choose_report_type.html
 msgid "Generate DNS Report"
-msgstr ""
+msgstr "Wygeneruj raport DNS"
 
 #: onboarding/view_helpers.py
 msgid "1: Welcome"
-msgstr ""
+msgstr "1: Witamy"
 
 #: onboarding/view_helpers.py
 msgid "2: Organization setup"
-msgstr ""
+msgstr "2: Konfiguracja organizacji"
 
 #: onboarding/view_helpers.py
 msgid "3: Add object"
-msgstr ""
+msgstr "3: Dodaj obiekt"
 
 #: onboarding/view_helpers.py
 msgid "4: Plugins"
-msgstr ""
+msgstr "4: Wtyczki"
 
 #: onboarding/view_helpers.py
 msgid "5: Generating report"
-msgstr ""
+msgstr "5: Generowanie raportu"
 
 #: onboarding/views.py
 #, python-brace-format
 msgid "{org_name} successfully created."
-msgstr ""
+msgstr "Pomyślnie utworzono {org_name}."
 
 #: onboarding/views.py
 #, python-brace-format
 msgid "{org_name} successfully updated."
-msgstr ""
+msgstr "{org_name} pomyślnie zaktualizowano."
 
 #: onboarding/views.py
 msgid "Creating an object"
-msgstr ""
+msgstr "Tworzenie obiektu"
 
 #: onboarding/views.py
 msgid "Fetch the parent DNS zone of a hostname"
-msgstr ""
+msgstr "Pobierz nadrzędną strefę DNS nazwy hosta"
 
 #: onboarding/views.py
 msgid "Finds subdomains by brute force"
-msgstr ""
+msgstr "Znajduje subdomeny metodą brutalnej siły"
 
 #: onboarding/views.py
 msgid "Please select a plugin to proceed."
-msgstr ""
+msgstr "Aby kontynuować, wybierz wtyczkę."
 
 #: onboarding/views.py
 msgid "Please select all required plugins to proceed."
-msgstr ""
+msgstr "Aby kontynuować, wybierz wszystkie wymagane wtyczki."
 
 #: onboarding/views.py reports/views/aggregate_report.py
 #: reports/views/generate_report.py
 msgid "An error occurred while enabling {}. The plugin is not available."
-msgstr ""
+msgstr "Wystąpił błąd podczas włączania {}. Wtyczka nie jest dostępna."
 
 #: onboarding/views.py
 msgid "Plugins successfully enabled."
-msgstr ""
+msgstr "Wtyczki zostały pomyślnie włączone."
 
 #: onboarding/views.py
 msgid "Web URL not found."
-msgstr ""
+msgstr "Nie znaleziono sieci Web URL."
 
 #: onboarding/views.py
 msgid ""
@@ -2559,111 +2802,114 @@ msgid ""
 "waiting for Boefjes to complete. In the meantime get familiar with OpenKAT "
 "and visit the Reports History tab later."
 msgstr ""
+"Wygenerowanie Twojego raportu zaplanowano na około 3 minuty, ponieważ "
+"czekamy na zakończenie Boefjes. W międzyczasie zapoznaj się z OpenKAT i "
+"odwiedź później zakładkę Historia raportów."
 
 #: reports/forms.py tools/forms/ooi_form.py
 msgid "Filter by OOI types"
-msgstr ""
+msgstr "Filtruj według typów OOI"
 
 #: reports/forms.py
 msgid "Today"
-msgstr ""
+msgstr "Dzisiaj"
 
 #: reports/forms.py
 msgid "Different date"
-msgstr ""
+msgstr "Inna data"
 
 #: reports/forms.py
 msgid "No, just once"
-msgstr ""
+msgstr "Nie, tylko raz"
 
 #: reports/forms.py
 msgid "Yes, repeat"
-msgstr ""
+msgstr "Tak, powtórz"
 
 #: reports/forms.py
 msgid "Start date"
-msgstr ""
+msgstr "Data rozpoczęcia"
 
 #: reports/forms.py
 msgid "Start time (UTC)"
-msgstr ""
+msgstr "Czas rozpoczęcia (UTC)"
 
 #: reports/forms.py
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Recurrence"
-msgstr ""
+msgstr "Nawrót"
 
 #: reports/forms.py
 msgid "No recurrence, just once"
-msgstr ""
+msgstr "Żadnych powtórzeń, tylko raz"
 
 #: reports/forms.py
 msgid "Daily"
-msgstr ""
+msgstr "Codziennie"
 
 #: reports/forms.py
 msgid "Weekly"
-msgstr ""
+msgstr "Tygodnik"
 
 #: reports/forms.py
 msgid "Monthly"
-msgstr ""
+msgstr "Miesięczny"
 
 #: reports/forms.py
 msgid "Yearly"
-msgstr ""
+msgstr "Rocznie"
 
 #: reports/forms.py
 msgid "day"
-msgstr ""
+msgstr "dzień"
 
 #: reports/forms.py
 msgid "week"
-msgstr ""
+msgstr "tydzień"
 
 #: reports/forms.py
 msgid "month"
-msgstr ""
+msgstr "miesiąc"
 
 #: reports/forms.py
 msgid "year"
-msgstr ""
+msgstr "rok"
 
 #: reports/forms.py
 msgid "Never"
-msgstr ""
+msgstr "Nigdy"
 
 #: reports/forms.py
 msgid "On"
-msgstr ""
+msgstr "NA"
 
 #: reports/forms.py
 msgid "After"
-msgstr ""
+msgstr "Po"
 
 #: reports/forms.py
 msgid "Report name format"
-msgstr ""
+msgstr "Format nazwy raportu"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/report_types/multi_organization_report/appendix.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Appendix"
-msgstr ""
+msgstr "Załącznik"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Currently filtered on"
-msgstr ""
+msgstr "Aktualnie filtrowane"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/partials/report_sidemenu.html
 #: reports/templates/summary/report_asset_overview.html
 msgid "Selected Report Types"
-msgstr ""
+msgstr "Wybrane typy raportów"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Selected report types"
-msgstr ""
+msgstr "Wybrane typy raportów"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/partials/plugin_overview_table.html
@@ -2673,65 +2919,65 @@ msgstr ""
 #: reports/templates/report_overview/subreports_table.html
 #: reports/templates/summary/report_asset_overview.html
 msgid "Report type"
-msgstr ""
+msgstr "Typ raportu"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Service Versions and Health"
-msgstr ""
+msgstr "Wersje usług i kondycja"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Service, version and health"
-msgstr ""
+msgstr "Serwis, wersja i stan zdrowia"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/summary/service_health.html rocky/templates/footer.html
 #: rocky/templates/health.html
 msgid "Service"
-msgstr ""
+msgstr "Praca"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/summary/service_health.html rocky/templates/health.html
 msgid "Version"
-msgstr ""
+msgstr "Wersja"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: rocky/templates/footer.html rocky/views/health.py
 msgid "Health"
-msgstr ""
+msgstr "Zdrowie"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: rocky/templates/health.html
 msgid "Healthy"
-msgstr ""
+msgstr "Zdrowy"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Unhealthy"
-msgstr ""
+msgstr "Niezdrowy"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Used Config objects"
-msgstr ""
+msgstr "Używane obiekty konfiguracyjne"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Used config objects"
-msgstr ""
+msgstr "Używane obiekty konfiguracyjne"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Primary Key"
-msgstr ""
+msgstr "Klucz podstawowy"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Bit ID"
-msgstr ""
+msgstr "Identyfikator bitowy"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "Config"
-msgstr ""
+msgstr "Konfig"
 
 #: reports/report_types/aggregate_organisation_report/appendix.html
 msgid "No config objects found."
-msgstr ""
+msgstr "Nie znaleziono obiektów konfiguracyjnych."
 
 #: reports/report_types/aggregate_organisation_report/asset_overview.html
 #: reports/report_types/multi_organization_report/asset_overview.html
@@ -2739,20 +2985,23 @@ msgstr ""
 #: reports/templates/partials/report_sidemenu.html
 #: reports/templates/summary/report_asset_overview.html
 msgid "Asset overview"
-msgstr ""
+msgstr "Przegląd zasobów"
 
 #: reports/report_types/aggregate_organisation_report/asset_overview.html
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid ""
-"An overview of the manually released scanned assets. Assets in <strong>bold</"
-"strong> are taken as a starting point, assets that are not in bold were "
-"found by OpenKAT itself."
+"An overview of the manually released scanned assets. Assets in "
+"<strong>bold</strong> are taken as a starting point, assets that are not in "
+"bold were found by OpenKAT itself."
 msgstr ""
+"Przegląd ręcznie zwolnionych zeskanowanych zasobów. Za punkt wyjścia "
+"przyjmuje się zasoby w <strong>bold</strong>, zasoby, które nie są "
+"pogrubione, zostały znalezione przez samego OpenKAT."
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 #: reports/report_types/aggregate_organisation_report/report.html
 msgid "Overview of the basic security status"
-msgstr ""
+msgstr "Przegląd podstawowego stanu bezpieczeństwa"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 msgid ""
@@ -2760,39 +3009,42 @@ msgid ""
 "assets. Basic security in order. In principle, all values in this table "
 "should be checked off."
 msgstr ""
+"Tabela ta zawiera przegląd podstawowego stanu zabezpieczeń znanych zasobów. "
+"Podstawowe zabezpieczenia w porządku. W zasadzie wszystkie wartości w tej "
+"tabeli należy zaznaczyć."
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 msgid "Basic security status"
-msgstr ""
+msgstr "Podstawowy stan bezpieczeństwa"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 #: reports/report_types/ipv6_report/report.html
 #: reports/report_types/multi_organization_report/ipv6.html
 #: reports/report_types/systems_report/report.html
 msgid "System type"
-msgstr ""
+msgstr "Typ systemu"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Safe connections"
-msgstr ""
+msgstr "Bezpieczne połączenia"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 msgid "System Specific"
-msgstr ""
+msgstr "Specyficzne dla systemu"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 msgid "RPKI"
-msgstr ""
+msgstr "RPKI"
 
 #: reports/report_types/aggregate_organisation_report/basic_security.html
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/rpki_report/report.html
 #: reports/report_types/safe_connections_report/report.html
 msgid "server"
-msgstr ""
+msgstr "serwer"
 
 #: reports/report_types/aggregate_organisation_report/findings.html
 #: reports/report_types/aggregate_organisation_report/report.html
@@ -2800,53 +3052,59 @@ msgid ""
 "This chapter contains information about the findings that have been "
 "identified for this organization."
 msgstr ""
+"W tym rozdziale znajdują się informacje na temat ustaleń zidentyfikowanych w"
+" przypadku tej organizacji."
 
 #: reports/report_types/aggregate_organisation_report/recommendations.html
 #: reports/report_types/multi_organization_report/recommendations.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Recommendations"
-msgstr ""
+msgstr "Zalecenia"
 
 #: reports/report_types/aggregate_organisation_report/recommendations.html
 #, python-format
 msgid "There is <i>%(total_findings)s</i> vulnerability"
 msgid_plural "There are <i>%(total_findings)s</i> vulnerabilities"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Występuje luka <i>%(total_findings)s</i>"
+msgstr[1] "Istnieją luki <i>%(total_findings)s</i>"
+msgstr[2] "Istnieją luki <i>%(total_findings)s</i>"
 
 #: reports/report_types/aggregate_organisation_report/recommendations.html
 #, python-format
 msgid "found on <i>%(total_systems)s</i> system."
 msgid_plural "found on <i>%(total_systems)s</i> systems."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "znaleziony w systemie <i>%(total_systems)s</i>."
+msgstr[1] "można znaleźć w systemach <i>%(total_systems)s</i>."
+msgstr[2] "można znaleźć w systemach <i>%(total_systems)s</i>."
 
 #: reports/report_types/aggregate_organisation_report/recommendations.html
 #: reports/report_types/multi_organization_report/recommendations.html
 msgid "There are no recommendations."
-msgstr ""
+msgstr "Nie ma żadnych zaleceń."
 
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Basic security"
-msgstr ""
+msgstr "Podstawowe bezpieczeństwo"
 
 #: reports/report_types/aggregate_organisation_report/report.html
 msgid ""
 "In this chapter, first a table of compliance checks is displayed, followed "
 "by a detailed examination of compliance issues for each component."
 msgstr ""
+"W tym rozdziale najpierw wyświetlana jest tabela kontroli zgodności, a "
+"następnie szczegółowe badanie kwestii zgodności dla każdego komponentu."
 
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "System specific"
-msgstr ""
+msgstr "Specyficzne dla systemu"
 
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Resource Public Key Infrastructure"
-msgstr ""
+msgstr "Infrastruktura klucza publicznego zasobów"
 
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/report_types/aggregate_organisation_report/vulnerabilities.html
@@ -2854,16 +3112,16 @@ msgstr ""
 #: reports/report_types/vulnerability_report/report.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Vulnerabilities"
-msgstr ""
+msgstr "Luki"
 
 #: reports/report_types/aggregate_organisation_report/report.html
 #: reports/report_types/aggregate_organisation_report/vulnerabilities.html
 msgid "Vulnerabilities found are grouped per system."
-msgstr ""
+msgstr "Wykryte luki są pogrupowane według systemów."
 
 #: reports/report_types/aggregate_organisation_report/report.py
 msgid "Aggregate Organisation Report"
-msgstr ""
+msgstr "Zbiorczy raport organizacji"
 
 #: reports/report_types/aggregate_organisation_report/rpki.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
@@ -2874,6 +3132,12 @@ msgid ""
 "misconfigurations and malicious route intercepts through verified route "
 "announcements, ensuring reliable server access and secure internet traffic."
 msgstr ""
+"Ta sekcja zawiera podstawowe informacje dotyczące bezpieczeństwa dotyczące "
+"infrastruktury klucza publicznego zasobów. Jeśli Twój serwer WWW "
+"wykorzystuje RPKI dla swoich adresów IP i powiązanych serwerów nazw, "
+"zwiększa to ochronę odwiedzających przed błędnymi konfiguracjami i złośliwym"
+" przechwytywaniem tras poprzez zweryfikowane ogłoszenia o trasach, "
+"zapewniając niezawodny dostęp do serwera i bezpieczny ruch internetowy."
 
 #: reports/report_types/aggregate_organisation_report/safe_connections.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
@@ -2884,41 +3148,49 @@ msgid ""
 "strong encryption which protects the data from interception during "
 "communiction."
 msgstr ""
+"W tym rozdziale sprawdzamy, czy połączenia wszystkich portów IP systemu są "
+"bezpieczne. Bezpieczne połączenia są ważne, aby zapobiec nieautoryzowanemu "
+"dostępowi i naruszeniom danych. Silne szyfry są kluczowe, ponieważ "
+"zapewniają silne szyfrowanie, które chroni dane przed przechwyceniem podczas"
+" komunikacji."
 
 #: reports/report_types/aggregate_organisation_report/summary.html
 #: reports/report_types/multi_organization_report/summary.html
 #: rocky/views/ooi_tree.py
 msgid "Summary"
-msgstr ""
+msgstr "Streszczenie"
 
 #: reports/report_types/aggregate_organisation_report/summary.html
 msgid "Critical Vulnerabilities"
-msgstr ""
+msgstr "Krytyczne luki w zabezpieczeniach"
 
 #: reports/report_types/aggregate_organisation_report/summary.html
 msgid "IPs scanned"
-msgstr ""
+msgstr "Przeskanowane adresy IP"
 
 #: reports/report_types/aggregate_organisation_report/summary.html
 msgid "Hostnames scanned"
-msgstr ""
+msgstr "Przeskanowano nazwy hostów"
 
 #: reports/report_types/aggregate_organisation_report/summary.html
 msgid "Terms in report"
-msgstr ""
+msgstr "Warunki w raporcie"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/rpki_report/report.html
 #: reports/report_types/safe_connections_report/report.html
 #, python-format
 msgid ""
-"This table shows which checks were performed. Following that, the compliance "
-"issues, if any, are shown for each %(type)s Server."
+"This table shows which checks were performed. Following that, the compliance"
+" issues, if any, are shown for each %(type)s Server."
 msgstr ""
+"W poniższej tabeli przedstawiono, jakie kontrole zostały przeprowadzone. "
+"Następnie dla każdego serwera %(type)s wyświetlane są ewentualne problemy ze"
+" zgodnością."
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 msgid "Check overview"
-msgstr ""
+msgstr "Sprawdź przegląd"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/mail_report/report.html
@@ -2928,7 +3200,7 @@ msgstr ""
 #: reports/report_types/safe_connections_report/report.html
 #: reports/report_types/web_system_report/report.html
 msgid "Check"
-msgstr ""
+msgstr "Sprawdzać"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/mail_report/report.html
@@ -2937,18 +3209,18 @@ msgstr ""
 #: reports/report_types/safe_connections_report/report.html
 #: reports/report_types/web_system_report/report.html
 msgid "Compliance"
-msgstr ""
+msgstr "Zgodność"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/rpki_report/report.html
 msgid "IPs are compliant"
-msgstr ""
+msgstr "Adresy IP są zgodne"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/safe_connections_report/report.html
 #: reports/report_types/vulnerability_report/report.html
 msgid "Host:"
-msgstr ""
+msgstr "Gospodarz:"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/mail_report/report.html
@@ -2957,7 +3229,7 @@ msgstr ""
 #: reports/report_types/safe_connections_report/report.html
 #: reports/report_types/web_system_report/report.html
 msgid "Compliance issue"
-msgstr ""
+msgstr "Problem zgodności"
 
 #: reports/report_types/aggregate_organisation_report/system_specific.html
 #: reports/report_types/mail_report/report.html
@@ -2971,7 +3243,7 @@ msgstr ""
 #: rocky/templates/partials/ooi_report_findings_block_table.html
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "Risk level"
-msgstr ""
+msgstr "Poziom ryzyka"
 
 #: reports/report_types/aggregate_organisation_report/system_specific_overview.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
@@ -2980,28 +3252,42 @@ msgid ""
 "security and compliance issues come into play for different systems. They "
 "are listed here under each other."
 msgstr ""
+"W tym miejscu przeprowadzane są kontrole specyficzne dla typów systemów. W "
+"przypadku różnych systemów wchodzą w grę różne kwestie związane z "
+"bezpieczeństwem i zgodnością. Są one wymienione tutaj pod sobą."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Term Overview"
-msgstr ""
+msgstr "Przegląd terminów"
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid "For definitions of terms used in this chapter, see the glossary below."
 msgstr ""
+"Definicje terminów używanych w tym rozdziale można znaleźć w słowniczku "
+"poniżej."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
 "Web servers and domains are examples of digital assets within this "
-"framework. Web servers are essential for hosting and serving websites or web "
-"applications, while domains represent the online addresses used to access "
-"these resources. Other examples of assets in the IT realm include databases, "
-"user accounts, software applications, and networking infrastructure. Asset "
+"framework. Web servers are essential for hosting and serving websites or web"
+" applications, while domains represent the online addresses used to access "
+"these resources. Other examples of assets in the IT realm include databases,"
+" user accounts, software applications, and networking infrastructure. Asset "
 "management is a critical aspect of cybersecurity, involving the "
 "identification, classification, and protection of these assets to safeguard "
 "against threats and ensure the overall security and functionality of an "
 "organization's IT environment."
 msgstr ""
+"Serwery internetowe i domeny są przykładami zasobów cyfrowych w tym "
+"kontekście. Serwery internetowe są niezbędne do hostingu i obsługi witryn "
+"internetowych lub aplikacji internetowych, natomiast domeny reprezentują "
+"adresy internetowe używane w celu uzyskania dostępu do tych zasobów. Inne "
+"przykłady zasobów w dziedzinie IT obejmują bazy danych, konta użytkowników, "
+"aplikacje i infrastrukturę sieciową. Zarządzanie aktywami to krytyczny "
+"aspekt cyberbezpieczeństwa, obejmujący identyfikację, klasyfikację i ochronę"
+" tych aktywów w celu ochrony przed zagrożeniami oraz zapewnienia ogólnego "
+"bezpieczeństwa i funkcjonalności środowiska IT organizacji."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
@@ -3009,13 +3295,20 @@ msgid ""
 "hostnames or the IP address has a declared scan level that is at least L1. "
 "Type systems are web servers, mail servers and name servers (DNS)."
 msgstr ""
+"Wiele nazw hostów, które odpowiadają jednemu adresowi IP, gdzie co najmniej "
+"jedna z nazw hostów lub adres IP ma zadeklarowany poziom skanowania co "
+"najmniej L1. Systemy typu to serwery WWW, serwery pocztowe i serwery nazw "
+"(DNS)."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
 "A fundamental component of the client-server model. A web server uses "
-"protocols like HTTP or HTTPS to facilitate communication between clients and "
-"the server."
+"protocols like HTTP or HTTPS to facilitate communication between clients and"
+" the server."
 msgstr ""
+"Podstawowy element modelu klient-serwer. Serwer WWW korzysta z protokołów "
+"takich jak HTTP lub HTTPS, aby ułatwić komunikację między klientami a "
+"serwerem."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
@@ -3029,16 +3322,32 @@ msgid ""
 "emails, handling tasks such as authentication, spam filtering, and message "
 "storage."
 msgstr ""
+"Serwer pocztowy to wyspecjalizowana aplikacja lub urządzenie sprzętowe, "
+"które ułatwia wysyłanie, odbieranie i przechowywanie wiadomości e-mail w "
+"sieci komputerowej. Działając w oparciu o protokół Simple Mail Transfer "
+"Protocol (SMTP) dla wiadomości wychodzących oraz protokół Internet Message "
+"Access Protocol (IMAP) lub Post Office Protocol (POP) dla wiadomości "
+"przychodzących, serwer pocztowy zarządza komunikacją e-mail, kierując "
+"wiadomości między użytkownikami i przechowując je do czasu ich pobrania. "
+"Serwer zapewnia sprawny i bezpieczny transfer poczty elektronicznej, "
+"obsługując takie zadania jak uwierzytelnianie, filtrowanie spamu i "
+"przechowywanie wiadomości."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
-"A nameserver, or Domain Name System (DNS) server, is a critical component of "
-"the internet infrastructure responsible for translating human-readable "
-"domain names into IP addresses, enabling the seamless navigation of the web. "
-"When a user enters a domain name in a web browser, the nameserver is queried "
-"to obtain the corresponding IP address of the server hosting the associated "
-"website or service."
+"A nameserver, or Domain Name System (DNS) server, is a critical component of"
+" the internet infrastructure responsible for translating human-readable "
+"domain names into IP addresses, enabling the seamless navigation of the web."
+" When a user enters a domain name in a web browser, the nameserver is "
+"queried to obtain the corresponding IP address of the server hosting the "
+"associated website or service."
 msgstr ""
+"Serwer nazw, czyli serwer systemu nazw domen (DNS), to krytyczny element "
+"infrastruktury internetowej odpowiedzialny za tłumaczenie czytelnych dla "
+"człowieka nazw domen na adresy IP, umożliwiających płynną nawigację w sieci."
+" Gdy użytkownik wprowadza nazwę domeny w przeglądarce internetowej, serwer "
+"nazw jest proszony o uzyskanie odpowiedniego adresu IP serwera hostującego "
+"powiązaną witrynę lub usługę."
 
 #: reports/report_types/aggregate_organisation_report/term_overview.html
 msgid ""
@@ -3053,15 +3362,26 @@ msgid ""
 "medical images, like X-rays, CT scans, and MRIs, utilizing a standardized "
 "format."
 msgstr ""
+"Serwer DICOM, czyli Digital Imaging and Communications in Medicine, to "
+"wyspecjalizowany serwer przeznaczony do przechowywania, wyszukiwania i "
+"wymiany obrazów medycznych i powiązanych informacji w branży opieki "
+"zdrowotnej. DICOM to powszechnie przyjęty standard zapewniający "
+"interoperacyjność i spójność w przesyłaniu obrazów medycznych i powiązanych "
+"danych pomiędzy różnymi urządzeniami i systemami, takimi jak sprzęt do "
+"obrazowania medycznego, systemy archiwizacji i komunikacji obrazów (PACS) "
+"oraz systemy informacji radiologicznej (RIS). Serwery DICOM przechowują i "
+"zarządzają obrazami medycznymi specyficznymi dla pacjenta, takimi jak "
+"zdjęcia rentgenowskie, tomografia komputerowa i rezonans magnetyczny, "
+"wykorzystując ustandaryzowany format."
 
 #: reports/report_types/aggregate_organisation_report/vulnerabilities.html
 #: reports/report_types/multi_organization_report/vulnerabilities.html
 msgid "No CVEs have been found."
-msgstr ""
+msgstr "Nie znaleziono żadnych CVE."
 
 #: reports/report_types/dns_report/report.html
 msgid "Records found"
-msgstr ""
+msgstr "Znaleziono zapisy"
 
 #: reports/report_types/dns_report/report.html
 msgid ""
@@ -3069,42 +3389,50 @@ msgid ""
 "DNSZone. Additionally the security measures table shows whether or not DNS "
 "relating security measures are enabled."
 msgstr ""
+"Raport DNS zawiera przegląd rekordów DNS znalezionych dla strefy DNSZone. "
+"Dodatkowo tabela środków bezpieczeństwa pokazuje, czy włączone są środki "
+"bezpieczeństwa powiązane z DNS."
 
 #: reports/report_types/dns_report/report.html
 msgid ""
 "<strong>Disclaimer:</strong> Not all DNSRecords are parsed in OpenKAT. DNS "
 "record types that are parsed and could be displayed in the table are:"
 msgstr ""
+"<strong>Zastrzeżenie:</strong> Nie wszystkie rekordy DNS są analizowane w "
+"OpenKAT. Typy rekordów DNS, które są analizowane i które można wyświetlić w "
+"tabeli, to:"
 
 #: reports/report_types/dns_report/report.html
 msgid "All existing DNS record types can be found here:"
-msgstr ""
+msgstr "Wszystkie istniejące typy rekordów DNS można znaleźć tutaj:"
 
 #: reports/report_types/dns_report/report.html
 msgid "Record"
-msgstr ""
+msgstr "Nagrywać"
 
 #: reports/report_types/dns_report/report.html
 msgid "TTL"
-msgstr ""
+msgstr "TTL"
 
 #: reports/report_types/dns_report/report.html
 msgid "Data"
-msgstr ""
+msgstr "Dane"
 
 #: reports/report_types/dns_report/report.html
 msgid "No records have been found."
-msgstr ""
+msgstr "Nie znaleziono żadnych zapisów."
 
 #: reports/report_types/dns_report/report.html
 msgid "Security measures"
-msgstr ""
+msgstr "Środki bezpieczeństwa"
 
 #: reports/report_types/dns_report/report.html
 msgid ""
-"The security measures table below shows which DNS relating security measures "
-"are enabled based on the contents of the DNS records."
+"The security measures table below shows which DNS relating security measures"
+" are enabled based on the contents of the DNS records."
 msgstr ""
+"Poniższa tabela środków bezpieczeństwa pokazuje, które środki bezpieczeństwa"
+" związane z DNS są włączone w oparciu o zawartość rekordów DNS."
 
 #: reports/report_types/dns_report/report.html
 #: reports/templates/partials/report_ooi_list.html
@@ -3117,48 +3445,52 @@ msgstr ""
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 #: rocky/views/mixins.py
 msgid "Type"
-msgstr ""
+msgstr "Typ"
 
 #: reports/report_types/dns_report/report.html
 msgid "Yes"
-msgstr ""
+msgstr "Tak"
 
 #: reports/report_types/dns_report/report.html
 msgid "No"
-msgstr ""
+msgstr "NIE"
 
 #: reports/report_types/dns_report/report.html
 #: reports/templates/partials/report_findings_table.html
 msgid "Other findings found"
-msgstr ""
+msgstr "Znaleziono inne ustalenia"
 
 #: reports/report_types/dns_report/report.html
 msgid "Findings information"
-msgstr ""
+msgstr "Informacje o wynikach"
 
 #: reports/report_types/dns_report/report.py
 msgid "DNS Report"
-msgstr ""
+msgstr "Raport DNS"
 
 #: reports/report_types/dns_report/report.py
 msgid ""
 "DNS reports focus on domain name system configuration and potential "
 "weaknesses."
 msgstr ""
+"Raporty DNS koncentrują się na konfiguracji systemu nazw domen i "
+"potencjalnych słabych stronach."
 
 #: reports/report_types/findings_report/report.html
 msgid ""
 "The Findings Report contains information about the findings that have been "
 "identified for the selected asset and organization."
 msgstr ""
+"Raport ustaleń zawiera informacje o ustaleniach zidentyfikowanych dla "
+"wybranego zasobu i organizacji."
 
 #: reports/report_types/findings_report/report.py
 msgid "Findings Report"
-msgstr ""
+msgstr "Raport z ustaleń"
 
 #: reports/report_types/findings_report/report.py
 msgid "Shows all the finding types and their occurrences."
-msgstr ""
+msgstr "Pokazuje wszystkie typy wyników i ich wystąpienia."
 
 #: reports/report_types/ipv6_report/report.html
 msgid ""
@@ -3167,204 +3499,225 @@ msgid ""
 "over IPv6 or not. A green compliance check is shown if this is the case. A "
 "grey compliance cross is shown if no IPv6 address was detected."
 msgstr ""
+"Raport IPv6 zawiera przegląd bieżącego stanu protokołu IPv6 "
+"zidentyfikowanego systemu. Poniższa tabela pokazuje, czy domena jest "
+"osiągalna poprzez IPv6, czy nie. W takim przypadku wyświetlana jest zielona "
+"kontrola zgodności. Jeśli nie wykryto adresu IPv6, wyświetlany jest szary "
+"krzyżyk zgodności."
 
 #: reports/report_types/ipv6_report/report.html
 msgid "IPv6 overview"
-msgstr ""
+msgstr "Omówienie protokołu IPv6"
 
 #: reports/report_types/ipv6_report/report.html
 #: reports/report_types/systems_report/report.html
 msgid "Domain"
-msgstr ""
+msgstr "Domena"
 
 #: reports/report_types/ipv6_report/report.py
 msgid "IPv6 Report"
-msgstr ""
+msgstr "Raport IPv6"
 
 #: reports/report_types/ipv6_report/report.py
 msgid "Check whether hostnames point to IPv6 addresses."
-msgstr ""
+msgstr "Sprawdź, czy nazwy hostów wskazują adresy IPv6."
 
 #: reports/report_types/mail_report/report.html
 msgid ""
 "The Mail Report provides an overview of the compliance checks associated "
 "with email servers. The current compliance checks the presence of SPF, DKIM "
 "and DMARC records. The table below shows for each of these checks how many "
-"of the identified mail servers are compliant, and if applicable a compliance "
-"issue description and risk level. The risk level may be different for your "
+"of the identified mail servers are compliant, and if applicable a compliance"
+" issue description and risk level. The risk level may be different for your "
 "specific environment."
 msgstr ""
+"Raport poczty zawiera przegląd kontroli zgodności związanych z serwerami "
+"poczty e-mail. Aktualna zgodność sprawdza obecność rekordów SPF, DKIM i "
+"DMARC. Poniższa tabela pokazuje dla każdej z tych kontroli, ile "
+"zidentyfikowanych serwerów pocztowych jest zgodnych oraz, jeśli ma to "
+"zastosowanie, opis problemu związanego ze zgodnością i poziom ryzyka. Poziom"
+" ryzyka może być inny w zależności od konkretnego środowiska."
 
 #: reports/report_types/mail_report/report.html
 msgid "Mailserver compliance"
-msgstr ""
+msgstr "Zgodność serwera pocztowego"
 
 #: reports/report_types/mail_report/report.html
 msgid "mailservers compliant"
-msgstr ""
+msgstr "zgodne z serwerami pocztowymi"
 
 #: reports/report_types/mail_report/report.html
 msgid "No mailservers have been found on this system."
-msgstr ""
+msgstr "W tym systemie nie znaleziono żadnych serwerów pocztowych."
 
 #: reports/report_types/mail_report/report.py
 msgid "Mail Report"
-msgstr ""
+msgstr "Raport pocztowy"
 
 #: reports/report_types/mail_report/report.py
 msgid ""
 "System specific Mail Report that focusses on IP addresses and hostnames."
 msgstr ""
+"Raport pocztowy specyficzny dla systemu, który koncentruje się na adresach "
+"IP i nazwach hostów."
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Overview of included assets"
-msgstr ""
+msgstr "Przegląd uwzględnionych zasobów"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Asset"
-msgstr ""
+msgstr "Zaleta"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 #: reports/report_types/multi_organization_report/basic_security_details.html
 msgid "Amount"
-msgstr ""
+msgstr "Kwota"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "IP addresses"
-msgstr ""
+msgstr "Adresy IP"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Domain names"
-msgstr ""
+msgstr "Nazwy domen"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Assets with most critical vulnerabilities"
-msgstr ""
+msgstr "Zasoby z najbardziej krytycznymi lukami w zabezpieczeniach"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Vulnerability"
-msgstr ""
+msgstr "Wrażliwość"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "Organisation"
-msgstr ""
+msgstr "Organizacja"
 
 #: reports/report_types/multi_organization_report/asset_overview.html
 msgid "No vulnerabilities found."
-msgstr ""
+msgstr "Nie znaleziono żadnych luk."
 
 #: reports/report_types/multi_organization_report/basic_security_details.html
 msgid "Overview of safe connections"
-msgstr ""
+msgstr "Przegląd bezpiecznych połączeń"
 
 #: reports/report_types/multi_organization_report/basic_security_details.html
 #: reports/report_types/safe_connections_report/report.html
 msgid "Only Safe Ciphers"
-msgstr ""
+msgstr "Tylko bezpieczne szyfry"
 
 #: reports/report_types/multi_organization_report/basic_security_details.html
 #: reports/report_types/safe_connections_report/report.html
 msgid "services are compliant"
-msgstr ""
+msgstr "usługi są zgodne"
 
 #: reports/report_types/multi_organization_report/basic_security_details.html
 msgid "System specific checks"
-msgstr ""
+msgstr "Kontrole specyficzne dla systemu"
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid "IPv6"
-msgstr ""
+msgstr "IPv6"
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid ""
-"IPv6 includes improvements in security features compared to IPv4. While IPv4 "
-"can implement security measures, IPv6 was designed with security in mind, "
+"IPv6 includes improvements in security features compared to IPv4. While IPv4"
+" can implement security measures, IPv6 was designed with security in mind, "
 "and its adoption can contribute to a more secure internet."
 msgstr ""
+"IPv6 zawiera ulepszenia funkcji bezpieczeństwa w porównaniu do IPv4. Chociaż"
+" protokół IPv4 może wdrożyć środki bezpieczeństwa, protokół IPv6 został "
+"zaprojektowany z myślą o bezpieczeństwie, a jego przyjęcie może przyczynić "
+"się do bezpieczniejszego Internetu."
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid "In total "
-msgstr ""
+msgstr "W sumie"
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid " out of "
-msgstr ""
+msgstr "z"
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid " systems have an IPv6 connection."
-msgstr ""
+msgstr "systemy mają połączenie IPv6."
 
 #: reports/report_types/multi_organization_report/ipv6.html
 msgid "Overview of IP version compliance"
-msgstr ""
+msgstr "Przegląd zgodności wersji protokołu IP"
 
 #: reports/report_types/multi_organization_report/open_ports.html
 msgid ""
 "See an overview of open ports found over all systems and the services these "
 "systems provide."
 msgstr ""
+"Zobacz przegląd otwartych portów znalezionych we wszystkich systemach i "
+"usługach świadczonych przez te systemy."
 
 #: reports/report_types/multi_organization_report/open_ports.html
 msgid "Overview of detected open ports"
-msgstr ""
+msgstr "Przegląd wykrytych otwartych portów"
 
 #: reports/report_types/multi_organization_report/open_ports.html
 #: reports/report_types/open_ports_report/report.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Open ports"
-msgstr ""
+msgstr "Otwórz porty"
 
 #: reports/report_types/multi_organization_report/open_ports.html
 msgid "Occurrences (IP addresses)"
-msgstr ""
+msgstr "Zdarzenia (adresy IP)"
 
 #: reports/report_types/multi_organization_report/open_ports.html
 #: reports/templates/summary/service_health.html
 msgid "Services"
-msgstr ""
+msgstr "Usługi"
 
 #: reports/report_types/multi_organization_report/open_ports.html
 msgid "No open ports found."
-msgstr ""
+msgstr "Nie znaleziono otwartych portów."
 
 #: reports/report_types/multi_organization_report/recommendations.html
 msgid "Overview of recommendations"
-msgstr ""
+msgstr "Przegląd zaleceń"
 
 #: reports/report_types/multi_organization_report/recommendations.html
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "Occurrence"
-msgstr ""
+msgstr "Występowanie"
 
 #: reports/report_types/multi_organization_report/report.html
 msgid "No findings have been identified yet."
-msgstr ""
+msgstr "Nie zidentyfikowano jeszcze żadnych ustaleń."
 
 #: reports/report_types/multi_organization_report/report.py
 msgid "Multi Organization Report"
-msgstr ""
+msgstr "Raport wielu organizacji"
 
 #: reports/report_types/multi_organization_report/summary.html
 msgid "Best scoring security check"
-msgstr ""
+msgstr "Najlepsza kontrola bezpieczeństwa punktacji"
 
 #: reports/report_types/multi_organization_report/summary.html
 msgid "Worst scoring security check"
-msgstr ""
+msgstr "Najgorsza kontrola bezpieczeństwa punktacji"
 
 #: reports/report_types/multi_organization_report/vulnerabilities.html
 msgid ""
 "Vulnerabilities found are grouped per system. Here, we only consider CVE "
 "vulnerabilities."
 msgstr ""
+"Wykryte luki są pogrupowane według systemów. W tym miejscu rozważamy jedynie"
+" luki w zabezpieczeniach CVE."
 
 #: reports/report_types/multi_organization_report/vulnerabilities.html
 msgid "Vulnerabilities grouped per system"
-msgstr ""
+msgstr "Luki pogrupowane według systemu"
 
 #: reports/report_types/multi_organization_report/vulnerabilities.html
 msgid "total"
-msgstr ""
+msgstr "całkowity"
 
 #: reports/report_types/name_server_report/report.html
 msgid ""
@@ -3377,73 +3730,89 @@ msgid ""
 "identified are shown too. The risk level may be different for your specific "
 "environment."
 msgstr ""
+"Raport serwera nazw zawiera przegląd kontroli zgodności przeprowadzonych w "
+"odniesieniu do zidentyfikowanych serwerów nazw domen (DNS). Kontrole "
+"zgodności sprawdzają obecność i ważność DNSSEC oraz to, czy nie "
+"zidentyfikowano żadnych niepotrzebnych portów jako otwartych. Poniższa "
+"tabela zawiera przegląd dostępnych kontroli, w tym to, czy system przeszedł "
+"pomyślnie przeprowadzone kontrole. Pokazano także poziom ryzyka i "
+"uzasadnienie zidentyfikowania problemu. Poziom ryzyka może być inny w "
+"zależności od konkretnego środowiska."
 
 #: reports/report_types/name_server_report/report.html
 msgid "Name server compliance"
-msgstr ""
+msgstr "Zgodność serwera nazw"
 
 #: reports/report_types/name_server_report/report.html
 msgid "DNSSEC Present"
-msgstr ""
+msgstr "DNSSEC Obecny"
 
 #: reports/report_types/name_server_report/report.html
 msgid "name servers compliant"
-msgstr ""
+msgstr "zgodne z serwerami nazw"
 
 #: reports/report_types/name_server_report/report.html
 msgid "Valid DNSSEC"
-msgstr ""
+msgstr "Obowiązuje DNSSEC"
 
 #: reports/report_types/name_server_report/report.html
 #: reports/report_types/web_system_report/report.html
 msgid "No unnecessary ports open"
-msgstr ""
+msgstr "Żadne niepotrzebne porty nie są otwarte"
 
 #: reports/report_types/name_server_report/report.html
 msgid "No nameservers have been found on this system."
-msgstr ""
+msgstr "W tym systemie nie znaleziono żadnych serwerów nazw."
 
 #: reports/report_types/name_server_report/report.py
 msgid "Name Server Report"
-msgstr ""
+msgstr "Raport serwera nazw"
 
 #: reports/report_types/name_server_report/report.py
 msgid "Name Server Report checks name servers on basic security standards."
 msgstr ""
+"Raport serwera nazw sprawdza serwery nazw pod kątem podstawowych standardów "
+"bezpieczeństwa."
 
 #: reports/report_types/open_ports_report/report.html
 msgid ""
-"The Open Ports Report provides an overview of the open ports identified on a "
-"system. The ports that are marked as <b>bold</b> were identified by direct "
-"scans performed by OpenKAT (such as nmap). Ports that are not marked in bold "
-"were identified through external services and/or scans (such as Shodan). "
+"The Open Ports Report provides an overview of the open ports identified on a"
+" system. The ports that are marked as <b>bold</b> were identified by direct "
+"scans performed by OpenKAT (such as nmap). Ports that are not marked in bold"
+" were identified through external services and/or scans (such as Shodan). "
 "Scans with the same hostnames, ports and IPs are merged."
 msgstr ""
+"Raport otwartych portów zawiera przegląd otwartych portów zidentyfikowanych "
+"w systemie. Porty oznaczone jako <b>bold</b> zostały zidentyfikowane poprzez"
+" bezpośrednie skanowanie wykonane przez OpenKAT (takie jak nmap). Porty, "
+"które nie są zaznaczone pogrubioną czcionką, zostały zidentyfikowane za "
+"pomocą usług zewnętrznych i/lub skanów (takich jak Shodan). Skanowania z "
+"tymi samymi nazwami hostów, portami i adresami IP są łączone."
 
 #: reports/report_types/open_ports_report/report.html
 msgid "Overview of open ports found for the scanned assets"
-msgstr ""
+msgstr "Przegląd otwartych portów znalezionych dla zeskanowanych zasobów"
 
 #: reports/report_types/open_ports_report/report.html
 #: reports/report_types/systems_report/report.html
 msgid "IP address"
-msgstr ""
+msgstr "Adres IP"
 
 #: reports/report_types/open_ports_report/report.html
 msgid "Hostnames"
-msgstr ""
+msgstr "Nazwy hostów"
 
 #: reports/report_types/open_ports_report/report.html
 msgid "Direct scan"
-msgstr ""
+msgstr "Bezpośrednie skanowanie"
 
 #: reports/report_types/open_ports_report/report.py
 msgid "Open Ports Report"
-msgstr ""
+msgstr "Otwórz raport portów"
 
 #: reports/report_types/open_ports_report/report.py
 msgid "Find open ports of IP addresses"
-msgstr ""
+msgstr "Znajdź otwarte porty adresów IP"
 
 #: reports/report_types/rpki_report/report.html
 msgid ""
@@ -3453,167 +3822,197 @@ msgid ""
 "misconfigurations and malicious route intercepts through verified route "
 "announcements, ensuring reliable server access and secure internet traffic."
 msgstr ""
+"Ta sekcja zawiera podstawowe informacje dotyczące bezpieczeństwa dotyczące "
+"infrastruktury klucza publicznego zasobów (RPKI). Jeśli Twój serwer WWW "
+"wykorzystuje RPKI dla swoich adresów IP i powiązanych serwerów nazw, wówczas"
+" zwiększa on ochronę odwiedzających przed błędnymi konfiguracjami i "
+"złośliwym przechwytywaniem tras poprzez zweryfikowane ogłoszenia o trasach, "
+"zapewniając niezawodny dostęp do serwera i bezpieczny ruch internetowy."
 
 #: reports/report_types/rpki_report/report.html
 msgid ""
 "The RPKI Report shows if an RPKI route announcement was available for the "
 "system and if this announcement is not expired."
 msgstr ""
+"Raport RPKI pokazuje, czy ogłoszenie trasy RPKI było dostępne dla systemu i "
+"czy to ogłoszenie nie wygasło."
 
 #: reports/report_types/rpki_report/report.html
 msgid "RPKI compliance"
-msgstr ""
+msgstr "Zgodność z RPKI"
 
 #: reports/report_types/rpki_report/report.html
 msgid "RPKI Available"
-msgstr ""
+msgstr "Dostępny RPKI"
 
 #: reports/report_types/rpki_report/report.html
 msgid "RPKI valid"
-msgstr ""
+msgstr "RPKI ważny"
 
 #: reports/report_types/rpki_report/report.html
 msgid "RPKI record is not valid."
-msgstr ""
+msgstr "Rekord RPKI jest nieprawidłowy."
 
 #: reports/report_types/rpki_report/report.html
 msgid "RPKI record does not exist."
-msgstr ""
+msgstr "Rekord RPKI nie istnieje."
 
 #: reports/report_types/rpki_report/report.html
 #: reports/report_types/safe_connections_report/report.html
 msgid "No IPs have been found on this system."
-msgstr ""
+msgstr "W tym systemie nie znaleziono żadnych adresów IP."
 
 #: reports/report_types/rpki_report/report.py
 msgid "RPKI Report"
-msgstr ""
+msgstr "Raport RPKI"
 
 #: reports/report_types/rpki_report/report.py
 msgid ""
-"Shows whether the IP is covered by a valid RPKI ROA. For a hostname it shows "
-"the IP addresses and whether they are covered by a valid RPKI ROA."
+"Shows whether the IP is covered by a valid RPKI ROA. For a hostname it shows"
+" the IP addresses and whether they are covered by a valid RPKI ROA."
 msgstr ""
+"Pokazuje, czy adres IP jest objęty ważnym RPKI ROA. W przypadku nazwy hosta "
+"pokazuje adresy IP i to, czy są one objęte prawidłowym RPKI ROA."
 
 #: reports/report_types/safe_connections_report/report.html
 msgid ""
 "The Safe Connections report provides an overview of the performed checks "
 "with regard to encrypted communication channels such as HTTPS. The table "
-"below gives an overview of the available checks including whether the system "
-"passed the performed checks. The risk level and reasoning as to why an issue "
-"was identified are shown too. The risk level may be different for your "
-"specific environment."
+"below gives an overview of the available checks including whether the system"
+" passed the performed checks. The risk level and reasoning as to why an "
+"issue was identified are shown too. The risk level may be different for your"
+" specific environment."
 msgstr ""
+"Raport Bezpieczne połączenia zawiera przegląd przeprowadzonych kontroli w "
+"odniesieniu do szyfrowanych kanałów komunikacji, takich jak HTTPS. Poniższa "
+"tabela zawiera przegląd dostępnych kontroli, w tym to, czy system przeszedł "
+"pomyślnie przeprowadzone kontrole. Pokazano także poziom ryzyka i "
+"uzasadnienie zidentyfikowania problemu. Poziom ryzyka może być inny w "
+"zależności od konkretnego środowiska."
 
 #: reports/report_types/safe_connections_report/report.html
 msgid "Safe connections compliance"
-msgstr ""
+msgstr "Zgodność z bezpiecznymi połączeniami"
 
 #: reports/report_types/safe_connections_report/report.py
 msgid "Safe Connections Report"
-msgstr ""
+msgstr "Raport bezpiecznych połączeń"
 
 #: reports/report_types/safe_connections_report/report.py
 msgid "Shows whether the IPService contains safe ciphers."
-msgstr ""
+msgstr "Pokazuje, czy usługa IPService zawiera bezpieczne szyfry."
 
 #: reports/report_types/systems_report/report.html
 msgid ""
-"The System Report provides an overview of the system types (types of similar "
-"services) that were identified for each system. The following system types "
+"The System Report provides an overview of the system types (types of similar"
+" services) that were identified for each system. The following system types "
 "can be identified: DNS servers, Web servers, Mail servers and those "
 "classified as 'Other' servers. Each hostname and/or IP address is given one "
 "or more system types depending on the identified ports and services. The "
 "table below gives an overview of these results."
 msgstr ""
+"Raport systemowy zawiera przegląd typów systemów (rodzajów podobnych usług) "
+"zidentyfikowanych dla każdego systemu. Można zidentyfikować następujące typy"
+" systemów: serwery DNS, serwery WWW, serwery pocztowe i serwery "
+"sklasyfikowane jako „Inne”. Każdej nazwie hosta i/lub adresowi IP przypisany"
+" jest jeden lub więcej typów systemów, w zależności od zidentyfikowanych "
+"portów i usług. Poniższa tabela zawiera przegląd tych wyników."
 
 #: reports/report_types/systems_report/report.html
 msgid "Selected assets"
-msgstr ""
+msgstr "Wybrane aktywa"
 
 #: reports/report_types/systems_report/report.html
 msgid "No system types have been identified on this system."
-msgstr ""
+msgstr "W tym systemie nie zidentyfikowano żadnych typów systemów."
 
 #: reports/report_types/systems_report/report.py
 msgid "System Report"
-msgstr ""
+msgstr "Raport systemowy"
 
 #: reports/report_types/systems_report/report.py
 msgid "Combine IP addresses, hostnames and services into systems."
-msgstr ""
+msgstr "Łącz adresy IP, nazwy hostów i usługi w systemy."
 
 #: reports/report_types/tls_report/report.html
 msgid ""
 "The TLS Report shows which TLS protocols and ciphers were identified on the "
 "host for the provided port."
 msgstr ""
+"Raport TLS pokazuje, które protokoły i szyfry TLS zostały zidentyfikowane na"
+" hoście dla podanego portu."
 
 #: reports/report_types/tls_report/report.html
 msgid ""
 "The table below provides an overview of the identified TLS protocols and "
 "ciphers, including a status suggestion."
 msgstr ""
+"Poniższa tabela zawiera przegląd zidentyfikowanych protokołów i szyfrów TLS,"
+" w tym sugestię statusu."
 
 #: reports/report_types/tls_report/report.html
 msgid "Ciphers"
-msgstr ""
+msgstr "Szyfry"
 
 #: reports/report_types/tls_report/report.html
 msgid "Protocol"
-msgstr ""
+msgstr "Protokół"
 
 #: reports/report_types/tls_report/report.html
 msgid "Encryption Algorithm"
-msgstr ""
+msgstr "Algorytm szyfrowania"
 
 #: reports/report_types/tls_report/report.html
 msgid "Bits"
-msgstr ""
+msgstr "Bity"
 
 #: reports/report_types/tls_report/report.html
 msgid "Key Size"
-msgstr ""
+msgstr "Rozmiar klucza"
 
 #: reports/report_types/tls_report/report.html
 #: rocky/templates/organizations/organization_list.html
 #: rocky/templates/organizations/organization_settings.html
 msgid "Code"
-msgstr ""
+msgstr "Kod"
 
 #: reports/report_types/tls_report/report.html
 msgid "Phase out"
-msgstr ""
+msgstr "Wycofanie się"
 
 #: reports/report_types/tls_report/report.html
 msgid "Good"
-msgstr ""
+msgstr "Dobry"
 
 #: reports/report_types/tls_report/report.html
 msgid ""
 "No ciphers were found for this combination of IP address, port and service."
-msgstr ""
+msgstr "Nie znaleziono szyfrów dla tej kombinacji adresu IP, portu i usługi."
 
 #: reports/report_types/tls_report/report.html
 msgid ""
-"The list below gives an overview of the findings based on the identified TLS "
-"protocols and ciphers. This includes the reasoning why the cipher or "
+"The list below gives an overview of the findings based on the identified TLS"
+" protocols and ciphers. This includes the reasoning why the cipher or "
 "protocol is marked as a finding."
 msgstr ""
+"Poniższa lista zawiera przegląd ustaleń na podstawie zidentyfikowanych "
+"protokołów i szyfrów TLS. Obejmuje to uzasadnienie, dlaczego szyfr lub "
+"protokół jest oznaczony jako wynik."
 
 #: reports/report_types/tls_report/report.py
 msgid "TLS Report"
-msgstr ""
+msgstr "Raport TLS"
 
 #: reports/report_types/tls_report/report.py
 msgid ""
 "TLS Report assesses the security of data encryption and transmission "
 "protocols."
 msgstr ""
+"Raport TLS ocenia bezpieczeństwo protokołów szyfrowania i transmisji danych."
 
 #: reports/report_types/vulnerability_report/report.html
 msgid "No vulnerabilities have been found on this system."
-msgstr ""
+msgstr "W tym systemie nie znaleziono żadnych luk."
 
 #: reports/report_types/vulnerability_report/report.html
 msgid ""
@@ -3622,302 +4021,344 @@ msgid ""
 "the table shows the CVE scoring, the number of occurrences, and the CVE "
 "details."
 msgstr ""
+"Raport o lukach zawiera przegląd wszystkich zidentyfikowanych luk w "
+"zabezpieczeniach CVE, które zostały zidentyfikowane w wybranych systemach. "
+"Dla każdego CVE tabela pokazuje punktację CVE, liczbę wystąpień i szczegóły "
+"CVE."
 
 #: reports/report_types/vulnerability_report/report.html
 msgid "vulnerabilities on this system"
-msgstr ""
+msgstr "luk w tym systemie"
 
 #: reports/report_types/vulnerability_report/report.html
 msgid "Advice"
-msgstr ""
+msgstr "Rada"
 
 #: reports/report_types/vulnerability_report/report.py
 msgid "Vulnerability Report"
-msgstr ""
+msgstr "Raport o lukach w zabezpieczeniach"
 
 #: reports/report_types/vulnerability_report/report.py
 msgid "Vulnerabilities found are grouped for each system."
-msgstr ""
+msgstr "Wykryte luki są pogrupowane dla każdego systemu."
 
 #: reports/report_types/vulnerability_report/report.py
 msgid "First seen"
-msgstr ""
+msgstr "Pierwszy raz widziany"
 
 #: reports/report_types/vulnerability_report/report.py
 msgid "Last seen"
-msgstr ""
+msgstr "Ostatnio widziany"
 
 #: reports/report_types/vulnerability_report/report.py
 msgid "Evidence"
-msgstr ""
+msgstr "Dowód"
 
 #: reports/report_types/web_system_report/report.html
 msgid ""
-"The Web System Report provides an overview of various web server checks that "
-"were performed against the scanned system(s). For each performed check the "
+"The Web System Report provides an overview of various web server checks that"
+" were performed against the scanned system(s). For each performed check the "
 "table below shows whether or not the server is compliant with the checks. A "
 "description of why this compliant check failed is also shown, including an "
 "general risk level. The risk level may be different for your specific "
 "environment."
 msgstr ""
+"Raport systemu sieciowego zawiera przegląd różnych kontroli serwera "
+"sieciowego przeprowadzonych w odniesieniu do przeskanowanych systemów. Dla "
+"każdej przeprowadzonej kontroli poniższa tabela pokazuje, czy serwer spełnia"
+" wymagania kontroli. Wyświetlany jest również opis przyczyny niepowodzenia "
+"kontroli zgodności, w tym ogólny poziom ryzyka. Poziom ryzyka może być inny "
+"w zależności od konkretnego środowiska."
 
 #: reports/report_types/web_system_report/report.html
 msgid "Web system compliance"
-msgstr ""
+msgstr "Zgodność systemu internetowego"
 
 #: reports/report_types/web_system_report/report.html
 msgid "CSP Present"
-msgstr ""
+msgstr "CSP Obecny"
 
 #: reports/report_types/web_system_report/report.html
 msgid "webservers compliant"
-msgstr ""
+msgstr "zgodne z serwerami internetowymi"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Secure CSP Header"
-msgstr ""
+msgstr "Zabezpiecz nagłówek CSP"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Redirects HTTP to HTTPS"
-msgstr ""
+msgstr "Przekierowuje HTTP do HTTPS"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Offers HTTPS"
-msgstr ""
+msgstr "Oferuje HTTPS"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Has a Security.txt"
-msgstr ""
+msgstr "Zawiera plik Security.txt"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Has a certificate"
-msgstr ""
+msgstr "Posiada certyfikat"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Certificate is valid"
-msgstr ""
+msgstr "Certyfikat jest ważny"
 
 #: reports/report_types/web_system_report/report.html
 msgid "Certificate is not expiring soon"
-msgstr ""
+msgstr "Certyfikat nie wygasa szybko"
 
 #: reports/report_types/web_system_report/report.html
 msgid "No webservers have been found on this system."
-msgstr ""
+msgstr "W tym systemie nie znaleziono żadnych serwerów internetowych."
 
 #: reports/report_types/web_system_report/report.py
 msgid "Web System Report"
-msgstr ""
+msgstr "Raport dotyczący systemu internetowego"
 
 #: reports/report_types/web_system_report/report.py
 msgid "Web System Reports check web systems on basic security standards."
 msgstr ""
+"Raporty systemu sieciowego sprawdzają systemy sieciowe pod kątem "
+"podstawowych standardów bezpieczeństwa."
 
 #: reports/templates/partials/export_report_settings.html
 msgid "Report schedule"
-msgstr ""
+msgstr "Harmonogram raportów"
 
 #: reports/templates/partials/export_report_settings.html
 msgid ""
 "When scheduling your report, you have two options. You can either choose to "
 "generate it just once now, or set it to run automatically at regular "
-"intervals, like daily, weekly, or monthly. If you need the report just for a "
-"single occasion, select the one-time option."
+"intervals, like daily, weekly, or monthly. If you need the report just for a"
+" single occasion, select the one-time option."
 msgstr ""
+"Planując raport, masz dwie możliwości. Możesz wygenerować go teraz tylko raz"
+" lub ustawić automatyczne uruchamianie w regularnych odstępach czasu, np. "
+"codziennie, co tydzień lub co miesiąc. Jeśli potrzebujesz raportu tylko na "
+"jedną okazję, wybierz opcję jednorazową."
 
 #: reports/templates/partials/export_report_settings.html
 #: reports/templates/report_overview/report_history_table.html
 msgid "Report name"
-msgstr ""
+msgstr "Nazwa raportu"
 
 #: reports/templates/partials/export_report_settings.html
 #, python-format, python-brace-format
 msgid ""
 "When generating reports, it is possible to give the report a name. The name "
-"can be static or dynamic. The default format for a report is '${report_type} "
-"for ${oois_count} objects'. These placeholders automatically adapt based on "
-"the report details. This format could for example return 'Aggregate Report "
+"can be static or dynamic. The default format for a report is '${report_type}"
+" for ${oois_count} objects'. These placeholders automatically adapt based on"
+" the report details. This format could for example return 'Aggregate Report "
 "for 15 objects'. Another placeholder that can be used is '${ooi}', which "
-"will show the name of the object when there is only one object. You can also "
-"customize the name by adding prefixes, suffixes, or other formats like '%%W' "
-"for the week number, using options from <a href=\"https://strftime.org/\" "
-"target=\"_blank\" rel=\"noopener\">Python strftime code</a>."
+"will show the name of the object when there is only one object. You can also"
+" customize the name by adding prefixes, suffixes, or other formats like "
+"'%%W' for the week number, using options from <a "
+"href=\"https://strftime.org/\" target=\"_blank\" rel=\"noopener\">Python "
+"strftime code</a>."
 msgstr ""
+"Podczas generowania raportów istnieje możliwość nadania raportowi nazwy. "
+"Nazwa może być statyczna lub dynamiczna. Domyślny format raportu to "
+"„${report_type} dla obiektów ${oois_count}”. Te symbole zastępcze "
+"dostosowują się automatycznie na podstawie szczegółów raportu. Ten format "
+"może na przykład zwrócić „Raport zbiorczy dla 15 obiektów”. Innym symbolem "
+"zastępczym, którego można użyć, jest „${ooi}”, który pokaże nazwę obiektu, "
+"gdy istnieje tylko jeden obiekt. Możesz także dostosować nazwę, dodając "
+"przedrostki, przyrostki lub inne formaty, takie jak „%%W” dla numeru "
+"tygodnia, korzystając z opcji z <a href=\"https://strftime.org/\" "
+"target=\"_blank\" rel=\"noopener\">Python strftime code</a>."
 
 #: reports/templates/partials/export_report_settings.html
 #: reports/templates/partials/generate_report_header.html
 #: reports/templates/partials/new_report_action_button.html
 #: reports/views/generate_report.py
 msgid "Generate report"
-msgstr ""
+msgstr "Wygeneruj raport"
 
 #: reports/templates/partials/generate_report_header.html
 msgid "To generate an aggregate report, complete the following steps."
-msgstr ""
+msgstr "Aby wygenerować raport zbiorczy, wykonaj następujące kroki."
 
 #: reports/templates/partials/generate_report_header.html
 msgid "To generate a multi report, complete the following steps."
-msgstr ""
+msgstr "Aby wygenerować raport wieloraportowy, wykonaj następujące kroki."
 
 #: reports/templates/partials/generate_report_header.html
 msgid "To generate separate report(s), complete the following steps."
-msgstr ""
+msgstr "Aby wygenerować osobne raporty, wykonaj następujące kroki."
 
 #: reports/templates/partials/generate_report_sidemenu.html
 #: reports/templates/partials/report_sidemenu.html
 msgid "Table of contents"
-msgstr ""
+msgstr "Spis treści"
 
 #: reports/templates/partials/new_report_action_button.html
 msgid "Actions for creating a new report"
-msgstr ""
+msgstr "Działania związane z utworzeniem nowego raportu"
 
 #: reports/templates/partials/new_report_action_button.html
 msgid "Separate report(s)"
-msgstr ""
+msgstr "Oddzielne raporty"
 
 #: reports/templates/partials/new_report_action_button.html
 #: reports/views/aggregate_report.py
 msgid "Aggregate report"
-msgstr ""
+msgstr "Raport zbiorczy"
 
 #: reports/templates/partials/new_report_action_button.html
 #: reports/views/multi_report.py
 msgid "Multi report"
-msgstr ""
+msgstr "Raport wielokrotny"
 
 #: reports/templates/partials/plugin_overview_table.html
 #: reports/templates/partials/report_sidemenu.html
 #: rocky/templates/oois/ooi_page_tabs.html
 msgid "Overview"
-msgstr ""
+msgstr "Przegląd"
 
 #: reports/templates/partials/plugin_overview_table.html
 msgid "Plugin overview table"
-msgstr ""
+msgstr "Tabela przeglądu wtyczek"
 
 #: reports/templates/partials/plugin_overview_table.html
 #: reports/templates/partials/report_setup_scan.html
 msgid "Required plugins"
-msgstr ""
+msgstr "Wymagane wtyczki"
 
 #: reports/templates/partials/plugin_overview_table.html
 #: reports/templates/partials/report_setup_scan.html
 msgid "Suggested plugins"
-msgstr ""
+msgstr "Sugerowane wtyczki"
 
 #: reports/templates/partials/plugin_overview_table.html
 msgid "Action required"
-msgstr ""
+msgstr "Wymagane działanie"
 
 #: reports/templates/partials/plugin_overview_table.html
 msgid "Ready"
-msgstr ""
+msgstr "Gotowy"
 
 #: reports/templates/partials/report_findings_table.html
 msgid ""
 "This table provides an overview of the identified findings on the scanned "
 "systems. For each finding type it shows the risk level, the number of "
 "occurrences and the first known occurrence of the finding. The risk level "
-"may be different for your specific environment. The details can be seen when "
-"expanding a row. A description, the source, impact and recommendation of the "
-"finding can be found here. It also shows in which findings the finding type "
-"occurred."
+"may be different for your specific environment. The details can be seen when"
+" expanding a row. A description, the source, impact and recommendation of "
+"the finding can be found here. It also shows in which findings the finding "
+"type occurred."
 msgstr ""
+"Tabela ta zawiera przegląd ustaleń zidentyfikowanych w przeskanowanych "
+"systemach. Dla każdego typu ustalenia pokazany jest poziom ryzyka, liczba "
+"wystąpień i pierwsze znane wystąpienie ustalenia. Poziom ryzyka może być "
+"inny w zależności od konkretnego środowiska. Szczegóły można zobaczyć "
+"podczas rozwijania wiersza. Opis, źródło, wpływ i zalecenia dotyczące "
+"ustalenia można znaleźć tutaj. Pokazuje także, w jakich ustaleniach wystąpił"
+" dany typ ustalenia."
 
 #: reports/templates/partials/report_findings_table.html
 msgid "First known occurrence"
-msgstr ""
+msgstr "Pierwsze znane zjawisko"
 
 #: reports/templates/partials/report_findings_table.html
 msgid "Open in report"
-msgstr ""
+msgstr "Otwórz w raporcie"
 
 #: reports/templates/partials/report_findings_table.html
 msgid ""
 "No critical and high findings have been identified for this organization."
 msgstr ""
+"W przypadku tej organizacji nie stwierdzono żadnych krytycznych i wysokich "
+"ustaleń."
 
 #: reports/templates/partials/report_findings_table.html
 msgid "No findings have been identified for this organization."
-msgstr ""
+msgstr "Nie stwierdzono żadnych ustaleń w przypadku tej organizacji."
 
 #: reports/templates/partials/report_header.html
 msgid "Download as PDF"
-msgstr ""
+msgstr "Pobierz jako PDF"
 
 #: reports/templates/partials/report_header.html
 #: rocky/templates/partials/ooi_list_toolbar.html
 msgid "Download as JSON"
-msgstr ""
+msgstr "Pobierz jako JSON"
 
 #: reports/templates/partials/report_header.html
 msgid "Open asset reports"
-msgstr ""
+msgstr "Otwórz raporty o zasobach"
 
 #: reports/templates/partials/report_header.html
 msgid "This is the OpenKAT report for organization"
-msgstr ""
+msgstr "To jest raport OpenKAT dla organizacji"
 
 #: reports/templates/partials/report_header.html
 msgid ""
 "All selected report types for the selected objects are displayed one below "
 "the other."
 msgstr ""
+"Wszystkie wybrane typy raportów dla wybranych obiektów są wyświetlane jeden "
+"pod drugim."
 
 #: reports/templates/partials/report_header.html
 msgid "Created with data from:"
-msgstr ""
+msgstr "Utworzono na podstawie danych z:"
 
 #: reports/templates/partials/report_header.html
 msgid "Created on:"
-msgstr ""
+msgstr "Utworzono:"
 
 #: reports/templates/partials/report_header.html
 msgid "Created from recipe:"
-msgstr ""
+msgstr "Utworzono z przepisu:"
 
 #: reports/templates/partials/report_header.html
 msgid "Recipe created by:"
-msgstr ""
+msgstr "Przepis stworzony przez:"
 
 #: reports/templates/partials/report_header.html
 #, python-format
 msgid "This sector contains %(length)s scanned organizations."
-msgstr ""
+msgstr "Ten sektor zawiera przeskanowane organizacje %(length)s."
 
 #: reports/templates/partials/report_header.html
 msgid "Of these organizations"
-msgstr ""
+msgstr "Z tych organizacji"
 
 #: reports/templates/partials/report_header.html
 msgid "organizations have tag"
-msgstr ""
+msgstr "organizacje mają tag"
 
 #: reports/templates/partials/report_header.html
 msgid "The basic security scores are around "
-msgstr ""
+msgstr "Podstawowe oceny bezpieczeństwa są w pobliżu"
 
 #: reports/templates/partials/report_header.html
 #, python-format
 msgid "A total of %(total)s critical vulnerabilities have been identified."
-msgstr ""
+msgstr "Zidentyfikowano ogółem krytyczne luki w zabezpieczeniach %(total)s."
 
 #: reports/templates/partials/report_introduction.html
 msgid "Introduction"
-msgstr ""
+msgstr "Wstęp"
 
 #: reports/templates/partials/report_introduction.html
 msgid ""
 "This report gives an overview of the current state of security for your "
-"organisation for the selected date. The summary section provides an overview "
-"of the selected systems (objects), plugins and reports. This is followed "
+"organisation for the selected date. The summary section provides an overview"
+" of the selected systems (objects), plugins and reports. This is followed "
 "with the findings for each report."
 msgstr ""
+"Raport ten zawiera przegląd aktualnego stanu bezpieczeństwa Twojej "
+"organizacji w wybranym terminie. Sekcja podsumowująca zawiera przegląd "
+"wybranych systemów (obiektów), wtyczek i raportów. Następnie przedstawiono "
+"ustalenia dotyczące każdego raportu."
 
 #: reports/templates/partials/report_names_form.html
 msgid "Report names:"
-msgstr ""
+msgstr "Nazwy raportów:"
 
 #: reports/templates/partials/report_names_form.html
 #: rocky/templates/forms/widgets/checkbox_group_table.html
@@ -3928,40 +4369,40 @@ msgstr ""
 #: rocky/templates/partials/form/field_input_multiselect.html
 #: rocky/templates/partials/form/field_input_radio.html
 msgid "Required"
-msgstr ""
+msgstr "Wymagany"
 
 #: reports/templates/partials/report_names_form.html
 msgid "Add reference date"
-msgstr ""
+msgstr "Dodaj datę referencyjną"
 
 #: reports/templates/partials/report_names_form.html
 #: reports/templates/report_overview/modal_partials/rename_modal.html
 msgid "Reset"
-msgstr ""
+msgstr "Nastawić"
 
 #: reports/templates/partials/report_names_form.html
 msgid "No reference date"
-msgstr ""
+msgstr "Brak daty referencyjnej"
 
 #: reports/templates/partials/report_names_form.html
 msgid "Day"
-msgstr ""
+msgstr "Dzień"
 
 #: reports/templates/partials/report_names_form.html
 msgid "Week"
-msgstr ""
+msgstr "Tydzień"
 
 #: reports/templates/partials/report_names_form.html
 msgid "Month"
-msgstr ""
+msgstr "Miesiąc"
 
 #: reports/templates/partials/report_names_form.html
 msgid "Year"
-msgstr ""
+msgstr "Rok"
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "Object selection"
-msgstr ""
+msgstr "Wybór obiektu"
 
 #: reports/templates/partials/report_ooi_list.html
 msgid ""
@@ -3969,52 +4410,67 @@ msgid ""
 "continue with a live set or you can select the objects manually from the "
 "table below."
 msgstr ""
+"Wybierz obiekty, które chcesz uwzględnić w swoim raporcie. Możesz albo "
+"kontynuować zestaw na żywo, albo wybrać obiekty ręcznie z poniższej tabeli."
 
 #: reports/templates/partials/report_ooi_list.html
 msgid ""
-"A live set is a set of objects based on the applied filters. Any object that "
-"matches this applied filter (now or in the future) will be used as input for "
-"the scheduled report. If your live set filter (e.g. 'hostnames' with 'L2 "
-"clearance' that are 'declared') shows 2 hostnames that match the filter "
+"A live set is a set of objects based on the applied filters. Any object that"
+" matches this applied filter (now or in the future) will be used as input "
+"for the scheduled report. If your live set filter (e.g. 'hostnames' with 'L2"
+" clearance' that are 'declared') shows 2 hostnames that match the filter "
 "today, the scheduled report will run for those 2 hostnames. If you add 3 "
-"more hostnames tomorrow (with the same filter criteria), your next scheduled "
-"report will contain 5 hostnames. Your live set will update as you go."
+"more hostnames tomorrow (with the same filter criteria), your next scheduled"
+" report will contain 5 hostnames. Your live set will update as you go."
 msgstr ""
+"Zestaw aktywny to zbiór obiektów bazujący na zastosowanych filtrach. Każdy "
+"obiekt pasujący do zastosowanego filtra (obecnie lub w przyszłości) zostanie"
+" użyty jako dane wejściowe dla zaplanowanego raportu. Jeśli Twój filtr "
+"aktywnego zestawu (np. „nazwy hostów” z „zadeklarowanym zezwoleniem L2”) "
+"pokazuje 2 nazwy hostów pasujące do filtra dzisiaj, zaplanowany raport "
+"zostanie wygenerowany dla tych 2 nazw hostów. Jeśli jutro dodasz jeszcze 3 "
+"nazwy hostów (z tymi samymi kryteriami filtrowania), Twój następny "
+"zaplanowany raport będzie zawierał 5 nazw hostów. Twój zestaw na żywo będzie"
+" aktualizowany na bieżąco."
 
 #: reports/templates/partials/report_ooi_list.html
 msgid ""
 "Based on the current dataset, your selected filters result in the following "
 "objects."
 msgstr ""
+"W oparciu o bieżący zbiór danych wybrane filtry dają w wyniku następujące "
+"obiekty."
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "objects selected"
-msgstr ""
+msgstr "wybrane obiekty"
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "Deselect all objects"
-msgstr ""
+msgstr "Odznacz wszystkie obiekty"
 
 #: reports/templates/partials/report_ooi_list.html
 #: rocky/templates/oois/ooi_list.html
 #, python-format
 msgid "Showing %(length)s of %(total)s objects"
-msgstr ""
+msgstr "Wyświetlanie obiektów %(length)s z %(total)s"
 
 #: reports/templates/partials/report_ooi_list.html
 #, python-format
 msgid "Select all %(total_oois)s object"
 msgid_plural "Select all %(total_oois)s objects"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Wybierz cały obiekt %(total_oois)s"
+msgstr[1] "Wybierz wszystkie obiekty %(total_oois)s"
+msgstr[2] "Wybierz wszystkie obiekty %(total_oois)s"
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "Object name"
-msgstr ""
+msgstr "Nazwa obiektu"
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "Report(s) may be empty due to no objects in the selected filters."
 msgstr ""
+"Raport(y) może być pusty ze względu na brak obiektów w wybranych filtrach."
 
 #: reports/templates/partials/report_ooi_list.html
 msgid ""
@@ -4022,53 +4478,64 @@ msgid ""
 "Future reports may contain data. It is still possible to generate the "
 "(potentially empty) report."
 msgstr ""
+"Raporty pasujące do wybranych filtrów będą w tym momencie puste. Przyszłe "
+"raporty mogą zawierać dane. Nadal możliwe jest wygenerowanie (potencjalnie "
+"pustego) raportu."
 
 #: reports/templates/partials/report_ooi_list.html
 msgid "Continue with live set"
-msgstr ""
+msgstr "Kontynuuj zestaw na żywo"
 
 #: reports/templates/partials/report_ooi_list.html
 #: reports/templates/partials/report_types_selection.html
 msgid "Continue with selection"
-msgstr ""
+msgstr "Kontynuuj wybór"
 
 #: reports/templates/partials/report_setup_scan.html
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 #: reports/views/multi_report.py
 msgid "Configuration"
-msgstr ""
+msgstr "Konfiguracja"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Set up the required plugins for this report."
-msgstr ""
+msgstr "Skonfiguruj wymagane wtyczki dla tego raportu."
 
 #: reports/templates/partials/report_setup_scan.html
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugins"
-msgstr ""
+msgstr "Wtyczki"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid ""
 "KAT will be able to generate a full report when all the required and "
 "suggested boefjes are enabled."
 msgstr ""
+"KAT będzie w stanie wygenerować pełny raport, gdy wszystkie wymagane i "
+"sugerowane boefje zostaną włączone."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid ""
 "If you choose not to enable a plugin, the data that plugin would collect or "
-"produce will be left out of the report which will then be generated based on "
-"the available data collected by the enabled plugins."
+"produce will be left out of the report which will then be generated based on"
+" the available data collected by the enabled plugins."
 msgstr ""
+"Jeśli zdecydujesz się nie włączać wtyczki, dane, które wtyczka będzie "
+"zbierać lub generować, zostaną pominięte w raporcie, który zostanie "
+"następnie wygenerowany na podstawie dostępnych danych zebranych przez "
+"włączone wtyczki."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid ""
 "Some plugins are mandatory as they are crucial for a report type. Reports "
 "that don't have their requirements met will be skipped."
 msgstr ""
+"Niektóre wtyczki są obowiązkowe, ponieważ mają kluczowe znaczenie dla typu "
+"raportu. Raporty, które nie spełniają wymagań, zostaną pominięte."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Warning! Before you proceed read the following points:"
-msgstr ""
+msgstr "Ostrzeżenie! Zanim przejdziesz dalej, przeczytaj następujące punkty:"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid ""
@@ -4076,57 +4543,64 @@ msgid ""
 "enabled plugins and set clearance levels. This means that scans will run "
 "automatically. Be patient; plugins may take some time before they have "
 "collected all their data. Enabling them just before report generation will "
-"likely result in inaccurate reports, as plugins have not finished collecting "
-"data."
+"likely result in inaccurate reports, as plugins have not finished collecting"
+" data."
 msgstr ""
+"OpenKAT przeznaczony jest do regularnego skanowania wszystkich znanych "
+"obiektów przy użyciu włączonych wtyczek i ustawiania poziomów luzu. Oznacza "
+"to, że skanowanie będzie przebiegać automatycznie. Bądź cierpliwy; wtyczki "
+"mogą zająć trochę czasu, zanim zgromadzą wszystkie swoje dane. Włączenie ich"
+" tuż przed wygenerowaniem raportu prawdopodobnie spowoduje powstanie "
+"niedokładnych raportów, ponieważ wtyczki nie zakończyły jeszcze zbierania "
+"danych."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Good job! All required plugins are enabled."
-msgstr ""
+msgstr "Dobra robota! Wszystkie wymagane wtyczki są włączone."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "This report type requires the following plugins to be enabled:"
-msgstr ""
+msgstr "Ten typ raportu wymaga włączenia następujących wtyczek:"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Toggle all required plugins"
-msgstr ""
+msgstr "Przełącz wszystkie wymagane wtyczki"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Show enabled plugins"
-msgstr ""
+msgstr "Pokaż włączone wtyczki"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "There are no required plugins."
-msgstr ""
+msgstr "Nie ma wymaganych wtyczek."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Good job! All suggested plugins are enabled."
-msgstr ""
+msgstr "Dobra robota! Wszystkie sugerowane wtyczki są włączone."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "The following plugins are optional to generate the report:"
-msgstr ""
+msgstr "Następujące wtyczki są opcjonalne do generowania raportu:"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Toggle all optional plugins"
-msgstr ""
+msgstr "Przełącz wszystkie opcjonalne wtyczki"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Hide suggested plugins"
-msgstr ""
+msgstr "Ukryj sugerowane wtyczki"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Show more suggested plugins"
-msgstr ""
+msgstr "Pokaż więcej sugerowanych wtyczek"
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "There are no optional plugins."
-msgstr ""
+msgstr "Nie ma opcjonalnych wtyczek."
 
 #: reports/templates/partials/report_setup_scan.html
 msgid "Enable selected plugins and continue"
-msgstr ""
+msgstr "Włącz wybrane wtyczki i kontynuuj"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid ""
@@ -4135,72 +4609,82 @@ msgid ""
 "            severity that have been identified for this organization.\n"
 "        "
 msgstr ""
+"\n"
+"Przegląd ten pokazuje całkowitą liczbę wyników przypadającą na jeden\n"
+"            dotkliwości, które zostały zidentyfikowane dla tej organizacji."
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Total per severity overview"
-msgstr ""
+msgstr "Łącznie według przeglądu ważności"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Critical"
-msgstr ""
+msgstr "Krytyczny"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "High"
-msgstr ""
+msgstr "Wysoki"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Medium"
-msgstr ""
+msgstr "Średni"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Low"
-msgstr ""
+msgstr "Niski"
 
 #: reports/templates/partials/report_severity_totals_table.html
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Pending"
-msgstr ""
+msgstr "Aż do"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Unknown"
-msgstr ""
+msgstr "Nieznany"
 
 #: reports/templates/partials/report_severity_totals_table.html
 msgid "Total"
-msgstr ""
+msgstr "Całkowity"
 
 #: reports/templates/partials/report_sidemenu.html
 msgid "Selected Objects"
-msgstr ""
+msgstr "Wybrane obiekty"
 
 #: reports/templates/partials/report_sidemenu.html
 msgid "Selected Plugins"
-msgstr ""
+msgstr "Wybrane wtyczki"
 
 #: reports/templates/partials/report_sidemenu.html
 msgid "Used Config Objects"
-msgstr ""
+msgstr "Używane obiekty konfiguracyjne"
 
 #: reports/templates/partials/report_types_selection.html
 msgid "Choose report types"
-msgstr ""
+msgstr "Wybierz typy raportów"
 
 #: reports/templates/partials/report_types_selection.html
 msgid ""
-"Various types of reports, such as DNS reports and TLS reports, are essential "
-"for identifying vulnerabilities in different aspects of a system's security. "
-"DNS reports focus on domain name system configuration and potential "
-"weaknesses, while TLS reports assess the security of data encryption and "
-"transmission protocols, helping organizations pinpoint areas where security "
-"improvements are needed."
+"Various types of reports, such as DNS reports and TLS reports, are essential"
+" for identifying vulnerabilities in different aspects of a system's "
+"security. DNS reports focus on domain name system configuration and "
+"potential weaknesses, while TLS reports assess the security of data "
+"encryption and transmission protocols, helping organizations pinpoint areas "
+"where security improvements are needed."
 msgstr ""
+"Różne typy raportów, takie jak raporty DNS i raporty TLS, są niezbędne do "
+"identyfikowania luk w różnych aspektach bezpieczeństwa systemu. Raporty DNS "
+"koncentrują się na konfiguracji systemu nazw domen i potencjalnych słabych "
+"stronach, podczas gdy raporty TLS oceniają bezpieczeństwo szyfrowania danych"
+" i protokołów transmisji, pomagając organizacjom wskazać obszary, w których "
+"konieczna jest poprawa bezpieczeństwa."
 
 #: reports/templates/partials/report_types_selection.html
 #, python-format
 msgid "Selected object (%(total_oois)s)"
 msgid_plural "Selected objects (%(total_oois)s)"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Wybrany obiekt (%(total_oois)s)"
+msgstr[1] "Wybrane obiekty (%(total_oois)s)"
+msgstr[2] "Wybrane obiekty (%(total_oois)s)"
 
 #: reports/templates/partials/report_types_selection.html
 #, python-format
@@ -4208,43 +4692,46 @@ msgid ""
 "You have selected a live set in the previous step. Based on the current "
 "dataset, this live set results in %(total_oois)s objects."
 msgstr ""
+"W poprzednim kroku wybrałeś zestaw na żywo. W oparciu o bieżący zbiór "
+"danych, ten aktywny zestaw daje w wyniku obiekty %(total_oois)s."
 
 #: reports/templates/partials/report_types_selection.html
 msgid "Applied filters:"
-msgstr ""
+msgstr "Zastosowane filtry:"
 
 #: reports/templates/partials/report_types_selection.html
 #, python-format
 msgid "You have selected %(total_oois)s object in the previous step."
 msgid_plural "You have selected %(total_oois)s objects in the previous step."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "W poprzednim kroku wybrałeś obiekt %(total_oois)s."
+msgstr[1] "W poprzednim kroku wybrałeś obiekty %(total_oois)s."
+msgstr[2] "W poprzednim kroku wybrałeś obiekty %(total_oois)s."
 
 #: reports/templates/partials/report_types_selection.html
 msgid "Change selection"
-msgstr ""
+msgstr "Zmień wybór"
 
 #: reports/templates/partials/report_types_selection.html
 msgid "Available report types"
-msgstr ""
+msgstr "Dostępne typy raportów"
 
 #: reports/templates/partials/report_types_selection.html
 msgid "All report types that are available for your selection."
-msgstr ""
+msgstr "Wszystkie typy raportów, które są dostępne do wyboru."
 
 #: reports/templates/partials/report_types_selection.html
 msgid "Toggle all report types"
-msgstr ""
+msgstr "Przełącz wszystkie typy raportów"
 
 #: reports/templates/partials/return_button.html
 #, python-format
 msgid "%(btn_text)s"
-msgstr ""
+msgstr "%(btn_text)s"
 
 #: reports/templates/report_overview/modal_partials/delete_modal.html
 #: reports/templates/report_overview/modal_partials/share_modal.html
 msgid "Delete the following report(s):"
-msgstr ""
+msgstr "Usuń następujące raporty:"
 
 #: reports/templates/report_overview/modal_partials/delete_modal.html
 #: reports/templates/report_overview/modal_partials/share_modal.html
@@ -4253,6 +4740,9 @@ msgid ""
 "report can still be accessed on timestamps before the deletion. Only the "
 "report is removed from the view, not the data it is based on."
 msgstr ""
+"Usunięte raporty są usuwane w widoku od momentu usunięcia. Dostęp do raportu"
+" będzie nadal możliwy według znaczników czasu sprzed usunięcia. Z widoku "
+"zostanie usunięty tylko raport, a nie dane, na których się opiera."
 
 #: reports/templates/report_overview/modal_partials/delete_modal.html
 #: reports/templates/report_overview/modal_partials/share_modal.html
@@ -4261,6 +4751,9 @@ msgid ""
 "is part of a combined report, it will remain available in the combined "
 "report."
 msgstr ""
+"Nadal istnieje możliwość wygenerowania nowego raportu na tę samą datę. Jeśli"
+" raport jest częścią raportu połączonego, pozostanie dostępny w raporcie "
+"połączonym."
 
 #: reports/templates/report_overview/modal_partials/delete_modal.html
 #: reports/templates/report_overview/modal_partials/rerun_modal.html
@@ -4268,81 +4761,88 @@ msgstr ""
 #: reports/templates/report_overview/scheduled_reports_table.html
 #: reports/templates/report_overview/subreports_table.html
 msgid "Reference date"
-msgstr ""
+msgstr "Data referencyjna"
 
 #: reports/templates/report_overview/modal_partials/enable_disable_schedule_modal.html
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Disable schedule"
-msgstr ""
+msgstr "Wyłącz harmonogram"
 
 #: reports/templates/report_overview/modal_partials/enable_disable_schedule_modal.html
 #, python-format
 msgid ""
-"Are you sure you want to disable the schedule for <strong>%(report_name)s</"
-"strong>? The recipe will still exist and the schedule can be enabled later "
-"on."
+"Are you sure you want to disable the schedule for "
+"<strong>%(report_name)s</strong>? The recipe will still exist and the "
+"schedule can be enabled later on."
 msgstr ""
+"Czy na pewno chcesz wyłączyć harmonogram dla "
+"<strong>%(report_name)s</strong>? Przepis będzie nadal istniał, a "
+"harmonogram będzie można włączyć później."
 
 #: reports/templates/report_overview/modal_partials/rename_modal.html
 msgid "Rename the following report(s):"
-msgstr ""
+msgstr "Zmień nazwę następujących raportów:"
 
 #: reports/templates/report_overview/modal_partials/rename_modal.html
 #: reports/templates/report_overview/report_history_table.html
 msgid "Rename"
-msgstr ""
+msgstr "Przemianować"
 
 #: reports/templates/report_overview/modal_partials/rerun_modal.html
 msgid "Rerun the following report(s):"
-msgstr ""
+msgstr "Uruchom ponownie następujące raporty:"
 
 #: reports/templates/report_overview/modal_partials/rerun_modal.html
 msgid ""
 "By submitting you're generating the selected reports again, using the "
 "current data."
 msgstr ""
+"Przesyłając ponownie generujesz wybrane raporty, korzystając z aktualnych "
+"danych."
 
 #: reports/templates/report_overview/modal_partials/rerun_modal.html
 #: reports/templates/report_overview/report_history_table.html
 msgid "Rerun"
-msgstr ""
+msgstr "Ponowne odtworzenie"
 
 #: reports/templates/report_overview/report_history.html
 msgid "Reports history"
-msgstr ""
+msgstr "Historia raportów"
 
 #: reports/templates/report_overview/report_history.html
 msgid ""
 "On this page you can see all the reports that have been generated in the "
 "past. To create a new report, click the 'Generate Report' button."
 msgstr ""
+"Na tej stronie możesz zobaczyć wszystkie raporty, które zostały wygenerowane"
+" w przeszłości. Aby utworzyć nowy raport, kliknij przycisk „Generuj raport”."
 
 #: reports/templates/report_overview/report_history_table.html
 #: reports/templates/report_overview/subreports.html
 #, python-format
 msgid "Showing %(length)s of %(total)s reports"
-msgstr ""
+msgstr "Wyświetlanie raportów %(length)s z %(total)s"
 
 #: reports/templates/report_overview/report_history_table.html
 #: rocky/templates/tasks/reports.html
 msgid "Reports:"
-msgstr ""
+msgstr "Raporty:"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "Shows parent report details"
-msgstr ""
+msgstr "Pokazuje szczegóły raportu nadrzędnego"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "Close asset report object details"
-msgstr ""
+msgstr "Zamknij szczegóły obiektu raportu o zasobach"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "Open asset report object details"
-msgstr ""
+msgstr "Otwórz szczegóły obiektu raportu o zasobach"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "Asset reports details"
-msgstr ""
+msgstr "Szczegóły raportów o zasobach"
 
 #: reports/templates/report_overview/report_history_table.html
 #, python-format
@@ -4353,129 +4853,139 @@ msgid_plural ""
 "This report consists of %(counter)s asset reports with the following report "
 "types and objects:"
 msgstr[0] ""
+"Ten raport składa się z raportu o zasobach %(counter)s z następującym typem "
+"raportu i obiektem:"
 msgstr[1] ""
+"Ten raport składa się z raportów zasobów %(counter)s z następującymi typami "
+"raportów i obiektami:"
+msgstr[2] ""
+"Ten raport składa się z raportów zasobów %(counter)s z następującymi typami "
+"raportów i obiektami:"
 
 #: reports/templates/report_overview/report_history_table.html
 #: reports/templates/report_overview/subreports_header.html
 #: reports/templates/report_overview/subreports_table.html
 #: reports/views/report_overview.py
 msgid "Asset reports"
-msgstr ""
+msgstr "Raporty dotyczące zasobów"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "Shows asset report details"
-msgstr ""
+msgstr "Pokazuje szczegóły raportu o zasobach"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "View all asset reports"
-msgstr ""
+msgstr "Wyświetl wszystkie raporty o zasobach"
 
 #: reports/templates/report_overview/report_history_table.html
 msgid "No reports have been generated yet."
-msgstr ""
+msgstr "Nie wygenerowano jeszcze żadnych raportów."
 
 #: reports/templates/report_overview/report_overview_header.html
 #: reports/views/base.py rocky/templates/header.html
 #: rocky/templates/tasks/partials/tab_navigation.html
 #: rocky/templates/tasks/reports.html rocky/views/tasks.py
 msgid "Reports"
-msgstr ""
+msgstr "Raporty"
 
 #: reports/templates/report_overview/report_overview_header.html
 msgid "An overview of reports that are scheduled or have been generated."
-msgstr ""
+msgstr "Przegląd raportów, które są zaplanowane lub zostały wygenerowane."
 
 #: reports/templates/report_overview/report_overview_navigation.html
 msgid "Scheduled"
-msgstr ""
+msgstr "Zaplanowany"
 
 #: reports/templates/report_overview/report_overview_navigation.html
 msgid "History"
-msgstr ""
+msgstr "Historia"
 
 #: reports/templates/report_overview/scheduled_reports.html
 msgid "Scheduled reports"
-msgstr ""
+msgstr "Zaplanowane raporty"
 
 #: reports/templates/report_overview/scheduled_reports.html
 msgid ""
-"On this page you can see all the reports that are or have been scheduled. To "
-"schedule a report, select a start date and recurrence while generating a "
+"On this page you can see all the reports that are or have been scheduled. To"
+" schedule a report, select a start date and recurrence while generating a "
 "report."
 msgstr ""
+"Na tej stronie możesz zobaczyć wszystkie raporty, które są lub zostały "
+"zaplanowane. Aby zaplanować raport, podczas generowania raportu wybierz datę"
+" początkową i częstotliwość."
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 #, python-format
 msgid "Showing %(length)s of %(total)s schedules"
-msgstr ""
+msgstr "Wyświetlanie harmonogramów %(length)s z %(total)s"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Scheduled reports:"
-msgstr ""
+msgstr "Zaplanowane raporty:"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Scheduled for"
-msgstr ""
+msgstr "Zaplanowane na"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Schedule status"
-msgstr ""
+msgstr "Stan harmonogramu"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Once"
-msgstr ""
+msgstr "Raz"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Recent reports"
-msgstr ""
+msgstr "Najnowsze raporty"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Scheduled Reports:"
-msgstr ""
+msgstr "Zaplanowane raporty:"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Show report details"
-msgstr ""
+msgstr "Pokaż szczegóły raportu"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "objects"
-msgstr ""
+msgstr "obiekty"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "Enable schedule"
-msgstr ""
+msgstr "Włącz harmonogram"
 
 #: reports/templates/report_overview/scheduled_reports_table.html
 msgid "No scheduled reports have been generated yet."
-msgstr ""
+msgstr "Nie wygenerowano jeszcze żadnych zaplanowanych raportów."
 
 #: reports/templates/report_overview/subreports_header.html
 msgid "Back to Reports History"
-msgstr ""
+msgstr "Powrót do historii raportów"
 
 #: reports/templates/report_overview/subreports_header.html
 msgid "An overview of all underlying reports of"
-msgstr ""
+msgstr "Przegląd wszystkich raportów bazowych"
 
 #: reports/templates/report_overview/subreports_header.html
 #: reports/templates/report_overview/subreports_table.html
 msgid "Shows report details"
-msgstr ""
+msgstr "Pokazuje szczegóły raportu"
 
 #: reports/templates/report_overview/subreports_table.html
 #: rocky/templates/tasks/boefjes.html
 #: rocky/templates/tasks/plugin_detail_task_list.html
 msgid "Input Object"
-msgstr ""
+msgstr "Obiekt wejściowy"
 
 #: reports/templates/report_schedules/delete_recipe_modal.html
 msgid "Delete report recipe"
-msgstr ""
+msgstr "Usuń przepis raportu"
 
 #: reports/templates/report_schedules/delete_recipe_modal.html
 #, python-format
 msgid "Are you sure you want to delete report recipe \"%(name)s\"?"
-msgstr ""
+msgstr "Czy na pewno chcesz usunąć przepis raportu „%(name)s”?"
 
 #: reports/templates/report_schedules/delete_recipe_modal.html
 msgid ""
@@ -4483,164 +4993,189 @@ msgid ""
 "not be possible anymore to see or enable the schedule. You will find "
 "previously generated reports in the report history tab."
 msgstr ""
+"Usunięcie tego przepisu raportu oznacza, że ​​zostanie on trwale usunięty. "
+"Nie będzie już możliwe wyświetlenie ani włączenie harmonogramu. W zakładce "
+"historia raportów znajdziesz wcześniej wygenerowane raporty."
 
 #: reports/templates/summary/report_asset_overview.html
 msgid ""
-"The objects listed in the table below were used to generate this report. For "
-"each object in the table it additionally shows the clearance level and "
+"The objects listed in the table below were used to generate this report. For"
+" each object in the table it additionally shows the clearance level and "
 "whether or not the object was added by a user ('Declared') or indirectly "
 "identified through another service or system ('Inherited')."
 msgstr ""
+"Do wygenerowania tego raportu wykorzystano obiekty wymienione w poniższej "
+"tabeli. Dla każdego obiektu w tabeli dodatkowo pokazany jest poziom "
+"uprawnień oraz to, czy obiekt został dodany przez użytkownika („Zgłoszony”),"
+" czy też pośrednio zidentyfikowany poprzez inną usługę lub system "
+"(„Odziedziczony”)."
 
 #: reports/templates/summary/report_asset_overview.html
 msgid "No objects found."
-msgstr ""
+msgstr "Nie znaleziono żadnych obiektów."
 
 #: reports/templates/summary/report_asset_overview.html
 msgid ""
 "The table below shows which reports were chosen to generate this report, "
 "including a report description."
 msgstr ""
+"Poniższa tabela pokazuje, które raporty zostały wybrane do wygenerowania "
+"tego raportu, wraz z opisem raportu."
 
 #: reports/templates/summary/report_asset_overview.html
 msgid "No report types found."
-msgstr ""
+msgstr "Nie znaleziono typów raportów."
 
 #: reports/templates/summary/selected_plugins.html
 msgid ""
 "The table below shows all required or optional plugins for the selected "
 "reports."
 msgstr ""
+"Poniższa tabela przedstawia wszystkie wymagane lub opcjonalne wtyczki dla "
+"wybranych raportów."
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Required and optional plugins"
-msgstr ""
+msgstr "Wtyczki wymagane i opcjonalne"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugin enabled"
-msgstr ""
+msgstr "Wtyczka włączona"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugin options"
-msgstr ""
+msgstr "Opcje wtyczek"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugin scan level"
-msgstr ""
+msgstr "Poziom skanowania wtyczki"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Enabled."
-msgstr ""
+msgstr "Włączony."
 
 #: reports/templates/summary/selected_plugins.html
 msgid "required"
-msgstr ""
+msgstr "wymagany"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "optional"
-msgstr ""
+msgstr "fakultatywny"
 
 #: reports/templates/summary/selected_plugins.html
 msgid "Plugin extra info"
-msgstr ""
+msgstr "Dodatkowe informacje o wtyczce"
 
 #: reports/templates/summary/selected_plugins.html
 msgid ""
 "There are no required or optional plugins needed for the selected report "
 "types."
-msgstr ""
+msgstr "Dla wybranych typów raportów nie są wymagane ani opcjonalne wtyczki."
 
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 #: reports/views/multi_report.py
 msgid "Select objects"
-msgstr ""
+msgstr "Wybierz obiekty"
 
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 #: reports/views/multi_report.py
 msgid "Select report types"
-msgstr ""
+msgstr "Wybierz typy raportów"
 
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 #: reports/views/multi_report.py
 msgid "Export setup"
-msgstr ""
+msgstr "Eksportuj konfigurację"
 
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 msgid "Save report"
-msgstr ""
+msgstr "Zapisz raport"
 
 #: reports/views/aggregate_report.py reports/views/generate_report.py
 msgid "You do not have the required permissions to enable plugins."
-msgstr ""
+msgstr "Nie masz wymaganych uprawnień, aby włączyć wtyczki."
 
 #: reports/views/base.py
 msgid "Select at least one OOI to proceed."
-msgstr ""
+msgstr "Wybierz co najmniej jeden OOI, aby kontynuować."
 
 #: reports/views/base.py
 msgid "Select at least one report type to proceed."
-msgstr ""
+msgstr "Aby kontynuować, wybierz co najmniej jeden typ raportu."
 
 #: reports/views/mixins.py
 msgid ""
 "No data could be found for %(report_types). Object(s) did not exist on "
 "%(date)s."
 msgstr ""
+"Nie można znaleźć danych dla %(typy_raportów). Obiekt(y) nie istniał na "
+"%(date)s."
 
 #: reports/views/multi_report.py
 msgid "View report"
-msgstr ""
+msgstr "Zobacz raport"
 
 #: reports/views/report_overview.py
 msgid "Not enough permissions"
-msgstr ""
+msgstr "Za mało uprawnień"
 
 #: reports/views/report_overview.py
 msgid "Recipe '{}' deleted successfully"
-msgstr ""
+msgstr "Przepis „{}” został pomyślnie usunięty"
 
 #: reports/views/report_overview.py
 msgid "Recipe not found."
-msgstr ""
+msgstr "Nie znaleziono przepisu."
 
 #: reports/views/report_overview.py
 msgid "No schedule or recipe selected"
-msgstr ""
+msgstr "Nie wybrano harmonogramu ani przepisu"
 
 #: reports/views/report_overview.py
 msgid ""
 "Schedule disabled successfully. '{}' will not be generated automatically "
 "until the schedule is enabled again."
 msgstr ""
+"Harmonogram został wyłączony pomyślnie. „{}” nie zostanie wygenerowany "
+"automatycznie, dopóki harmonogram nie zostanie ponownie włączony."
 
 #: reports/views/report_overview.py
 msgid ""
 "Schedule enabled successfully. '{}' will be generated according to schedule."
 msgstr ""
+"Harmonogram został pomyślnie włączony. '{}' zostanie wygenerowane zgodnie z "
+"harmonogramem."
 
 #: reports/views/report_overview.py
 msgid "An unexpected error occurred, please check logs for more info."
 msgstr ""
+"Wystąpił nieoczekiwany błąd. Sprawdź dzienniki, aby uzyskać więcej "
+"informacji."
 
 #: reports/views/report_overview.py
 msgid "Other OOI type selected than Report"
-msgstr ""
+msgstr "Wybrano inny typ OOI niż Raport"
 
 #: reports/views/report_overview.py
 msgid "Deletion successful."
-msgstr ""
+msgstr "Usunięcie powiodło się."
 
 #: reports/views/report_overview.py
 msgid ""
 "Multi organization reports cannot be rescheduled. It consists of imported "
 "data from different organizations and is not based on newly generated data."
 msgstr ""
+"Nie można przełożyć harmonogramu raportów obejmujących wiele organizacji. "
+"Składa się z danych zaimportowanych z różnych organizacji i nie opiera się "
+"na nowo wygenerowanych danych."
 
 #: reports/views/report_overview.py
 msgid ""
 "Rerun successful. It may take a moment before the new report has been "
 "generated."
 msgstr ""
+"Ponowne uruchomienie pomyślne. Wygenerowanie nowego raportu może chwilę "
+"potrwać."
 
 #: reports/views/report_overview.py
 #, python-format
@@ -4648,379 +5183,389 @@ msgid ""
 "Couldn't rerun %s, since the recipe for this report has been disabled or "
 "deleted."
 msgstr ""
+"Nie można ponownie uruchomić %s, ponieważ przepis dla tego raportu został "
+"wyłączony lub usunięty."
 
 #: reports/views/report_overview.py
 msgid "Renaming failed. Empty report name found."
-msgstr ""
+msgstr "Zmiana nazwy nie powiodła się. Znaleziono pustą nazwę raportu."
 
 #: reports/views/report_overview.py
 msgid "Report names and reports does not match."
-msgstr ""
+msgstr "Nazwy raportów i raporty nie są zgodne."
 
 #: reports/views/report_overview.py
 msgid "Reports successfully renamed."
-msgstr ""
+msgstr "Pomyślnie zmieniono nazwę raportów."
 
 #: reports/views/report_overview.py
 msgid "Report {} could not be renamed."
-msgstr ""
+msgstr "Nie można zmienić nazwy raportu {}."
 
 #: reports/views/view_helpers.py
 msgid "1: Select objects"
-msgstr ""
+msgstr "1: Wybierz obiekty"
 
 #: reports/views/view_helpers.py
 msgid "2: Choose report types"
-msgstr ""
+msgstr "2: Wybierz typy raportów"
 
 #: reports/views/view_helpers.py
 msgid "3: Configuration"
-msgstr ""
+msgstr "3: Konfiguracja"
 
 #: reports/views/view_helpers.py
 msgid "4: Export setup"
-msgstr ""
+msgstr "4: Eksportuj konfigurację"
 
 #: reports/views/view_helpers.py
 msgid "3: Export setup"
-msgstr ""
+msgstr "3: Eksportuj konfigurację"
 
 #: tools/forms/base.py
 msgid "Date"
-msgstr ""
+msgstr "Data"
 
 #: tools/forms/boefje.py
 msgid "For example: -sTU --top-ports 1000"
-msgstr ""
+msgstr "Na przykład: -sTU --top-ports 1000"
 
 #: tools/forms/boefje.py
 msgid "JSON Schema"
-msgstr ""
+msgstr "Schemat JSON"
 
 #: tools/forms/boefje.py
 msgid "Input object type"
-msgstr ""
+msgstr "Typ obiektu wejściowego"
 
 #: tools/forms/boefje.py
 msgid "Output mime types"
-msgstr ""
+msgstr "Wyjściowe typy MIME"
 
 #: tools/forms/boefje.py
 msgid "Scan type"
-msgstr ""
+msgstr "Typ skanowania"
 
 #: tools/forms/boefje.py
 msgid "Interval amount"
-msgstr ""
+msgstr "Kwota interwału"
 
 #: tools/forms/boefje.py
 msgid ""
 "Specify the scanning interval for this Boefje. The default is 24 hours. For "
 "example: 5 minutes will let the Boefje scan every 5 minutes."
 msgstr ""
+"Określ interwał skanowania dla tego Boefje. Wartość domyślna to 24 godziny. "
+"Na przykład: 5 minut pozwoli Boefje skanować co 5 minut."
 
 #: tools/forms/boefje.py
 msgid "Interval frequency"
-msgstr ""
+msgstr "Częstotliwość interwałowa"
 
 #: tools/forms/boefje.py
 msgid "Object creation/change"
-msgstr ""
+msgstr "Tworzenie/zmiana obiektu"
 
 #: tools/forms/boefje.py
 msgid ""
 "Choose weather the Boefje should run after creating and/or changing an "
 "object. "
 msgstr ""
+"Wybierz pogodę, w której Boefje ma działać po utworzeniu i/lub zmianie "
+"obiektu."
 
 #: tools/forms/finding_type.py
 msgid "KAT-ID"
-msgstr ""
+msgstr "KAT-ID"
 
 #: tools/forms/finding_type.py
 msgid "Unique ID within OpenKAT, for this type"
-msgstr ""
+msgstr "Unikalny identyfikator w OpenKAT dla tego typu"
 
 #: tools/forms/finding_type.py
 msgid "Title"
-msgstr ""
+msgstr "Tytuł"
 
 #: tools/forms/finding_type.py
 msgid "Give the finding type a fitting title"
-msgstr ""
+msgstr "Nadaj typowi wyniku pasujący tytuł"
 
 #: tools/forms/finding_type.py
 msgid "Describe the finding type"
-msgstr ""
+msgstr "Opisz typ wyniku"
 
 #: tools/forms/finding_type.py
 msgid "Risk"
-msgstr ""
+msgstr "Ryzyko"
 
 #: tools/forms/finding_type.py
 msgid "Solution"
-msgstr ""
+msgstr "Rozwiązanie"
 
 #: tools/forms/finding_type.py
 msgid "How can this be solved?"
-msgstr ""
+msgstr "Jak można to rozwiązać?"
 
 #: tools/forms/finding_type.py
 msgid "Describe how this type of finding can be solved"
-msgstr ""
+msgstr "Opisz, jak można rozwiązać tego typu ustalenia"
 
 #: tools/forms/finding_type.py
 msgid "References"
-msgstr ""
+msgstr "Referencje"
 
 #: tools/forms/finding_type.py
 msgid "Please give some references on the solution"
-msgstr ""
+msgstr "Proszę o jakieś odniesienia do rozwiązania"
 
 #: tools/forms/finding_type.py
 msgid "Please give sources and references on the suggested solution"
 msgstr ""
+"Proszę o podanie źródeł i referencji na temat sugerowanego rozwiązania"
 
 #: tools/forms/finding_type.py
 msgid "Impact description"
-msgstr ""
+msgstr "Opis wpływu"
 
 #: tools/forms/finding_type.py
 msgid "Describe the solutions impact"
-msgstr ""
+msgstr "Opisz wpływ rozwiązań"
 
 #: tools/forms/finding_type.py
 msgid "Solution chance"
-msgstr ""
+msgstr "Szansa na rozwiązanie"
 
 #: tools/forms/finding_type.py
 msgid "Solution impact"
-msgstr ""
+msgstr "Wpływ rozwiązania"
 
 #: tools/forms/finding_type.py
 msgid "Solution effort"
-msgstr ""
+msgstr "Wysiłek rozwiązania"
 
 #: tools/forms/finding_type.py
 msgid "ID should start with "
-msgstr ""
+msgstr "Identyfikator powinien zaczynać się od"
 
 #: tools/forms/finding_type.py
 msgid "Finding type already exists"
-msgstr ""
+msgstr "Typ wyszukiwania już istnieje"
 
 #: tools/forms/finding_type.py
 msgid "Click to select one of the available options"
-msgstr ""
+msgstr "Kliknij, aby wybrać jedną z dostępnych opcji"
 
 #: tools/forms/finding_type.py
 #: rocky/templates/partials/finding_occurrence_definition_list.html
 msgid "Proof"
-msgstr ""
+msgstr "Dowód"
 
 #: tools/forms/finding_type.py
 msgid "Provide evidence of your finding"
-msgstr ""
+msgstr "Przedstaw dowód swojego ustalenia"
 
 #: tools/forms/finding_type.py
 msgid "Describe your finding"
-msgstr ""
+msgstr "Opisz swoje odkrycie"
 
 #: tools/forms/finding_type.py
 msgid "Reproduce finding"
-msgstr ""
+msgstr "Odtwórz znalezisko"
 
 #: tools/forms/finding_type.py
 msgid "Please explain how to reproduce your finding"
-msgstr ""
+msgstr "Proszę wyjaśnić, jak odtworzyć swoje ustalenia"
 
 #: tools/forms/finding_type.py tools/forms/upload_raw.py
 msgid "Date/Time (UTC)"
-msgstr ""
+msgstr "Data/godzina (UTC)"
 
 #: tools/forms/finding_type.py tools/forms/upload_raw.py
 msgid "Doc! I'm from the future, I'm here to take you back!"
 msgstr ""
+"Doktorze! Jestem z przyszłości, jestem tu, żeby cię zabrać z powrotem!"
 
 #: tools/forms/finding_type.py
 msgid "OOI doesn't exist"
-msgstr ""
+msgstr "OOI nie istnieje"
 
 #: tools/forms/findings.py
 msgid "Show non-muted findings"
-msgstr ""
+msgstr "Pokaż niewyciszone wyniki"
 
 #: tools/forms/findings.py
 msgid "Show muted findings"
-msgstr ""
+msgstr "Pokaż wyciszone wyniki"
 
 #: tools/forms/findings.py
 msgid "Show muted and non-muted findings"
-msgstr ""
+msgstr "Pokaż wyciszone i niewyciszone wyniki"
 
 #: tools/forms/findings.py
 msgid "Filter by severity"
-msgstr ""
+msgstr "Filtruj według ważności"
 
 #: tools/forms/findings.py
 msgid "Filter by muted findings"
-msgstr ""
+msgstr "Filtruj według wyciszonych wyników"
 
 #: tools/forms/findings.py tools/forms/ooi_form.py tools/forms/scheduler.py
 msgid "Search"
-msgstr ""
+msgstr "Szukaj"
 
 #: tools/forms/findings.py
 msgid "Object ID contains (case sensitive)"
-msgstr ""
+msgstr "Identyfikator obiektu zawiera (wielkość liter ma znaczenie)"
 
 #: tools/forms/ooi.py
 msgid "Filter types"
-msgstr ""
+msgstr "Typy filtrów"
 
 #: tools/forms/ooi.py
 msgid "Clearance Level"
-msgstr ""
+msgstr "Poziom rozliczenia"
 
 #: tools/forms/ooi.py
 msgid "Next scan"
-msgstr ""
+msgstr "Następny skan"
 
 #: tools/forms/ooi.py
 msgid "Show objects that don't meet the Boefjes scan level."
-msgstr ""
+msgstr "Pokaż obiekty, które nie spełniają poziomu skanowania Boefjes."
 
 #: tools/forms/ooi.py
 msgid "Show Boefjes that exceed the objects clearance level."
-msgstr ""
+msgstr "Pokaż Boefjes, które przekraczają poziom prześwitu obiektów."
 
 #: tools/forms/ooi.py
 msgid ""
-"All the boefjes with a scan level below or equal to the clearance level will "
-"be allowed to scan this object."
+"All the boefjes with a scan level below or equal to the clearance level will"
+" be allowed to scan this object."
 msgstr ""
+"Wszystkie boefje z poziomem skanowania niższym lub równym poziomowi "
+"zezwolenia będą mogły skanować ten obiekt."
 
 #: tools/forms/ooi.py
 msgid "Expires by (UTC)"
-msgstr ""
+msgstr "Wygasa do (UTC)"
 
 #: tools/forms/ooi_form.py
 msgid "option"
-msgstr ""
+msgstr "opcja"
 
 #: tools/forms/ooi_form.py
 #, python-brace-format
 msgid "Optionally choose a {option_label}"
-msgstr ""
+msgstr "Opcjonalnie wybierz {option_label}"
 
 #: tools/forms/ooi_form.py
 #, python-brace-format
 msgid "Please choose a {option_label}"
-msgstr ""
+msgstr "Proszę wybrać {option_label}"
 
 #: tools/forms/ooi_form.py
 msgid "Filter by clearance level"
-msgstr ""
+msgstr "Filtruj według poziomu luzu"
 
 #: tools/forms/ooi_form.py
 msgid "Filter by clearance type"
-msgstr ""
+msgstr "Filtruj według typu luzu"
 
 #: tools/forms/scheduler.py
 msgid "From"
-msgstr ""
+msgstr "Z"
 
 #: tools/forms/scheduler.py
 msgid "To"
-msgstr ""
+msgstr "Do"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Cancelled"
-msgstr ""
+msgstr "Odwołany"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Completed"
-msgstr ""
+msgstr "Zakończony"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Dispatched"
-msgstr ""
+msgstr "Wysłany"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Failed"
-msgstr ""
+msgstr "Przegrany"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Queued"
-msgstr ""
+msgstr "W kolejce"
 
 #: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
 msgid "Running"
-msgstr ""
+msgstr "Działanie"
 
 #: tools/forms/scheduler.py
 msgid "Search by object name"
-msgstr ""
+msgstr "Szukaj według nazwy obiektu"
 
 #: tools/forms/scheduler.py
 msgid "The selected date is in the future. Please select a different date."
-msgstr ""
+msgstr "Wybrana data przypada w przyszłości. Proszę wybrać inną datę."
 
 #: tools/forms/settings.py
 msgid "--- Show all ----"
-msgstr ""
+msgstr "--- Pokaż wszystko ----"
 
 #: tools/forms/settings.py
 msgid "recommendation"
-msgstr ""
+msgstr "zalecenie"
 
 #: tools/forms/settings.py
 msgid "low"
-msgstr ""
+msgstr "Niski"
 
 #: tools/forms/settings.py
 msgid "medium"
-msgstr ""
+msgstr "średni"
 
 #: tools/forms/settings.py
 msgid "high"
-msgstr ""
+msgstr "wysoki"
 
 #: tools/forms/settings.py
 msgid "very high"
-msgstr ""
+msgstr "bardzo wysoki"
 
 #: tools/forms/settings.py
 msgid "critical"
-msgstr ""
+msgstr "krytyczny"
 
 #: tools/forms/settings.py
 msgid "quickfix"
-msgstr ""
+msgstr "szybka poprawka"
 
 #: tools/forms/settings.py
 msgid "Declared"
-msgstr ""
+msgstr "Zdeklarowany"
 
 #: tools/forms/settings.py
 msgid "Inherited"
-msgstr ""
+msgstr "Dziedziczny"
 
 #: tools/forms/settings.py
 msgid "Empty"
-msgstr ""
+msgstr "Pusty"
 
 #: tools/forms/settings.py
 msgid "Add one finding type ID per line."
-msgstr ""
+msgstr "Dodaj jeden identyfikator typu wyniku w każdym wierszu."
 
 #: tools/forms/settings.py
 msgid "Add the date and time of your finding (UTC)"
-msgstr ""
+msgstr "Dodaj datę i godzinę swojego znaleziska (UTC)"
 
 #: tools/forms/settings.py
 msgid "Add the date and time of when the raw file was generated (UTC)"
-msgstr ""
+msgstr "Dodaj datę i godzinę wygenerowania pliku raw (UTC)"
 
 #: tools/forms/settings.py
 msgid ""
@@ -5028,20 +5573,28 @@ msgid ""
 "to see the status of your network through time. Select a datetime to change "
 "the view to represent that moment in time."
 msgstr ""
+"OpenKAT przechowuje wskazanie czasu przy każdej obserwacji, dzięki czemu "
+"możliwe jest sprawdzenie stanu sieci w czasie. Wybierz datę i godzinę, aby "
+"zmienić widok reprezentujący ten moment w czasie."
 
 #: tools/forms/settings.py
 msgid ""
-"<p>The name of the Docker image. For example: <i>'ghcr.io/minvws/openkat/"
-"nmap'</i>. In OpenKAT, all Boefjes with the same container image will be "
-"seen as 'variants' and will be shown together on the Boefje detail page. </"
-"p> "
+"<p>The name of the Docker image. For example: "
+"<i>'ghcr.io/minvws/openkat/nmap'</i>. In OpenKAT, all Boefjes with the same "
+"container image will be seen as 'variants' and will be shown together on the"
+" Boefje detail page. </p> "
 msgstr ""
+"<p>Nazwa obrazu Dockera. Na przykład: <i>'ghcr.io/minvws/openkat/nmap'</i>. "
+"W OpenKAT wszystkie Boefjes z tym samym obrazem kontenera będą postrzegane "
+"jako „warianty” i będą wyświetlane razem na stronie szczegółów Boefje. </p>"
 
 #: tools/forms/settings.py
 msgid ""
 "A description of the Boefje explaining in short what it can do. This will "
 "both be displayed inside the KAT-alogus and on the Boefje details page."
 msgstr ""
+"Opis Boefje wyjaśniający w skrócie, co potrafi. Będą one wyświetlane zarówno"
+" wewnątrz KAT-alogus, jak i na stronie szczegółów Boefje."
 
 #: tools/forms/settings.py
 msgid ""
@@ -5049,164 +5602,197 @@ msgid ""
 "objects, press and hold the 'ctrl'/'command' key and then click the items "
 "you want to select. "
 msgstr ""
+"Wybierz typ(y) obiektów używanych przez Boefje. Aby wybrać wiele obiektów, "
+"naciśnij i przytrzymaj klawisz „Ctrl”/„Command”, a następnie kliknij "
+"elementy, które chcesz wybrać."
 
 #: tools/forms/settings.py
 msgid ""
 "<p>If any other settings are needed for your Boefje, add these as a JSON "
 "Schema, otherwise, leave the field empty or 'null'.</p> <p> This JSON is "
-"used as the basis for a form for the user. When the user enables this Boefje "
-"they can get the option to give extra information. For example, it can "
+"used as the basis for a form for the user. When the user enables this Boefje"
+" they can get the option to give extra information. For example, it can "
 "contain an API key that the script requires.</p> <p>More information about "
-"what the schema.json file looks like can be found <a href='https://docs."
-"openkat.nl/developer_documentation/development_tutorial/creating_a_boefje."
-"html'> here</a>.</p> "
+"what the schema.json file looks like can be found <a "
+"href='https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html'>"
+" here</a>.</p> "
 msgstr ""
+"<p>Jeśli dla Twojego Boefje potrzebne są inne ustawienia, dodaj je jako "
+"schemat JSON, w przeciwnym razie pozostaw pole puste lub „null”. </p> <p> To"
+" JSON służy jako podstawa formularza dla użytkownika. Gdy użytkownik włączy "
+"ten Boefje, może uzyskać opcję podania dodatkowych informacji. Przykładowo "
+"może zawierać klucz API wymagany przez skrypt.</p> <p>Więcej informacji o "
+"tym, jak wygląda plik schema.json znajdziesz <a "
+"href='https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html'>"
+" tutaj</a>.</p>"
 
 #: tools/forms/settings.py
 msgid ""
 "<p>Add a set of mime types that are produced by this Boefje, separated by "
-"commas. For example: <i>'text/html'</i>, <i>'image/jpeg'</i> or <i>'boefje/"
-"{boefje-id}'</i></p> <p>These output mime types will be shown on the Boefje "
-"detail page as information for other users. </p> "
+"commas. For example: <i>'text/html'</i>, <i>'image/jpeg'</i> or "
+"<i>'boefje/{boefje-id}'</i></p> <p>These output mime types will be shown on "
+"the Boefje detail page as information for other users. </p> "
 msgstr ""
+"<p>Adodaj zestaw typów MIME generowanych przez ten Boefje, oddzielając je "
+"przecinkami. Na przykład: <i>'text/html'</i>, <i>'image/jpeg'</i> lub "
+"<i>'boefje/{boefje-id}'</i></p> <p>Te wyjściowe typy MIME będą wyświetlane "
+"na stronie szczegółów Boefje jako informacja dla innych użytkowników. </p>"
 
 #: tools/forms/settings.py
 msgid ""
 "<p>Select a clearance level for your Boefje. For more information about the "
-"different clearance levels please check the <a href='https://docs.openkat.nl/"
-"manual/usermanual.html#scan-levels-clearance-indemnities'> documentation</a>."
-"</p> "
+"different clearance levels please check the <a "
+"href='https://docs.openkat.nl/manual/usermanual.html#scan-levels-clearance-"
+"indemnities'> documentation</a>.</p> "
 msgstr ""
+"<p>Wybierz poziom luzu dla swojego Boefje. Więcej informacji na temat "
+"różnych poziomów luzu można znaleźć w dokumentacji <a "
+"href='https://docs.openkat.nl/manual/usermanual.html#scan-levels-clearance-"
+"indemnities'></a>.</p>"
 
 #: tools/forms/settings.py
 msgid ""
-"Choose when this Boefje will scan objects. It can run on a given interval or "
-"it can run every time an object has been created or changed. "
+"Choose when this Boefje will scan objects. It can run on a given interval or"
+" it can run every time an object has been created or changed. "
 msgstr ""
+"Wybierz, kiedy Boefje będzie skanował obiekty. Może działać w określonym "
+"przedziale czasu lub może działać za każdym razem, gdy obiekt zostanie "
+"utworzony lub zmieniony."
 
 #: tools/forms/settings.py
 msgid "Depth of the tree."
-msgstr ""
+msgstr "Głębokość drzewa."
 
 #: tools/forms/upload_csv.py
 msgid "Only CSV file supported"
-msgstr ""
+msgstr "Obsługiwany jest tylko plik CSV"
 
 #: tools/forms/upload_csv.py
 msgid "File could not be decoded"
-msgstr ""
+msgstr "Nie można zdekodować pliku"
 
 #: tools/forms/upload_csv.py
 msgid "No file selected"
-msgstr ""
+msgstr "Nie wybrano pliku"
 
 #: tools/forms/upload_csv.py
 msgid "The uploaded file is empty."
-msgstr ""
+msgstr "Przesłany plik jest pusty."
 
 #: tools/forms/upload_csv.py
 msgid "The number of columns do not meet the requirements."
-msgstr ""
+msgstr "Liczba kolumn nie spełnia wymagań."
 
 #: tools/forms/upload_csv.py
 msgid "OOI Type in CSV does not meet the criteria."
-msgstr ""
+msgstr "OOI Typ w CSV nie spełnia kryteriów."
 
 #: tools/forms/upload_csv.py
 msgid "An error has occurred during the parsing of the csv file:"
-msgstr ""
+msgstr "Wystąpił błąd podczas analizowania pliku csv:"
 
 #: tools/forms/upload_csv.py
 msgid "Upload CSV file"
-msgstr ""
+msgstr "Prześlij plik CSV"
 
 #: tools/forms/upload_csv.py
 msgid "Only accepts CSV file."
-msgstr ""
+msgstr "Akceptuje tylko plik CSV."
 
 #: tools/forms/upload_oois.py rocky/templates/partials/explanations.html
 msgid "Object Type"
-msgstr ""
+msgstr "Typ obiektu"
 
 #: tools/forms/upload_oois.py
 msgid "Choose a type of which objects are added."
-msgstr ""
+msgstr "Wybierz typ dodawanych obiektów."
 
 #: tools/forms/upload_raw.py
 msgid "Mime types"
-msgstr ""
+msgstr "Typy mimów"
 
 #: tools/forms/upload_raw.py
 msgid ""
-"<p>Add a set of mime types, separated by commas, for example:</"
-"p><p><i>\"text/html, image/jpeg\"</i> or <i>\"boefje/dns-records\"</i>.</"
-"p><p>Mime types are used to match the correct normalizer to a raw file. When "
-"the mime type \"boefje/dns-records\" is added, the normalizer expects the "
-"raw file to contain dns scan information.</p>"
+"<p>Add a set of mime types, separated by commas, for "
+"example:</p><p><i>\"text/html, image/jpeg\"</i> or <i>\"boefje/dns-"
+"records\"</i>.</p><p>Mime types are used to match the correct normalizer to "
+"a raw file. When the mime type \"boefje/dns-records\" is added, the "
+"normalizer expects the raw file to contain dns scan information.</p>"
 msgstr ""
+"<p>Adodaj zestaw typów MIME rozdzielonych przecinkami, na przykład: "
+"</p><p><i>\"text/html, image/jpeg\"</i> lub <i>\"boefje/dns-"
+"records\"</i>.</p><p>Typy Mime służą do dopasowania prawidłowego "
+"normalizatora do surowy plik. Po dodaniu typu MIME „boefje/dns-records” "
+"normalizator oczekuje, że surowy plik będzie zawierał informacje o skanie "
+"dns.</p>"
 
 #: tools/forms/upload_raw.py rocky/templates/partials/ooi_list_toolbar.html
 #: rocky/templates/upload_raw.html
 msgid "Upload raw file"
-msgstr ""
+msgstr "Prześlij surowy plik"
 
 #: tools/forms/upload_raw.py
 msgid "Input or Scan OOI"
-msgstr ""
+msgstr "Wprowadź lub zeskanuj OOI"
 
 #: tools/forms/upload_raw.py
 msgid "Click to select one of the available options, or type one yourself"
 msgstr ""
+"Kliknij, aby wybrać jedną z dostępnych opcji, lub wpisz ją samodzielnie"
 
 #: tools/forms/upload_raw.py
 msgid "OOI doesn't exist, try another valid time"
-msgstr ""
+msgstr "OOI nie istnieje, spróbuj inny prawidłowy czas"
 
 #: tools/models.py
 msgid ""
-"A short code containing only lower-case unicode letters, numbers, hyphens or "
-"underscores that will be used in URLs and paths."
+"A short code containing only lower-case unicode letters, numbers, hyphens or"
+" underscores that will be used in URLs and paths."
 msgstr ""
+"Krótki kod zawierający wyłącznie małe litery, cyfry, łączniki i podkreślenia"
+" Unicode, który będzie używany w adresach URL i ścieżkach."
 
 #: tools/models.py
 msgid ""
 "This organization code is reserved by OpenKAT and cannot be used. Choose "
 "another organization code."
 msgstr ""
+"Ten kod organizacji jest zastrzeżony przez OpenKAT i nie może być używany. "
+"Wybierz inny kod organizacji."
 
 #: tools/models.py
 msgid "new"
-msgstr ""
+msgstr "nowy"
 
 #: tools/templatetags/ooi_extra.py
 msgid "Unknown user"
-msgstr ""
+msgstr "Nieznany użytkownik"
 
 #: tools/view_helpers.py rocky/templates/header.html
 #: rocky/templates/organizations/organization_member_list.html
 #: rocky/views/organization_member_edit.py
 msgid "Members"
-msgstr ""
+msgstr "Członkowie"
 
 #: rocky/forms.py
 msgid "Current status"
-msgstr ""
+msgstr "Aktualny stan"
 
 #: rocky/forms.py rocky/templates/organizations/organization_member_list.html
 msgid "Active"
-msgstr ""
+msgstr "Aktywny"
 
 #: rocky/forms.py rocky/templates/organizations/organization_member_list.html
 msgid "New"
-msgstr ""
+msgstr "Nowy"
 
 #: rocky/forms.py
 msgid "Account status"
-msgstr ""
+msgstr "Stan konta"
 
 #: rocky/forms.py
 msgid "Not blocked"
-msgstr ""
+msgstr "Nie zablokowane"
 
 #: rocky/messaging.py
 msgid ""
@@ -5214,242 +5800,258 @@ msgid ""
 "needs at least a clearance level of L{} in order to do a proper onboarding. "
 "Edit this member and change the clearance level if necessary."
 msgstr ""
+"Zaufałeś temu członkowi z poziomem uprawnień L{}. Aby móc przeprowadzić "
+"prawidłowe wdrożenie, ten członek potrzebuje co najmniej poziomu uprawnień "
+"L{}. Edytuj ten element i w razie potrzeby zmień poziom uprawnień."
 
 #: rocky/paginator.py
 msgid "That page number is not an integer"
-msgstr ""
+msgstr "Numer strony nie jest liczbą całkowitą"
 
 #: rocky/paginator.py
 msgid "That page number is less than 1"
-msgstr ""
+msgstr "Numer tej strony jest mniejszy niż 1"
 
 #: rocky/paginator.py
 msgid "That page contains no results"
-msgstr ""
+msgstr "Ta strona nie zawiera żadnych wyników"
 
 #: rocky/scheduler.py
 msgid ""
 "The Scheduler has an unexpected error. Check the Scheduler logs for further "
 "details."
 msgstr ""
+"W harmonogramie wystąpił nieoczekiwany błąd. Więcej szczegółów można znaleźć"
+" w dziennikach programu planującego."
 
 #: rocky/scheduler.py
 msgid "Could not connect to Scheduler. Service is possibly down."
 msgstr ""
+"Nie można połączyć się z Harmonogramem. Usługa prawdopodobnie nie działa."
 
 #: rocky/scheduler.py
 msgid "Your request could not be validated."
-msgstr ""
+msgstr "Nie można zweryfikować Twojego żądania."
 
 #: rocky/scheduler.py
 msgid "Task could not be found."
-msgstr ""
+msgstr "Nie udało się znaleźć zadania."
 
 #: rocky/scheduler.py
 msgid ""
 "Scheduler is receiving too many requests. Increase SCHEDULER_PQ_MAXSIZE or "
 "wait for task to finish."
 msgstr ""
+"Harmonogram otrzymuje zbyt wiele żądań. Zwiększ SCHEDULER_PQ_MAXSIZE lub "
+"poczekaj na zakończenie zadania."
 
 #: rocky/scheduler.py
 msgid "Bad request. Your request could not be interpreted by the Scheduler."
 msgstr ""
+"Zła prośba. Twoja prośba nie mogła zostać zinterpretowana przez "
+"Harmonogramu."
 
 #: rocky/scheduler.py
 msgid "The Scheduler has received a conflict. Your task is already in queue."
-msgstr ""
+msgstr "Harmonogram odebrał konflikt. Twoje zadanie jest już w kolejce."
 
 #: rocky/scheduler.py
 msgid "A HTTPError occurred. See Scheduler logs for more info."
 msgstr ""
+"Wystąpił błąd HTTP. Aby uzyskać więcej informacji, zobacz dzienniki "
+"harmonogramu."
 
 #: rocky/scheduler.py
 msgid "Schedule list: "
-msgstr ""
+msgstr "Lista harmonogramów:"
 
 #: rocky/scheduler.py
 msgid "Task list: "
-msgstr ""
+msgstr "Lista zadań:"
 
 #: rocky/settings.py
 msgid "Blue light"
-msgstr ""
+msgstr "Niebieskie światło"
 
 #: rocky/settings.py
 msgid "Blue medium"
-msgstr ""
+msgstr "Niebieski średni"
 
 #: rocky/settings.py
 msgid "Blue dark"
-msgstr ""
+msgstr "Niebieski ciemny"
 
 #: rocky/settings.py
 msgid "Green light"
-msgstr ""
+msgstr "Zielone światło"
 
 #: rocky/settings.py
 msgid "Green medium"
-msgstr ""
+msgstr "Zielony średni"
 
 #: rocky/settings.py
 msgid "Green dark"
-msgstr ""
+msgstr "Zielony ciemny"
 
 #: rocky/settings.py
 msgid "Yellow light"
-msgstr ""
+msgstr "Żółte światło"
 
 #: rocky/settings.py
 msgid "Yellow medium"
-msgstr ""
+msgstr "Żółty średni"
 
 #: rocky/settings.py
 msgid "Yellow dark"
-msgstr ""
+msgstr "Żółty ciemny"
 
 #: rocky/settings.py
 msgid "Orange light"
-msgstr ""
+msgstr "Pomarańczowe światło"
 
 #: rocky/settings.py
 msgid "Orange medium"
-msgstr ""
+msgstr "Pomarańczowy średni"
 
 #: rocky/settings.py
 msgid "Orange dark"
-msgstr ""
+msgstr "Pomarańczowy ciemny"
 
 #: rocky/settings.py
 msgid "Red light"
-msgstr ""
+msgstr "Czerwone światło"
 
 #: rocky/settings.py
 msgid "Red medium"
-msgstr ""
+msgstr "Czerwony średni"
 
 #: rocky/settings.py
 msgid "Red dark"
-msgstr ""
+msgstr "Czerwony ciemny"
 
 #: rocky/settings.py
 msgid "Violet light"
-msgstr ""
+msgstr "Fioletowe światło"
 
 #: rocky/settings.py
 msgid "Violet medium"
-msgstr ""
+msgstr "Fioletowy środek"
 
 #: rocky/settings.py
 msgid "Violet dark"
-msgstr ""
+msgstr "Fioletowy ciemny"
 
 #: rocky/settings.py
 msgid "Plain"
-msgstr ""
+msgstr "Zwykły"
 
 #: rocky/settings.py
 msgid "Solid"
-msgstr ""
+msgstr "Solidny"
 
 #: rocky/settings.py
 msgid "Dashed"
-msgstr ""
+msgstr "Przerywana"
 
 #: rocky/settings.py
 msgid "Dotted"
-msgstr ""
+msgstr "Kropkowany"
 
 #: rocky/templates/403.html
 msgid "Error code 403: Unauthorized"
-msgstr ""
+msgstr "Kod błędu 403: Nieautoryzowany"
 
 #: rocky/templates/403.html
 msgid "Your account is not authorized to access this page or organization."
 msgstr ""
+"Twoje konto nie ma uprawnień dostępu do tej strony lub tej organizacji."
 
 #: rocky/templates/403.html
 msgid "Please contact your system administrator."
-msgstr ""
+msgstr "Skontaktuj się z administratorem systemu."
 
 #: rocky/templates/403.html rocky/templates/404.html
 msgid "You may want to go back to the"
-msgstr ""
+msgstr "Może zechcesz wrócić do"
 
 #: rocky/templates/403.html rocky/templates/404.html
 msgid "Crisis Room"
-msgstr ""
+msgstr "Pokój kryzysowy"
 
 #: rocky/templates/404.html
 msgid "Error code 404: Page not found"
-msgstr ""
+msgstr "Kod błędu 404: Nie znaleziono strony"
 
 #: rocky/templates/404.html
 msgid ""
 "The page you wanted to see or the file you wanted to view was not found."
 msgstr ""
+"Strona, którą chciałeś wyświetlić lub plik, który chciałeś wyświetlić, nie "
+"został znaleziony."
 
 #: rocky/templates/admin/base.html
 msgid "Skip to main content"
-msgstr ""
+msgstr "Przejdź do głównej treści"
 
 #: rocky/templates/admin/base.html
 msgid "Welcome,"
-msgstr ""
+msgstr "Powitanie,"
 
 #: rocky/templates/admin/base.html
 msgid "View site"
-msgstr ""
+msgstr "Zobacz witrynę"
 
 #: rocky/templates/admin/base.html
 msgid "Documentation"
-msgstr ""
+msgstr "Dokumentacja"
 
 #: rocky/templates/admin/base.html
 msgid "Change password"
-msgstr ""
+msgstr "Zmień hasło"
 
 #: rocky/templates/admin/base.html
 msgid "Log out"
-msgstr ""
+msgstr "Wyloguj się"
 
 #: rocky/templates/admin/base.html rocky/templates/header.html
 msgid "Breadcrumbs"
-msgstr ""
+msgstr "Bułka tarta"
 
 #: rocky/templates/admin/base.html rocky/templates/admin/change_form.html
 #: rocky/templates/admin/change_list.html
 #: rocky/templates/admin/delete_confirmation.html
 #: rocky/templates/admin/delete_selected_confirmation.html
 msgid "Home"
-msgstr ""
+msgstr "Dom"
 
 #: rocky/templates/admin/change_form.html
 #, python-format
 msgid "Add %(name)s"
-msgstr ""
+msgstr "Dodaj %(name)s"
 
 #: rocky/templates/admin/change_form.html
 #: rocky/templates/admin/change_list.html
 msgid "Please correct the error below."
 msgid_plural "Please correct the errors below."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Popraw poniższy błąd."
+msgstr[1] "Popraw poniższe błędy."
+msgstr[2] "Popraw poniższe błędy."
 
 #: rocky/templates/admin/change_list.html
 msgid "Filter"
-msgstr ""
+msgstr "Filtr"
 
 #: rocky/templates/admin/change_list.html
 msgid "Hide counts"
-msgstr ""
+msgstr "Ukryj liczby"
 
 #: rocky/templates/admin/change_list.html
 msgid "Show counts"
-msgstr ""
+msgstr "Pokaż liczniki"
 
 #: rocky/templates/admin/change_list.html
 msgid "Clear all filters"
-msgstr ""
+msgstr "Wyczyść wszystkie filtry"
 
 #: rocky/templates/admin/delete_confirmation.html
 #, python-format
@@ -5458,13 +6060,18 @@ msgid ""
 "related objects, but your account doesn't have permission to delete the "
 "following types of objects"
 msgstr ""
+"Usunięcie %(object_name)s '%(escaped_object)s' spowodowałoby usunięcie "
+"powiązanych obiektów, ale Twoje konto nie ma uprawnień do usuwania "
+"następujących typów obiektów"
 
 #: rocky/templates/admin/delete_confirmation.html
 #, python-format
 msgid ""
-"Deleting the %(object_name)s '%(escaped_object)s' would require deleting the "
-"following protected related objects"
+"Deleting the %(object_name)s '%(escaped_object)s' would require deleting the"
+" following protected related objects"
 msgstr ""
+"Usunięcie %(object_name)s „%(escaped_object)s” wymagałoby usunięcia "
+"następujących chronionych powiązanych obiektów"
 
 #: rocky/templates/admin/delete_confirmation.html
 #, python-format
@@ -5472,20 +6079,22 @@ msgid ""
 "Are you sure you want to delete the %(object_name)s \"%(escaped_object)s\"? "
 "All of the following related items will be deleted"
 msgstr ""
+"Czy na pewno chcesz usunąć %(object_name)s \"%(escaped_object)s\"? Wszystkie"
+" poniższe powiązane elementy zostaną usunięte"
 
 #: rocky/templates/admin/delete_confirmation.html
 #: rocky/templates/admin/delete_selected_confirmation.html
 msgid "Yes, I’m sure"
-msgstr ""
+msgstr "Tak, jestem pewien"
 
 #: rocky/templates/admin/delete_confirmation.html
 #: rocky/templates/admin/delete_selected_confirmation.html
 msgid "No, take me back"
-msgstr ""
+msgstr "Nie, zabierz mnie z powrotem"
 
 #: rocky/templates/admin/delete_selected_confirmation.html
 msgid "Delete multiple objects"
-msgstr ""
+msgstr "Usuń wiele obiektów"
 
 #: rocky/templates/admin/delete_selected_confirmation.html
 #, python-format
@@ -5494,6 +6103,9 @@ msgid ""
 "objects, but your account doesn't have permission to delete the following "
 "types of objects"
 msgstr ""
+"Usunięcie wybranego %(objects_name)s spowodowałoby usunięcie powiązanych "
+"obiektów, ale Twoje konto nie ma uprawnień do usuwania następujących typów "
+"obiektów"
 
 #: rocky/templates/admin/delete_selected_confirmation.html
 #, python-format
@@ -5501,6 +6113,8 @@ msgid ""
 "Deleting the selected %(objects_name)s would require deleting the following "
 "protected related objects"
 msgstr ""
+"Usunięcie wybranego %(objects_name)s wymagałoby usunięcia następujących "
+"chronionych powiązanych obiektów"
 
 #: rocky/templates/admin/delete_selected_confirmation.html
 #, python-format
@@ -5508,64 +6122,69 @@ msgid ""
 "Are you sure you want to delete the selected %(objects_name)s? All of the "
 "following objects and their related items will be deleted"
 msgstr ""
+"Czy na pewno chcesz usunąć wybrane %(objects_name)s? Wszystkie poniższe "
+"obiekty i powiązane z nimi elementy zostaną usunięte"
 
 #: rocky/templates/admin/popup_response.html
 msgid "Popup closing…"
-msgstr ""
+msgstr "Zamykanie wyskakującego okienka…"
 
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
-#: rocky/templates/header.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
 msgid "Close menu"
-msgstr ""
+msgstr "Zamknij menu"
 
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
-#: rocky/templates/header.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html rocky/templates/header.html
 msgid "Main navigation"
-msgstr ""
+msgstr "Główna nawigacja"
 
 #: rocky/templates/dashboard_client.html
 msgid "Indemnifications"
-msgstr ""
+msgstr "Odszkodowania"
 
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html
 #: rocky/templates/partials/secondary-menu.html
 msgid "Logout"
-msgstr ""
+msgstr "Wyloguj się"
 
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html
 msgid "Welcome"
-msgstr ""
+msgstr "Powitanie"
 
-#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
+#: rocky/templates/dashboard_client.html
+#: rocky/templates/dashboard_redteam.html
 msgid "User overview"
-msgstr ""
+msgstr "Przegląd użytkowników"
 
 #: rocky/templates/dashboard_redteam.html
 #: rocky/templates/partials/notifications_block.html
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "warning"
-msgstr ""
+msgstr "ostrzeżenie"
 
 #: rocky/templates/dashboard_redteam.html
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 #: rocky/templates/partials/notifications_block.html
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "Warning:"
-msgstr ""
+msgstr "Ostrzeżenie:"
 
 #: rocky/templates/dashboard_redteam.html
 msgid "Organization code missing"
-msgstr ""
+msgstr "Brak kodu organizacji"
 
 #: rocky/templates/finding_type_add.html
 #: rocky/templates/partials/findings_list_toolbar.html
 #: rocky/views/finding_type_add.py
 msgid "Add finding type"
-msgstr ""
+msgstr "Dodaj typ wyniku"
 
 #: rocky/templates/finding_type_add.html
 msgid "Finding Type"
-msgstr ""
+msgstr "Typ znalezienia"
 
 #: rocky/templates/findings/finding_add.html
 #: rocky/templates/oois/ooi_detail_findings_list.html
@@ -5573,11 +6192,11 @@ msgstr ""
 #: rocky/templates/partials/findings_list_toolbar.html
 #: rocky/views/finding_add.py
 msgid "Add finding"
-msgstr ""
+msgstr "Dodaj znalezisko"
 
 #: rocky/templates/findings/finding_list.html
 msgid "Findings "
-msgstr ""
+msgstr "Ustalenia"
 
 #: rocky/templates/findings/finding_list.html
 #, python-format
@@ -5586,107 +6205,114 @@ msgid ""
 "<strong>%(organization_name)s</strong>. Each finding relates to an object. "
 "Click a finding for additional information."
 msgstr ""
+"Przegląd wszystkich ustaleń znalezionych przez OpenKAT dla organizacji "
+"<strong>%(organization_name)s</strong>. Każde znalezisko odnosi się do "
+"obiektu. Kliknij wynik, aby uzyskać dodatkowe informacje."
 
 #: rocky/templates/findings/finding_list.html
 #, python-format
 msgid "Showing %(length)s of %(total)s findings"
-msgstr ""
+msgstr "Wyświetlanie wyników %(length)s z %(total)s"
 
 #: rocky/templates/findings/finding_list.html
 #: rocky/templates/partials/mute_findings_modal.html
 msgid "Mute findings"
-msgstr ""
+msgstr "Wycisz ustalenia"
 
 #: rocky/templates/findings/finding_list.html
 msgid "Unmute findings"
-msgstr ""
+msgstr "Wyłącz wyciszenie wyników"
 
 #: rocky/templates/findings/findings_filter.html
 #: rocky/templates/partials/elements/ooi_list_settings_form.html
 #: rocky/templates/tasks/partials/task_filter.html
 msgid "Set filters"
-msgstr ""
+msgstr "Ustaw filtry"
 
 #: rocky/templates/findings/findings_filter.html
 #: rocky/templates/partials/elements/ooi_list_settings_form.html
 #: rocky/templates/tasks/partials/task_filter.html
 msgid "Clear filters"
-msgstr ""
+msgstr "Wyczyść filtry"
 
 #: rocky/templates/footer.html rocky/views/privacy_statement.py
 msgid "Privacy Statement"
-msgstr ""
+msgstr "Oświadczenie o ochronie prywatności"
 
 #: rocky/templates/forms/json_schema_form.html
 msgid "Fill out this form to answer the Question (again):"
-msgstr ""
+msgstr "Wypełnij ten formularz, aby odpowiedzieć na pytanie (ponownie):"
 
 #: rocky/templates/graph-d3.html
 msgid ""
 "Click a circle to collapse / expand the tree, click the text to view the "
 "tree from that OOI and hover over the text to see details."
 msgstr ""
+"Kliknij okrąg, aby zwinąć/rozwinąć drzewo, kliknij tekst, aby wyświetlić "
+"drzewo z tego OOI i najedź kursorem na tekst, aby zobaczyć szczegóły."
 
 #: rocky/templates/graph-d3.html
 msgid "Tree graph"
-msgstr ""
+msgstr "Wykres drzewa"
 
 #: rocky/templates/header.html
 msgid "Menu"
-msgstr ""
+msgstr "Menu"
 
 #: rocky/templates/header.html
 msgid "OpenKAT logo, go to the homepage of OpenKAT"
-msgstr ""
+msgstr "Logo OpenKAT, przejdź do strony głównej OpenKAT"
 
 #: rocky/templates/header.html rocky/templates/tasks/ooi_detail_task_list.html
 #: rocky/templates/tasks/partials/tasks_overview_header.html
 #: rocky/templates/tasks/plugin_detail_task_list.html
 #: rocky/views/task_detail.py rocky/views/tasks.py
 msgid "Tasks"
-msgstr ""
+msgstr "Zadania"
 
 #: rocky/templates/health.html
 msgid "Health Checks"
-msgstr ""
+msgstr "Kontrole stanu zdrowia"
 
 #: rocky/templates/health.html
 msgid "Health checks"
-msgstr ""
+msgstr "Kontrole stanu zdrowia"
 
 #: rocky/templates/health.html
 msgid "Additional"
-msgstr ""
+msgstr "Dodatkowy"
 
 #: rocky/templates/indemnification_present.html
 msgid "Indemnification"
-msgstr ""
+msgstr "Odszkodowanie"
 
 #: rocky/templates/indemnification_present.html
 msgid ""
 "Indemnification on the organization present. You may now add objects and "
 "start scans."
 msgstr ""
+"Zabezpieczenie od obecnej organizacji. Możesz teraz dodawać obiekty i "
+"rozpoczynać skanowanie."
 
 #: rocky/templates/indemnification_present.html
 msgid "Go to Objects"
-msgstr ""
+msgstr "Przejdź do Obiektów"
 
 #: rocky/templates/indemnification_present.html
 msgid "Go to"
-msgstr ""
+msgstr "Idź do"
 
 #: rocky/templates/landing_page.html
 msgid "Welcome to OpenKAT"
-msgstr ""
+msgstr "Witamy w OpenKAT"
 
 #: rocky/templates/landing_page.html
 msgid "Kwetsbaarheden Analyse Tool"
-msgstr ""
+msgstr "Narzędzie analityczne Kwetsbaarheden"
 
 #: rocky/templates/landing_page.html
 msgid "What is OpenKAT?"
-msgstr ""
+msgstr "Co to jest OpenKAT?"
 
 #: rocky/templates/landing_page.html
 msgid ""
@@ -5694,261 +6320,297 @@ msgid ""
 "by the Ministry of Health, Welfare and Sport to make your and our world "
 "safer."
 msgstr ""
+"OpenKAT to narzędzie do analizy podatności. Projekt Open Source opracowany "
+"przez Ministerstwo Zdrowia, Opieki Społecznej i Sportu, aby uczynić Twój i "
+"nasz świat bezpieczniejszym."
 
 #: rocky/templates/landing_page.html
 msgid "OpenKAT sees"
-msgstr ""
+msgstr "OpenKAT widzi"
 
 #: rocky/templates/landing_page.html
 msgid ""
 "Dozens of tools are integrated in OpenKAT to view the world (digital and "
 "analog)."
 msgstr ""
+"W OpenKAT zintegrowanych jest kilkadziesiąt narzędzi umożliwiających "
+"oglądanie świata (cyfrowego i analogowego)."
 
 #: rocky/templates/landing_page.html
 msgid "Our motto is therefore: I see, I see, what you do not see."
-msgstr ""
+msgstr "Naszą dewizą jest zatem: Widzę, widzę, czego Ty nie widzisz."
 
 #: rocky/templates/landing_page.html
 msgid "OpenKAT knows"
-msgstr ""
+msgstr "OpenKAT wie"
 
 #: rocky/templates/landing_page.html
 msgid ""
 "OpenKAT does not forget (just like that), and can be queried without "
 "scanning again. Also about a historical situation."
 msgstr ""
+"OpenKAT nie zapomina (tak po prostu) i można go zapytać bez ponownego "
+"skanowania. Także o sytuacji historycznej."
 
 #: rocky/templates/landing_page.html
 msgid "OpenKAT is secure"
-msgstr ""
+msgstr "OpenKAT jest bezpieczny"
 
 #: rocky/templates/landing_page.html
 msgid ""
 "Forensically secured storage of evidence is one of the basic ingredients of "
 "OpenKAT."
 msgstr ""
+"Zabezpieczone kryminalistycznie przechowywanie dowodów jest jednym z "
+"podstawowych składników OpenKAT."
 
 #: rocky/templates/landing_page.html
 msgid "OpenKAT is sweet"
-msgstr ""
+msgstr "OpenKAT jest słodki"
 
 #: rocky/templates/landing_page.html
 msgid ""
-"OpenKAT thinks about privacy, and stores what is necessary, within the rules "
-"of your organization and the law."
+"OpenKAT thinks about privacy, and stores what is necessary, within the rules"
+" of your organization and the law."
 msgstr ""
+"OpenKAT myśli o prywatności i przechowuje to, co konieczne, w ramach zasad "
+"obowiązujących w Twojej organizacji i prawa."
 
 #: rocky/templates/landing_page.html
 msgid "A wide playing field"
-msgstr ""
+msgstr "Szerokie pole do gry"
 
 #: rocky/templates/landing_page.html
 msgid ""
-"OpenKAT makes a copy of the actual reality by means of the integrated tools. "
-"Within this copy you can search for answers to countless security and policy "
-"questions. Expected and unexpected changes in the world are made visible, "
-"and where necessary reported or made known directly to the right people."
+"OpenKAT makes a copy of the actual reality by means of the integrated tools."
+" Within this copy you can search for answers to countless security and "
+"policy questions. Expected and unexpected changes in the world are made "
+"visible, and where necessary reported or made known directly to the right "
+"people."
 msgstr ""
+"OpenKAT tworzy kopię rzeczywistej rzeczywistości za pomocą zintegrowanych "
+"narzędzi. W tej kopii możesz szukać odpowiedzi na niezliczone pytania "
+"dotyczące bezpieczeństwa i zasad. Oczekiwane i nieoczekiwane zmiany na "
+"świecie są widoczne, a w razie potrzeby zgłaszane lub udostępniane "
+"bezpośrednio właściwym osobom."
 
 #: rocky/templates/legal/privacy_statement.html
 msgid "OpenKAT Privacy Statement"
-msgstr ""
+msgstr "OpenKAT Oświadczenie o ochronie prywatności"
 
 #: rocky/templates/legal/privacy_statement.html
 msgid ""
 "OpenKAT is dedicated to protecting the confidentiality and privacy of "
-"information entrusted to it. As part of this fundamental obligation, OpenKAT "
-"is committed to the appropriate protection and use of personal information "
+"information entrusted to it. As part of this fundamental obligation, OpenKAT"
+" is committed to the appropriate protection and use of personal information "
 "(sometimes referred to as \"personal data\", \"personally identifiable "
 "information\" or \"PII\") that has been collected online."
 msgstr ""
+"OpenKAT przykłada dużą wagę do ochrony poufności i prywatności powierzonych "
+"mu informacji. W ramach tego podstawowego obowiązku OpenKAT zobowiązuje się "
+"do odpowiedniej ochrony i wykorzystania danych osobowych (czasami nazywanych"
+" „danymi osobowymi”, „danymi osobowymi” lub „PII”), które zostały zebrane "
+"online."
 
 #: rocky/templates/oois/error.html
 msgid "Object List"
-msgstr ""
+msgstr "Lista obiektów"
 
 #: rocky/templates/oois/error.html
 msgid "An error occurred. Please contact a system administrator."
-msgstr ""
+msgstr "Wystąpił błąd. Skontaktuj się z administratorem systemu."
 
 #: rocky/templates/oois/ooi_add.html
 #, python-format
 msgid "Add a %(display_type)s"
-msgstr ""
+msgstr "Dodaj %(display_type)s"
 
 #: rocky/templates/oois/ooi_add.html
 msgid ""
 "Here you can add the asset of the client. Findings can be added to these in "
 "the findings page."
 msgstr ""
+"Tutaj możesz dodać zasób klienta. Wyniki można dodać do nich na stronie "
+"wyników."
 
 #: rocky/templates/oois/ooi_add.html
 #, python-format
 msgid "Add %(display_type)s"
-msgstr ""
+msgstr "Dodaj %(display_type)s"
 
 #: rocky/templates/oois/ooi_add_type_select.html
 #: rocky/templates/oois/ooi_detail_add_related_object.html
 #: rocky/templates/partials/elements/ooi_add_type_select_form.html
 #: rocky/templates/partials/ooi_list_toolbar.html rocky/views/ooi_add.py
 msgid "Add object"
-msgstr ""
+msgstr "Dodaj obiekt"
 
 #: rocky/templates/oois/ooi_add_type_select.html
 msgid "Select the type of object you want to create."
-msgstr ""
+msgstr "Wybierz typ obiektu, który chcesz utworzyć."
 
 #: rocky/templates/oois/ooi_delete.html
 #, python-format
 msgid "Delete %(primary_key)s"
-msgstr ""
+msgstr "Usuń %(primary_key)s"
 
 #: rocky/templates/oois/ooi_delete.html
 msgid "Are you sure?"
-msgstr ""
+msgstr "Czy jesteś pewien?"
 
 #: rocky/templates/oois/ooi_delete.html
 #, python-format
 msgid "Here you can delete the %(display_type)s."
-msgstr ""
+msgstr "Tutaj możesz usunąć plik %(display_type)s."
 
 #: rocky/templates/oois/ooi_delete.html
 msgid "To be deleted object(s)"
-msgstr ""
+msgstr "Obiekt(y) do usunięcia"
 
 #: rocky/templates/oois/ooi_delete.html
 #: rocky/templates/partials/elements/ooi_tree_condensed_table.html
 msgid "Key"
-msgstr ""
+msgstr "Klawisz"
 
 #: rocky/templates/oois/ooi_delete.html
 #: rocky/templates/partials/ooi_detail_toolbar.html
 #, python-format
 msgid "Delete %(display_type)s"
-msgstr ""
+msgstr "Usuń %(display_type)s"
 
 #: rocky/templates/oois/ooi_delete.html
 msgid "Deletion not possible for types: KATFindingType and CVEFindingType"
-msgstr ""
+msgstr "Usunięcie nie jest możliwe dla typów: KATFindingType i CVEFindingType"
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "using boefjes"
-msgstr ""
+msgstr "za pomocą boefjes"
 
 #: rocky/templates/oois/ooi_detail.html
 #: rocky/templates/organizations/organization_settings.html
 msgid "indemnification warning"
-msgstr ""
+msgstr "ostrzeżenie dotyczące odszkodowania"
 
 #: rocky/templates/oois/ooi_detail.html
 #, python-format
 msgid ""
-"<strong>Warning:</strong> There is no indemnification for this organization. "
-"Go to the <a href=\"%(organization_settings)s\">organization settings page</"
-"a> to add one."
+"<strong>Warning:</strong> There is no indemnification for this organization."
+" Go to the <a href=\"%(organization_settings)s\">organization settings "
+"page</a> to add one."
 msgstr ""
+"<strong>Ostrzeżenie:</strong> Ta organizacja nie otrzymuje żadnego "
+"zabezpieczenia. Przejdź do strony ustawień organizacji <a "
+"href=\"%(organization_settings)s\"></a>, aby ją dodać."
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "Permission warning"
-msgstr ""
+msgstr "Ostrzeżenie dotyczące pozwolenia"
 
 #: rocky/templates/oois/ooi_detail.html
 msgid ""
 "<strong>Warning:</strong> You don't have the proper permission at the "
 "organizational level to scan objects. Contact your administrator."
 msgstr ""
+"<strong>Ostrzeżenie:</strong> Nie masz odpowiednich uprawnień na poziomie "
+"organizacji do skanowania obiektów. Skontaktuj się ze swoim administratorem."
 
 #: rocky/templates/oois/ooi_detail.html
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Scan warning"
-msgstr ""
+msgstr "Ostrzeżenie o skanowaniu"
 
 #: rocky/templates/oois/ooi_detail.html
 #, python-format
 msgid ""
-"<strong>Warning:</strong> You are not allowed to scan this OOI. Your maximum "
-"clearance level is %(member_clearance_level)s and this OOI has level "
+"<strong>Warning:</strong> You are not allowed to scan this OOI. Your maximum"
+" clearance level is %(member_clearance_level)s and this OOI has level "
 "%(boefje_scan_level)s. Go to your <a href=\"%(account_details)s\">account "
 "details</a> to manage your clearance level."
 msgstr ""
+"<strong>Ostrzeżenie:</strong> Nie masz uprawnień do skanowania tego OOI. "
+"Twój maksymalny poziom uprawnień to %(member_clearance_level)s, a ten OOI ma"
+" poziom %(boefje_scan_level)s. Przejdź do szczegółów konta <a "
+"href=\"%(account_details)s\"></a>, aby zarządzać poziomem uprawnień."
 
 #: rocky/templates/oois/ooi_detail.html rocky/templates/scan.html
 msgid "Boefjes overview"
-msgstr ""
+msgstr "Przegląd Boefjes"
 
 #: rocky/templates/oois/ooi_detail.html
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 #: rocky/templates/scan.html rocky/templates/tasks/boefjes.html
 #: rocky/templates/tasks/normalizers.html
 msgid "Boefje"
-msgstr ""
+msgstr "Boefje"
 
 #: rocky/templates/oois/ooi_detail.html rocky/templates/scan.html
 msgid "Scan profile"
-msgstr ""
+msgstr "Skanuj profil"
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "Unable to start scan. See the warning for more details."
 msgstr ""
+"Nie można rozpocząć skanowania. Więcej szczegółów znajdziesz w ostrzeżeniu."
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "Start scan"
-msgstr ""
+msgstr "Rozpocznij skanowanie"
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "There are no boefjes enabled to scan an OOI of type"
-msgstr ""
+msgstr "Nie ma włączonych boefjes do skanowania typu OOI"
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "See"
-msgstr ""
+msgstr "Widzieć"
 
 #: rocky/templates/oois/ooi_detail.html
 msgid "to find and enable boefjes that can scan within the current level."
 msgstr ""
+"aby znaleźć i włączyć boefje, które mogą skanować w obrębie bieżącego "
+"poziomu."
 
 #: rocky/templates/oois/ooi_detail_add_related_object.html
 #: rocky/templates/partials/ooi_detail_related_object.html
 msgid "Add related object"
-msgstr ""
+msgstr "Dodaj powiązany obiekt"
 
 #: rocky/templates/oois/ooi_detail_add_related_object.html
 #: rocky/templates/oois/ooi_detail_object.html
 msgid "Object details"
-msgstr ""
+msgstr "Szczegóły obiektu"
 
 #: rocky/templates/oois/ooi_detail_add_related_object.html
 #: rocky/templates/partials/elements/ooi_add_type_select_form.html
 msgid "Object type"
-msgstr ""
+msgstr "Typ obiektu"
 
 #: rocky/templates/oois/ooi_detail_add_related_object.html
 #: rocky/templates/partials/elements/ooi_add_type_select_form.html
 msgid "Choose an object type to add"
-msgstr ""
+msgstr "Wybierz typ obiektu do dodania"
 
 #: rocky/templates/oois/ooi_detail_add_related_object.html
 #: rocky/templates/partials/elements/ooi_add_type_select_form.html
 msgid "Select an object type to add."
-msgstr ""
+msgstr "Wybierz typ obiektu do dodania."
 
 #: rocky/templates/oois/ooi_detail_findings_list.html
 msgid "Overview of findings for"
-msgstr ""
+msgstr "Przegląd ustaleń dla"
 
 #: rocky/templates/oois/ooi_detail_findings_list.html
 msgid "Score"
-msgstr ""
+msgstr "Wynik"
 
 #: rocky/templates/oois/ooi_detail_findings_list.html
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "Finding details"
-msgstr ""
+msgstr "Znalezienie szczegółów"
 
 #: rocky/templates/oois/ooi_detail_findings_overview.html
 msgid "Overview of the number of findings and their severity found on"
-msgstr ""
+msgstr "Przegląd liczby stwierdzonych ustaleń i ich wagi"
 
 #: rocky/templates/oois/ooi_detail_findings_overview.html
 msgid ""
@@ -5956,206 +6618,219 @@ msgid ""
 "table shows the number of unique findings found as well as the number of "
 "occurrences."
 msgstr ""
+"Wyniki mogą wystąpić wielokrotnie. Aby zapewnić lepszy wgląd, poniższa "
+"tabela pokazuje liczbę znalezionych unikalnych wyników, a także liczbę "
+"wystąpień."
 
 #: rocky/templates/oois/ooi_detail_findings_overview.html
 msgid "See finding details"
-msgstr ""
+msgstr "Zobacz szczegóły wyszukiwania"
 
 #: rocky/templates/oois/ooi_detail_findings_overview.html
 msgid "Total findings"
-msgstr ""
+msgstr "Łączne ustalenia"
 
 #: rocky/templates/oois/ooi_detail_object.html
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Inactive"
-msgstr ""
+msgstr "Nieaktywny"
 
 #: rocky/templates/oois/ooi_detail_origins_declarations.html
 msgid "Declarations"
-msgstr ""
+msgstr "Deklaracje"
 
 #: rocky/templates/oois/ooi_detail_origins_inference.html
 msgid "Inferred by"
-msgstr ""
+msgstr "Wywnioskowane przez"
 
 #: rocky/templates/oois/ooi_detail_origins_inference.html
 msgid "Bit"
-msgstr ""
+msgstr "Fragment"
 
 #: rocky/templates/oois/ooi_detail_origins_inference.html
 msgid "Parameters"
-msgstr ""
+msgstr "Parametry"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "Last observed by"
-msgstr ""
+msgstr "Ostatnio obserwowany przez"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "Task ID"
-msgstr ""
+msgstr "Identyfikator zadania"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "When"
-msgstr ""
+msgstr "Gdy"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 #: rocky/templates/tasks/normalizers.html
 msgid "Normalizer"
-msgstr ""
+msgstr "Normalizator"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "This scan was manually created."
-msgstr ""
+msgstr "Ten skan został utworzony ręcznie."
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "The boefje has since been deleted or disabled."
-msgstr ""
+msgstr "Od tego czasu boefje zostało usunięte lub wyłączone."
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 msgid "No Raw file could be found, this might point to an error in OpenKAT"
-msgstr ""
+msgstr "Nie znaleziono pliku Raw, może to wskazywać na błąd w OpenKAT"
 
 #: rocky/templates/oois/ooi_detail_origins_observations.html
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Warning"
-msgstr ""
+msgstr "Ostrzeżenie"
 
 #: rocky/templates/oois/ooi_edit.html
 #, python-format
 msgid "Edit %(type)s: %(ooi_human_readable)s"
-msgstr ""
+msgstr "Edytuj %(type)s: %(ooi_human_readable)s"
 
 #: rocky/templates/oois/ooi_edit.html
 msgid "Primary key fields cannot be edited."
-msgstr ""
+msgstr "Pola klucza podstawowego nie mogą być edytowane."
 
 #: rocky/templates/oois/ooi_edit.html
 #, python-format
 msgid "Save %(display_type)s"
-msgstr ""
+msgstr "Zapisz %(display_type)s"
 
 #: rocky/templates/oois/ooi_findings.html
 msgid "Currently no findings have been identified for OOI"
-msgstr ""
+msgstr "Obecnie nie zidentyfikowano żadnych ustaleń dla OOI"
 
 #: rocky/templates/oois/ooi_list.html
 #, python-format
 msgid ""
-"An overview of objects found for organization <strong>%(organization_name)s</"
-"strong>. Objects can be added manually or by running Boefjes. Click an "
-"object for additional information."
+"An overview of objects found for organization "
+"<strong>%(organization_name)s</strong>. Objects can be added manually or by "
+"running Boefjes. Click an object for additional information."
 msgstr ""
+"Przegląd obiektów znalezionych dla organizacji "
+"<strong>%(organization_name)s</strong>. Obiekty można dodawać ręcznie lub "
+"uruchamiając Boefjes. Kliknij obiekt, aby uzyskać dodatkowe informacje."
 
 #: rocky/templates/oois/ooi_list.html
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Edit clearance level"
-msgstr ""
+msgstr "Edytuj poziom zezwolenia"
 
 #: rocky/templates/oois/ooi_mute_finding.html
 msgid "Mute finding:"
-msgstr ""
+msgstr "Wycisz znalezienie:"
 
 #: rocky/templates/oois/ooi_mute_finding.html
 msgid "Give a reason below why you want to mute this finding."
-msgstr ""
+msgstr "Podaj poniżej powód, dla którego chcesz zignorować to ustalenie."
 
 #: rocky/templates/oois/ooi_mute_finding.html
 #: rocky/templates/partials/mute_findings_modal.html
 #: rocky/templates/partials/ooi_detail_toolbar.html
 msgid "Mute finding"
-msgstr ""
+msgstr "Wycisz znalezienie"
 
 #: rocky/templates/oois/ooi_mute_finding.html
 msgid "Mute"
-msgstr ""
+msgstr "Niemy"
 
 #: rocky/templates/oois/ooi_page_tabs.html
 msgid "List of views for OOI"
-msgstr ""
+msgstr "Lista widoków dla OOI"
 
 #: rocky/templates/oois/ooi_past_due_warning.html
 msgid "This object is past due"
-msgstr ""
+msgstr "Ten obiekt jest przeterminowany"
 
 #: rocky/templates/oois/ooi_past_due_warning.html
 msgid "This object is past due and has been deleted"
-msgstr ""
+msgstr "Obiekt ten jest przeterminowany i został usunięty"
 
 #: rocky/templates/oois/ooi_past_due_warning.html
 msgid ""
 "This object is past due. You are viewing the object state in a past state."
 msgstr ""
+"Ten obiekt jest przeterminowany. Oglądasz stan obiektu w stanie przeszłym."
 
 #: rocky/templates/oois/ooi_past_due_warning.html
 msgid ""
 "You will not be able to add Findings or other OOI's to past due objects."
 msgstr ""
+"Nie będziesz mógł dodawać Wyników ani innych OOI do przeterminowanych "
+"obiektów."
 
 #: rocky/templates/oois/ooi_past_due_warning.html
 #: rocky/templates/partials/hyperlink_ooi_id.html
 #, python-format
 msgid "Show details for %(name)s"
-msgstr ""
+msgstr "Pokaż szczegóły %(name)s"
 
 #: rocky/templates/oois/ooi_past_due_warning.html
 msgid "View the current state"
-msgstr ""
+msgstr "Zobacz aktualny stan"
 
 #: rocky/templates/oois/ooi_past_due_warning.html
 msgid ""
 "You will not be able to add Findings or other OOI's, this object has been "
 "deleted and is no longer available."
 msgstr ""
+"Nie będziesz mógł dodać Wyników ani innych OOI, ten obiekt został usunięty i"
+" nie jest już dostępny."
 
 #: rocky/templates/oois/ooi_summary.html
 msgid "Summary for"
-msgstr ""
+msgstr "Podsumowanie dla"
 
 #: rocky/templates/oois/ooi_summary.html
 msgid "Below you can see findings that were found for"
-msgstr ""
+msgstr "Poniżej możesz zobaczyć znalezione wyniki"
 
 #: rocky/templates/oois/ooi_summary.html
 msgid "and direct  children of this"
-msgstr ""
+msgstr "i kieruj w tym dzieci"
 
 #: rocky/templates/oois/ooi_summary.html
 msgid "This"
-msgstr ""
+msgstr "Ten"
 
 #: rocky/templates/oois/ooi_summary.html
 msgid "tree view"
-msgstr ""
+msgstr "widok na drzewo"
 
 #: rocky/templates/oois/ooi_summary.html
 msgid "of the"
-msgstr ""
+msgstr "z"
 
 #: rocky/templates/oois/ooi_summary.html
 msgid "shows the same objects."
-msgstr ""
+msgstr "pokazuje te same obiekty."
 
 #: rocky/templates/organizations/organization_add.html
 msgid ""
-"Please enter the following organization details. These details can be edited "
-"within the organization page within OpenKAT when necessary."
+"Please enter the following organization details. These details can be edited"
+" within the organization page within OpenKAT when necessary."
 msgstr ""
+"Proszę wprowadzić następujące dane organizacyjne. W razie potrzeby szczegóły"
+" te można edytować na stronie organizacji w OpenKAT."
 
 #: rocky/templates/organizations/organization_edit.html
 msgid "Edit organization"
-msgstr ""
+msgstr "Edytuj organizację"
 
 #: rocky/templates/organizations/organization_edit.html
 msgid "Save organization"
-msgstr ""
+msgstr "Zapisz organizację"
 
 #: rocky/templates/organizations/organization_list.html
 msgid "An overview of all organizations you are a member of."
-msgstr ""
+msgstr "Przegląd wszystkich organizacji, których jesteś członkiem."
 
 #: rocky/templates/organizations/organization_list.html
 msgid "Add new organization"
-msgstr ""
+msgstr "Dodaj nową organizację"
 
 #: rocky/templates/organizations/organization_list.html
 #, python-format
@@ -6164,72 +6839,79 @@ msgid ""
 "                            Showing %(total)s organizations\n"
 "                        "
 msgstr ""
+"\n"
+"                            Wyświetlanie organizacji: %(total)s\n"
+"                        "
 
 #: rocky/templates/organizations/organization_list.html
 msgid "Organization overview:"
-msgstr ""
+msgstr "Przegląd organizacji:"
 
 #: rocky/templates/organizations/organization_list.html
 #: rocky/templates/organizations/organization_settings.html
 msgid "Tags"
-msgstr ""
+msgstr "Tagi"
 
 #: rocky/templates/organizations/organization_list.html
 msgid "There were no organizations found for your user account"
-msgstr ""
+msgstr "Nie znaleziono organizacji dla Twojego konta użytkownika"
 
 #: rocky/templates/organizations/organization_list.html
 msgid "Actions to perform for all of your organizations."
-msgstr ""
+msgstr "Działania do wykonania dla wszystkich organizacji."
 
 #: rocky/templates/organizations/organization_list.html
 #: rocky/templates/organizations/organization_settings.html
 msgid "Rerun all bits"
-msgstr ""
+msgstr "Uruchom ponownie wszystkie bity"
 
 #: rocky/templates/organizations/organization_member_add.html
 msgid "Change account type"
-msgstr ""
+msgstr "Zmień typ konta"
 
 #: rocky/templates/organizations/organization_member_add_header.html
 #: rocky/views/organization_member_add.py
 msgid "Add member"
-msgstr ""
+msgstr "Dodaj członka"
 
 #: rocky/templates/organizations/organization_member_add_header.html
 #, python-format
 msgid ""
-"Creating a new member of organization <strong>%(organization)s</strong>. For "
-"detailed information about the different account types, check the <a "
+"Creating a new member of organization <strong>%(organization)s</strong>. For"
+" detailed information about the different account types, check the <a "
 "href=\"https://docs.openkat.nl/basics/users-and-organisations.html#users\" "
 "target=\"_blank\" rel=\"noopener\">documentation</a>."
 msgstr ""
+"Tworzenie nowego członka organizacji <strong>%(organization)s</strong>. Aby "
+"uzyskać szczegółowe informacje na temat różnych typów kont, sprawdź "
+"dokumentację <a href=\"https://docs.openkat.nl/basics/users-and-"
+"organisations.html#users\" target=\"_blank\" rel=\"noopener\"></a>."
 
 #: rocky/templates/organizations/organization_member_edit.html
 #: rocky/views/organization_member_edit.py
 msgid "Edit member"
-msgstr ""
+msgstr "Edytuj członka"
 
 #: rocky/templates/organizations/organization_member_edit.html
 msgid "Save member"
-msgstr ""
+msgstr "Zapisz członka"
 
 #: rocky/templates/organizations/organization_member_list.html
 #, python-format
 msgid "An overview of members of <strong>%(organization_name)s</strong>."
-msgstr ""
+msgstr "Przegląd członków <strong>%(organization_name)s</strong>."
 
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Add member(s)"
-msgstr ""
+msgstr "Dodaj członków"
 
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Manually"
-msgstr ""
+msgstr "Ręcznie"
 
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Upload a CSV"
-msgstr ""
+msgstr "Prześlij plik CSV"
 
 #: rocky/templates/organizations/organization_member_list.html
 #, python-format
@@ -6238,27 +6920,30 @@ msgid ""
 "                        Showing %(total)s members\n"
 "                    "
 msgstr ""
+"\n"
+"                        Wyświetlanie członków: %(total)s\n"
+"                    "
 
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Member overview:"
-msgstr ""
+msgstr "Przegląd członków:"
 
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Role"
-msgstr ""
+msgstr "Rola"
 
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Assigned clearance level"
-msgstr ""
+msgstr "Przypisany poziom zezwolenia"
 
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Super user"
-msgstr ""
+msgstr "Super użytkownik"
 
 #: rocky/templates/organizations/organization_member_upload.html
 #: rocky/views/organization_member_add.py
 msgid "Add members"
-msgstr ""
+msgstr "Dodaj członków"
 
 #: rocky/templates/organizations/organization_member_upload.html
 #, python-format
@@ -6266,14 +6951,19 @@ msgid ""
 "To upload multiple members at once, you can upload a CSV file or you can <a "
 "href=\"%(download_url)s\">download the template</a>."
 msgstr ""
+"Aby przesłać wielu członków jednocześnie, możesz przesłać plik CSV lub <a "
+"href=\"%(download_url)s\">pobrać szablon</a>."
 
 #: rocky/templates/organizations/organization_member_upload.html
-msgid "To create a custom CSV file, make sure it meets the following criteria:"
+msgid ""
+"To create a custom CSV file, make sure it meets the following criteria:"
 msgstr ""
+"Aby utworzyć niestandardowy plik CSV, upewnij się, że spełnia on następujące"
+" kryteria:"
 
 #: rocky/templates/organizations/organization_member_upload.html
 msgid "Upload"
-msgstr ""
+msgstr "Wgrywać"
 
 #: rocky/templates/organizations/organization_settings.html
 #, python-format
@@ -6281,189 +6971,201 @@ msgid ""
 "An overview of general information and settings for "
 "<strong>%(organization_name)s</strong>."
 msgstr ""
+"Przegląd ogólnych informacji i ustawień dla "
+"<strong>%(organization_name)s</strong>."
 
 #: rocky/templates/organizations/organization_settings.html
 msgid ""
 "<strong>Warning:</strong> Indemnification is not set for this organization."
 msgstr ""
+"<strong>Ostrzeżenie:</strong> Dla tej organizacji nie ustawiono "
+"zabezpieczenia."
 
 #: rocky/templates/organizations/organization_settings.html
 #: rocky/views/indemnification_add.py
 msgid "Add indemnification"
-msgstr ""
+msgstr "Dodaj odszkodowanie"
 
 #: rocky/templates/partials/current_config.html
 msgid "Current configuration"
-msgstr ""
+msgstr "Aktualna konfiguracja"
 
 #: rocky/templates/partials/delete_ooi_modal.html
 msgid "Delete objects"
-msgstr ""
+msgstr "Usuń obiekty"
 
 #: rocky/templates/partials/delete_ooi_modal.html
 msgid ""
-"Are you sure you want to delete all the selected objects? The history of the "
-"deleted objects will still be available."
+"Are you sure you want to delete all the selected objects? The history of the"
+" deleted objects will still be available."
 msgstr ""
+"Czy na pewno chcesz usunąć wszystkie zaznaczone obiekty? Historia usuniętych"
+" obiektów będzie nadal dostępna."
 
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 msgid "Edit clearance level settings"
-msgstr ""
+msgstr "Edytuj ustawienia poziomu zezwolenia"
 
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 msgid "You are editing clearance level of all the selected objects."
-msgstr ""
+msgstr "Edytujesz poziom luzu wszystkich wybranych obiektów."
 
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 msgid "Switching between declare and inherit"
-msgstr ""
+msgstr "Przełączanie pomiędzy deklaracją i dziedziczeniem"
 
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 msgid ""
 "Clearance levels can be automatically inherited or you can manually declare "
-"the clearance level for an object. Switching to inherit clearance level will "
-"also recalculate the clearance levels of objects that inherit from these "
+"the clearance level for an object. Switching to inherit clearance level will"
+" also recalculate the clearance levels of objects that inherit from these "
 "clearance levels."
 msgstr ""
+"Poziomy zezwolenia mogą być dziedziczone automatycznie lub można ręcznie "
+"zadeklarować poziom zezwolenia dla obiektu. Przełączenie na dziedziczenie "
+"poziomu uprawnień spowoduje również ponowne obliczenie poziomów uprawnień "
+"obiektów, które dziedziczą z tych poziomów uprawnień."
 
 #: rocky/templates/partials/elements/ooi_detail_settings.html
 msgid "Observed at"
-msgstr ""
+msgstr "Zaobserwowano o godz"
 
 #: rocky/templates/partials/elements/ooi_detail_settings.html
 #: rocky/templates/partials/elements/ooi_report_settings.html
 msgid "Show settings"
-msgstr ""
+msgstr "Pokaż ustawienia"
 
 #: rocky/templates/partials/elements/ooi_detail_settings.html
 #: rocky/templates/partials/elements/ooi_report_settings.html
 msgid "Hide settings"
-msgstr ""
+msgstr "Ukryj ustawienia"
 
 #: rocky/templates/partials/elements/ooi_list_settings_form.html
 msgid "Toggle all OOI types"
-msgstr ""
+msgstr "Przełącz wszystkie typy OOI"
 
 #: rocky/templates/partials/elements/ooi_tree_condensed_table.html
 msgid "Children"
-msgstr ""
+msgstr "Dzieci"
 
 #: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
 #, python-format
 msgid "Show details for %(object_id)s, with %(child_count)s children."
 msgstr ""
+"Pokaż szczegóły dla %(object_id)s, z elementami podrzędnymi %(child_count)s."
 
 #: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
 #, python-format
 msgid ""
 "Show tree for %(object_id)s with only children of type %(object_ooi_type)s"
 msgstr ""
+"Pokaż drzewo dla %(object_id)s z tylko dziećmi typu %(object_ooi_type)s"
 
 #: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
 #, python-format
 msgid "Unfold %(object_id)s with %(child_count)s children"
-msgstr ""
+msgstr "Rozłóż %(object_id)s z dziećmi %(child_count)s"
 
 #: rocky/templates/partials/elements/ooi_tree_table.html
 msgid "go to:"
-msgstr ""
+msgstr "przejdź do:"
 
 #: rocky/templates/partials/elements/ooi_tree_table.html
 msgid "Go to detailpage"
-msgstr ""
+msgstr "Przejdź do strony szczegółów"
 
 #: rocky/templates/partials/elements/ooi_tree_table.html
 msgid "detail"
-msgstr ""
+msgstr "szczegół"
 
 #: rocky/templates/partials/elements/ooi_tree_table.html
 msgid "Go to tree view"
-msgstr ""
+msgstr "Przejdź do widoku drzewa"
 
 #: rocky/templates/partials/elements/ooi_tree_table.html
 msgid "tree"
-msgstr ""
+msgstr "drzewo"
 
 #: rocky/templates/partials/elements/ooi_tree_table.html
 msgid "Go to graph view"
-msgstr ""
+msgstr "Przejdź do widoku wykresu"
 
 #: rocky/templates/partials/elements/ooi_tree_table.html
 msgid "graph"
-msgstr ""
+msgstr "wykres"
 
 #: rocky/templates/partials/explanations.html
 msgid "Clearance level inheritance"
-msgstr ""
+msgstr "Dziedziczenie poziomu uprawnień"
 
 #: rocky/templates/partials/explanations.html
 msgid "OOI"
-msgstr ""
+msgstr "OOI"
 
 #: rocky/templates/partials/explanations.html
 msgid "This OOI"
-msgstr ""
+msgstr "To OOI"
 
 #: rocky/templates/partials/explanations.html
 msgid "Origin"
-msgstr ""
+msgstr "Pochodzenie"
 
 #: rocky/templates/partials/explanations.html
 msgid "declared"
-msgstr ""
+msgstr "zdeklarowany"
 
 #: rocky/templates/partials/explanations.html
 msgid "inherited from ↓"
-msgstr ""
+msgstr "odziedziczone od ↓"
 
 #: rocky/templates/partials/explanations.html
 msgid "Show clearance level inheritance"
-msgstr ""
+msgstr "Pokaż dziedziczenie poziomu uprawnień"
 
 #: rocky/templates/partials/finding_occurrence_definition_list.html
 msgid "Reproduction"
-msgstr ""
+msgstr "Reprodukcja"
 
 #: rocky/templates/partials/form/checkbox_group_table_form.html
 msgid "Please enable plugin to start scanning."
-msgstr ""
+msgstr "Włącz wtyczkę, aby rozpocząć skanowanie."
 
 #: rocky/templates/partials/form/field_input.html
 msgid "Not set"
-msgstr ""
+msgstr "Nie ustawiono"
 
 #: rocky/templates/partials/form/field_input.html
 msgid "Forgot email"
-msgstr ""
+msgstr "Zapomniałem e-maila"
 
 #: rocky/templates/partials/form/field_input.html
 msgid "Forgot password"
-msgstr ""
+msgstr "Zapomniałem hasła"
 
 #: rocky/templates/partials/form/field_input_errors.html
 #: rocky/templates/partials/notifications_block.html
 msgid "error"
-msgstr ""
+msgstr "błąd"
 
 #: rocky/templates/partials/form/field_input_errors.html
 #: rocky/templates/partials/form/form_errors.html
 #: rocky/templates/partials/notifications_block.html
 msgid "Error:"
-msgstr ""
+msgstr "Błąd:"
 
 #: rocky/templates/partials/form/field_input_help_text.html
 msgid "Open explanation"
-msgstr ""
+msgstr "Otwarte wyjaśnienie"
 
 #: rocky/templates/partials/form/field_input_help_text.html
 msgid "Close explanation"
-msgstr ""
+msgstr "Zamknij wyjaśnienie"
 
 #: rocky/templates/partials/form/field_input_help_text.html
 #: rocky/templates/partials/notifications_block.html
 #: rocky/templates/two_factor/core/login.html
 msgid "Explanation:"
-msgstr ""
+msgstr "Wyjaśnienie:"
 
 #: rocky/templates/partials/form/indemnification_add_form.html
 msgid ""
@@ -6472,222 +7174,231 @@ msgid ""
 "negative impact on (your) assets. Therefore it is important to know and be "
 "aware of the impact of security scans."
 msgstr ""
+"Wykonywanie skanów bezpieczeństwa zasobów jest zazwyczaj dozwolone tylko "
+"wtedy, gdy masz pozwolenie na skanowanie tych zasobów. Niektóre skany mogą "
+"mieć również negatywny wpływ na (Twoje) zasoby. Dlatego ważne jest, aby znać"
+" i mieć świadomość wpływu skanowań bezpieczeństwa."
 
 #: rocky/templates/partials/form/indemnification_add_form.html
 msgid ""
-"An organization indemnification is required before you can use OpenKAT. With "
-"the indemnification you declare that you, as a person, can be held "
+"An organization indemnification is required before you can use OpenKAT. With"
+" the indemnification you declare that you, as a person, can be held "
 "accountable."
 msgstr ""
+"Przed użyciem OpenKAT wymagane jest zabezpieczenie organizacji. Poprzez "
+"zabezpieczenie oświadczasz, że jako osoba możesz zostać pociągnięty do "
+"odpowiedzialności."
 
 #: rocky/templates/partials/form/indemnification_add_form.html
 msgid "Set an indemnification"
-msgstr ""
+msgstr "Ustal odszkodowanie"
 
 #: rocky/templates/partials/hyperlink_ooi_type.html
 #, python-format
 msgid "Only show objects of type %(type)s"
-msgstr ""
+msgstr "Pokazuj tylko obiekty typu %(type)s"
 
 #: rocky/templates/partials/list_filters.html
 msgid "Hide filter options"
-msgstr ""
+msgstr "Ukryj opcje filtrów"
 
 #: rocky/templates/partials/list_filters.html
 msgid "Show filter options"
-msgstr ""
+msgstr "Pokaż opcje filtrów"
 
 #: rocky/templates/partials/list_paginator.html
 msgid "List pagination"
-msgstr ""
+msgstr "Paginacja listy"
 
 #: rocky/templates/partials/list_paginator.html
 msgid "Previous Page"
-msgstr ""
+msgstr "Poprzednia strona"
 
 #: rocky/templates/partials/list_paginator.html
 msgid "Previous"
-msgstr ""
+msgstr "Poprzedni"
 
 #: rocky/templates/partials/list_paginator.html
 msgid "Five Pages Back"
-msgstr ""
+msgstr "Pięć stron wstecz"
 
 #: rocky/templates/partials/list_paginator.html
 #: rocky/templates/partials/pagination.html
 msgid "Page"
-msgstr ""
+msgstr "Strona"
 
 #: rocky/templates/partials/list_paginator.html
 msgid "Current"
-msgstr ""
+msgstr "Aktualny"
 
 #: rocky/templates/partials/list_paginator.html
 msgid "Five Pages Forward"
-msgstr ""
+msgstr "Pięć stron dalej"
 
 #: rocky/templates/partials/list_paginator.html
 msgid "Next Page"
-msgstr ""
+msgstr "Następna strona"
 
 #: rocky/templates/partials/list_paginator.html
 msgid "Next"
-msgstr ""
+msgstr "Następny"
 
 #: rocky/templates/partials/mute_findings_modal.html
 msgid "You are muting the selected findings."
-msgstr ""
+msgstr "Wyciszasz wybrane wyniki."
 
 #: rocky/templates/partials/mute_findings_modal.html
 msgid "Reason:"
-msgstr ""
+msgstr "Powód:"
 
 #: rocky/templates/partials/mute_findings_modal.html
 msgid "Expires by (UTC):"
-msgstr ""
+msgstr "Wygasa do (UTC):"
 
 #: rocky/templates/partials/notifications_block.html
 msgid "Confirmation:"
-msgstr ""
+msgstr "Potwierdzenie:"
 
 #: rocky/templates/partials/ooi_detail_related_object.html
 msgid "No related object known for"
-msgstr ""
+msgstr "Nie jest znany żaden powiązany obiekt"
 
 #: rocky/templates/partials/ooi_detail_toolbar.html
 msgid "Generate Report"
-msgstr ""
+msgstr "Wygeneruj raport"
 
 #: rocky/templates/partials/ooi_detail_toolbar.html
 #, python-format
 msgid "Edit %(display_type)s"
-msgstr ""
+msgstr "Edytuj %(display_type)s"
 
 #: rocky/templates/partials/ooi_head.html
 msgid "Data from:"
-msgstr ""
+msgstr "Dane z:"
 
 #: rocky/templates/partials/ooi_head.html
 msgid "(Now)"
-msgstr ""
+msgstr "(Teraz)"
 
 #: rocky/templates/partials/ooi_list_toolbar.html
 msgid "Scan for objects"
-msgstr ""
+msgstr "Skanuj w poszukiwaniu obiektów"
 
 #: rocky/templates/partials/ooi_list_toolbar.html
 #: rocky/templates/upload_csv.html rocky/views/upload_csv.py
 msgid "Upload CSV"
-msgstr ""
+msgstr "Prześlij CSV"
 
 #: rocky/templates/partials/ooi_list_toolbar.html
 msgid "Export"
-msgstr ""
+msgstr "Eksport"
 
 #: rocky/templates/partials/ooi_list_toolbar.html
 msgid "Download as CSV"
-msgstr ""
+msgstr "Pobierz jako CSV"
 
 #: rocky/templates/partials/ooi_report_findings_block.html
 #, python-format
 msgid "%(total)s findings on %(name)s"
-msgstr ""
+msgstr "Ustalenia %(total)s dotyczące %(name)s"
 
 #: rocky/templates/partials/ooi_report_findings_block_table.html
 #, python-format
 msgid "Findings for %(type)s %(name)s on %(observed_at)s:"
-msgstr ""
+msgstr "Wyniki dla %(type)s %(name)s na %(observed_at)s:"
 
 #: rocky/templates/partials/ooi_report_findings_block_table.html
 msgid "Open finding details"
-msgstr ""
+msgstr "Otwórz szczegóły znalezienia"
 
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 #, python-format
 msgid "Details of %(object_id)s"
-msgstr ""
+msgstr "Szczegóły %(object_id)s"
 
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid ""
 "The severity of this findingtype has not (yet) been determined by the data "
 "source. This situation requires manual investigation of the severity."
 msgstr ""
+"Źródło danych nie określiło (jeszcze) wagi tego rodzaju ustalenia. Ta "
+"sytuacja wymaga ręcznego zbadania powagi."
 
 #: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
 msgid "Total occurrences"
-msgstr ""
+msgstr "Całkowita liczba wystąpień"
 
 #: rocky/templates/partials/ooi_tree_toolbar_bottom.html
 msgid "Tree - dense view"
-msgstr ""
+msgstr "Drzewo - gęsty widok"
 
 #: rocky/templates/partials/ooi_tree_toolbar_bottom.html
 msgid "Tree - table view"
-msgstr ""
+msgstr "Drzewo - widok tabeli"
 
 #: rocky/templates/partials/organization_member_list_filters.html
 msgid "Update List"
-msgstr ""
+msgstr "Aktualizuj listę"
 
 #: rocky/templates/partials/organization_properties_table.html
 msgid "Organization name"
-msgstr ""
+msgstr "Nazwa organizacji"
 
 #: rocky/templates/partials/organization_properties_table.html
 msgid "Organization code"
-msgstr ""
+msgstr "Kod organizacji"
 
 #: rocky/templates/partials/organizations_menu_dropdown.html
 msgid "Select organization"
-msgstr ""
+msgstr "Wybierz organizację"
 
 #: rocky/templates/partials/organizations_menu_dropdown.html
 msgid "All organizations"
-msgstr ""
+msgstr "Wszystkie organizacje"
 
 #: rocky/templates/partials/page-meta.html
 msgid "Logged in as:"
-msgstr ""
+msgstr "Zalogowałem się jako:"
 
 #: rocky/templates/partials/pagination.html
 msgid "of"
-msgstr ""
+msgstr "z"
 
 #: rocky/templates/partials/pagination.html
 msgid "first"
-msgstr ""
+msgstr "Pierwszy"
 
 #: rocky/templates/partials/pagination.html
 msgid "previous"
-msgstr ""
+msgstr "poprzedni"
 
 #: rocky/templates/partials/pagination.html
 msgid "next"
-msgstr ""
+msgstr "Następny"
 
 #: rocky/templates/partials/pagination.html
 msgid "last"
-msgstr ""
+msgstr "ostatni"
 
 #: rocky/templates/partials/secondary-menu.html
 msgid "User navigation"
-msgstr ""
+msgstr "Nawigacja użytkownika"
 
 #: rocky/templates/partials/secondary-menu.html
 msgid "Close user navigation"
-msgstr ""
+msgstr "Zamknij nawigację użytkownika"
 
 #: rocky/templates/partials/secondary-menu.html
 msgid "My organizations"
-msgstr ""
+msgstr "Moje organizacje"
 
 #: rocky/templates/partials/secondary-menu.html
 msgid "Profile"
-msgstr ""
+msgstr "Profil"
 
 #: rocky/templates/partials/skip-to-content.html
 msgid "Go to content"
-msgstr ""
+msgstr "Przejdź do treści"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid ""
@@ -6696,50 +7407,58 @@ msgid ""
 "This means that the clearance level might stay the same, increase or "
 "decrease, depending on other declared clearance levels."
 msgstr ""
+"Poziom zezwolenia określa poziom skanów boefje dozwolonych dla tego obiektu."
+" Obiekt dziedziczy poziom odstępu od obiektów sąsiadujących. Oznacza to, że "
+"poziom dopuszczenia może pozostać taki sam, wzrosnąć lub zmniejszyć, w "
+"zależności od innych zadeklarowanych poziomów dopuszczenia."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Empty clearance level explanation"
-msgstr ""
+msgstr "Wyjaśnienie poziomu luzu pustego"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Empty:"
-msgstr ""
+msgstr "Pusty:"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid ""
 "This object has a clearance level of \"empty\". This means that this object "
 "has no clearance level."
 msgstr ""
+"Ten obiekt ma poziom zezwolenia „pusty”. Oznacza to, że obiekt ten nie ma "
+"poziomu zezwolenia."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Indemnification warning"
-msgstr ""
+msgstr "Ostrzeżenie dotyczące odszkodowania"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Indemnification is not set for this organization."
-msgstr ""
+msgstr "Dla tej organizacji nie przewidziano zabezpieczenia."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Go to the"
-msgstr ""
+msgstr "Idź do"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "organization settings page"
-msgstr ""
+msgstr "stronę ustawień organizacji"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "to add one."
-msgstr ""
+msgstr "aby dodać jeden."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Set clearance level warning"
-msgstr ""
+msgstr "Ustaw ostrzeżenie o poziomie luzu"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid ""
 "You don't have permissions to set the clearance level. Contact your "
 "administrator."
 msgstr ""
+"Nie masz uprawnień, aby ustawić poziom uprawnień. Skontaktuj się ze swoim "
+"administratorem."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 #, python-format
@@ -6748,123 +7467,128 @@ msgid ""
 "clearance level is %(member_clearance_level)s and this OOI has level "
 "%(boefje_scan_level)s."
 msgstr ""
+"Nie możesz ustawić poziomu luzu dla tego OOI. Twój maksymalny poziom "
+"uprawnień to %(member_clearance_level)s, a ten OOI ma poziom "
+"%(boefje_scan_level)s."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Go to your"
-msgstr ""
+msgstr "Idź do swojego"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "account details"
-msgstr ""
+msgstr "szczegóły konta"
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "to manage your clearance level."
-msgstr ""
+msgstr "aby zarządzać poziomem uprawnień."
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Current clearance level"
-msgstr ""
+msgstr "Aktualny poziom uprawnień"
 
 #: rocky/templates/tasks/boefje_task_detail.html
 msgid ""
 "An overview of the boefje task, the input OOI and the RAW data it generated."
 msgstr ""
+"Przegląd zadania boefje, danych wejściowych OOI i wygenerowanych przez nie "
+"danych RAW."
 
 #: rocky/templates/tasks/boefje_task_detail.html
 #: rocky/templates/tasks/partials/task_actions.html
 msgid "Download meta and raw data"
-msgstr ""
+msgstr "Pobierz meta i surowe dane"
 
 #: rocky/templates/tasks/boefje_task_detail.html
 msgid "Download meta data"
-msgstr ""
+msgstr "Pobierz metadane"
 
 #: rocky/templates/tasks/boefje_task_detail.html
 msgid "Input object"
-msgstr ""
+msgstr "Obiekt wejściowy"
 
 #: rocky/templates/tasks/boefjes.html
 msgid "There are no tasks for boefjes."
-msgstr ""
+msgstr "Nie ma zadań dla boefjes."
 
 #: rocky/templates/tasks/boefjes.html
 msgid "List of tasks for boefjes."
-msgstr ""
+msgstr "Lista zadań dla boefjesa."
 
 #: rocky/templates/tasks/boefjes.html rocky/templates/tasks/reports.html
 msgid "Organization Code"
-msgstr ""
+msgstr "Kod organizacji"
 
 #: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
 #: rocky/templates/tasks/ooi_detail_task_list.html
 #: rocky/templates/tasks/plugin_detail_task_list.html
 msgid "Created date"
-msgstr ""
+msgstr "Data utworzenia"
 
 #: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
 #: rocky/templates/tasks/reports.html
 msgid "Modified date"
-msgstr ""
+msgstr "Zmodyfikowana data"
 
 #: rocky/templates/tasks/normalizers.html
 msgid "There are no tasks for normalizers."
-msgstr ""
+msgstr "Nie ma zadań dla normalizatorów."
 
 #: rocky/templates/tasks/normalizers.html
 msgid "List of tasks for normalizers."
-msgstr ""
+msgstr "Lista zadań dla normalizatorów."
 
 #: rocky/templates/tasks/normalizers.html
 msgid "Boefje input OOI"
-msgstr ""
+msgstr "Boefje Wejście OOI"
 
 #: rocky/templates/tasks/normalizers.html
 msgid "Manually added"
-msgstr ""
+msgstr "Dodano ręcznie"
 
 #: rocky/templates/tasks/ooi_detail_task_list.html
 msgid "There have been no tasks."
-msgstr ""
+msgstr "Nie było żadnych zadań."
 
 #: rocky/templates/tasks/partials/stats.html
 msgid "Task statistics - Last 24 hours"
-msgstr ""
+msgstr "Statystyki zadań - Ostatnie 24 godziny"
 
 #: rocky/templates/tasks/partials/stats.html
 msgid "All times in UTC, blocks of 1 hour."
-msgstr ""
+msgstr "Wszystkie czasy w UTC, bloki po 1 godzinie."
 
 #: rocky/templates/tasks/partials/stats.html
 msgid "Timeslot"
-msgstr ""
+msgstr "Szczelina czasowa"
 
 #: rocky/templates/tasks/partials/stats.html
 msgid "Could not load stats, Scheduler error."
-msgstr ""
+msgstr "Nie można załadować statystyk, błąd harmonogramu."
 
 #: rocky/templates/tasks/partials/tab_navigation.html
 msgid "List of tasks"
-msgstr ""
+msgstr "Lista zadań"
 
 #: rocky/templates/tasks/partials/task_actions.html
 msgid "Loading..."
-msgstr ""
+msgstr "Załadunek..."
 
 #: rocky/templates/tasks/partials/task_actions.html
 msgid "Yielded objects"
-msgstr ""
+msgstr "Otrzymane obiekty"
 
 #: rocky/templates/tasks/partials/task_actions.html
 msgid "Yielded raw files"
-msgstr ""
+msgstr "Otrzymane surowe pliki"
 
 #: rocky/templates/tasks/partials/task_actions.html
 msgid "Reschedule"
-msgstr ""
+msgstr "Zmień termin"
 
 #: rocky/templates/tasks/partials/task_actions.html
 msgid "Download task data"
-msgstr ""
+msgstr "Pobierz dane zadania"
 
 #: rocky/templates/tasks/partials/tasks_overview_header.html
 #, python-format
@@ -6875,39 +7599,44 @@ msgid ""
 "Report tasks. This task aggregates and presents findings from both Boefjes "
 "and Normalizers."
 msgstr ""
+"Przegląd zadań dla <strong>%(organization)s</strong>. Zadania są podzielone "
+"na Boefjes, Normalizers i Raporty. Boefjes skanuje obiekty i wysyła "
+"Normalizers na wyjściowym typie MIME. Dodatkowo istnieje Raport zadań. To "
+"zadanie agreguje i prezentuje ustalenia zarówno z Boefjes, jak i "
+"Normalizers."
 
 #: rocky/templates/tasks/plugin_detail_task_list.html
 msgid "There are no tasks for"
-msgstr ""
+msgstr "Nie ma zadań dot"
 
 #: rocky/templates/tasks/plugin_detail_task_list.html
 msgid "List of tasks for"
-msgstr ""
+msgstr "Lista zadań dot"
 
 #: rocky/templates/tasks/reports.html
 msgid "There are no tasks for reports."
-msgstr ""
+msgstr "Brak zadań dla raportów."
 
 #: rocky/templates/tasks/reports.html
 msgid "List of tasks for reports."
-msgstr ""
+msgstr "Lista zadań dla raportów."
 
 #: rocky/templates/tasks/reports.html
 msgid "Recipe ID"
-msgstr ""
+msgstr "Identyfikator przepisu"
 
 #: rocky/templates/two_factor/_wizard_actions.html
 msgid "Log in"
-msgstr ""
+msgstr "Zaloguj się"
 
 #: rocky/templates/two_factor/_wizard_actions.html
 msgid "Authenticate"
-msgstr ""
+msgstr "Uwierzytelniać"
 
 #: rocky/templates/two_factor/core/backup_tokens.html
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Backup Tokens"
-msgstr ""
+msgstr "Tokeny zapasowe"
 
 #: rocky/templates/two_factor/core/backup_tokens.html
 msgid ""
@@ -6916,45 +7645,52 @@ msgid ""
 "you've used up all your backup tokens, you can generate a new set of backup "
 "tokens. Only the backup tokens shown below will be valid."
 msgstr ""
+"Tokenów zapasowych można używać, gdy podstawowy i zapasowy numer telefonu "
+"nie są dostępne. Poniższe tokeny zapasowe mogą zostać użyte do weryfikacji "
+"logowania. Jeśli wykorzystałeś wszystkie tokeny zapasowe, możesz wygenerować"
+" nowy zestaw tokenów zapasowych. Tylko tokeny zapasowe pokazane poniżej będą"
+" ważne."
 
 #: rocky/templates/two_factor/core/backup_tokens.html
 msgid "Print these tokens and keep them somewhere safe."
-msgstr ""
+msgstr "Wydrukuj te żetony i przechowuj je w bezpiecznym miejscu."
 
 #: rocky/templates/two_factor/core/backup_tokens.html
 msgid "You don't have any backup codes yet."
-msgstr ""
+msgstr "Nie masz jeszcze żadnych kodów zapasowych."
 
 #: rocky/templates/two_factor/core/backup_tokens.html
 msgid "Generate Tokens"
-msgstr ""
+msgstr "Generuj tokeny"
 
 #: rocky/templates/two_factor/core/backup_tokens.html
 #: rocky/templates/two_factor/core/setup_complete.html
 msgid "Back to Account Security"
-msgstr ""
+msgstr "Powrót do Bezpieczeństwo konta"
 
 #: rocky/templates/two_factor/core/login.html
 msgid "You are logged in."
-msgstr ""
+msgstr "Jesteś zalogowany."
 
 #: rocky/templates/two_factor/core/login.html
 msgid "Two factor authentication is enabled for your account."
-msgstr ""
+msgstr "Na Twoim koncie włączone jest uwierzytelnianie dwuskładnikowe."
 
 #: rocky/templates/two_factor/core/login.html
 msgid ""
 "Two factor authentication is not enabled for your account. Enable it to "
 "continue."
 msgstr ""
+"Na Twoim koncie nie jest włączone uwierzytelnianie dwuskładnikowe. Włącz, "
+"aby kontynuować."
 
 #: rocky/templates/two_factor/core/login.html
 msgid "Setup two factor authentication"
-msgstr ""
+msgstr "Skonfiguruj uwierzytelnianie dwuskładnikowe"
 
 #: rocky/templates/two_factor/core/login.html
 msgid "Credentials"
-msgstr ""
+msgstr "Referencje"
 
 #: rocky/templates/two_factor/core/login.html
 msgid ""
@@ -6962,18 +7698,22 @@ msgid ""
 "been generated for you to print and keep safe. Please enter one of these "
 "backup tokens to login to your account."
 msgstr ""
+"Użyj tego formularza, aby wprowadzić tokeny zapasowe do logowania. Tokeny te"
+" zostały wygenerowane, abyś mógł je wydrukować i zachować w bezpiecznym "
+"miejscu. Aby zalogować się na swoje konto, wprowadź jeden z tych tokenów "
+"zapasowych."
 
 #: rocky/templates/two_factor/core/login.html
 msgid "As a last resort, you can use a backup token:"
-msgstr ""
+msgstr "W ostateczności możesz skorzystać z tokena zapasowego:"
 
 #: rocky/templates/two_factor/core/login.html
 msgid "Use Backup Token"
-msgstr ""
+msgstr "Użyj tokena zapasowego"
 
 #: rocky/templates/two_factor/core/otp_required.html
 msgid "Permission Denied"
-msgstr ""
+msgstr "Odmowa pozwolenia"
 
 #: rocky/templates/two_factor/core/otp_required.html
 msgid ""
@@ -6981,256 +7721,289 @@ msgid ""
 "authentication for security reasons. You need to enable these security "
 "features in order to access this page."
 msgstr ""
+"Strona, o którą prosiłeś, ze względów bezpieczeństwa wymusza na "
+"użytkownikach weryfikację przy użyciu uwierzytelniania dwuskładnikowego. Aby"
+" uzyskać dostęp do tej strony, musisz włączyć te funkcje zabezpieczeń."
 
 #: rocky/templates/two_factor/core/otp_required.html
 #: rocky/templates/two_factor/profile/profile.html
 msgid ""
-"Two-factor authentication is not enabled for your account. Enable two-factor "
-"authentication for enhanced account security."
+"Two-factor authentication is not enabled for your account. Enable two-factor"
+" authentication for enhanced account security."
 msgstr ""
+"Uwierzytelnianie dwuskładnikowe nie jest włączone dla Twojego konta. Włącz "
+"uwierzytelnianie dwuskładnikowe, aby zwiększyć bezpieczeństwo konta."
 
 #: rocky/templates/two_factor/core/otp_required.html
 #: rocky/templates/two_factor/core/setup.html
 #: rocky/templates/two_factor/core/setup_complete.html
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Enable Two-Factor Authentication"
-msgstr ""
+msgstr "Włącz uwierzytelnianie dwuskładnikowe"
 
 #: rocky/templates/two_factor/core/phone_register.html
 msgid "Add Backup Phone"
-msgstr ""
+msgstr "Dodaj telefon zapasowy"
 
 #: rocky/templates/two_factor/core/phone_register.html
 msgid ""
 "You'll be adding a backup phone number to your account. This number will be "
 "used if your primary method of registration is not available."
 msgstr ""
+"Do swojego konta dodasz zapasowy numer telefonu. Numer ten zostanie użyty, "
+"jeśli podstawowa metoda rejestracji nie będzie dostępna."
 
 #: rocky/templates/two_factor/core/phone_register.html
 msgid ""
 "We've sent a token to your phone number. Please enter the token you've "
 "received."
-msgstr ""
+msgstr "Wysłaliśmy token na Twój numer telefonu. Wprowadź otrzymany token."
 
 #: rocky/templates/two_factor/core/setup.html
 msgid ""
 "To start using a token generator, please use your smartphone to scan the QR "
-"code below or use the setup key. For example, use GoogleAuthenticator. Then, "
-"enter the token generated by the app."
+"code below or use the setup key. For example, use GoogleAuthenticator. Then,"
+" enter the token generated by the app."
 msgstr ""
+"Aby rozpocząć korzystanie z generatora tokenów, zeskanuj poniższy kod QR "
+"swoim smartfonem lub użyj klucza konfiguracyjnego. Na przykład użyj "
+"GoogleAuthenticator. Następnie wprowadź token wygenerowany przez aplikację."
 
 #: rocky/templates/two_factor/core/setup.html
 msgid "QR code"
-msgstr ""
+msgstr "Kod QR"
 
 #: rocky/templates/two_factor/core/setup.html
 msgid "Setup key"
-msgstr ""
+msgstr "Klucz konfiguracyjny"
 
 #: rocky/templates/two_factor/core/setup.html
 msgid ""
-"The secret key is a 32 characters representation of the QR code. There are 2 "
-"options to setup the two factor authtentication. You can scan the QR code "
+"The secret key is a 32 characters representation of the QR code. There are 2"
+" options to setup the two factor authtentication. You can scan the QR code "
 "above or you can insert this key using the secret key option of the "
 "authenticator app."
 msgstr ""
+"Tajny klucz to 32-znakowa reprezentacja kodu QR. Istnieją 2 opcje "
+"konfiguracji uwierzytelniania dwuskładnikowego. Możesz zeskanować powyższy "
+"kod QR lub wprowadzić ten klucz, korzystając z opcji tajnego klucza w "
+"aplikacji uwierzytelniającej."
 
 #: rocky/templates/two_factor/core/setup_complete.html
-msgid "Congratulations, you've successfully enabled two-factor authentication."
-msgstr ""
+msgid ""
+"Congratulations, you've successfully enabled two-factor authentication."
+msgstr "Gratulacje, pomyślnie włączyłeś uwierzytelnianie dwuskładnikowe."
 
 #: rocky/templates/two_factor/core/setup_complete.html
 msgid "Start using OpenKAT"
-msgstr ""
+msgstr "Zacznij używać OpenKAT"
 
 #: rocky/templates/two_factor/core/setup_complete.html
 msgid ""
 "However, it might happen that you don't have access to your primary token "
 "device. To enable account recovery, add a phone number."
 msgstr ""
+"Może się jednak zdarzyć, że nie będziesz mieć dostępu do swojego głównego "
+"urządzenia tokena. Aby umożliwić odzyskanie konta, dodaj numer telefonu."
 
 #: rocky/templates/two_factor/core/setup_complete.html
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Add Phone Number"
-msgstr ""
+msgstr "Dodaj numer telefonu"
 
 #: rocky/templates/two_factor/profile/disable.html
 msgid "Disable Two-factor Authentication"
-msgstr ""
+msgstr "Wyłącz uwierzytelnianie dwuskładnikowe"
 
 #: rocky/templates/two_factor/profile/disable.html
 msgid ""
 "You are about to disable two-factor authentication. This weakens your "
 "account security, are you sure?"
 msgstr ""
+"Zamierzasz wyłączyć uwierzytelnianie dwuskładnikowe. Osłabia to "
+"bezpieczeństwo Twojego konta, jesteś pewien?"
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Account Security"
-msgstr ""
+msgstr "Bezpieczeństwo konta"
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Tokens will be generated by your token generator."
-msgstr ""
+msgstr "Tokeny zostaną wygenerowane przez Twój generator tokenów."
 
 #: rocky/templates/two_factor/profile/profile.html
 #, python-format
 msgid "Primary method: %(primary)s"
-msgstr ""
+msgstr "Metoda podstawowa: %(primary)s"
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Tokens will be generated by your YubiKey."
-msgstr ""
+msgstr "Tokeny zostaną wygenerowane przez Twój YubiKey."
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Backup Phone Numbers"
-msgstr ""
+msgstr "Zapasowe numery telefonów"
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid ""
 "If your primary method is not available, we are able to send backup tokens "
 "to the phone numbers listed below."
 msgstr ""
+"Jeśli Twoja podstawowa metoda nie jest dostępna, jesteśmy w stanie wysłać "
+"tokeny zapasowe na numery telefonów wymienione poniżej."
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Unregister"
-msgstr ""
+msgstr "Wyrejestruj się"
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid ""
 "If you don't have any device with you, you can access your account using "
 "backup tokens."
 msgstr ""
+"Jeśli nie masz przy sobie żadnego urządzenia, możesz uzyskać dostęp do "
+"swojego konta za pomocą tokenów zapasowych."
 
 #: rocky/templates/two_factor/profile/profile.html
 #, python-format
 msgid "You have only one backup token remaining."
 msgid_plural "You have %(counter)s backup tokens remaining."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Pozostał Ci tylko jeden token zapasowy."
+msgstr[1] "Pozostały Ci tokeny zapasowe %(counter)s."
+msgstr[2] "Pozostały Ci tokeny zapasowe %(counter)s."
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Show Codes"
-msgstr ""
+msgstr "Pokaż kody"
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid "Disable Two-Factor Authentication"
-msgstr ""
+msgstr "Wyłącz uwierzytelnianie dwuskładnikowe"
 
 #: rocky/templates/two_factor/profile/profile.html
 msgid ""
-"However we strongly discourage you to do so, you can also disable two-factor "
-"authentication for your account."
+"However we strongly discourage you to do so, you can also disable two-factor"
+" authentication for your account."
 msgstr ""
+"Jednak zdecydowanie odradzamy to robić, możesz także wyłączyć "
+"uwierzytelnianie dwuskładnikowe dla swojego konta."
 
 #: rocky/templates/two_factor/twilio/sms_message.html
 #, python-format
 msgid "Your OTP token is %(token)s"
-msgstr ""
+msgstr "Twój token OTP to %(token)s"
 
 #: rocky/templates/upload_csv.html
 msgid "Automate the creation of multiple objects by uploading a CSV file."
-msgstr ""
+msgstr "Zautomatyzuj tworzenie wielu obiektów, przesyłając plik CSV."
 
 #: rocky/templates/upload_csv.html
 msgid "These are the criteria for CSV upload:"
-msgstr ""
+msgstr "Oto kryteria przesyłania CSV:"
 
 #: rocky/templates/upload_raw.html
 msgid "Automate the creation of multiple objects by uploading a raw file."
-msgstr ""
+msgstr "Zautomatyzuj tworzenie wielu obiektów, przesyłając surowy plik."
 
 #: rocky/templates/upload_raw.html
 msgid ""
-"An input OOI can be selected for the normalizer to attach newly yielded OOIs "
-"to. If no input OOI was used for the raw file, a placeholder ExternalScan "
+"An input OOI can be selected for the normalizer to attach newly yielded OOIs"
+" to. If no input OOI was used for the raw file, a placeholder ExternalScan "
 "OOI can be used. ExternalScan OOIs can be created from the objects page. "
 "When a new version of the raw file is generated, the same ExternalScan OOI "
 "should be chosen to ensure that old results are overwritten."
 msgstr ""
+"Można wybrać wejście OOI dla normalizatora, do którego będzie dołączone nowo"
+" uzyskane OOIs. Jeśli dla pliku nieprzetworzonego nie użyto żadnego wejścia "
+"OOI, można zastosować element zastępczy Zewnętrzny skan OOI. Zewnętrzny "
+"skaner OOIs można utworzyć ze strony obiektów. Kiedy generowana jest nowa "
+"wersja nieprzetworzonego pliku, należy wybrać ten sam program OutsideScan "
+"OOI, aby mieć pewność, że stare wyniki zostaną nadpisane."
 
 #: rocky/templates/upload_raw.html rocky/views/upload_raw.py
 msgid "Upload raw"
-msgstr ""
+msgstr "Prześlij surowe"
 
 #: rocky/views/bytes_raw.py
 msgid "Getting raw data failed."
-msgstr ""
+msgstr "Pobieranie nieprzetworzonych danych nie powiodło się."
 
 #: rocky/views/bytes_raw.py
 msgid "The task does not have any raw data."
-msgstr ""
+msgstr "Zadanie nie zawiera żadnych surowych danych."
 
 #: rocky/views/finding_list.py rocky/views/ooi_list.py
 msgid "Unknown action."
-msgstr ""
+msgstr "Nieznana akcja."
 
 #: rocky/views/health.py
 msgid "Beautified"
-msgstr ""
+msgstr "Upiększony"
 
 #: rocky/views/indemnification_add.py
 msgid "Indemnification successfully set."
-msgstr ""
+msgstr "Zabezpieczenie zostało pomyślnie ustalone."
 
 #: rocky/views/mixins.py
 msgid "The selected date is in the future."
-msgstr ""
+msgstr "Wybrana data przypada w przyszłości."
 
 #: rocky/views/mixins.py
 msgid "Can not parse date, falling back to show current date."
-msgstr ""
+msgstr "Nie można przeanalizować daty, cofając się do bieżącej daty."
 
 #: rocky/views/mixins.py
 #, python-format
 msgid "Could not load origins for OOI: %s from octopoes"
-msgstr ""
+msgstr "Nie można załadować źródeł OOI: %s z ośmiornic"
 
 #: rocky/views/mixins.py
 msgid "Could not load normalizer metas from bytes"
-msgstr ""
+msgstr "Nie można załadować meta normalizatora z bajtów"
 
 #: rocky/views/mixins.py
 #, python-format
 msgid "Could not load boefje %s from katalogus"
-msgstr ""
+msgstr "Nie można załadować boefje %s z katalogów"
 
 #: rocky/views/mixins.py
 msgid "You do not have the permission to add items to a dashboard."
-msgstr ""
+msgstr "Nie masz uprawnień do dodawania elementów do pulpitu nawigacyjnego."
 
 #: rocky/views/mixins.py
 msgid "Dashboard item has been added."
-msgstr ""
+msgstr "Dodano element panelu kontrolnego."
 
 #: rocky/views/ooi_add.py
 #, python-format
 msgid "Add %(ooi_type)s"
-msgstr ""
+msgstr "Dodaj %(ooi_type)s"
 
 #: rocky/views/ooi_detail.py
 msgid ""
 "Cannot set clearance level. It must be provided and must be a valid number."
 msgstr ""
+"Nie można ustawić poziomu luzu. Należy go podać i musi to być ważny numer."
 
 #: rocky/views/ooi_detail.py
 msgid "Only Question OOIs can be answered."
-msgstr ""
+msgstr "Można odpowiedzieć tylko na pytanie OOIs."
 
 #: rocky/views/ooi_detail.py
 msgid "Question has been answered."
-msgstr ""
+msgstr "Odpowiedź na pytanie została udzielona."
 
 #: rocky/views/ooi_detail_related_object.py
 msgid " (as "
-msgstr ""
+msgstr "(Jak"
 
 #: rocky/views/ooi_findings.py
 msgid "Object findings"
-msgstr ""
+msgstr "Ustalenia obiektu"
 
 #: rocky/views/ooi_list.py
 msgid "No OOIs selected."
-msgstr ""
+msgstr "Nie wybrano OOIs."
 
 #: rocky/views/ooi_list.py
 #, python-format
@@ -7238,6 +8011,8 @@ msgid ""
 "Could not raise clearance levels to L%s. Indemnification not present at "
 "organization %s."
 msgstr ""
+"Nie można podnieść poziomów zezwolenia do L%s. Odszkodowanie nie występuje w"
+" organizacji %s."
 
 #: rocky/views/ooi_list.py
 #, python-format
@@ -7245,6 +8020,9 @@ msgid ""
 "Could not raise clearance level to L%s. You were trusted a clearance level "
 "of L%s. Contact your administrator to receive a higher clearance."
 msgstr ""
+"Nie można podnieść poziomu zezwolenia do L%s. Zaufano Ci na poziomie "
+"uprawnień L%s. Skontaktuj się z administratorem, aby otrzymać wyższe "
+"zezwolenie."
 
 #: rocky/views/ooi_list.py
 #, python-format
@@ -7252,42 +8030,46 @@ msgid ""
 "Could not raise clearance level to L%s. You acknowledged a clearance level "
 "of L%s. Please accept the clearance level below to proceed."
 msgstr ""
+"Nie można podnieść poziomu zezwolenia do L%s. Potwierdziłeś poziom "
+"zezwolenia L%s. Aby kontynuować, zaakceptuj poniższy poziom uprawnień."
 
 #: rocky/views/ooi_list.py
 msgid "An error occurred while saving clearance levels."
-msgstr ""
+msgstr "Wystąpił błąd podczas zapisywania poziomów dopuszczenia."
 
 #: rocky/views/ooi_list.py
 msgid "One of the OOI's doesn't exist"
-msgstr ""
+msgstr "Jeden z OOI nie istnieje"
 
 #: rocky/views/ooi_list.py
 #, python-format
 msgid "Successfully set scan profile to %s for %d OOIs."
-msgstr ""
+msgstr "Pomyślnie ustaw profil skanowania na %s dla %d OOIs."
 
 #: rocky/views/ooi_list.py
 msgid "An error occurred while setting clearance levels to inherit."
-msgstr ""
+msgstr "Wystąpił błąd podczas ustawiania dziedziczonych poziomów uprawnień."
 
 #: rocky/views/ooi_list.py
 msgid ""
-"An error occurred while setting clearance levels to inherit: one of the OOIs "
-"doesn't exist."
+"An error occurred while setting clearance levels to inherit: one of the OOIs"
+" doesn't exist."
 msgstr ""
+"Wystąpił błąd podczas ustawiania poziomów zezwolenia do dziedziczenia: jeden"
+" z OOIs nie istnieje."
 
 #: rocky/views/ooi_list.py
 #, python-format
 msgid "Successfully set %d OOI(s) clearance level to inherit."
-msgstr ""
+msgstr "Pomyślnie ustawiono poziom uprawnień %d OOI(s) do dziedziczenia."
 
 #: rocky/views/ooi_list.py
 msgid "An error occurred while deleting oois."
-msgstr ""
+msgstr "Wystąpił błąd podczas usuwania oois."
 
 #: rocky/views/ooi_list.py
 msgid "An error occurred while deleting OOIs: one of the OOIs doesn't exist."
-msgstr ""
+msgstr "Wystąpił błąd podczas usuwania OOIs: jeden z OOIs nie istnieje."
 
 #: rocky/views/ooi_list.py
 #, python-format
@@ -7295,115 +8077,116 @@ msgid ""
 "Successfully deleted %d ooi(s). Note: Bits can recreate objects "
 "automatically."
 msgstr ""
+"Pomyślnie usunięto ooi %d. Uwaga: Bity mogą automatycznie odtwarzać obiekty."
 
 #: rocky/views/ooi_mute.py
 msgid "Please select at least one finding."
-msgstr ""
+msgstr "Proszę wybrać co najmniej jedno ustalenie."
 
 #: rocky/views/ooi_mute.py
 msgid "Finding(s) successfully unmuted."
-msgstr ""
+msgstr "Pomyślnie wyłączono wyciszenie wyników."
 
 #: rocky/views/ooi_mute.py
 msgid "Finding(s) successfully muted."
-msgstr ""
+msgstr "Wyniki zostały pomyślnie wyciszone."
 
 #: rocky/views/ooi_tree.py
 msgid "Tree Visualisation"
-msgstr ""
+msgstr "Wizualizacja drzewa"
 
 #: rocky/views/ooi_tree.py
 msgid "Graph Visualisation"
-msgstr ""
+msgstr "Wizualizacja wykresu"
 
 #: rocky/views/ooi_view.py
 msgid "Observed_at: "
-msgstr ""
+msgstr "Zaobserwowane_w:"
 
 #: rocky/views/ooi_view.py
 msgid "OOI types: "
-msgstr ""
+msgstr "Typy OOI:"
 
 #: rocky/views/ooi_view.py
 msgid "Clearance level: "
-msgstr ""
+msgstr "Poziom rozliczenia:"
 
 #: rocky/views/ooi_view.py
 msgid "Clearance type: "
-msgstr ""
+msgstr "Rodzaj rozliczenia:"
 
 #: rocky/views/ooi_view.py
 msgid "Searching for: "
-msgstr ""
+msgstr "Wyszukiwanie:"
 
 #: rocky/views/organization_add.py
 msgid "Setup"
-msgstr ""
+msgstr "Organizować coś"
 
 #: rocky/views/organization_add.py
 msgid "Organization added successfully."
-msgstr ""
+msgstr "Organizacja została dodana pomyślnie."
 
 #: rocky/views/organization_add.py
 msgid "You are not allowed to add organizations."
-msgstr ""
+msgstr "Nie możesz dodawać organizacji."
 
 #: rocky/views/organization_edit.py
 #, python-format
 msgid "Organization %s successfully updated."
-msgstr ""
+msgstr "Organizacja %s została pomyślnie zaktualizowana."
 
 #: rocky/views/organization_member_add.py
 msgid "Add column titles, followed by each object on a new line."
-msgstr ""
+msgstr "Dodaj tytuły kolumn, a następnie każdy obiekt w nowym wierszu."
 
 #: rocky/views/organization_member_add.py
 msgid "The columns are: "
-msgstr ""
+msgstr "Kolumny to:"
 
 #: rocky/views/organization_member_add.py
 msgid "Clearance levels should be between -1 and 4."
-msgstr ""
+msgstr "Poziomy prześwitu powinny mieścić się w przedziale od -1 do 4."
 
 #: rocky/views/organization_member_add.py
 msgid "Account type can be one of: "
-msgstr ""
+msgstr "Typ konta może być jednym z:"
 
 #: rocky/views/organization_member_add.py
 msgid "Member added successfully."
-msgstr ""
+msgstr "Pomyślnie dodano członka."
 
 #: rocky/views/organization_member_add.py
 msgid "The csv file is missing required columns"
-msgstr ""
+msgstr "W pliku CSV brakuje wymaganych kolumn"
 
 #: rocky/views/organization_member_add.py
 #, python-brace-format
 msgid "Invalid account type: '{account_type}'"
-msgstr ""
+msgstr "Nieprawidłowy typ konta: „{account_type}”"
 
 #: rocky/views/organization_member_add.py
 #, python-brace-format
 msgid "Invalid data for: '{email}'"
-msgstr ""
+msgstr "Nieprawidłowe dane dla: „{email}”"
 
 #: rocky/views/organization_member_add.py
 #, python-brace-format
 msgid "Invalid email address: '{email}'"
-msgstr ""
+msgstr "Nieprawidłowy adres e-mail: „{email}”"
 
 #: rocky/views/organization_member_add.py
 msgid "Successfully processed users from csv."
-msgstr ""
+msgstr "Pomyślnie przetworzono użytkowników z pliku CSV."
 
 #: rocky/views/organization_member_add.py
 msgid "Error parsing the csv file. Please verify its contents."
-msgstr ""
+msgstr "Błąd podczas analizowania pliku CSV. Proszę sprawdzić jego zawartość."
 
 #: rocky/views/organization_member_edit.py
 #, python-format
 msgid "Member %s successfully updated."
-msgstr ""
+msgstr "Element %s został pomyślnie zaktualizowany."
 
 #: rocky/views/organization_member_edit.py
 #, python-format
@@ -7413,44 +8196,54 @@ msgid ""
 "level L%s. For this reason the acknowledged clearance level has been set at "
 "the same level as trusted clearance level."
 msgstr ""
+"Zaktualizowany poziom zaufania zaufanego L%s jest niższy niż uznany poziom "
+"zezwolenia członka L%s. Ten członek ma uprawnienia tylko na poziomie L%s. Z "
+"tego powodu potwierdzony poziom dopuszczenia został ustalony na tym samym "
+"poziomie, co zaufany poziom dopuszczenia."
 
 #: rocky/views/organization_member_edit.py
 msgid ""
 "You have trusted this member with a higher trusted level than member "
 "acknowledged. Member must first accept this level to use it."
 msgstr ""
+"Zaufałeś temu członkowi na wyższym poziomie zaufania niż zatwierdzony przez "
+"członka. Aby móc z niego skorzystać, użytkownik musi najpierw zaakceptować "
+"ten poziom."
 
 #: rocky/views/organization_member_list.py
 #, python-format
 msgid "Blocked member %s successfully."
-msgstr ""
+msgstr "Pomyślnie zablokowano element %s."
 
 #: rocky/views/organization_member_list.py
 #, python-format
 msgid "Unblocked member %s successfully."
-msgstr ""
+msgstr "Pomyślnie odblokowano element %s."
 
 #: rocky/views/organization_settings.py
 #, python-brace-format
 msgid "Recalculated {number_of_bits} bits. Duration: {duration}"
-msgstr ""
+msgstr "Przeliczono bity {number_of_bits}. Czas trwania: {duration}"
 
 #: rocky/views/page_actions.py
 msgid "Could not process your request, action required."
-msgstr ""
+msgstr "Nie można przetworzyć żądania. Wymagane jest podjęcie działania."
 
 #: rocky/views/scan_profile.py
 msgid ""
-"Cannot set clearance level. The clearance type must be inherited or declared."
+"Cannot set clearance level. The clearance type must be inherited or "
+"declared."
 msgstr ""
+"Nie można ustawić poziomu luzu. Typ zezwolenia musi być dziedziczony lub "
+"zadeklarowany."
 
 #: rocky/views/scans.py
 msgid "Scans"
-msgstr ""
+msgstr "Skany"
 
 #: rocky/views/scheduler.py
 msgid "Your report has been scheduled."
-msgstr ""
+msgstr "Twój raport został zaplanowany."
 
 #: rocky/views/scheduler.py
 msgid ""
@@ -7458,63 +8251,77 @@ msgid ""
 "will be added to the object list when they are in. It may take some time, a "
 "refresh of the page may be needed to show the results."
 msgstr ""
+"Twoje zadanie zostało zaplanowane i wkrótce zostanie uruchomione w tle. "
+"Wyniki zostaną dodane do listy obiektów po ich wprowadzeniu. Może to zająć "
+"trochę czasu, może być konieczne odświeżenie strony, aby wyświetlić wyniki."
 
 #: rocky/views/tasks.py
 #, python-brace-format
 msgid "Fetching tasks failed: no connection with scheduler: {error}"
 msgstr ""
+"Pobieranie zadań nie powiodło się: brak połączenia z harmonogramem: {error}"
 
 #: rocky/views/tasks.py
 msgid "All Tasks"
-msgstr ""
+msgstr "Wszystkie zadania"
 
 #: rocky/views/upload_csv.py
 msgid "Add column titles. Followed by each object on a new line."
-msgstr ""
+msgstr "Dodaj tytuły kolumn. Po każdym obiekcie w nowej linii."
 
 #: rocky/views/upload_csv.py
 msgid ""
 "For URL object type, a column 'raw' with URL values is required, starting "
 "with http:// or https://, optionally a second column 'network' is supported "
 msgstr ""
+"Dla typu obiektu URL wymagana jest kolumna „raw” z wartościami URL, "
+"zaczynając od http:// lub https://, opcjonalnie obsługiwana jest druga "
+"kolumna „sieć”"
 
 #: rocky/views/upload_csv.py
 msgid ""
 "For Hostname object type, a column with 'name' values is required, "
 "optionally a second column 'network' is supported "
 msgstr ""
+"W przypadku obiektu typu Hostname wymagana jest kolumna z wartościami "
+"„nazwa”, opcjonalnie obsługiwana jest druga kolumna „sieć”."
 
 #: rocky/views/upload_csv.py
 msgid ""
 "For IPAddressV4 and IPAddressV6 object types, a column of 'address' is "
 "required, optionally a second column 'network' is supported "
 msgstr ""
+"Dla typów obiektów IPAddressV4 i IPAddressV6 wymagana jest kolumna „adres”, "
+"opcjonalnie obsługiwana jest druga kolumna „sieć”"
 
 #: rocky/views/upload_csv.py
 msgid ""
 "Clearance levels can be controlled by a column 'clearance' taking numerical "
-"values 0, 1, 2, 3, and 4 for the corresponding clearance level (other values "
-"are ignored) "
+"values 0, 1, 2, 3, and 4 for the corresponding clearance level (other values"
+" are ignored) "
 msgstr ""
+"Poziomy zezwolenia można kontrolować za pomocą kolumny „prześwit”, "
+"przyjmując wartości liczbowe 0, 1, 2, 3 i 4 dla odpowiedniego poziomu "
+"zezwolenia (inne wartości są ignorowane)"
 
 #: rocky/views/upload_csv.py
 msgid "Object(s) could not be created for row number(s): "
-msgstr ""
+msgstr "Nie można utworzyć obiektów dla numerów wierszy:"
 
 #: rocky/views/upload_csv.py
 msgid "Object(s) successfully added."
-msgstr ""
+msgstr "Obiekt(y) pomyślnie dodano."
 
 #: rocky/views/upload_raw.py
 #, python-format
 msgid "Raw file could not be uploaded to Bytes: status code %d"
-msgstr ""
+msgstr "Nie można przesłać pliku surowego do Bytes: kod stanu %d"
 
 #: rocky/views/upload_raw.py
 #, python-format
 msgid "Raw file could not be uploaded to Bytes: %s"
-msgstr ""
+msgstr "Nie można przesłać pliku surowego do Bytes: %s"
 
 #: rocky/views/upload_raw.py
 msgid "Raw file successfully added."
-msgstr ""
+msgstr "Pomyślnie dodano plik surowy."

--- a/rocky/rocky/locale/pl/LC_MESSAGES/django.po
+++ b/rocky/rocky/locale/pl/LC_MESSAGES/django.po
@@ -1,0 +1,7520 @@
+# Polish translations for OpenKAT.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+#: reports/forms.py
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenKAT\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-03-28 14:22+0000\n"
+"PO-Revision-Date: 2026-07-15 00:00+0000\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: Polish <https://hosted.weblate.org/projects/openkat/nl-kat-coordination/pl/>\n"
+"Language: pl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n == 1 ? 0 : n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14) ? 1 : 2);\n"
+
+#: account/admin.py
+msgid "Permissions"
+msgstr ""
+
+#: account/admin.py
+msgid "Important dates"
+msgstr ""
+
+#: account/forms/account_setup.py crisis_room/forms.py
+#: katalogus/templates/katalogus_settings.html
+#: katalogus/templates/plugin_container_image.html
+#: reports/report_types/dns_report/report.html
+#: reports/report_types/tls_report/report.html
+#: reports/templates/partials/report_names_form.html
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/modal_partials/rename_modal.html
+#: reports/templates/report_overview/modal_partials/rerun_modal.html
+#: reports/templates/report_overview/modal_partials/share_modal.html
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+#: reports/templates/report_overview/subreports_table.html
+#: tools/forms/boefje.py rocky/templates/organizations/organization_list.html
+#: rocky/templates/organizations/organization_settings.html
+#: rocky/templates/partials/ooi_detail_related_object.html
+msgid "Name"
+msgstr ""
+
+#: account/forms/account_setup.py
+msgid "The name that will be used in order to communicate."
+msgstr ""
+
+#: account/forms/account_setup.py
+msgid "Please provide username"
+msgstr ""
+
+#: account/forms/account_setup.py
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Email"
+msgstr ""
+
+#: account/forms/account_setup.py
+msgid "Enter an email address."
+msgstr ""
+
+#: account/forms/account_setup.py
+msgid "Password"
+msgstr ""
+
+#: account/forms/account_setup.py
+msgid "Choose a super secret password"
+msgstr ""
+
+#: account/forms/account_setup.py
+msgid "Choose another email."
+msgstr ""
+
+#: account/forms/account_setup.py tools/forms/settings.py
+msgid "--- Please select one of the available options ----"
+msgstr ""
+
+#: account/forms/account_setup.py
+msgid "Account type"
+msgstr ""
+
+#: account/forms/account_setup.py
+msgid "Please select an account type to proceed."
+msgstr ""
+
+#: account/forms/account_setup.py
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+msgid "Trusted clearance level"
+msgstr ""
+
+#: account/forms/account_setup.py
+msgid "Select a clearance level you trust this member with."
+msgstr ""
+
+#: account/forms/account_setup.py onboarding/forms.py tools/forms/ooi.py
+msgid "Please select a clearance level to proceed."
+msgstr ""
+
+#: account/forms/account_setup.py tools/models.py
+msgid "The name of the organization."
+msgstr ""
+
+#: account/forms/account_setup.py
+msgid "explanation-organization-name"
+msgstr ""
+
+#: account/forms/account_setup.py
+#, python-brace-format
+msgid "A unique code of maximum {code_length} characters in length."
+msgstr ""
+
+#: account/forms/account_setup.py
+msgid "explanation-organization-code"
+msgstr ""
+
+#: account/forms/account_setup.py
+msgid "Organization name is required to proceed."
+msgstr ""
+
+#: account/forms/account_setup.py
+msgid "Choose another organization."
+msgstr ""
+
+#: account/forms/account_setup.py
+msgid "Organization code is required to proceed."
+msgstr ""
+
+#: account/forms/account_setup.py
+msgid "Choose another code for your organization."
+msgstr ""
+
+#: account/forms/account_setup.py
+msgid ""
+"I declare that OpenKAT may scan the assets of my organization and that I "
+"have permission to scan these assets. I am aware of the implications a scan "
+"(with a higher scan level) brings on my systems."
+msgstr ""
+
+#: account/forms/account_setup.py
+msgid ""
+"I declare that I am authorized to give this indemnification on behalf of my "
+"organization. I have the experience and knowledge to know what the "
+"consequences might be and can be held responsible for them."
+msgstr ""
+
+#: account/forms/account_setup.py
+msgid "Trusted to change Clearance Levels."
+msgstr ""
+
+#: account/forms/account_setup.py
+msgid "Acknowledged to change Clearance Levels."
+msgstr ""
+
+#: account/forms/account_setup.py rocky/forms.py
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Blocked"
+msgstr ""
+
+#: account/forms/account_setup.py
+msgid ""
+"Set the members status to blocked, so they don't have access to the "
+"organization anymore."
+msgstr ""
+
+#: account/forms/account_setup.py
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Accepted clearance level"
+msgstr ""
+
+#: account/forms/account_setup.py
+msgid "Enter tags separated by comma."
+msgstr ""
+
+#: account/forms/account_setup.py
+msgid "The two password fields didn’t match."
+msgstr ""
+
+#: account/forms/account_setup.py
+msgid "New password"
+msgstr ""
+
+#: account/forms/account_setup.py
+msgid "Enter a new password"
+msgstr ""
+
+#: account/forms/account_setup.py
+msgid "New password confirmation"
+msgstr ""
+
+#: account/forms/account_setup.py
+msgid "Repeat the new password"
+msgstr ""
+
+#: account/forms/account_setup.py
+msgid "Confirm the new password"
+msgstr ""
+
+#: account/forms/login.py
+msgid "Please enter a correct email address and password."
+msgstr ""
+
+#: account/forms/login.py
+msgid "This account is inactive."
+msgstr ""
+
+#: account/forms/login.py
+msgid "Insert the email you registered with or got at OpenKAT installation."
+msgstr ""
+
+#: account/forms/organization.py
+msgid "Organization is required."
+msgstr ""
+
+#: account/forms/organization.py tools/view_helpers.py
+#: rocky/templates/dashboard_redteam.html
+#: rocky/templates/organizations/organization_list.html
+#: rocky/views/organization_add.py
+msgid "Organizations"
+msgstr ""
+
+#: account/forms/organization.py
+msgid "The organization from which to clone settings."
+msgstr ""
+
+#: account/forms/password_reset.py account/templates/account_detail.html
+msgid "Email address"
+msgstr ""
+
+#: account/forms/password_reset.py
+msgid "A reset link will be sent to this email"
+msgstr ""
+
+#: account/forms/password_reset.py
+msgid "The email address connected to your OpenKAT-account"
+msgstr ""
+
+#: account/forms/token.py
+msgid ""
+"Insert the token generated by the authenticator app to setup the two factor "
+"authentication."
+msgstr ""
+
+#: account/forms/token.py
+msgid "Insert the token generated by your token authenticator app."
+msgstr ""
+
+#: account/forms/token.py
+msgid "Backup token"
+msgstr ""
+
+#: account/mixins.py
+msgid "Clearance level has been set."
+msgstr ""
+
+#: account/mixins.py
+#, python-format
+msgid ""
+"Could not raise clearance level of %s to L%s. Indemnification not present at "
+"organization %s."
+msgstr ""
+
+#: account/mixins.py
+#, python-format
+msgid ""
+"Could not raise clearance level of %s to L%s. You were trusted a clearance "
+"level of L%s. Contact your administrator to receive a higher clearance."
+msgstr ""
+
+#: account/mixins.py
+#, python-format
+msgid ""
+"Could not raise clearance level of %s to L%s. You acknowledged a clearance "
+"level of L%s. Please accept the clearance level first on your profile page "
+"to proceed."
+msgstr ""
+
+#: account/models.py
+msgid "The email must be set"
+msgstr ""
+
+#: account/models.py
+msgid "Superuser must have is_staff=True."
+msgstr ""
+
+#: account/models.py
+msgid "Superuser must have is_superuser=True."
+msgstr ""
+
+#: account/models.py
+msgid "full name"
+msgstr ""
+
+#: account/models.py
+msgid "email"
+msgstr ""
+
+#: account/models.py
+msgid "staff status"
+msgstr ""
+
+#: account/models.py
+msgid "Designates whether the user can log into this admin site."
+msgstr ""
+
+#: account/models.py tools/models.py
+msgid "active"
+msgstr ""
+
+#: account/models.py
+msgid ""
+"Designates whether this user should be treated as active. Unselect this "
+"instead of deleting accounts."
+msgstr ""
+
+#: account/models.py
+msgid "date joined"
+msgstr ""
+
+#: account/models.py
+msgid "The clearance level of the user for all organizations."
+msgstr ""
+
+#: account/models.py
+msgid "name"
+msgstr ""
+
+#: account/templates/account_detail.html account/views/account.py
+msgid "Account details"
+msgstr ""
+
+#: account/templates/account_detail.html account/templates/password_reset.html
+#: account/views/password_reset.py
+msgid "Reset password"
+msgstr ""
+
+#: account/templates/account_detail.html
+msgid "Full name"
+msgstr ""
+
+#: account/templates/account_detail.html
+msgid "Member type"
+msgstr ""
+
+#: account/templates/account_detail.html
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: rocky/templates/tasks/normalizers.html
+msgid "Organization"
+msgstr ""
+
+#: account/templates/account_detail.html
+msgid "Permission to set OOI clearance levels"
+msgstr ""
+
+#: account/templates/account_detail.html
+msgid "OOI clearance"
+msgstr ""
+
+#: account/templates/account_detail.html
+msgid "You don't have any clearance to scan objects."
+msgstr ""
+
+#: account/templates/account_detail.html
+msgid ""
+"Get in contact with the admin to give you the necessary clearance level."
+msgstr ""
+
+#: account/templates/account_detail.html
+msgid "You have currently accepted clearance up to level"
+msgstr ""
+
+#: account/templates/account_detail.html
+msgid "Explanation OOI Clearance"
+msgstr ""
+
+#: account/templates/account_detail.html
+msgid ""
+"You can withdraw this at anytime you like, but know that you won't be able "
+"to change clearance levels anymore when you do."
+msgstr ""
+
+#: account/templates/account_detail.html
+#, python-format
+msgid "Withdraw L%(acl)s clearance and responsibility"
+msgstr ""
+
+#: account/templates/account_detail.html
+msgid "Explanation OOI clearance"
+msgstr ""
+
+#: account/templates/account_detail.html
+#, python-format
+msgid ""
+"You are granted clearance for level L%(tcl)s by your admin. Before you can "
+"change OOI clearance levels up to this level, you need to accept this "
+"permission. Remember: <strong>with great power comes great responsibility.</"
+"strong>"
+msgstr ""
+
+#: account/templates/account_detail.html
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+#, python-format
+msgid "Accept level L%(tcl)s clearance and responsibility"
+msgstr ""
+
+#: account/templates/password_reset.html
+msgid "Use the form below to reset your password."
+msgstr ""
+
+#: account/templates/password_reset.html
+#: account/templates/password_reset_confirm.html
+msgid "Send"
+msgstr ""
+
+#: account/templates/password_reset.html
+#: account/templates/password_reset_confirm.html
+msgid "Back"
+msgstr ""
+
+#: account/templates/password_reset_confirm.html
+msgid "Confirm reset password"
+msgstr ""
+
+#: account/templates/password_reset_confirm.html
+msgid "Use the form below to confirm resetting your password"
+msgstr ""
+
+#: account/templates/password_reset_confirm.html
+msgid "Confirm password"
+msgstr ""
+
+#: account/templates/password_reset_confirm.html
+msgid "The link is invalid"
+msgstr ""
+
+#: account/templates/password_reset_confirm.html
+msgid ""
+"The password reset link was invalid, possibly because it has already been "
+"used.  Please request a new password reset."
+msgstr ""
+
+#: account/templates/password_reset_email.html
+#, python-format
+msgid ""
+"You're receiving this email because you requested a password reset for your "
+"user account at %(site_name)s."
+msgstr ""
+
+#: account/templates/password_reset_email.html
+#: account/templates/registration_email.html
+msgid "Please go to the following page and choose a new password:"
+msgstr ""
+
+#: account/templates/password_reset_email.html
+#: account/templates/registration_email.html
+msgid "Sincerely,"
+msgstr ""
+
+#: account/templates/password_reset_email.html
+#: account/templates/registration_email.html
+msgid "The OpenKAT team"
+msgstr ""
+
+#: account/templates/password_reset_subject.txt
+#, python-format
+msgid "Password reset on %(site_name)s"
+msgstr ""
+
+#: account/templates/recover_email.html account/views/recover_email.py
+msgid "Recover email address"
+msgstr ""
+
+#: account/templates/recover_email.html
+msgid "Information on how to recover your connected email address"
+msgstr ""
+
+#: account/templates/recover_email.html
+msgid "Forgotten email address?"
+msgstr ""
+
+#: account/templates/recover_email.html
+msgid ""
+"If you don’t remember the email address connected to your account, contact:"
+msgstr ""
+
+#: account/templates/recover_email.html
+msgid "Please contact the system administrator."
+msgstr ""
+
+#: account/templates/recover_email.html
+msgid "Back to login"
+msgstr ""
+
+#: account/templates/recover_email.html
+msgid "Back to Home"
+msgstr ""
+
+#: account/templates/registration_email.html
+#, python-format
+msgid ""
+"Welcome to OpenKAT. You're receiving this email because you have been added "
+"to organization \"%(organization)s\" at %(site_name)s."
+msgstr ""
+
+#: account/templates/registration_subject.txt
+#, python-format
+msgid "Verify OpenKAT account on %(site_name)s"
+msgstr ""
+
+#: account/validators.py
+msgid ""
+"Your password must contain at least the following but longer passwords are "
+"recommended:"
+msgstr ""
+
+#: account/validators.py
+msgid " characters"
+msgstr ""
+
+#: account/validators.py
+msgid " digits"
+msgstr ""
+
+#: account/validators.py
+msgid " letters"
+msgstr ""
+
+#: account/validators.py
+msgid ""
+" special characters such as: {str(validators.get('special_characters',''))}"
+msgstr ""
+
+#: account/validators.py
+msgid " lower case letters"
+msgstr ""
+
+#: account/validators.py
+msgid " upper case letters"
+msgstr ""
+
+#: account/views/login.py
+msgid "Your session has timed out. Please login again."
+msgstr ""
+
+#: account/views/login.py rocky/templates/header.html
+msgid "OpenKAT"
+msgstr ""
+
+#: account/views/login.py account/views/password_reset.py
+#: account/views/recover_email.py rocky/templates/partials/secondary-menu.html
+#: rocky/templates/two_factor/core/login.html
+msgid "Login"
+msgstr ""
+
+#: account/views/login.py
+msgid "Two factor authentication"
+msgstr ""
+
+#: account/views/password_reset.py
+msgid "We couldn't send a password reset link. Contact "
+msgstr ""
+
+#: account/views/password_reset.py
+msgid ""
+"We couldn't send a password reset link. Contact your system administrator."
+msgstr ""
+
+#: components/modal/template.html
+msgid "Close modal"
+msgstr ""
+
+#: components/modal/template.html
+#: crisis_room/templates/partials/delete_dashboard_item_modal.html
+#: crisis_room/templates/partials/delete_dashboard_modal.html
+#: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
+#: crisis_room/templates/partials/new_dashboard_item_modal.html
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+#: crisis_room/templates/partials/new_dashboard_modal.html
+#: katalogus/templates/change_clearance_level.html
+#: katalogus/templates/confirmation_clone_settings.html
+#: katalogus/templates/plugin_settings_delete.html
+#: reports/templates/report_overview/modal_partials/enable_disable_schedule_modal.html
+#: reports/templates/report_schedules/delete_recipe_modal.html
+#: rocky/templates/oois/ooi_delete.html
+#: rocky/templates/oois/ooi_mute_finding.html
+#: rocky/templates/organizations/organization_edit.html
+#: rocky/templates/organizations/organization_member_edit.html
+#: rocky/templates/partials/delete_ooi_modal.html
+#: rocky/templates/partials/edit_ooi_clearance_level_modal.html
+#: rocky/templates/partials/mute_findings_modal.html
+#: rocky/templates/two_factor/_wizard_actions.html
+msgid "Cancel"
+msgstr ""
+
+#: crisis_room/forms.py
+msgid "Title on dashboard"
+msgstr ""
+
+#: crisis_room/forms.py
+msgid "Dashboard item size"
+msgstr ""
+
+#: crisis_room/forms.py
+msgid "Full width"
+msgstr ""
+
+#: crisis_room/forms.py
+msgid "Half width"
+msgstr ""
+
+#: crisis_room/forms.py
+msgid "An item with that name already exists. Try a different title."
+msgstr ""
+
+#: crisis_room/forms.py
+msgid "An error occurred while adding dashboard item."
+msgstr ""
+
+#: crisis_room/forms.py
+msgid "Number of rows in list"
+msgstr ""
+
+#: crisis_room/forms.py
+msgid "List sorting by"
+msgstr ""
+
+#: crisis_room/forms.py
+msgid "Type (A-Z)"
+msgstr ""
+
+#: crisis_room/forms.py
+msgid "Type (Z-A)"
+msgstr ""
+
+#: crisis_room/forms.py
+msgid "Clearance level (Low-High)"
+msgstr ""
+
+#: crisis_room/forms.py
+msgid "Clearance level (High-Low)"
+msgstr ""
+
+#: crisis_room/forms.py
+msgid "Show table columns"
+msgstr ""
+
+#: crisis_room/forms.py
+msgid "Severity (Low-High)"
+msgstr ""
+
+#: crisis_room/forms.py
+msgid "Severity (High-Low)"
+msgstr ""
+
+#: crisis_room/forms.py
+msgid "Finding (A-Z)"
+msgstr ""
+
+#: crisis_room/forms.py
+msgid "Finding (Z-A)"
+msgstr ""
+
+#: crisis_room/models.py
+msgid "Findings Dashboard"
+msgstr ""
+
+#: crisis_room/models.py
+msgid ""
+"Where on the dashboard do you want to show the data? Position {} is the most "
+"top level and the max position is {}."
+msgstr ""
+
+#: crisis_room/models.py
+msgid "Will be displayed on the general crisis room, for all organizations."
+msgstr ""
+
+#: crisis_room/models.py
+msgid "Will be displayed on a single organization dashboard"
+msgstr ""
+
+#: crisis_room/models.py
+msgid "Will be displayed on the findings dashboard for all organizations"
+msgstr ""
+
+#: crisis_room/models.py
+msgid "Can change position up or down of a dashboard item."
+msgstr ""
+
+#: crisis_room/models.py
+msgid "You have to choose between a recipe or a query, but not both."
+msgstr ""
+
+#: crisis_room/models.py
+msgid "You have set a query and not where it is from. Also set the source."
+msgstr ""
+
+#: crisis_room/models.py
+msgid ""
+"DashboardItem must contain at least a 'recipe' or a 'source' with a 'query'."
+msgstr ""
+
+#: crisis_room/models.py
+msgid "Max dashboard items reached."
+msgstr ""
+
+#: crisis_room/templates/crisis_room.html
+#: crisis_room/templates/organization_crisis_room.html
+#: rocky/templates/header.html
+msgid "Crisis room"
+msgstr ""
+
+#: crisis_room/templates/crisis_room.html
+msgid "Crisis room overview for all organizations."
+msgstr ""
+
+#: crisis_room/templates/crisis_room_dashboards.html
+msgid "Dashboards"
+msgstr ""
+
+#: crisis_room/templates/crisis_room_dashboards.html
+msgid ""
+"On this page you can see an overview of the dashboards for all "
+"organizations. **More context can be written here**"
+msgstr ""
+
+#: crisis_room/templates/crisis_room_dashboards.html
+msgid "dashboards"
+msgstr ""
+
+#: crisis_room/templates/crisis_room_dashboards.html
+msgid "There are no dashboards to display."
+msgstr ""
+
+#: crisis_room/templates/crisis_room_findings.html
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: reports/report_types/findings_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Findings overview"
+msgstr ""
+
+#: crisis_room/templates/crisis_room_findings.html
+msgid ""
+"\n"
+"                            This overview shows the total number of findings "
+"per\n"
+"                            severity that have been identified for all "
+"organizations.\n"
+"                            This data is based on the latest Crisis Room "
+"Findings Report\n"
+"                            of each organization.\n"
+"                        "
+msgstr ""
+
+#: crisis_room/templates/crisis_room_findings.html
+msgid "Findings per organization"
+msgstr ""
+
+#: crisis_room/templates/crisis_room_findings.html
+msgid ""
+"This table shows the findings that have been identified for each "
+"organization, sorted by the finding types and grouped by organizations. This "
+"data is based on the latest Crisis Room Findings Report of each organization."
+msgstr ""
+
+#: crisis_room/templates/crisis_room_findings.html
+#: reports/report_types/findings_report/report.html
+msgid ""
+"No findings have been identified yet. As soon as they have been identified, "
+"they will be shown on this page."
+msgstr ""
+
+#: crisis_room/templates/crisis_room_findings.html
+msgid ""
+"There are no organizations yet. After creating an organization, the "
+"identified findings will be shown here."
+msgstr ""
+
+#: crisis_room/templates/crisis_room_header.html
+#: crisis_room/templates/organization_crisis_room_header.html
+msgid "Crisis room navigation"
+msgstr ""
+
+#: crisis_room/templates/crisis_room_header.html
+#: crisis_room/templates/partials/new_dashboard_item_action_button.html
+#: reports/report_types/aggregate_organisation_report/findings.html
+#: reports/report_types/aggregate_organisation_report/report.html
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/findings_report/report.html
+#: reports/report_types/mail_report/report.html
+#: reports/report_types/multi_organization_report/report.html
+#: reports/report_types/name_server_report/report.html
+#: reports/report_types/tls_report/report.html
+#: reports/report_types/vulnerability_report/report.html
+#: reports/report_types/web_system_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/partials/report_sidemenu.html
+#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
+#: rocky/templates/header.html
+#: rocky/templates/oois/ooi_detail_findings_list.html
+#: rocky/templates/oois/ooi_detail_findings_overview.html
+#: rocky/templates/oois/ooi_page_tabs.html
+#: rocky/templates/partials/ooi_report_findings_block.html
+#: rocky/templates/partials/ooi_report_findings_block_table.html
+#: rocky/views/finding_list.py rocky/views/finding_type_add.py
+#: rocky/views/ooi_view.py
+msgid "Findings"
+msgstr ""
+
+#: crisis_room/templates/organization_crisis_room.html
+msgid "Options for dashboard"
+msgstr ""
+
+#: crisis_room/templates/organization_crisis_room.html
+msgid "Show all descriptions"
+msgstr ""
+
+#: crisis_room/templates/organization_crisis_room.html
+msgid "Hide all descriptions"
+msgstr ""
+
+#: crisis_room/templates/organization_crisis_room.html
+#: crisis_room/templates/partials/delete_dashboard_modal.html
+msgid "Delete dashboard"
+msgstr ""
+
+#: crisis_room/templates/organization_crisis_room.html
+msgid ""
+"There are no dashboards yet. Click on \"Add dashboard\" to create a new "
+"dashboard."
+msgstr ""
+
+#: crisis_room/templates/organization_crisis_room_dashboard_items.html
+#: katalogus/templates/partials/objects_to_scan.html
+#: rocky/templates/forms/widgets/checkbox_group_table.html
+#: rocky/templates/oois/ooi_list.html
+msgid "Object list"
+msgstr ""
+
+#: crisis_room/templates/organization_crisis_room_dashboard_items.html
+msgid "Finding list"
+msgstr ""
+
+#: crisis_room/templates/organization_crisis_room_dashboard_items.html
+#: crisis_room/templates/partials/new_dashboard_item_action_button.html
+msgid "Report section"
+msgstr ""
+
+#: crisis_room/templates/organization_crisis_room_dashboard_items.html
+msgid "There are no dashboard items added yet."
+msgstr ""
+
+#: crisis_room/templates/organization_crisis_room_dashboard_items.html
+msgid ""
+"You can add dashboard items via the filters on the objects and findings page "
+"or you can add a report section."
+msgstr ""
+
+#: crisis_room/templates/organization_crisis_room_dashboard_items.html
+msgid "Add objects"
+msgstr ""
+
+#: crisis_room/templates/organization_crisis_room_dashboard_items.html
+msgid "Add findings"
+msgstr ""
+
+#: crisis_room/templates/organization_crisis_room_dashboard_items.html
+msgid "Add report section"
+msgstr ""
+
+#: crisis_room/templates/organization_crisis_room_header.html
+#: crisis_room/templates/partials/new_dashboard_modal.html
+msgid "Add dashboard"
+msgstr ""
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+msgid "Findings per organization overview"
+msgstr ""
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/partials/report_severity_totals_table.html
+#: tools/forms/finding_type.py
+msgid "Finding types"
+msgstr ""
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: reports/report_types/dns_report/report.html
+#: reports/report_types/vulnerability_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/partials/report_severity_totals_table.html
+#: rocky/templates/oois/ooi_detail_findings_overview.html
+#: rocky/templates/partials/ooi_report_findings_block_table.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid "Occurrences"
+msgstr ""
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+msgid "Highest risk level"
+msgstr ""
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+msgid "Critical finding types"
+msgstr ""
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: reports/report_types/dns_report/report.html
+#: reports/report_types/vulnerability_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/summary/selected_plugins.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/partials/ooi_report_findings_block_table.html
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
+#: rocky/templates/tasks/ooi_detail_task_list.html
+#: rocky/templates/tasks/plugin_detail_task_list.html
+msgid "Details"
+msgstr ""
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: katalogus/templates/plugin_container_image.html
+#: reports/report_types/dns_report/report.html
+#: reports/report_types/vulnerability_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+#: reports/templates/summary/selected_plugins.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
+#: rocky/templates/tasks/ooi_detail_task_list.html
+#: rocky/templates/tasks/plugin_detail_task_list.html
+msgid "Close details"
+msgstr ""
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: katalogus/templates/plugin_container_image.html
+#: reports/report_types/dns_report/report.html
+#: reports/report_types/vulnerability_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+#: reports/templates/summary/selected_plugins.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
+#: rocky/templates/tasks/ooi_detail_task_list.html
+#: rocky/templates/tasks/plugin_detail_task_list.html
+msgid "Open details"
+msgstr ""
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+msgid ""
+"This overview shows the total number of findings per severity that have been "
+"identified for this organization."
+msgstr ""
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: reports/report_types/findings_report/report.html
+msgid "Critical and high findings"
+msgstr ""
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: reports/report_types/findings_report/report.html
+msgid ""
+"This table shows the top 25 critical and high findings that have been "
+"identified for this organization, grouped by finding types. A table with all "
+"the identified findings can be found in the Findings Report."
+msgstr ""
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+msgid "No findings have been identified. Check report for more details."
+msgstr ""
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+msgid "View findings report"
+msgstr ""
+
+#: crisis_room/templates/partials/crisis_room_findings_table.html
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Edit report recipe"
+msgstr ""
+
+#: crisis_room/templates/partials/dashboard_finding_list.html
+#, python-format
+msgid "Showing %(length)s findings"
+msgstr ""
+
+#: crisis_room/templates/partials/dashboard_finding_list.html
+msgid "Go to findings"
+msgstr ""
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+msgid "Findings table "
+msgstr ""
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: crisis_room/templates/partials/dashboard_ooi_list_table.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/oois/ooi_list.html
+msgid "column headers with buttons are sortable"
+msgstr ""
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+#, python-format
+msgid "Show details for %(finding)s"
+msgstr ""
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/oois/ooi_page_tabs.html
+#: rocky/templates/partials/elements/ooi_tree_condensed_table.html
+#: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
+#: rocky/views/mixins.py
+msgid "Tree"
+msgstr ""
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/oois/ooi_page_tabs.html
+#: rocky/templates/partials/elements/ooi_tree_condensed_table.html
+#: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
+#: rocky/views/mixins.py
+msgid "Graph"
+msgstr ""
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: reports/report_types/dns_report/report.html
+#: rocky/templates/oois/ooi_detail_findings_list.html
+#: rocky/templates/oois/ooi_detail_findings_overview.html rocky/views/mixins.py
+msgid "Severity"
+msgstr ""
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: reports/report_types/dns_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+#: rocky/views/mixins.py
+msgid "Finding"
+msgstr ""
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/partials/ooi_report_findings_block_table.html
+msgid "Finding type"
+msgstr ""
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+#, python-format
+msgid "Show details for %(finding_type)s"
+msgstr ""
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+msgid "OOI type"
+msgstr ""
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+#, python-format
+msgid "Show %(ooi_type)s objects"
+msgstr ""
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/views/mixins.py
+msgid "Location"
+msgstr ""
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#, python-format
+msgid "Show details for %(ooi)s"
+msgstr ""
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: rocky/templates/findings/finding_list.html
+msgid "Risk score"
+msgstr ""
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: katalogus/templates/normalizer_detail.html
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: reports/report_types/dns_report/report.html
+#: reports/report_types/vulnerability_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/summary/report_asset_overview.html tools/forms/boefje.py
+#: tools/forms/finding_type.py rocky/templates/findings/finding_list.html
+#: rocky/templates/oois/ooi_detail.html
+#: rocky/templates/oois/ooi_detail_findings_list.html rocky/templates/scan.html
+msgid "Description"
+msgstr ""
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: reports/report_types/multi_organization_report/recommendations.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/partials/report_severity_totals_table.html
+#: rocky/templates/findings/finding_list.html
+msgid "Recommendation"
+msgstr ""
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: reports/report_types/vulnerability_report/report.py
+#: reports/templates/partials/report_findings_table.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/oois/ooi_detail_origins_inference.html
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid "Source"
+msgstr ""
+
+#: crisis_room/templates/partials/dashboard_finding_list_table.html
+#: reports/templates/partials/report_findings_table.html
+#: rocky/templates/findings/finding_list.html
+msgid "Impact"
+msgstr ""
+
+#: crisis_room/templates/partials/dashboard_item_action_button.html
+msgid "Options for dashboard items"
+msgstr ""
+
+#: crisis_room/templates/partials/dashboard_item_action_button.html
+msgid "Show description"
+msgstr ""
+
+#: crisis_room/templates/partials/dashboard_item_action_button.html
+msgid "Hide description"
+msgstr ""
+
+#: crisis_room/templates/partials/dashboard_item_action_button.html
+msgid "Position up"
+msgstr ""
+
+#: crisis_room/templates/partials/dashboard_item_action_button.html
+msgid "Position down"
+msgstr ""
+
+#: crisis_room/templates/partials/dashboard_item_action_button.html
+msgid "Rerun report"
+msgstr ""
+
+#: crisis_room/templates/partials/dashboard_item_action_button.html
+#: crisis_room/templates/partials/delete_dashboard_item_modal.html
+msgid "Delete item"
+msgstr ""
+
+#: crisis_room/templates/partials/dashboard_ooi_list.html
+#, python-format
+msgid "Showing %(length)s objects"
+msgstr ""
+
+#: crisis_room/templates/partials/dashboard_ooi_list.html
+msgid "Go to objects"
+msgstr ""
+
+#: crisis_room/templates/partials/dashboard_ooi_list_table.html
+#: rocky/templates/oois/ooi_list.html
+msgid "Objects "
+msgstr ""
+
+#: crisis_room/templates/partials/delete_dashboard_item_modal.html
+#, python-format
+msgid "Are you sure you want to delete '%(name)s' from this dashboard?"
+msgstr ""
+
+#: crisis_room/templates/partials/delete_dashboard_item_modal.html
+#: crisis_room/templates/partials/delete_dashboard_modal.html
+#: katalogus/templates/plugin_settings_delete.html
+#: katalogus/views/plugin_settings_delete.py
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+#: rocky/templates/admin/delete_confirmation.html
+#: rocky/templates/oois/ooi_list.html
+#: rocky/templates/partials/delete_ooi_modal.html rocky/views/ooi_delete.py
+msgid "Delete"
+msgstr ""
+
+#: crisis_room/templates/partials/delete_dashboard_modal.html
+#, python-format
+msgid ""
+"Are you sure you want to delete dashboard '%(dashboard)s'? All the items on "
+"the dashboard will be deleted as well."
+msgstr ""
+
+#: crisis_room/templates/partials/new_dashboard_item_action_button.html
+msgid "Actions for adding dashboard items"
+msgstr ""
+
+#: crisis_room/templates/partials/new_dashboard_item_action_button.html
+msgid "Add item"
+msgstr ""
+
+#: crisis_room/templates/partials/new_dashboard_item_action_button.html
+#: crisis_room/templates/partials/report_dashboard_item_filter.html
+#: reports/templates/partials/report_ooi_list.html
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/summary/ooi_selection.html tools/forms/ooi.py
+#: tools/view_helpers.py rocky/templates/admin/delete_confirmation.html
+#: rocky/templates/admin/delete_selected_confirmation.html
+#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
+#: rocky/templates/header.html rocky/views/ooi_add.py rocky/views/ooi_list.py
+#: rocky/views/ooi_view.py rocky/views/upload_csv.py rocky/views/upload_raw.py
+msgid "Objects"
+msgstr ""
+
+#: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
+msgid "Add dashboard item"
+msgstr ""
+
+#: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
+msgid ""
+"To  add a <strong>report section</strong>, go to the history page and open a "
+"report. Then go to the section that you want to add to your dashboard and "
+"press the options button next to the section name to create a dashboard item."
+msgstr ""
+
+#: crisis_room/templates/partials/new_dashboard_item_explanation_modal.html
+msgid "Go to report history"
+msgstr ""
+
+#: crisis_room/templates/partials/new_dashboard_item_modal.html
+#, python-format
+msgid ""
+"\n"
+"    Add %(item_type)s to dashboard\n"
+msgstr ""
+
+#: crisis_room/templates/partials/new_dashboard_item_modal.html
+#, python-format
+msgid ""
+"Add these %(item_type)s with the selected filters to the dashboard of your "
+"choice."
+msgstr ""
+
+#: crisis_room/templates/partials/new_dashboard_item_modal.html
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+#: katalogus/templates/partials/no_enabling_permission_message.html
+#: katalogus/templates/plugin_container_image.html
+#: rocky/templates/partials/edit_ooi_clearance_level_modal.html
+#: rocky/templates/partials/form/field_input_help_text.html
+#: rocky/templates/partials/notifications_block.html
+#: rocky/templates/two_factor/core/login.html
+msgid "explanation"
+msgstr ""
+
+#: crisis_room/templates/partials/new_dashboard_item_modal.html
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+msgid "You do not have a custom dashboard yet"
+msgstr ""
+
+#: crisis_room/templates/partials/new_dashboard_item_modal.html
+#, python-format
+msgid ""
+"In order to add these %(item_type)s to a dashboard, you first need to create "
+"a dashboard. Please add a dashboard in the crisis room of your organization."
+msgstr ""
+
+#: crisis_room/templates/partials/new_dashboard_item_modal.html
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/oois/ooi_list.html
+msgid "Add to dashboard"
+msgstr ""
+
+#: crisis_room/templates/partials/new_dashboard_item_modal.html
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+msgid "Go to crisis room"
+msgstr ""
+
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+msgid "Add report section to dashboard"
+msgstr ""
+
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+msgid ""
+"In order to add this report section to a dashboard, you first need to create "
+"a dashboard. Please create a dashboard in the crisis room of your "
+"organization."
+msgstr ""
+
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+msgid "Report must be scheduled for dashboard items"
+msgstr ""
+
+#: crisis_room/templates/partials/new_dashboard_item_modal_report_section.html
+msgid ""
+"In order for dashboard information to be updated on a regular basis instead "
+"of showing static data, the report should be scheduled. The frequency of the "
+"schedules recurrence determines how fresh the data on the dashboard will be."
+msgstr ""
+
+#: crisis_room/templates/partials/report_dashboard_item_filter.html
+msgid "Applied filters"
+msgstr ""
+
+#: crisis_room/templates/partials/report_dashboard_item_filter.html
+msgid "Object types"
+msgstr ""
+
+#: crisis_room/templates/partials/report_dashboard_item_filter.html
+#: katalogus/templates/change_clearance_level.html onboarding/forms.py
+#: reports/templates/partials/report_ooi_list.html
+#: reports/templates/summary/ooi_selection.html tools/forms/boefje.py
+#: tools/forms/ooi.py rocky/templates/oois/ooi_page_tabs.html
+#: rocky/templates/partials/explanations.html
+#: rocky/templates/scan_profiles/scan_profile_detail.html rocky/views/mixins.py
+msgid "Clearance level"
+msgstr ""
+
+#: crisis_room/templates/partials/report_dashboard_item_filter.html
+#: reports/templates/partials/report_ooi_list.html
+#: reports/templates/summary/ooi_selection.html tools/forms/ooi.py
+#: rocky/views/mixins.py
+msgid "Clearance type"
+msgstr ""
+
+#: crisis_room/templates/partials/report_dashboard_item_filter.html
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/modal_partials/rerun_modal.html
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Input objects"
+msgstr ""
+
+#: crisis_room/templates/partials/report_dashboard_item_filter.html
+msgid "Show all objects"
+msgstr ""
+
+#: crisis_room/templates/partials/report_dashboard_item_filter.html
+#: reports/templates/partials/report_types_selection.html
+msgid "No filters applied"
+msgstr ""
+
+#: crisis_room/templates/partials/report_section_action_button.html
+msgid "Add section to dashboard"
+msgstr ""
+
+#: katalogus/client.py
+msgid ""
+"The KATalogus has an unexpected error. Check the logs for further details."
+msgstr ""
+
+#: katalogus/client.py
+#, python-format
+msgid "An HTTP %d error occurred. Check logs for more info."
+msgstr ""
+
+#: katalogus/client.py
+msgid "An HTTP error occurred. Check logs for more info."
+msgstr ""
+
+#: katalogus/client.py
+msgid "Boefje with this name already exists."
+msgstr ""
+
+#: katalogus/client.py
+msgid "Boefje with this ID already exists."
+msgstr ""
+
+#: katalogus/client.py
+msgid "Access to resource not allowed"
+msgstr ""
+
+#: katalogus/client.py
+msgid "User is not allowed to see plugin settings"
+msgstr ""
+
+#: katalogus/client.py
+msgid "User is not allowed to set plugin settings"
+msgstr ""
+
+#: katalogus/client.py
+msgid "User is not allowed to delete plugin settings"
+msgstr ""
+
+#: katalogus/client.py
+msgid "User is not allowed to view plugin settings"
+msgstr ""
+
+#: katalogus/client.py
+msgid "User is not allowed to access the other organization"
+msgstr ""
+
+#: katalogus/client.py
+msgid "User is not allowed to enable plugins"
+msgstr ""
+
+#: katalogus/client.py
+msgid "User is not allowed to disable plugins"
+msgstr ""
+
+#: katalogus/client.py
+msgid "User is not allowed to create plugins"
+msgstr ""
+
+#: katalogus/client.py
+msgid "User is not allowed to edit plugins"
+msgstr ""
+
+#: katalogus/forms/katalogus_filter.py
+msgid "Show all"
+msgstr ""
+
+#: katalogus/forms/katalogus_filter.py
+#: katalogus/templates/partials/enable_disable_plugin.html
+#: katalogus/templates/partials/plugin_tile_modal.html
+#: katalogus/templates/plugin_container_image.html
+#: reports/report_types/dns_report/report.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Enabled"
+msgstr ""
+
+#: katalogus/forms/katalogus_filter.py
+#: katalogus/templates/partials/enable_disable_plugin.html
+#: katalogus/templates/partials/plugin_tile_modal.html
+#: katalogus/templates/plugin_container_image.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+#: reports/templates/summary/selected_plugins.html
+msgid "Disabled"
+msgstr ""
+
+#: katalogus/forms/katalogus_filter.py
+msgid "Enabled-Disabled"
+msgstr ""
+
+#: katalogus/forms/katalogus_filter.py
+msgid "Disabled-Enabled"
+msgstr ""
+
+#: katalogus/forms/katalogus_filter.py
+msgid "Filter options"
+msgstr ""
+
+#: katalogus/forms/katalogus_filter.py
+msgid "Sorting options"
+msgstr ""
+
+#: katalogus/forms/plugin_settings.py
+msgid "This field is required."
+msgstr ""
+
+#: katalogus/templates/about_plugins.html
+#: katalogus/templates/partials/plugins_navigation.html
+msgid "About plugins"
+msgstr ""
+
+#: katalogus/templates/about_plugins.html katalogus/templates/katalogus.html
+msgid ""
+"Plugins gather data, objects and insight. Each plugin has its own focus area "
+"and strengths and may be able to work with other plugins to gain even more "
+"insights."
+msgstr ""
+
+#: katalogus/templates/about_plugins.html katalogus/templates/boefjes.html
+msgid ""
+"Boefjes are used to scan for objects. They detect vulnerabilities, security "
+"issues, and give insight. Each boefje is a separate scan that can run on a "
+"selection of objects."
+msgstr ""
+
+#: katalogus/templates/about_plugins.html katalogus/templates/normalizers.html
+msgid ""
+"Normalizers analyze the information and turn it into objects for the data "
+"model in Octopoes."
+msgstr ""
+
+#: katalogus/templates/about_plugins.html
+msgid ""
+"Bits are business rules that look for insight within the current dataset and "
+"search for specific insight and draw conclusions."
+msgstr ""
+
+#: katalogus/templates/boefje_detail.html
+#: katalogus/templates/partials/plugin_tile_modal.html
+#: katalogus/templates/plugin_container_image.html
+msgid "Scan level"
+msgstr ""
+
+#: katalogus/templates/boefje_detail.html
+#: katalogus/templates/normalizer_detail.html
+msgid "Consumes"
+msgstr ""
+
+#: katalogus/templates/boefje_detail.html
+#, python-format
+msgid "%(plugin_name)s is able to scan the following object types:"
+msgstr ""
+
+#: katalogus/templates/boefje_detail.html
+#: katalogus/templates/normalizer_detail.html
+#, python-format
+msgid "%(plugin_name)s does not need any input objects."
+msgstr ""
+
+#: katalogus/templates/boefje_detail.html
+#: katalogus/templates/normalizer_detail.html
+#: katalogus/templates/partials/plugin_tile_modal.html
+msgid "Produces"
+msgstr ""
+
+#: katalogus/templates/boefje_detail.html
+#: katalogus/templates/normalizer_detail.html
+#: katalogus/templates/partials/plugin_tile_modal.html
+#, python-format
+msgid "%(plugin_name)s can produce the following output:"
+msgstr ""
+
+#: katalogus/templates/boefje_detail.html
+#, python-format
+msgid "%(plugin_name)s doesn't produce any output mime types."
+msgstr ""
+
+#: katalogus/templates/boefje_setup.html
+msgid "Boefje variant setup"
+msgstr ""
+
+#: katalogus/templates/boefje_setup.html
+#: rocky/templates/organizations/organization_member_list.html
+#: rocky/templates/organizations/organization_settings.html
+#: rocky/views/ooi_edit.py rocky/views/organization_edit.py
+msgid "Edit"
+msgstr ""
+
+#: katalogus/templates/boefje_setup.html
+msgid "Boefje setup"
+msgstr ""
+
+#: katalogus/templates/boefje_setup.html
+msgid ""
+"You can create a new Boefje. If you want more information on this, you can "
+"check out the <a href=\"https://docs.openkat.nl/developer_documentation/"
+"development_tutorial/creating_a_boefje.html\">documentation</a>."
+msgstr ""
+
+#: katalogus/templates/boefje_setup.html
+#: rocky/templates/partials/edit_ooi_clearance_level_modal.html
+msgid "Save changes"
+msgstr ""
+
+#: katalogus/templates/boefje_setup.html
+msgid "Discard changes"
+msgstr ""
+
+#: katalogus/templates/boefje_setup.html
+msgid "Create variant"
+msgstr ""
+
+#: katalogus/templates/boefje_setup.html
+msgid "Discard variant"
+msgstr ""
+
+#: katalogus/templates/boefje_setup.html
+msgid "Create new Boefje"
+msgstr ""
+
+#: katalogus/templates/boefje_setup.html
+msgid "Discard new Boefje"
+msgstr ""
+
+#: katalogus/templates/boefjes.html
+msgid "Add Boefje"
+msgstr ""
+
+#: katalogus/templates/boefjes.html katalogus/templates/katalogus.html
+#: katalogus/templates/normalizers.html
+msgid "available"
+msgstr ""
+
+#: katalogus/templates/change_clearance_level.html
+#: katalogus/templates/partials/objects_to_scan.html
+#: reports/templates/partials/report_setup_scan.html
+msgid "scan level warning"
+msgstr ""
+
+#: katalogus/templates/change_clearance_level.html
+#, python-format
+msgid ""
+"%(plugin_name)s will only scan objects with a corresponding clearance level "
+"of <strong>L%(scan_level)s</strong> or higher."
+msgstr ""
+
+#: katalogus/templates/change_clearance_level.html
+msgid "Scan object"
+msgstr ""
+
+#: katalogus/templates/change_clearance_level.html
+#, python-format
+msgid ""
+"The following objects are not yet cleared for level %(scan_level)s, please "
+"be advised that by continuing you will declare a level %(scan_level)s on "
+"these objects."
+msgstr ""
+
+#: katalogus/templates/change_clearance_level.html
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: reports/templates/summary/report_asset_overview.html
+msgid "Selected objects"
+msgstr ""
+
+#: katalogus/templates/change_clearance_level.html
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/summary/ooi_selection.html rocky/views/mixins.py
+msgid "Object"
+msgstr ""
+
+#: katalogus/templates/change_clearance_level.html
+msgid "Are you sure you want to scan anyways?"
+msgstr ""
+
+#: katalogus/templates/change_clearance_level.html
+#: rocky/templates/oois/ooi_detail.html
+msgid "Scan"
+msgstr ""
+
+#: katalogus/templates/clone_settings.html
+#: katalogus/templates/confirmation_clone_settings.html
+msgid "Clone settings"
+msgstr ""
+
+#: katalogus/templates/clone_settings.html
+#, python-format
+msgid ""
+"Use the form below to clone the settings from "
+"<strong>%(current_organization)s</strong> to the selected organization. This "
+"includes both the KAT-alogus settings as well as enabled and disabled "
+"plugins."
+msgstr ""
+
+#: katalogus/templates/confirmation_clone_settings.html
+msgid "Clone"
+msgstr ""
+
+#: katalogus/templates/katalogus.html
+msgid "All plugins"
+msgstr ""
+
+#: katalogus/templates/katalogus_settings.html
+msgid "KAT-alogus settings"
+msgstr ""
+
+#: katalogus/templates/katalogus_settings.html
+msgid ""
+"There are currently no settings defined. Add settings at the plugin detail "
+"page."
+msgstr ""
+
+#: katalogus/templates/katalogus_settings.html
+#: rocky/templates/two_factor/core/otp_required.html
+msgid "Go back"
+msgstr ""
+
+#: katalogus/templates/katalogus_settings.html
+msgid "This is an overview of the latest settings of all plugins."
+msgstr ""
+
+#: katalogus/templates/katalogus_settings.html
+msgid "Latest plugin settings"
+msgstr ""
+
+#: katalogus/templates/katalogus_settings.html
+#: rocky/templates/tasks/ooi_detail_task_list.html
+msgid "Plugin"
+msgstr ""
+
+#: katalogus/templates/katalogus_settings.html
+#: katalogus/templates/plugin_settings_list.html
+#: rocky/templates/oois/ooi_delete.html
+msgid "Value"
+msgstr ""
+
+#: katalogus/templates/normalizer_detail.html
+#, python-format
+msgid "%(plugin_name)s is able to process the following mime types:"
+msgstr ""
+
+#: katalogus/templates/partials/boefje_tile.html
+msgid "This object type is required"
+msgstr ""
+
+#: katalogus/templates/partials/boefje_tile.html
+msgid "Scan level:"
+msgstr ""
+
+#: katalogus/templates/partials/boefje_tile.html
+msgid "Publisher:"
+msgstr ""
+
+#: katalogus/templates/partials/boefje_tile.html
+#: katalogus/templates/partials/plugin_tile.html
+#: katalogus/templates/partials/plugin_tile_modal.html
+msgid "See details"
+msgstr ""
+
+#: katalogus/templates/partials/enable_disable_plugin.html
+msgid "Enable"
+msgstr ""
+
+#: katalogus/templates/partials/enable_disable_plugin.html
+#: rocky/templates/two_factor/profile/disable.html
+msgid "Disable"
+msgstr ""
+
+#: katalogus/templates/partials/katalogus_filter.html
+#: rocky/templates/findings/findings_filter.html
+#: rocky/templates/partials/ooi_list_filters.html
+#: rocky/templates/partials/organization_member_list_filters.html
+#: rocky/templates/tasks/partials/task_filter.html
+msgid "Hide filters"
+msgstr ""
+
+#: katalogus/templates/partials/katalogus_filter.html
+#: rocky/templates/findings/findings_filter.html
+#: rocky/templates/partials/ooi_list_filters.html
+#: rocky/templates/partials/organization_member_list_filters.html
+#: rocky/templates/tasks/partials/task_filter.html
+msgid "Show filters"
+msgstr ""
+
+#: katalogus/templates/partials/katalogus_filter.html
+#: rocky/templates/findings/findings_filter.html
+#: rocky/templates/partials/ooi_list_filters.html
+#: rocky/templates/partials/organization_member_list_filters.html
+#: rocky/templates/tasks/partials/task_filter.html
+msgid "applied"
+msgstr ""
+
+#: katalogus/templates/partials/katalogus_filter.html
+msgid "Filter plugins"
+msgstr ""
+
+#: katalogus/templates/partials/katalogus_filter.html
+msgid "Clear filter"
+msgstr ""
+
+#: katalogus/templates/partials/katalogus_header.html
+#: katalogus/views/change_clearance_level.py katalogus/views/katalogus.py
+#: katalogus/views/katalogus_settings.py katalogus/views/plugin_detail.py
+#: katalogus/views/plugin_settings_add.py
+#: katalogus/views/plugin_settings_delete.py
+#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
+#: rocky/templates/header.html
+msgid "KAT-alogus"
+msgstr ""
+
+#: katalogus/templates/partials/katalogus_header.html
+msgid "An overview of all available plugins."
+msgstr ""
+
+#: katalogus/templates/partials/katalogus_header.html
+#: katalogus/templates/plugin_settings_list.html
+#: katalogus/views/katalogus_settings.py tools/view_helpers.py
+#: rocky/templates/header.html
+#: rocky/templates/organizations/organization_list.html
+#: rocky/templates/organizations/organization_settings.html
+msgid "Settings"
+msgstr ""
+
+#: katalogus/templates/partials/katalogus_toolbar.html
+msgid "Gridview"
+msgstr ""
+
+#: katalogus/templates/partials/katalogus_toolbar.html
+msgid "Tableview"
+msgstr ""
+
+#: katalogus/templates/partials/modal_report_types.html
+msgid "Required for"
+msgstr ""
+
+#: katalogus/templates/partials/modal_report_types.html
+msgid "report types"
+msgstr ""
+
+#: katalogus/templates/partials/modal_report_types.html
+msgid "Report types for "
+msgstr ""
+
+#: katalogus/templates/partials/no_enabling_permission_message.html
+msgid "No permission to enable/disable plugins"
+msgstr ""
+
+#: katalogus/templates/partials/no_enabling_permission_message.html
+msgid "Contact your administrator to request permission."
+msgstr ""
+
+#: katalogus/templates/partials/objects_to_scan.html
+#, python-format
+msgid ""
+"This Boefje will only scan objects with a corresponding clearance level of "
+"<strong>L%(scan_level)s</strong> or higher. There is no indemnification for "
+"this Boefje to scan an OOI with a lower clearance level than "
+"<strong>L%(scan_level)s</strong>. Use the filter to show OOI's with a lower "
+"clearance level."
+msgstr ""
+
+#: katalogus/templates/partials/objects_to_scan.html
+msgid "Warning scan level:"
+msgstr ""
+
+#: katalogus/templates/partials/objects_to_scan.html
+msgid ""
+"Scanning OOI's with a lower clearance level will result in OpenKAT "
+"increasing the clearance level on that OOI, not only for this scan but from "
+"now on out, until it manually gets set to something else again. This means "
+"that all other enabled Boefjes will use this higher clearance level aswel."
+msgstr ""
+
+#: katalogus/templates/partials/objects_to_scan.html
+#, python-format
+msgid ""
+"You currently don't have any objects that meet the scan level of %(name)s. "
+"Add objects with a complying clearance level, or alter the clearance level "
+"of existing objects."
+msgstr ""
+
+#: katalogus/templates/partials/objects_to_scan.html
+#, python-format
+msgid ""
+"You currently don't have scannable objects for %(name)s. Add objects to use "
+"this Boefje. This Boefje is able to scan objects of the following types:"
+msgstr ""
+
+#: katalogus/templates/partials/plugin_settings_required.html
+msgid "The form could not be initialized."
+msgstr ""
+
+#: katalogus/templates/partials/plugin_settings_required.html
+msgid "Required settings"
+msgstr ""
+
+#: katalogus/templates/partials/plugin_settings_required.html
+#: rocky/templates/partials/ooi_list_toolbar.html
+msgid "Add"
+msgstr ""
+
+#: katalogus/templates/partials/plugin_tile.html
+msgid "Required for:"
+msgstr ""
+
+#: katalogus/templates/partials/plugin_tile_modal.html
+msgid "Boefje details"
+msgstr ""
+
+#: katalogus/templates/partials/plugin_tile_modal.html reports/forms.py
+#: reports/templates/report_overview/report_history_table.html
+msgid "Report types"
+msgstr ""
+
+#: katalogus/templates/partials/plugin_tile_modal.html
+msgid "This boefje is required by the following report types."
+msgstr ""
+
+#: katalogus/templates/partials/plugin_tile_modal.html
+msgid "Go to boefje detail page"
+msgstr ""
+
+#: katalogus/templates/partials/plugins.html
+msgid "Plugins overview:"
+msgstr ""
+
+#: katalogus/templates/partials/plugins.html
+#: reports/templates/summary/selected_plugins.html
+msgid "Plugin name"
+msgstr ""
+
+#: katalogus/templates/partials/plugins.html
+#: reports/templates/summary/selected_plugins.html
+msgid "Plugin type"
+msgstr ""
+
+#: katalogus/templates/partials/plugins.html
+#: reports/templates/summary/selected_plugins.html
+msgid "Plugin description"
+msgstr ""
+
+#: katalogus/templates/partials/plugins.html
+#: reports/templates/partials/report_header.html
+#: reports/templates/report_overview/report_history_table.html
+#: rocky/templates/organizations/organization_list.html
+#: rocky/templates/organizations/organization_settings.html
+msgid "Actions"
+msgstr ""
+
+#: katalogus/templates/partials/plugins.html
+msgid "Detail page"
+msgstr ""
+
+#: katalogus/templates/partials/plugins_navigation.html
+#: reports/templates/report_overview/report_overview_navigation.html
+msgid "Plugins Navigation"
+msgstr ""
+
+#: katalogus/templates/partials/plugins_navigation.html
+#: rocky/templates/scan.html rocky/templates/tasks/boefjes.html
+#: rocky/templates/tasks/partials/tab_navigation.html rocky/views/tasks.py
+msgid "Boefjes"
+msgstr ""
+
+#: katalogus/templates/partials/plugins_navigation.html
+#: rocky/templates/tasks/normalizers.html
+#: rocky/templates/tasks/partials/tab_navigation.html rocky/views/tasks.py
+msgid "Normalizers"
+msgstr ""
+
+#: katalogus/templates/partials/plugins_navigation.html
+#: tools/forms/scheduler.py
+msgid "All"
+msgstr ""
+
+#: katalogus/templates/plugin_container_image.html tools/forms/boefje.py
+msgid "Container image"
+msgstr ""
+
+#: katalogus/templates/plugin_container_image.html
+msgid "The container image for this Boefje is:"
+msgstr ""
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Variants"
+msgstr ""
+
+#: katalogus/templates/plugin_container_image.html
+msgid ""
+"Boefje variants that use the same container image. For more information "
+"about Boefje variants you can read the documentation."
+msgstr ""
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Add variant"
+msgstr ""
+
+#: katalogus/templates/plugin_container_image.html
+#: rocky/templates/partials/notifications_block.html
+msgid "confirmation"
+msgstr ""
+
+#: katalogus/templates/plugin_container_image.html
+#, python-format
+msgid "Variant %(plugin.name)s created."
+msgstr ""
+
+#: katalogus/templates/plugin_container_image.html
+msgid "The Boefje variant is successfully created and can now be used."
+msgstr ""
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Overview of variants"
+msgstr ""
+
+#: katalogus/templates/plugin_container_image.html
+#: reports/report_types/tls_report/report.html
+#: reports/templates/partials/plugin_overview_table.html
+#: rocky/templates/organizations/organization_member_list.html
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
+#: rocky/templates/tasks/ooi_detail_task_list.html
+#: rocky/templates/tasks/plugin_detail_task_list.html
+#: rocky/templates/tasks/reports.html
+msgid "Status"
+msgstr ""
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Age"
+msgstr ""
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Scan interval"
+msgstr ""
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Run on"
+msgstr ""
+
+#: katalogus/templates/plugin_container_image.html
+msgid "current"
+msgstr ""
+
+#: katalogus/templates/plugin_container_image.html
+#: reports/report_types/dns_report/report.html
+msgid "minutes"
+msgstr ""
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Default system scan frequency"
+msgstr ""
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Boefje ID"
+msgstr ""
+
+#: katalogus/templates/plugin_container_image.html
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/modal_partials/rerun_modal.html
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/report_overview/subreports_table.html
+#: rocky/templates/tasks/reports.html
+msgid "Creation date"
+msgstr ""
+
+#: katalogus/templates/plugin_container_image.html tools/forms/boefje.py
+msgid "Arguments"
+msgstr ""
+
+#: katalogus/templates/plugin_container_image.html
+msgid "The following arguments are used for this Boefje variant:"
+msgstr ""
+
+#: katalogus/templates/plugin_container_image.html
+msgid "There are no arguments used for this Boefje variant."
+msgstr ""
+
+#: katalogus/templates/plugin_container_image.html
+msgid "Edit variant"
+msgstr ""
+
+#: katalogus/templates/plugin_container_image.html
+msgid "This Boefje has no variants yet."
+msgstr ""
+
+#: katalogus/templates/plugin_container_image.html
+msgid ""
+"You can make a variant and change the arguments and JSON Schema to customize "
+"it to fit your needs."
+msgstr ""
+
+#: katalogus/templates/plugin_settings_add.html
+msgid "Add setting"
+msgid_plural "Add settings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: katalogus/templates/plugin_settings_add.html
+msgid "Setting"
+msgid_plural "Settings"
+msgstr[0] ""
+msgstr[1] ""
+
+#: katalogus/templates/plugin_settings_add.html
+msgid "Add setting and enable boefje"
+msgid_plural "Add settings and enable boefje"
+msgstr[0] ""
+msgstr[1] ""
+
+#: katalogus/templates/plugin_settings_delete.html
+msgid "Delete settings"
+msgstr ""
+
+#: katalogus/templates/plugin_settings_delete.html
+#, python-format
+msgid ""
+"Are you sure you want to delete all settings for the plugin %(plugin_name)s?"
+msgstr ""
+
+#: katalogus/templates/plugin_settings_list.html
+msgid ""
+"In the table below the settings for this specific Boefje can be seen. Set or "
+"change the value of the variables by editing the settings."
+msgstr ""
+
+#: katalogus/templates/plugin_settings_list.html
+msgid "Configure Settings"
+msgstr ""
+
+#: katalogus/templates/plugin_settings_list.html
+msgid "Overview of settings"
+msgstr ""
+
+#: katalogus/templates/plugin_settings_list.html
+msgid "Variable"
+msgstr ""
+
+#: katalogus/views/change_clearance_level.py
+msgid "Session has terminated, please select objects again."
+msgstr ""
+
+#: katalogus/views/change_clearance_level.py
+msgid "Change clearance level"
+msgstr ""
+
+#: katalogus/views/katalogus_settings.py
+msgid "Settings from {} to {} successfully cloned."
+msgstr ""
+
+#: katalogus/views/katalogus_settings.py
+#: katalogus/views/plugin_settings_list.py
+msgid "Failed getting settings for boefje {}"
+msgstr ""
+
+#: katalogus/views/mixins.py
+msgid ""
+"Getting information for plugin {} failed. Please check the KATalogus logs."
+msgstr ""
+
+#: katalogus/views/plugin_detail.py
+msgid ""
+"Some selected OOIs needs an increase of clearance level to perform scans. "
+"You do not have the permission to change clearance level."
+msgstr ""
+
+#: katalogus/views/plugin_enable_disable.py
+msgid "{} '{}' disabled."
+msgstr ""
+
+#: katalogus/views/plugin_enable_disable.py
+msgid "{} '{}' enabled."
+msgstr ""
+
+#: katalogus/views/plugin_enable_disable.py
+msgid ""
+"You have not acknowledged your clearance level. Go to your profile page to "
+"acknowledge your clearance level."
+msgstr ""
+
+#: katalogus/views/plugin_enable_disable.py
+msgid ""
+"Your clearance level is not set. Go to your profile page to see your "
+"clearance or contact the administrator to set a clearance level."
+msgstr ""
+
+#: katalogus/views/plugin_enable_disable.py
+msgid ""
+"Your clearance level is L{}. Contact your administrator to get a higher "
+"clearance level."
+msgstr ""
+
+#: katalogus/views/plugin_enable_disable.py
+msgid "To enable {} you need at least a clearance level of L{}. "
+msgstr ""
+
+#: katalogus/views/plugin_settings_add.py
+msgid "Trying to add settings to boefje without schema"
+msgstr ""
+
+#: katalogus/views/plugin_settings_add.py
+msgid "No changes to the settings added: no form data present"
+msgstr ""
+
+#: katalogus/views/plugin_settings_add.py
+msgid "Added settings for '{}'"
+msgstr ""
+
+#: katalogus/views/plugin_settings_add.py
+msgid "Failed adding settings"
+msgstr ""
+
+#: katalogus/views/plugin_settings_add.py
+msgid "Enabling {} failed"
+msgstr ""
+
+#: katalogus/views/plugin_settings_add.py
+msgid "Boefje '{}' enabled."
+msgstr ""
+
+#: katalogus/views/plugin_settings_add.py
+msgid "Add settings"
+msgstr ""
+
+#: katalogus/views/plugin_settings_delete.py
+msgid "Settings for plugin {} successfully deleted."
+msgstr ""
+
+#: katalogus/views/plugin_settings_delete.py
+msgid "Plugin {} has no settings."
+msgstr ""
+
+#: katalogus/views/plugin_settings_delete.py
+msgid ""
+"Failed deleting Settings for plugin {}. Check the Katalogus logs for more "
+"info."
+msgstr ""
+
+#: onboarding/forms.py
+msgid ""
+"The clearance level determines how aggressive the object can be scanned by "
+"plugins. A higher clearance level means more aggressive scans are allowed."
+msgstr ""
+
+#: onboarding/forms.py tools/forms/ooi.py
+msgid "explanation-clearance-level"
+msgstr ""
+
+#: onboarding/forms.py
+msgid "Please enter a valid URL starting with 'http://' or 'https://'."
+msgstr ""
+
+#: onboarding/templates/partials/onboarding_header.html
+msgid "Onboarding"
+msgstr ""
+
+#: onboarding/templates/partials/step_1_introduction_text.html
+msgid "Welcome to OpenKAT!"
+msgstr ""
+
+#: onboarding/templates/partials/step_1_introduction_text.html
+msgid ""
+"Welcome to the onboarding of OpenKAT. We will walk you through some steps to "
+"set everything up."
+msgstr ""
+
+#: onboarding/templates/partials/step_1_introduction_text.html
+msgid ""
+"At the end of this onboarding you have added your first object, created your "
+"first DNS report and learned about some basic concepts used within OpenKAT."
+msgstr ""
+
+#: onboarding/templates/partials/step_1_introduction_text.html
+msgid "The full documentation for OpenKAT can be found at:"
+msgstr ""
+
+#: onboarding/templates/partials/step_2_organization_text.html
+#: rocky/templates/organizations/organization_add.html
+msgid "Organization setup"
+msgstr ""
+
+#: onboarding/templates/partials/step_2_organization_text.html
+msgid ""
+"Please enter the following organization details. The organization name can "
+"be changed later in the interface. The organization code cannot be changed "
+"as this is used by the database."
+msgstr ""
+
+#: onboarding/templates/step_10_report.html
+#: reports/report_types/concatenated_report/report.py
+msgid "Report"
+msgstr ""
+
+#: onboarding/templates/step_10_report.html
+msgid "Boefjes are scanning"
+msgstr ""
+
+#: onboarding/templates/step_10_report.html
+msgid ""
+"The enabled Boefjes are running in the background to gather the data for "
+"your DNS Report. This may take a few minutes."
+msgstr ""
+
+#: onboarding/templates/step_10_report.html
+msgid ""
+"In the meantime you can explore OpenKAT and view your DNS Report on the "
+"Reports page once it has been generated."
+msgstr ""
+
+#: onboarding/templates/step_10_report.html
+msgid "Continue to OpenKAT"
+msgstr ""
+
+#: onboarding/templates/step_1_introduction_registration.html
+#: onboarding/templates/step_1a_introduction.html
+msgid "Let's get started"
+msgstr ""
+
+#: onboarding/templates/step_2a_organization_setup.html
+#: onboarding/templates/step_2b_organization_update.html
+#: rocky/templates/organizations/organization_add.html
+#: rocky/templates/organizations/organization_settings.html
+#: rocky/templates/partials/organization_properties_table.html
+msgid "Organization details"
+msgstr ""
+
+#: onboarding/templates/step_2a_organization_setup.html
+#: rocky/templates/forms/json_schema_form.html
+#: rocky/templates/organizations/organization_add.html
+#: rocky/templates/organizations/organization_member_add.html
+#: rocky/templates/organizations/organization_member_add_account_type.html
+#: rocky/templates/partials/elements/ooi_detail_settings.html
+#: rocky/templates/partials/elements/ooi_report_settings.html
+#: rocky/templates/partials/form/indemnification_add_form.html
+#: rocky/templates/two_factor/_wizard_actions.html
+msgid "Submit"
+msgstr ""
+
+#: onboarding/templates/step_2b_organization_update.html
+msgid "Submit changes"
+msgstr ""
+
+#: onboarding/templates/step_2b_organization_update.html
+#: onboarding/templates/step_3_indemnification_setup.html
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+#: onboarding/templates/step_7_clearance_level_introduction.html
+msgid "Continue"
+msgstr ""
+
+#: onboarding/templates/step_3_indemnification_setup.html
+msgid "Indemnification setup"
+msgstr ""
+
+#: onboarding/templates/step_3_indemnification_setup.html
+msgid "Indemnification on the organization is already present."
+msgstr ""
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+msgid "User clearance level"
+msgstr ""
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+msgid ""
+"The user clearance level specifies the maximum scan level for security scans "
+"and the maximum clearance level you can assign to objects (e.g. a URL)."
+msgstr ""
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+msgid ""
+"The administrator assigns a maximum user clearance level to each user. This "
+"will make sure that only trusted users can start more aggressive scans."
+msgstr ""
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+msgid ""
+"A user must accept a clearance level, before they perform actions in "
+"OpenKAT. Here you may accept the maximum trusted clearance level, as "
+"assigned by your administrator. On your user settings page you can choose to "
+"lower your accepted clearance level after completing the onboarding."
+msgstr ""
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+msgid "What is my clearance level?"
+msgstr ""
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+#, python-format
+msgid ""
+"Unfortunately you cannot continue the onboarding. </br> Your administrator "
+"has trusted you with a clearance level of <strong>L%(tcl)s</strong>. </br> "
+"You need at least a clearance level of "
+"<strong>L%(dns_report_least_clearance_level)s</strong> to scan "
+"<strong>%(ooi)s</strong> </br> Contact your administrator to receive a "
+"higher clearance."
+msgstr ""
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+#: onboarding/templates/step_5_add_scan_ooi.html
+#: onboarding/templates/step_6_set_clearance_level.html
+#: onboarding/templates/step_7_clearance_level_introduction.html
+#: onboarding/templates/step_8_setup_scan_select_plugins.html
+#: onboarding/templates/step_9_choose_report_type.html
+#: rocky/templates/partials/form/boefje_tiles_form.html
+msgid "Skip onboarding"
+msgstr ""
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+#, python-format
+msgid ""
+"Your administrator has trusted you with a clearance level of "
+"<strong>L%(tcl)s</strong>. </br> You must first accept this clearance level "
+"to continue."
+msgstr ""
+
+#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+#, python-format
+msgid ""
+"Your administrator has <strong>trusted</strong> you with a clearance level "
+"of <strong>L%(tcl)s</strong>."
+msgstr ""
+
+#: onboarding/templates/step_5_add_scan_ooi.html
+msgid "Add an object"
+msgstr ""
+
+#: onboarding/templates/step_5_add_scan_ooi.html
+msgid ""
+"OpenKAT uses various kinds of objects, like IP addresses, hostnames and "
+"URLs. In the onboarding we will add an URL object, such as our vulnerable "
+"OpenKAT website: https://mispo.es."
+msgstr ""
+
+#: onboarding/templates/step_5_add_scan_ooi.html
+#: rocky/templates/partials/ooi_detail_related_object.html
+msgid "Related objects"
+msgstr ""
+
+#: onboarding/templates/step_5_add_scan_ooi.html
+msgid ""
+"Most objects have dependencies on the existence of related objects. For "
+"example a URL needs to be connected to a network, hostname, fqdn (fully "
+"qualified domain name) and IP address. When possible OpenKAT automatically "
+"collects and adds these related objects by running scans. Objects can also "
+"be manually added."
+msgstr ""
+
+#: onboarding/templates/step_5_add_scan_ooi.html
+msgid "Create object"
+msgstr ""
+
+#: onboarding/templates/step_6_set_clearance_level.html
+msgid "Set object clearance level"
+msgstr ""
+
+#: onboarding/templates/step_6_set_clearance_level.html
+msgid ""
+"After creating a new object you can set a clearance level for this object. A "
+"clearance level determines how aggressive the object can be scanned. A "
+"higher clearance level, means that more aggressive scans are allowed. "
+"Clearance levels can always be adjusted later on."
+msgstr ""
+
+#: onboarding/templates/step_6_set_clearance_level.html
+#, python-format
+msgid ""
+"For the onboarding we use a clearance level of "
+"L%(dns_report_least_clearance_level)s, meaning only informational scans are "
+"allowed."
+msgstr ""
+
+#: onboarding/templates/step_6_set_clearance_level.html
+msgid "Set clearance level"
+msgstr ""
+
+#: onboarding/templates/step_7_clearance_level_introduction.html
+msgid "Plugin introduction"
+msgstr ""
+
+#: onboarding/templates/step_7_clearance_level_introduction.html
+msgid ""
+"OpenKAT uses plugins to scan your objects. Each plugin has a scan level to "
+"specify how aggressive the scan is. Plugins can only scan those objects with "
+"a clearance level that is equal to, or higher than the scan level of the "
+"plugin. Plugin scan level are indicated by the number of cat paws."
+msgstr ""
+
+#: onboarding/templates/step_7_clearance_level_introduction.html
+msgid ""
+"The plugin <strong>DNS Zone</strong> has a scan level of 1, meaning that it "
+"performs non-intrusive scans which look for publicly available information. "
+"It scans objects with a clearance level of 1 or higher."
+msgstr ""
+
+#: onboarding/templates/step_7_clearance_level_introduction.html
+msgid ""
+"The plugin <strong>Fierce</strong> has a scan level of 3, meaning that it "
+"more aggressive and could potentially break things. It scans objects with a "
+"clearance level of 3 or higher."
+msgstr ""
+
+#: onboarding/templates/step_8_setup_scan_select_plugins.html
+msgid "Enabling plugins and start scanning"
+msgstr ""
+
+#: onboarding/templates/step_8_setup_scan_select_plugins.html
+msgid ""
+"OpenKAT uses plugins to scan, check and analyze. There are three types of "
+"plugins."
+msgstr ""
+
+#: onboarding/templates/step_8_setup_scan_select_plugins.html
+msgid ""
+"The first plugin are <b>Boefjes</b>, which scan objects for data. These are "
+"security tools like nmap, LeakIX and WPscan. </p>"
+msgstr ""
+
+#: onboarding/templates/step_8_setup_scan_select_plugins.html
+msgid ""
+"The other two plugins are <b>Normalizers</b> and <b>Bits</b>, which are used "
+"to process the output of Boefjes. They can create findings and related "
+"objects. Bits are also used to create organization specific findings, based "
+"on policy requirements. </p>"
+msgstr ""
+
+#: onboarding/templates/step_8_setup_scan_select_plugins.html
+msgid ""
+"For the onboarding we will enable the Boefjes shown below. Once enabled "
+"these Boefjes gather publicly available information on suitable objects with "
+"a clearance level of 1 or higher. Normalizers and Bits are enabled by "
+"default."
+msgstr ""
+
+#: onboarding/templates/step_8_setup_scan_select_plugins.html
+msgid "Enable and continue"
+msgstr ""
+
+#: onboarding/templates/step_9_choose_report_type.html
+msgid "Generate a report"
+msgstr ""
+
+#: onboarding/templates/step_9_choose_report_type.html
+msgid ""
+"Reports can be used to gain more insights in your organizations assets. You "
+"can generate different types of reports in OpenKAT. Each report may require "
+"one or more plugins that provide the input for the report."
+msgstr ""
+
+#: onboarding/templates/step_9_choose_report_type.html
+msgid ""
+"For the onboarding we will generate a DNS report for your added URL. In the "
+"previous step you enabled the required plugins for this report."
+msgstr ""
+
+#: onboarding/templates/step_9_choose_report_type.html
+msgid "Generate DNS Report"
+msgstr ""
+
+#: onboarding/view_helpers.py
+msgid "1: Welcome"
+msgstr ""
+
+#: onboarding/view_helpers.py
+msgid "2: Organization setup"
+msgstr ""
+
+#: onboarding/view_helpers.py
+msgid "3: Add object"
+msgstr ""
+
+#: onboarding/view_helpers.py
+msgid "4: Plugins"
+msgstr ""
+
+#: onboarding/view_helpers.py
+msgid "5: Generating report"
+msgstr ""
+
+#: onboarding/views.py
+#, python-brace-format
+msgid "{org_name} successfully created."
+msgstr ""
+
+#: onboarding/views.py
+#, python-brace-format
+msgid "{org_name} successfully updated."
+msgstr ""
+
+#: onboarding/views.py
+msgid "Creating an object"
+msgstr ""
+
+#: onboarding/views.py
+msgid "Fetch the parent DNS zone of a hostname"
+msgstr ""
+
+#: onboarding/views.py
+msgid "Finds subdomains by brute force"
+msgstr ""
+
+#: onboarding/views.py
+msgid "Please select a plugin to proceed."
+msgstr ""
+
+#: onboarding/views.py
+msgid "Please select all required plugins to proceed."
+msgstr ""
+
+#: onboarding/views.py reports/views/aggregate_report.py
+#: reports/views/generate_report.py
+msgid "An error occurred while enabling {}. The plugin is not available."
+msgstr ""
+
+#: onboarding/views.py
+msgid "Plugins successfully enabled."
+msgstr ""
+
+#: onboarding/views.py
+msgid "Web URL not found."
+msgstr ""
+
+#: onboarding/views.py
+msgid ""
+"Your report is scheduled for generation in about 3 minutes, as we are "
+"waiting for Boefjes to complete. In the meantime get familiar with OpenKAT "
+"and visit the Reports History tab later."
+msgstr ""
+
+#: reports/forms.py tools/forms/ooi_form.py
+msgid "Filter by OOI types"
+msgstr ""
+
+#: reports/forms.py
+msgid "Today"
+msgstr ""
+
+#: reports/forms.py
+msgid "Different date"
+msgstr ""
+
+#: reports/forms.py
+msgid "No, just once"
+msgstr ""
+
+#: reports/forms.py
+msgid "Yes, repeat"
+msgstr ""
+
+#: reports/forms.py
+msgid "Start date"
+msgstr ""
+
+#: reports/forms.py
+msgid "Start time (UTC)"
+msgstr ""
+
+#: reports/forms.py
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Recurrence"
+msgstr ""
+
+#: reports/forms.py
+msgid "No recurrence, just once"
+msgstr ""
+
+#: reports/forms.py
+msgid "Daily"
+msgstr ""
+
+#: reports/forms.py
+msgid "Weekly"
+msgstr ""
+
+#: reports/forms.py
+msgid "Monthly"
+msgstr ""
+
+#: reports/forms.py
+msgid "Yearly"
+msgstr ""
+
+#: reports/forms.py
+msgid "day"
+msgstr ""
+
+#: reports/forms.py
+msgid "week"
+msgstr ""
+
+#: reports/forms.py
+msgid "month"
+msgstr ""
+
+#: reports/forms.py
+msgid "year"
+msgstr ""
+
+#: reports/forms.py
+msgid "Never"
+msgstr ""
+
+#: reports/forms.py
+msgid "On"
+msgstr ""
+
+#: reports/forms.py
+msgid "After"
+msgstr ""
+
+#: reports/forms.py
+msgid "Report name format"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: reports/report_types/multi_organization_report/appendix.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Appendix"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Currently filtered on"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: reports/templates/partials/report_sidemenu.html
+#: reports/templates/summary/report_asset_overview.html
+msgid "Selected Report Types"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Selected report types"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: reports/templates/partials/plugin_overview_table.html
+#: reports/templates/report_overview/modal_partials/rename_modal.html
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+#: reports/templates/report_overview/subreports_table.html
+#: reports/templates/summary/report_asset_overview.html
+msgid "Report type"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Service Versions and Health"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Service, version and health"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: reports/templates/summary/service_health.html rocky/templates/footer.html
+#: rocky/templates/health.html
+msgid "Service"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: reports/templates/summary/service_health.html rocky/templates/health.html
+msgid "Version"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: rocky/templates/footer.html rocky/views/health.py
+msgid "Health"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+#: rocky/templates/health.html
+msgid "Healthy"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Unhealthy"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Used Config objects"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Used config objects"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Primary Key"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Bit ID"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "Config"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/appendix.html
+msgid "No config objects found."
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/asset_overview.html
+#: reports/report_types/multi_organization_report/asset_overview.html
+#: reports/templates/partials/generate_report_sidemenu.html
+#: reports/templates/partials/report_sidemenu.html
+#: reports/templates/summary/report_asset_overview.html
+msgid "Asset overview"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/asset_overview.html
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid ""
+"An overview of the manually released scanned assets. Assets in <strong>bold</"
+"strong> are taken as a starting point, assets that are not in bold were "
+"found by OpenKAT itself."
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/basic_security.html
+#: reports/report_types/aggregate_organisation_report/report.html
+msgid "Overview of the basic security status"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/basic_security.html
+msgid ""
+"This table provides an overview of the basic security status of the known "
+"assets. Basic security in order. In principle, all values in this table "
+"should be checked off."
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/basic_security.html
+msgid "Basic security status"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/basic_security.html
+#: reports/report_types/ipv6_report/report.html
+#: reports/report_types/multi_organization_report/ipv6.html
+#: reports/report_types/systems_report/report.html
+msgid "System type"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/basic_security.html
+#: reports/report_types/aggregate_organisation_report/report.html
+#: reports/report_types/multi_organization_report/basic_security_details.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Safe connections"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/basic_security.html
+msgid "System Specific"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/basic_security.html
+msgid "RPKI"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/basic_security.html
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/rpki_report/report.html
+#: reports/report_types/safe_connections_report/report.html
+msgid "server"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/findings.html
+#: reports/report_types/aggregate_organisation_report/report.html
+msgid ""
+"This chapter contains information about the findings that have been "
+"identified for this organization."
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/recommendations.html
+#: reports/report_types/multi_organization_report/recommendations.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Recommendations"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/recommendations.html
+#, python-format
+msgid "There is <i>%(total_findings)s</i> vulnerability"
+msgid_plural "There are <i>%(total_findings)s</i> vulnerabilities"
+msgstr[0] ""
+msgstr[1] ""
+
+#: reports/report_types/aggregate_organisation_report/recommendations.html
+#, python-format
+msgid "found on <i>%(total_systems)s</i> system."
+msgid_plural "found on <i>%(total_systems)s</i> systems."
+msgstr[0] ""
+msgstr[1] ""
+
+#: reports/report_types/aggregate_organisation_report/recommendations.html
+#: reports/report_types/multi_organization_report/recommendations.html
+msgid "There are no recommendations."
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/report.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Basic security"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/report.html
+msgid ""
+"In this chapter, first a table of compliance checks is displayed, followed "
+"by a detailed examination of compliance issues for each component."
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/report.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "System specific"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/report.html
+#: reports/report_types/multi_organization_report/basic_security_details.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Resource Public Key Infrastructure"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/report.html
+#: reports/report_types/aggregate_organisation_report/vulnerabilities.html
+#: reports/report_types/multi_organization_report/vulnerabilities.html
+#: reports/report_types/vulnerability_report/report.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Vulnerabilities"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/report.html
+#: reports/report_types/aggregate_organisation_report/vulnerabilities.html
+msgid "Vulnerabilities found are grouped per system."
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/report.py
+msgid "Aggregate Organisation Report"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/rpki.html
+#: reports/report_types/multi_organization_report/basic_security_details.html
+msgid ""
+"This section contains basic security information about resource public key "
+"infrastructure. If your web server employs RPKI for its IP addresses and "
+"associated nameservers, then it enhances visitor protection against "
+"misconfigurations and malicious route intercepts through verified route "
+"announcements, ensuring reliable server access and secure internet traffic."
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/safe_connections.html
+#: reports/report_types/multi_organization_report/basic_security_details.html
+msgid ""
+"In this chapter we check if the connections of all the IP ports of the "
+"system are safe. Safe connections are important to prevent unauthorised "
+"access and data breaches. Strong ciphers are crucial because they ensure "
+"strong encryption which protects the data from interception during "
+"communiction."
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/summary.html
+#: reports/report_types/multi_organization_report/summary.html
+#: rocky/views/ooi_tree.py
+msgid "Summary"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/summary.html
+msgid "Critical Vulnerabilities"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/summary.html
+msgid "IPs scanned"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/summary.html
+msgid "Hostnames scanned"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/summary.html
+msgid "Terms in report"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/rpki_report/report.html
+#: reports/report_types/safe_connections_report/report.html
+#, python-format
+msgid ""
+"This table shows which checks were performed. Following that, the compliance "
+"issues, if any, are shown for each %(type)s Server."
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+msgid "Check overview"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/mail_report/report.html
+#: reports/report_types/multi_organization_report/basic_security_details.html
+#: reports/report_types/name_server_report/report.html
+#: reports/report_types/rpki_report/report.html
+#: reports/report_types/safe_connections_report/report.html
+#: reports/report_types/web_system_report/report.html
+msgid "Check"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/mail_report/report.html
+#: reports/report_types/name_server_report/report.html
+#: reports/report_types/rpki_report/report.html
+#: reports/report_types/safe_connections_report/report.html
+#: reports/report_types/web_system_report/report.html
+msgid "Compliance"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/rpki_report/report.html
+msgid "IPs are compliant"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/safe_connections_report/report.html
+#: reports/report_types/vulnerability_report/report.html
+msgid "Host:"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/mail_report/report.html
+#: reports/report_types/name_server_report/report.html
+#: reports/report_types/rpki_report/report.html
+#: reports/report_types/safe_connections_report/report.html
+#: reports/report_types/web_system_report/report.html
+msgid "Compliance issue"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/system_specific.html
+#: reports/report_types/mail_report/report.html
+#: reports/report_types/name_server_report/report.html
+#: reports/report_types/rpki_report/report.html
+#: reports/report_types/safe_connections_report/report.html
+#: reports/report_types/vulnerability_report/report.html
+#: reports/report_types/web_system_report/report.html
+#: reports/templates/partials/report_findings_table.html
+#: reports/templates/partials/report_severity_totals_table.html
+#: rocky/templates/partials/ooi_report_findings_block_table.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid "Risk level"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/system_specific_overview.html
+#: reports/report_types/multi_organization_report/basic_security_details.html
+msgid ""
+"This is where checks are done that are specific to system types. Different "
+"security and compliance issues come into play for different systems. They "
+"are listed here under each other."
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/term_overview.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Term Overview"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/term_overview.html
+msgid "For definitions of terms used in this chapter, see the glossary below."
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/term_overview.html
+msgid ""
+"Web servers and domains are examples of digital assets within this "
+"framework. Web servers are essential for hosting and serving websites or web "
+"applications, while domains represent the online addresses used to access "
+"these resources. Other examples of assets in the IT realm include databases, "
+"user accounts, software applications, and networking infrastructure. Asset "
+"management is a critical aspect of cybersecurity, involving the "
+"identification, classification, and protection of these assets to safeguard "
+"against threats and ensure the overall security and functionality of an "
+"organization's IT environment."
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/term_overview.html
+msgid ""
+"Multiple hostnames that resolve to one IP address where at least one of the "
+"hostnames or the IP address has a declared scan level that is at least L1. "
+"Type systems are web servers, mail servers and name servers (DNS)."
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/term_overview.html
+msgid ""
+"A fundamental component of the client-server model. A web server uses "
+"protocols like HTTP or HTTPS to facilitate communication between clients and "
+"the server."
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/term_overview.html
+msgid ""
+"A mail server is a specialized software application or hardware device that "
+"facilitates the sending, receiving, and storage of emails within a computer "
+"network. Operating on the Simple Mail Transfer Protocol (SMTP) for outgoing "
+"messages and either Internet Message Access Protocol (IMAP) or Post Office "
+"Protocol (POP) for incoming messages, a mail server manages email "
+"communication by routing messages between users and storing them until they "
+"are retrieved. The server ensures the efficient and secure transfer of "
+"emails, handling tasks such as authentication, spam filtering, and message "
+"storage."
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/term_overview.html
+msgid ""
+"A nameserver, or Domain Name System (DNS) server, is a critical component of "
+"the internet infrastructure responsible for translating human-readable "
+"domain names into IP addresses, enabling the seamless navigation of the web. "
+"When a user enters a domain name in a web browser, the nameserver is queried "
+"to obtain the corresponding IP address of the server hosting the associated "
+"website or service."
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/term_overview.html
+msgid ""
+"A DICOM server, which stands for Digital Imaging and Communications in "
+"Medicine, is a specialized server designed for the storage, retrieval, and "
+"exchange of medical images and related information in the healthcare "
+"industry. DICOM is a widely adopted standard that ensures interoperability "
+"and consistency in the communication of medical images and associated data "
+"among different devices and systems, such as medical imaging equipment, "
+"picture archiving and communication systems (PACS), and radiology "
+"information systems (RIS). DICOM servers store and manage patient-specific "
+"medical images, like X-rays, CT scans, and MRIs, utilizing a standardized "
+"format."
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/vulnerabilities.html
+#: reports/report_types/multi_organization_report/vulnerabilities.html
+msgid "No CVEs have been found."
+msgstr ""
+
+#: reports/report_types/dns_report/report.html
+msgid "Records found"
+msgstr ""
+
+#: reports/report_types/dns_report/report.html
+msgid ""
+"The DNS report gives an overview of the DNS records that were found for the "
+"DNSZone. Additionally the security measures table shows whether or not DNS "
+"relating security measures are enabled."
+msgstr ""
+
+#: reports/report_types/dns_report/report.html
+msgid ""
+"<strong>Disclaimer:</strong> Not all DNSRecords are parsed in OpenKAT. DNS "
+"record types that are parsed and could be displayed in the table are:"
+msgstr ""
+
+#: reports/report_types/dns_report/report.html
+msgid "All existing DNS record types can be found here:"
+msgstr ""
+
+#: reports/report_types/dns_report/report.html
+msgid "Record"
+msgstr ""
+
+#: reports/report_types/dns_report/report.html
+msgid "TTL"
+msgstr ""
+
+#: reports/report_types/dns_report/report.html
+msgid "Data"
+msgstr ""
+
+#: reports/report_types/dns_report/report.html
+msgid "No records have been found."
+msgstr ""
+
+#: reports/report_types/dns_report/report.html
+msgid "Security measures"
+msgstr ""
+
+#: reports/report_types/dns_report/report.html
+msgid ""
+"The security measures table below shows which DNS relating security measures "
+"are enabled based on the contents of the DNS records."
+msgstr ""
+
+#: reports/report_types/dns_report/report.html
+#: reports/templates/partials/report_ooi_list.html
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/modal_partials/rerun_modal.html
+#: reports/templates/summary/ooi_selection.html tools/forms/ooi.py
+#: rocky/templates/partials/elements/ooi_tree_condensed_table.html
+#: rocky/templates/partials/explanations.html
+#: rocky/templates/partials/ooi_detail_related_object.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+#: rocky/views/mixins.py
+msgid "Type"
+msgstr ""
+
+#: reports/report_types/dns_report/report.html
+msgid "Yes"
+msgstr ""
+
+#: reports/report_types/dns_report/report.html
+msgid "No"
+msgstr ""
+
+#: reports/report_types/dns_report/report.html
+#: reports/templates/partials/report_findings_table.html
+msgid "Other findings found"
+msgstr ""
+
+#: reports/report_types/dns_report/report.html
+msgid "Findings information"
+msgstr ""
+
+#: reports/report_types/dns_report/report.py
+msgid "DNS Report"
+msgstr ""
+
+#: reports/report_types/dns_report/report.py
+msgid ""
+"DNS reports focus on domain name system configuration and potential "
+"weaknesses."
+msgstr ""
+
+#: reports/report_types/findings_report/report.html
+msgid ""
+"The Findings Report contains information about the findings that have been "
+"identified for the selected asset and organization."
+msgstr ""
+
+#: reports/report_types/findings_report/report.py
+msgid "Findings Report"
+msgstr ""
+
+#: reports/report_types/findings_report/report.py
+msgid "Shows all the finding types and their occurrences."
+msgstr ""
+
+#: reports/report_types/ipv6_report/report.html
+msgid ""
+"The IPv6 report provides an overview of the current IPv6 status of the "
+"identified system. The table below shows whether the domain is reachable "
+"over IPv6 or not. A green compliance check is shown if this is the case. A "
+"grey compliance cross is shown if no IPv6 address was detected."
+msgstr ""
+
+#: reports/report_types/ipv6_report/report.html
+msgid "IPv6 overview"
+msgstr ""
+
+#: reports/report_types/ipv6_report/report.html
+#: reports/report_types/systems_report/report.html
+msgid "Domain"
+msgstr ""
+
+#: reports/report_types/ipv6_report/report.py
+msgid "IPv6 Report"
+msgstr ""
+
+#: reports/report_types/ipv6_report/report.py
+msgid "Check whether hostnames point to IPv6 addresses."
+msgstr ""
+
+#: reports/report_types/mail_report/report.html
+msgid ""
+"The Mail Report provides an overview of the compliance checks associated "
+"with email servers. The current compliance checks the presence of SPF, DKIM "
+"and DMARC records. The table below shows for each of these checks how many "
+"of the identified mail servers are compliant, and if applicable a compliance "
+"issue description and risk level. The risk level may be different for your "
+"specific environment."
+msgstr ""
+
+#: reports/report_types/mail_report/report.html
+msgid "Mailserver compliance"
+msgstr ""
+
+#: reports/report_types/mail_report/report.html
+msgid "mailservers compliant"
+msgstr ""
+
+#: reports/report_types/mail_report/report.html
+msgid "No mailservers have been found on this system."
+msgstr ""
+
+#: reports/report_types/mail_report/report.py
+msgid "Mail Report"
+msgstr ""
+
+#: reports/report_types/mail_report/report.py
+msgid ""
+"System specific Mail Report that focusses on IP addresses and hostnames."
+msgstr ""
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid "Overview of included assets"
+msgstr ""
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid "Asset"
+msgstr ""
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+#: reports/report_types/multi_organization_report/basic_security_details.html
+msgid "Amount"
+msgstr ""
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid "IP addresses"
+msgstr ""
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid "Domain names"
+msgstr ""
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid "Assets with most critical vulnerabilities"
+msgstr ""
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid "Vulnerability"
+msgstr ""
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid "Organisation"
+msgstr ""
+
+#: reports/report_types/multi_organization_report/asset_overview.html
+msgid "No vulnerabilities found."
+msgstr ""
+
+#: reports/report_types/multi_organization_report/basic_security_details.html
+msgid "Overview of safe connections"
+msgstr ""
+
+#: reports/report_types/multi_organization_report/basic_security_details.html
+#: reports/report_types/safe_connections_report/report.html
+msgid "Only Safe Ciphers"
+msgstr ""
+
+#: reports/report_types/multi_organization_report/basic_security_details.html
+#: reports/report_types/safe_connections_report/report.html
+msgid "services are compliant"
+msgstr ""
+
+#: reports/report_types/multi_organization_report/basic_security_details.html
+msgid "System specific checks"
+msgstr ""
+
+#: reports/report_types/multi_organization_report/ipv6.html
+msgid "IPv6"
+msgstr ""
+
+#: reports/report_types/multi_organization_report/ipv6.html
+msgid ""
+"IPv6 includes improvements in security features compared to IPv4. While IPv4 "
+"can implement security measures, IPv6 was designed with security in mind, "
+"and its adoption can contribute to a more secure internet."
+msgstr ""
+
+#: reports/report_types/multi_organization_report/ipv6.html
+msgid "In total "
+msgstr ""
+
+#: reports/report_types/multi_organization_report/ipv6.html
+msgid " out of "
+msgstr ""
+
+#: reports/report_types/multi_organization_report/ipv6.html
+msgid " systems have an IPv6 connection."
+msgstr ""
+
+#: reports/report_types/multi_organization_report/ipv6.html
+msgid "Overview of IP version compliance"
+msgstr ""
+
+#: reports/report_types/multi_organization_report/open_ports.html
+msgid ""
+"See an overview of open ports found over all systems and the services these "
+"systems provide."
+msgstr ""
+
+#: reports/report_types/multi_organization_report/open_ports.html
+msgid "Overview of detected open ports"
+msgstr ""
+
+#: reports/report_types/multi_organization_report/open_ports.html
+#: reports/report_types/open_ports_report/report.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Open ports"
+msgstr ""
+
+#: reports/report_types/multi_organization_report/open_ports.html
+msgid "Occurrences (IP addresses)"
+msgstr ""
+
+#: reports/report_types/multi_organization_report/open_ports.html
+#: reports/templates/summary/service_health.html
+msgid "Services"
+msgstr ""
+
+#: reports/report_types/multi_organization_report/open_ports.html
+msgid "No open ports found."
+msgstr ""
+
+#: reports/report_types/multi_organization_report/recommendations.html
+msgid "Overview of recommendations"
+msgstr ""
+
+#: reports/report_types/multi_organization_report/recommendations.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid "Occurrence"
+msgstr ""
+
+#: reports/report_types/multi_organization_report/report.html
+msgid "No findings have been identified yet."
+msgstr ""
+
+#: reports/report_types/multi_organization_report/report.py
+msgid "Multi Organization Report"
+msgstr ""
+
+#: reports/report_types/multi_organization_report/summary.html
+msgid "Best scoring security check"
+msgstr ""
+
+#: reports/report_types/multi_organization_report/summary.html
+msgid "Worst scoring security check"
+msgstr ""
+
+#: reports/report_types/multi_organization_report/vulnerabilities.html
+msgid ""
+"Vulnerabilities found are grouped per system. Here, we only consider CVE "
+"vulnerabilities."
+msgstr ""
+
+#: reports/report_types/multi_organization_report/vulnerabilities.html
+msgid "Vulnerabilities grouped per system"
+msgstr ""
+
+#: reports/report_types/multi_organization_report/vulnerabilities.html
+msgid "total"
+msgstr ""
+
+#: reports/report_types/name_server_report/report.html
+msgid ""
+"The Name Server Report provides an overview of the compliance checks that "
+"were performed against the identified Domain Name Servers (DNS). The "
+"compliance checks verify the presence and validity of DNSSEC and whether no "
+"unnecessary ports were identified to be open. The table below gives an "
+"overview of the available checks including whether the system passed the "
+"performed checks. The risk level and reasoning as to why an issue was "
+"identified are shown too. The risk level may be different for your specific "
+"environment."
+msgstr ""
+
+#: reports/report_types/name_server_report/report.html
+msgid "Name server compliance"
+msgstr ""
+
+#: reports/report_types/name_server_report/report.html
+msgid "DNSSEC Present"
+msgstr ""
+
+#: reports/report_types/name_server_report/report.html
+msgid "name servers compliant"
+msgstr ""
+
+#: reports/report_types/name_server_report/report.html
+msgid "Valid DNSSEC"
+msgstr ""
+
+#: reports/report_types/name_server_report/report.html
+#: reports/report_types/web_system_report/report.html
+msgid "No unnecessary ports open"
+msgstr ""
+
+#: reports/report_types/name_server_report/report.html
+msgid "No nameservers have been found on this system."
+msgstr ""
+
+#: reports/report_types/name_server_report/report.py
+msgid "Name Server Report"
+msgstr ""
+
+#: reports/report_types/name_server_report/report.py
+msgid "Name Server Report checks name servers on basic security standards."
+msgstr ""
+
+#: reports/report_types/open_ports_report/report.html
+msgid ""
+"The Open Ports Report provides an overview of the open ports identified on a "
+"system. The ports that are marked as <b>bold</b> were identified by direct "
+"scans performed by OpenKAT (such as nmap). Ports that are not marked in bold "
+"were identified through external services and/or scans (such as Shodan). "
+"Scans with the same hostnames, ports and IPs are merged."
+msgstr ""
+
+#: reports/report_types/open_ports_report/report.html
+msgid "Overview of open ports found for the scanned assets"
+msgstr ""
+
+#: reports/report_types/open_ports_report/report.html
+#: reports/report_types/systems_report/report.html
+msgid "IP address"
+msgstr ""
+
+#: reports/report_types/open_ports_report/report.html
+msgid "Hostnames"
+msgstr ""
+
+#: reports/report_types/open_ports_report/report.html
+msgid "Direct scan"
+msgstr ""
+
+#: reports/report_types/open_ports_report/report.py
+msgid "Open Ports Report"
+msgstr ""
+
+#: reports/report_types/open_ports_report/report.py
+msgid "Find open ports of IP addresses"
+msgstr ""
+
+#: reports/report_types/rpki_report/report.html
+msgid ""
+"This section contains basic security information about Resource Public Key "
+"Infrastructure (RPKI). If your web server employs RPKI for its IP addresses "
+"and associated nameservers, then it enhances visitor protection against "
+"misconfigurations and malicious route intercepts through verified route "
+"announcements, ensuring reliable server access and secure internet traffic."
+msgstr ""
+
+#: reports/report_types/rpki_report/report.html
+msgid ""
+"The RPKI Report shows if an RPKI route announcement was available for the "
+"system and if this announcement is not expired."
+msgstr ""
+
+#: reports/report_types/rpki_report/report.html
+msgid "RPKI compliance"
+msgstr ""
+
+#: reports/report_types/rpki_report/report.html
+msgid "RPKI Available"
+msgstr ""
+
+#: reports/report_types/rpki_report/report.html
+msgid "RPKI valid"
+msgstr ""
+
+#: reports/report_types/rpki_report/report.html
+msgid "RPKI record is not valid."
+msgstr ""
+
+#: reports/report_types/rpki_report/report.html
+msgid "RPKI record does not exist."
+msgstr ""
+
+#: reports/report_types/rpki_report/report.html
+#: reports/report_types/safe_connections_report/report.html
+msgid "No IPs have been found on this system."
+msgstr ""
+
+#: reports/report_types/rpki_report/report.py
+msgid "RPKI Report"
+msgstr ""
+
+#: reports/report_types/rpki_report/report.py
+msgid ""
+"Shows whether the IP is covered by a valid RPKI ROA. For a hostname it shows "
+"the IP addresses and whether they are covered by a valid RPKI ROA."
+msgstr ""
+
+#: reports/report_types/safe_connections_report/report.html
+msgid ""
+"The Safe Connections report provides an overview of the performed checks "
+"with regard to encrypted communication channels such as HTTPS. The table "
+"below gives an overview of the available checks including whether the system "
+"passed the performed checks. The risk level and reasoning as to why an issue "
+"was identified are shown too. The risk level may be different for your "
+"specific environment."
+msgstr ""
+
+#: reports/report_types/safe_connections_report/report.html
+msgid "Safe connections compliance"
+msgstr ""
+
+#: reports/report_types/safe_connections_report/report.py
+msgid "Safe Connections Report"
+msgstr ""
+
+#: reports/report_types/safe_connections_report/report.py
+msgid "Shows whether the IPService contains safe ciphers."
+msgstr ""
+
+#: reports/report_types/systems_report/report.html
+msgid ""
+"The System Report provides an overview of the system types (types of similar "
+"services) that were identified for each system. The following system types "
+"can be identified: DNS servers, Web servers, Mail servers and those "
+"classified as 'Other' servers. Each hostname and/or IP address is given one "
+"or more system types depending on the identified ports and services. The "
+"table below gives an overview of these results."
+msgstr ""
+
+#: reports/report_types/systems_report/report.html
+msgid "Selected assets"
+msgstr ""
+
+#: reports/report_types/systems_report/report.html
+msgid "No system types have been identified on this system."
+msgstr ""
+
+#: reports/report_types/systems_report/report.py
+msgid "System Report"
+msgstr ""
+
+#: reports/report_types/systems_report/report.py
+msgid "Combine IP addresses, hostnames and services into systems."
+msgstr ""
+
+#: reports/report_types/tls_report/report.html
+msgid ""
+"The TLS Report shows which TLS protocols and ciphers were identified on the "
+"host for the provided port."
+msgstr ""
+
+#: reports/report_types/tls_report/report.html
+msgid ""
+"The table below provides an overview of the identified TLS protocols and "
+"ciphers, including a status suggestion."
+msgstr ""
+
+#: reports/report_types/tls_report/report.html
+msgid "Ciphers"
+msgstr ""
+
+#: reports/report_types/tls_report/report.html
+msgid "Protocol"
+msgstr ""
+
+#: reports/report_types/tls_report/report.html
+msgid "Encryption Algorithm"
+msgstr ""
+
+#: reports/report_types/tls_report/report.html
+msgid "Bits"
+msgstr ""
+
+#: reports/report_types/tls_report/report.html
+msgid "Key Size"
+msgstr ""
+
+#: reports/report_types/tls_report/report.html
+#: rocky/templates/organizations/organization_list.html
+#: rocky/templates/organizations/organization_settings.html
+msgid "Code"
+msgstr ""
+
+#: reports/report_types/tls_report/report.html
+msgid "Phase out"
+msgstr ""
+
+#: reports/report_types/tls_report/report.html
+msgid "Good"
+msgstr ""
+
+#: reports/report_types/tls_report/report.html
+msgid ""
+"No ciphers were found for this combination of IP address, port and service."
+msgstr ""
+
+#: reports/report_types/tls_report/report.html
+msgid ""
+"The list below gives an overview of the findings based on the identified TLS "
+"protocols and ciphers. This includes the reasoning why the cipher or "
+"protocol is marked as a finding."
+msgstr ""
+
+#: reports/report_types/tls_report/report.py
+msgid "TLS Report"
+msgstr ""
+
+#: reports/report_types/tls_report/report.py
+msgid ""
+"TLS Report assesses the security of data encryption and transmission "
+"protocols."
+msgstr ""
+
+#: reports/report_types/vulnerability_report/report.html
+msgid "No vulnerabilities have been found on this system."
+msgstr ""
+
+#: reports/report_types/vulnerability_report/report.html
+msgid ""
+"The Vulnerability Report provides an overview of all identified CVE "
+"vulnerabilities that were identified on the selected systems. For each CVE "
+"the table shows the CVE scoring, the number of occurrences, and the CVE "
+"details."
+msgstr ""
+
+#: reports/report_types/vulnerability_report/report.html
+msgid "vulnerabilities on this system"
+msgstr ""
+
+#: reports/report_types/vulnerability_report/report.html
+msgid "Advice"
+msgstr ""
+
+#: reports/report_types/vulnerability_report/report.py
+msgid "Vulnerability Report"
+msgstr ""
+
+#: reports/report_types/vulnerability_report/report.py
+msgid "Vulnerabilities found are grouped for each system."
+msgstr ""
+
+#: reports/report_types/vulnerability_report/report.py
+msgid "First seen"
+msgstr ""
+
+#: reports/report_types/vulnerability_report/report.py
+msgid "Last seen"
+msgstr ""
+
+#: reports/report_types/vulnerability_report/report.py
+msgid "Evidence"
+msgstr ""
+
+#: reports/report_types/web_system_report/report.html
+msgid ""
+"The Web System Report provides an overview of various web server checks that "
+"were performed against the scanned system(s). For each performed check the "
+"table below shows whether or not the server is compliant with the checks. A "
+"description of why this compliant check failed is also shown, including an "
+"general risk level. The risk level may be different for your specific "
+"environment."
+msgstr ""
+
+#: reports/report_types/web_system_report/report.html
+msgid "Web system compliance"
+msgstr ""
+
+#: reports/report_types/web_system_report/report.html
+msgid "CSP Present"
+msgstr ""
+
+#: reports/report_types/web_system_report/report.html
+msgid "webservers compliant"
+msgstr ""
+
+#: reports/report_types/web_system_report/report.html
+msgid "Secure CSP Header"
+msgstr ""
+
+#: reports/report_types/web_system_report/report.html
+msgid "Redirects HTTP to HTTPS"
+msgstr ""
+
+#: reports/report_types/web_system_report/report.html
+msgid "Offers HTTPS"
+msgstr ""
+
+#: reports/report_types/web_system_report/report.html
+msgid "Has a Security.txt"
+msgstr ""
+
+#: reports/report_types/web_system_report/report.html
+msgid "Has a certificate"
+msgstr ""
+
+#: reports/report_types/web_system_report/report.html
+msgid "Certificate is valid"
+msgstr ""
+
+#: reports/report_types/web_system_report/report.html
+msgid "Certificate is not expiring soon"
+msgstr ""
+
+#: reports/report_types/web_system_report/report.html
+msgid "No webservers have been found on this system."
+msgstr ""
+
+#: reports/report_types/web_system_report/report.py
+msgid "Web System Report"
+msgstr ""
+
+#: reports/report_types/web_system_report/report.py
+msgid "Web System Reports check web systems on basic security standards."
+msgstr ""
+
+#: reports/templates/partials/export_report_settings.html
+msgid "Report schedule"
+msgstr ""
+
+#: reports/templates/partials/export_report_settings.html
+msgid ""
+"When scheduling your report, you have two options. You can either choose to "
+"generate it just once now, or set it to run automatically at regular "
+"intervals, like daily, weekly, or monthly. If you need the report just for a "
+"single occasion, select the one-time option."
+msgstr ""
+
+#: reports/templates/partials/export_report_settings.html
+#: reports/templates/report_overview/report_history_table.html
+msgid "Report name"
+msgstr ""
+
+#: reports/templates/partials/export_report_settings.html
+#, python-format, python-brace-format
+msgid ""
+"When generating reports, it is possible to give the report a name. The name "
+"can be static or dynamic. The default format for a report is '${report_type} "
+"for ${oois_count} objects'. These placeholders automatically adapt based on "
+"the report details. This format could for example return 'Aggregate Report "
+"for 15 objects'. Another placeholder that can be used is '${ooi}', which "
+"will show the name of the object when there is only one object. You can also "
+"customize the name by adding prefixes, suffixes, or other formats like '%%W' "
+"for the week number, using options from <a href=\"https://strftime.org/\" "
+"target=\"_blank\" rel=\"noopener\">Python strftime code</a>."
+msgstr ""
+
+#: reports/templates/partials/export_report_settings.html
+#: reports/templates/partials/generate_report_header.html
+#: reports/templates/partials/new_report_action_button.html
+#: reports/views/generate_report.py
+msgid "Generate report"
+msgstr ""
+
+#: reports/templates/partials/generate_report_header.html
+msgid "To generate an aggregate report, complete the following steps."
+msgstr ""
+
+#: reports/templates/partials/generate_report_header.html
+msgid "To generate a multi report, complete the following steps."
+msgstr ""
+
+#: reports/templates/partials/generate_report_header.html
+msgid "To generate separate report(s), complete the following steps."
+msgstr ""
+
+#: reports/templates/partials/generate_report_sidemenu.html
+#: reports/templates/partials/report_sidemenu.html
+msgid "Table of contents"
+msgstr ""
+
+#: reports/templates/partials/new_report_action_button.html
+msgid "Actions for creating a new report"
+msgstr ""
+
+#: reports/templates/partials/new_report_action_button.html
+msgid "Separate report(s)"
+msgstr ""
+
+#: reports/templates/partials/new_report_action_button.html
+#: reports/views/aggregate_report.py
+msgid "Aggregate report"
+msgstr ""
+
+#: reports/templates/partials/new_report_action_button.html
+#: reports/views/multi_report.py
+msgid "Multi report"
+msgstr ""
+
+#: reports/templates/partials/plugin_overview_table.html
+#: reports/templates/partials/report_sidemenu.html
+#: rocky/templates/oois/ooi_page_tabs.html
+msgid "Overview"
+msgstr ""
+
+#: reports/templates/partials/plugin_overview_table.html
+msgid "Plugin overview table"
+msgstr ""
+
+#: reports/templates/partials/plugin_overview_table.html
+#: reports/templates/partials/report_setup_scan.html
+msgid "Required plugins"
+msgstr ""
+
+#: reports/templates/partials/plugin_overview_table.html
+#: reports/templates/partials/report_setup_scan.html
+msgid "Suggested plugins"
+msgstr ""
+
+#: reports/templates/partials/plugin_overview_table.html
+msgid "Action required"
+msgstr ""
+
+#: reports/templates/partials/plugin_overview_table.html
+msgid "Ready"
+msgstr ""
+
+#: reports/templates/partials/report_findings_table.html
+msgid ""
+"This table provides an overview of the identified findings on the scanned "
+"systems. For each finding type it shows the risk level, the number of "
+"occurrences and the first known occurrence of the finding. The risk level "
+"may be different for your specific environment. The details can be seen when "
+"expanding a row. A description, the source, impact and recommendation of the "
+"finding can be found here. It also shows in which findings the finding type "
+"occurred."
+msgstr ""
+
+#: reports/templates/partials/report_findings_table.html
+msgid "First known occurrence"
+msgstr ""
+
+#: reports/templates/partials/report_findings_table.html
+msgid "Open in report"
+msgstr ""
+
+#: reports/templates/partials/report_findings_table.html
+msgid ""
+"No critical and high findings have been identified for this organization."
+msgstr ""
+
+#: reports/templates/partials/report_findings_table.html
+msgid "No findings have been identified for this organization."
+msgstr ""
+
+#: reports/templates/partials/report_header.html
+msgid "Download as PDF"
+msgstr ""
+
+#: reports/templates/partials/report_header.html
+#: rocky/templates/partials/ooi_list_toolbar.html
+msgid "Download as JSON"
+msgstr ""
+
+#: reports/templates/partials/report_header.html
+msgid "Open asset reports"
+msgstr ""
+
+#: reports/templates/partials/report_header.html
+msgid "This is the OpenKAT report for organization"
+msgstr ""
+
+#: reports/templates/partials/report_header.html
+msgid ""
+"All selected report types for the selected objects are displayed one below "
+"the other."
+msgstr ""
+
+#: reports/templates/partials/report_header.html
+msgid "Created with data from:"
+msgstr ""
+
+#: reports/templates/partials/report_header.html
+msgid "Created on:"
+msgstr ""
+
+#: reports/templates/partials/report_header.html
+msgid "Created from recipe:"
+msgstr ""
+
+#: reports/templates/partials/report_header.html
+msgid "Recipe created by:"
+msgstr ""
+
+#: reports/templates/partials/report_header.html
+#, python-format
+msgid "This sector contains %(length)s scanned organizations."
+msgstr ""
+
+#: reports/templates/partials/report_header.html
+msgid "Of these organizations"
+msgstr ""
+
+#: reports/templates/partials/report_header.html
+msgid "organizations have tag"
+msgstr ""
+
+#: reports/templates/partials/report_header.html
+msgid "The basic security scores are around "
+msgstr ""
+
+#: reports/templates/partials/report_header.html
+#, python-format
+msgid "A total of %(total)s critical vulnerabilities have been identified."
+msgstr ""
+
+#: reports/templates/partials/report_introduction.html
+msgid "Introduction"
+msgstr ""
+
+#: reports/templates/partials/report_introduction.html
+msgid ""
+"This report gives an overview of the current state of security for your "
+"organisation for the selected date. The summary section provides an overview "
+"of the selected systems (objects), plugins and reports. This is followed "
+"with the findings for each report."
+msgstr ""
+
+#: reports/templates/partials/report_names_form.html
+msgid "Report names:"
+msgstr ""
+
+#: reports/templates/partials/report_names_form.html
+#: rocky/templates/forms/widgets/checkbox_group_table.html
+#: rocky/templates/oois/ooi_detail_add_related_object.html
+#: rocky/templates/partials/edit_ooi_clearance_level_modal.html
+#: rocky/templates/partials/form/field_input.html
+#: rocky/templates/partials/form/field_input_checkbox.html
+#: rocky/templates/partials/form/field_input_multiselect.html
+#: rocky/templates/partials/form/field_input_radio.html
+msgid "Required"
+msgstr ""
+
+#: reports/templates/partials/report_names_form.html
+msgid "Add reference date"
+msgstr ""
+
+#: reports/templates/partials/report_names_form.html
+#: reports/templates/report_overview/modal_partials/rename_modal.html
+msgid "Reset"
+msgstr ""
+
+#: reports/templates/partials/report_names_form.html
+msgid "No reference date"
+msgstr ""
+
+#: reports/templates/partials/report_names_form.html
+msgid "Day"
+msgstr ""
+
+#: reports/templates/partials/report_names_form.html
+msgid "Week"
+msgstr ""
+
+#: reports/templates/partials/report_names_form.html
+msgid "Month"
+msgstr ""
+
+#: reports/templates/partials/report_names_form.html
+msgid "Year"
+msgstr ""
+
+#: reports/templates/partials/report_ooi_list.html
+msgid "Object selection"
+msgstr ""
+
+#: reports/templates/partials/report_ooi_list.html
+msgid ""
+"Select which objects you want to include in your report. You can either "
+"continue with a live set or you can select the objects manually from the "
+"table below."
+msgstr ""
+
+#: reports/templates/partials/report_ooi_list.html
+msgid ""
+"A live set is a set of objects based on the applied filters. Any object that "
+"matches this applied filter (now or in the future) will be used as input for "
+"the scheduled report. If your live set filter (e.g. 'hostnames' with 'L2 "
+"clearance' that are 'declared') shows 2 hostnames that match the filter "
+"today, the scheduled report will run for those 2 hostnames. If you add 3 "
+"more hostnames tomorrow (with the same filter criteria), your next scheduled "
+"report will contain 5 hostnames. Your live set will update as you go."
+msgstr ""
+
+#: reports/templates/partials/report_ooi_list.html
+msgid ""
+"Based on the current dataset, your selected filters result in the following "
+"objects."
+msgstr ""
+
+#: reports/templates/partials/report_ooi_list.html
+msgid "objects selected"
+msgstr ""
+
+#: reports/templates/partials/report_ooi_list.html
+msgid "Deselect all objects"
+msgstr ""
+
+#: reports/templates/partials/report_ooi_list.html
+#: rocky/templates/oois/ooi_list.html
+#, python-format
+msgid "Showing %(length)s of %(total)s objects"
+msgstr ""
+
+#: reports/templates/partials/report_ooi_list.html
+#, python-format
+msgid "Select all %(total_oois)s object"
+msgid_plural "Select all %(total_oois)s objects"
+msgstr[0] ""
+msgstr[1] ""
+
+#: reports/templates/partials/report_ooi_list.html
+msgid "Object name"
+msgstr ""
+
+#: reports/templates/partials/report_ooi_list.html
+msgid "Report(s) may be empty due to no objects in the selected filters."
+msgstr ""
+
+#: reports/templates/partials/report_ooi_list.html
+msgid ""
+"Reports matching the selected filters will be empty at this moment in time. "
+"Future reports may contain data. It is still possible to generate the "
+"(potentially empty) report."
+msgstr ""
+
+#: reports/templates/partials/report_ooi_list.html
+msgid "Continue with live set"
+msgstr ""
+
+#: reports/templates/partials/report_ooi_list.html
+#: reports/templates/partials/report_types_selection.html
+msgid "Continue with selection"
+msgstr ""
+
+#: reports/templates/partials/report_setup_scan.html
+#: reports/views/aggregate_report.py reports/views/generate_report.py
+#: reports/views/multi_report.py
+msgid "Configuration"
+msgstr ""
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Set up the required plugins for this report."
+msgstr ""
+
+#: reports/templates/partials/report_setup_scan.html
+#: reports/templates/summary/selected_plugins.html
+msgid "Plugins"
+msgstr ""
+
+#: reports/templates/partials/report_setup_scan.html
+msgid ""
+"KAT will be able to generate a full report when all the required and "
+"suggested boefjes are enabled."
+msgstr ""
+
+#: reports/templates/partials/report_setup_scan.html
+msgid ""
+"If you choose not to enable a plugin, the data that plugin would collect or "
+"produce will be left out of the report which will then be generated based on "
+"the available data collected by the enabled plugins."
+msgstr ""
+
+#: reports/templates/partials/report_setup_scan.html
+msgid ""
+"Some plugins are mandatory as they are crucial for a report type. Reports "
+"that don't have their requirements met will be skipped."
+msgstr ""
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Warning! Before you proceed read the following points:"
+msgstr ""
+
+#: reports/templates/partials/report_setup_scan.html
+msgid ""
+"OpenKAT is designed to scan all known objects on a regular basis using the "
+"enabled plugins and set clearance levels. This means that scans will run "
+"automatically. Be patient; plugins may take some time before they have "
+"collected all their data. Enabling them just before report generation will "
+"likely result in inaccurate reports, as plugins have not finished collecting "
+"data."
+msgstr ""
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Good job! All required plugins are enabled."
+msgstr ""
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "This report type requires the following plugins to be enabled:"
+msgstr ""
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Toggle all required plugins"
+msgstr ""
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Show enabled plugins"
+msgstr ""
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "There are no required plugins."
+msgstr ""
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Good job! All suggested plugins are enabled."
+msgstr ""
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "The following plugins are optional to generate the report:"
+msgstr ""
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Toggle all optional plugins"
+msgstr ""
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Hide suggested plugins"
+msgstr ""
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Show more suggested plugins"
+msgstr ""
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "There are no optional plugins."
+msgstr ""
+
+#: reports/templates/partials/report_setup_scan.html
+msgid "Enable selected plugins and continue"
+msgstr ""
+
+#: reports/templates/partials/report_severity_totals_table.html
+msgid ""
+"\n"
+"            This overview shows the total number of findings per\n"
+"            severity that have been identified for this organization.\n"
+"        "
+msgstr ""
+
+#: reports/templates/partials/report_severity_totals_table.html
+msgid "Total per severity overview"
+msgstr ""
+
+#: reports/templates/partials/report_severity_totals_table.html
+msgid "Critical"
+msgstr ""
+
+#: reports/templates/partials/report_severity_totals_table.html
+msgid "High"
+msgstr ""
+
+#: reports/templates/partials/report_severity_totals_table.html
+msgid "Medium"
+msgstr ""
+
+#: reports/templates/partials/report_severity_totals_table.html
+msgid "Low"
+msgstr ""
+
+#: reports/templates/partials/report_severity_totals_table.html
+#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+msgid "Pending"
+msgstr ""
+
+#: reports/templates/partials/report_severity_totals_table.html
+msgid "Unknown"
+msgstr ""
+
+#: reports/templates/partials/report_severity_totals_table.html
+msgid "Total"
+msgstr ""
+
+#: reports/templates/partials/report_sidemenu.html
+msgid "Selected Objects"
+msgstr ""
+
+#: reports/templates/partials/report_sidemenu.html
+msgid "Selected Plugins"
+msgstr ""
+
+#: reports/templates/partials/report_sidemenu.html
+msgid "Used Config Objects"
+msgstr ""
+
+#: reports/templates/partials/report_types_selection.html
+msgid "Choose report types"
+msgstr ""
+
+#: reports/templates/partials/report_types_selection.html
+msgid ""
+"Various types of reports, such as DNS reports and TLS reports, are essential "
+"for identifying vulnerabilities in different aspects of a system's security. "
+"DNS reports focus on domain name system configuration and potential "
+"weaknesses, while TLS reports assess the security of data encryption and "
+"transmission protocols, helping organizations pinpoint areas where security "
+"improvements are needed."
+msgstr ""
+
+#: reports/templates/partials/report_types_selection.html
+#, python-format
+msgid "Selected object (%(total_oois)s)"
+msgid_plural "Selected objects (%(total_oois)s)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: reports/templates/partials/report_types_selection.html
+#, python-format
+msgid ""
+"You have selected a live set in the previous step. Based on the current "
+"dataset, this live set results in %(total_oois)s objects."
+msgstr ""
+
+#: reports/templates/partials/report_types_selection.html
+msgid "Applied filters:"
+msgstr ""
+
+#: reports/templates/partials/report_types_selection.html
+#, python-format
+msgid "You have selected %(total_oois)s object in the previous step."
+msgid_plural "You have selected %(total_oois)s objects in the previous step."
+msgstr[0] ""
+msgstr[1] ""
+
+#: reports/templates/partials/report_types_selection.html
+msgid "Change selection"
+msgstr ""
+
+#: reports/templates/partials/report_types_selection.html
+msgid "Available report types"
+msgstr ""
+
+#: reports/templates/partials/report_types_selection.html
+msgid "All report types that are available for your selection."
+msgstr ""
+
+#: reports/templates/partials/report_types_selection.html
+msgid "Toggle all report types"
+msgstr ""
+
+#: reports/templates/partials/return_button.html
+#, python-format
+msgid "%(btn_text)s"
+msgstr ""
+
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/modal_partials/share_modal.html
+msgid "Delete the following report(s):"
+msgstr ""
+
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/modal_partials/share_modal.html
+msgid ""
+"Deleted reports are removed in the view from the moment of deletion. The "
+"report can still be accessed on timestamps before the deletion. Only the "
+"report is removed from the view, not the data it is based on."
+msgstr ""
+
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/modal_partials/share_modal.html
+msgid ""
+"It is still possible to generate a new report for same date. If the report "
+"is part of a combined report, it will remain available in the combined "
+"report."
+msgstr ""
+
+#: reports/templates/report_overview/modal_partials/delete_modal.html
+#: reports/templates/report_overview/modal_partials/rerun_modal.html
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+#: reports/templates/report_overview/subreports_table.html
+msgid "Reference date"
+msgstr ""
+
+#: reports/templates/report_overview/modal_partials/enable_disable_schedule_modal.html
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Disable schedule"
+msgstr ""
+
+#: reports/templates/report_overview/modal_partials/enable_disable_schedule_modal.html
+#, python-format
+msgid ""
+"Are you sure you want to disable the schedule for <strong>%(report_name)s</"
+"strong>? The recipe will still exist and the schedule can be enabled later "
+"on."
+msgstr ""
+
+#: reports/templates/report_overview/modal_partials/rename_modal.html
+msgid "Rename the following report(s):"
+msgstr ""
+
+#: reports/templates/report_overview/modal_partials/rename_modal.html
+#: reports/templates/report_overview/report_history_table.html
+msgid "Rename"
+msgstr ""
+
+#: reports/templates/report_overview/modal_partials/rerun_modal.html
+msgid "Rerun the following report(s):"
+msgstr ""
+
+#: reports/templates/report_overview/modal_partials/rerun_modal.html
+msgid ""
+"By submitting you're generating the selected reports again, using the "
+"current data."
+msgstr ""
+
+#: reports/templates/report_overview/modal_partials/rerun_modal.html
+#: reports/templates/report_overview/report_history_table.html
+msgid "Rerun"
+msgstr ""
+
+#: reports/templates/report_overview/report_history.html
+msgid "Reports history"
+msgstr ""
+
+#: reports/templates/report_overview/report_history.html
+msgid ""
+"On this page you can see all the reports that have been generated in the "
+"past. To create a new report, click the 'Generate Report' button."
+msgstr ""
+
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/report_overview/subreports.html
+#, python-format
+msgid "Showing %(length)s of %(total)s reports"
+msgstr ""
+
+#: reports/templates/report_overview/report_history_table.html
+#: rocky/templates/tasks/reports.html
+msgid "Reports:"
+msgstr ""
+
+#: reports/templates/report_overview/report_history_table.html
+msgid "Shows parent report details"
+msgstr ""
+
+#: reports/templates/report_overview/report_history_table.html
+msgid "Close asset report object details"
+msgstr ""
+
+#: reports/templates/report_overview/report_history_table.html
+msgid "Open asset report object details"
+msgstr ""
+
+#: reports/templates/report_overview/report_history_table.html
+msgid "Asset reports details"
+msgstr ""
+
+#: reports/templates/report_overview/report_history_table.html
+#, python-format
+msgid ""
+"This report consists of %(counter)s asset report with the following report "
+"type and object:"
+msgid_plural ""
+"This report consists of %(counter)s asset reports with the following report "
+"types and objects:"
+msgstr[0] ""
+msgstr[1] ""
+
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/report_overview/subreports_header.html
+#: reports/templates/report_overview/subreports_table.html
+#: reports/views/report_overview.py
+msgid "Asset reports"
+msgstr ""
+
+#: reports/templates/report_overview/report_history_table.html
+msgid "Shows asset report details"
+msgstr ""
+
+#: reports/templates/report_overview/report_history_table.html
+msgid "View all asset reports"
+msgstr ""
+
+#: reports/templates/report_overview/report_history_table.html
+msgid "No reports have been generated yet."
+msgstr ""
+
+#: reports/templates/report_overview/report_overview_header.html
+#: reports/views/base.py rocky/templates/header.html
+#: rocky/templates/tasks/partials/tab_navigation.html
+#: rocky/templates/tasks/reports.html rocky/views/tasks.py
+msgid "Reports"
+msgstr ""
+
+#: reports/templates/report_overview/report_overview_header.html
+msgid "An overview of reports that are scheduled or have been generated."
+msgstr ""
+
+#: reports/templates/report_overview/report_overview_navigation.html
+msgid "Scheduled"
+msgstr ""
+
+#: reports/templates/report_overview/report_overview_navigation.html
+msgid "History"
+msgstr ""
+
+#: reports/templates/report_overview/scheduled_reports.html
+msgid "Scheduled reports"
+msgstr ""
+
+#: reports/templates/report_overview/scheduled_reports.html
+msgid ""
+"On this page you can see all the reports that are or have been scheduled. To "
+"schedule a report, select a start date and recurrence while generating a "
+"report."
+msgstr ""
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+#, python-format
+msgid "Showing %(length)s of %(total)s schedules"
+msgstr ""
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Scheduled reports:"
+msgstr ""
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Scheduled for"
+msgstr ""
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Schedule status"
+msgstr ""
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Once"
+msgstr ""
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Recent reports"
+msgstr ""
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Scheduled Reports:"
+msgstr ""
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Show report details"
+msgstr ""
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "objects"
+msgstr ""
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "Enable schedule"
+msgstr ""
+
+#: reports/templates/report_overview/scheduled_reports_table.html
+msgid "No scheduled reports have been generated yet."
+msgstr ""
+
+#: reports/templates/report_overview/subreports_header.html
+msgid "Back to Reports History"
+msgstr ""
+
+#: reports/templates/report_overview/subreports_header.html
+msgid "An overview of all underlying reports of"
+msgstr ""
+
+#: reports/templates/report_overview/subreports_header.html
+#: reports/templates/report_overview/subreports_table.html
+msgid "Shows report details"
+msgstr ""
+
+#: reports/templates/report_overview/subreports_table.html
+#: rocky/templates/tasks/boefjes.html
+#: rocky/templates/tasks/plugin_detail_task_list.html
+msgid "Input Object"
+msgstr ""
+
+#: reports/templates/report_schedules/delete_recipe_modal.html
+msgid "Delete report recipe"
+msgstr ""
+
+#: reports/templates/report_schedules/delete_recipe_modal.html
+#, python-format
+msgid "Are you sure you want to delete report recipe \"%(name)s\"?"
+msgstr ""
+
+#: reports/templates/report_schedules/delete_recipe_modal.html
+msgid ""
+"Deleting this report recipe means it will be permanently deleted. It will "
+"not be possible anymore to see or enable the schedule. You will find "
+"previously generated reports in the report history tab."
+msgstr ""
+
+#: reports/templates/summary/report_asset_overview.html
+msgid ""
+"The objects listed in the table below were used to generate this report. For "
+"each object in the table it additionally shows the clearance level and "
+"whether or not the object was added by a user ('Declared') or indirectly "
+"identified through another service or system ('Inherited')."
+msgstr ""
+
+#: reports/templates/summary/report_asset_overview.html
+msgid "No objects found."
+msgstr ""
+
+#: reports/templates/summary/report_asset_overview.html
+msgid ""
+"The table below shows which reports were chosen to generate this report, "
+"including a report description."
+msgstr ""
+
+#: reports/templates/summary/report_asset_overview.html
+msgid "No report types found."
+msgstr ""
+
+#: reports/templates/summary/selected_plugins.html
+msgid ""
+"The table below shows all required or optional plugins for the selected "
+"reports."
+msgstr ""
+
+#: reports/templates/summary/selected_plugins.html
+msgid "Required and optional plugins"
+msgstr ""
+
+#: reports/templates/summary/selected_plugins.html
+msgid "Plugin enabled"
+msgstr ""
+
+#: reports/templates/summary/selected_plugins.html
+msgid "Plugin options"
+msgstr ""
+
+#: reports/templates/summary/selected_plugins.html
+msgid "Plugin scan level"
+msgstr ""
+
+#: reports/templates/summary/selected_plugins.html
+msgid "Enabled."
+msgstr ""
+
+#: reports/templates/summary/selected_plugins.html
+msgid "required"
+msgstr ""
+
+#: reports/templates/summary/selected_plugins.html
+msgid "optional"
+msgstr ""
+
+#: reports/templates/summary/selected_plugins.html
+msgid "Plugin extra info"
+msgstr ""
+
+#: reports/templates/summary/selected_plugins.html
+msgid ""
+"There are no required or optional plugins needed for the selected report "
+"types."
+msgstr ""
+
+#: reports/views/aggregate_report.py reports/views/generate_report.py
+#: reports/views/multi_report.py
+msgid "Select objects"
+msgstr ""
+
+#: reports/views/aggregate_report.py reports/views/generate_report.py
+#: reports/views/multi_report.py
+msgid "Select report types"
+msgstr ""
+
+#: reports/views/aggregate_report.py reports/views/generate_report.py
+#: reports/views/multi_report.py
+msgid "Export setup"
+msgstr ""
+
+#: reports/views/aggregate_report.py reports/views/generate_report.py
+msgid "Save report"
+msgstr ""
+
+#: reports/views/aggregate_report.py reports/views/generate_report.py
+msgid "You do not have the required permissions to enable plugins."
+msgstr ""
+
+#: reports/views/base.py
+msgid "Select at least one OOI to proceed."
+msgstr ""
+
+#: reports/views/base.py
+msgid "Select at least one report type to proceed."
+msgstr ""
+
+#: reports/views/mixins.py
+msgid ""
+"No data could be found for %(report_types). Object(s) did not exist on "
+"%(date)s."
+msgstr ""
+
+#: reports/views/multi_report.py
+msgid "View report"
+msgstr ""
+
+#: reports/views/report_overview.py
+msgid "Not enough permissions"
+msgstr ""
+
+#: reports/views/report_overview.py
+msgid "Recipe '{}' deleted successfully"
+msgstr ""
+
+#: reports/views/report_overview.py
+msgid "Recipe not found."
+msgstr ""
+
+#: reports/views/report_overview.py
+msgid "No schedule or recipe selected"
+msgstr ""
+
+#: reports/views/report_overview.py
+msgid ""
+"Schedule disabled successfully. '{}' will not be generated automatically "
+"until the schedule is enabled again."
+msgstr ""
+
+#: reports/views/report_overview.py
+msgid ""
+"Schedule enabled successfully. '{}' will be generated according to schedule."
+msgstr ""
+
+#: reports/views/report_overview.py
+msgid "An unexpected error occurred, please check logs for more info."
+msgstr ""
+
+#: reports/views/report_overview.py
+msgid "Other OOI type selected than Report"
+msgstr ""
+
+#: reports/views/report_overview.py
+msgid "Deletion successful."
+msgstr ""
+
+#: reports/views/report_overview.py
+msgid ""
+"Multi organization reports cannot be rescheduled. It consists of imported "
+"data from different organizations and is not based on newly generated data."
+msgstr ""
+
+#: reports/views/report_overview.py
+msgid ""
+"Rerun successful. It may take a moment before the new report has been "
+"generated."
+msgstr ""
+
+#: reports/views/report_overview.py
+#, python-format
+msgid ""
+"Couldn't rerun %s, since the recipe for this report has been disabled or "
+"deleted."
+msgstr ""
+
+#: reports/views/report_overview.py
+msgid "Renaming failed. Empty report name found."
+msgstr ""
+
+#: reports/views/report_overview.py
+msgid "Report names and reports does not match."
+msgstr ""
+
+#: reports/views/report_overview.py
+msgid "Reports successfully renamed."
+msgstr ""
+
+#: reports/views/report_overview.py
+msgid "Report {} could not be renamed."
+msgstr ""
+
+#: reports/views/view_helpers.py
+msgid "1: Select objects"
+msgstr ""
+
+#: reports/views/view_helpers.py
+msgid "2: Choose report types"
+msgstr ""
+
+#: reports/views/view_helpers.py
+msgid "3: Configuration"
+msgstr ""
+
+#: reports/views/view_helpers.py
+msgid "4: Export setup"
+msgstr ""
+
+#: reports/views/view_helpers.py
+msgid "3: Export setup"
+msgstr ""
+
+#: tools/forms/base.py
+msgid "Date"
+msgstr ""
+
+#: tools/forms/boefje.py
+msgid "For example: -sTU --top-ports 1000"
+msgstr ""
+
+#: tools/forms/boefje.py
+msgid "JSON Schema"
+msgstr ""
+
+#: tools/forms/boefje.py
+msgid "Input object type"
+msgstr ""
+
+#: tools/forms/boefje.py
+msgid "Output mime types"
+msgstr ""
+
+#: tools/forms/boefje.py
+msgid "Scan type"
+msgstr ""
+
+#: tools/forms/boefje.py
+msgid "Interval amount"
+msgstr ""
+
+#: tools/forms/boefje.py
+msgid ""
+"Specify the scanning interval for this Boefje. The default is 24 hours. For "
+"example: 5 minutes will let the Boefje scan every 5 minutes."
+msgstr ""
+
+#: tools/forms/boefje.py
+msgid "Interval frequency"
+msgstr ""
+
+#: tools/forms/boefje.py
+msgid "Object creation/change"
+msgstr ""
+
+#: tools/forms/boefje.py
+msgid ""
+"Choose weather the Boefje should run after creating and/or changing an "
+"object. "
+msgstr ""
+
+#: tools/forms/finding_type.py
+msgid "KAT-ID"
+msgstr ""
+
+#: tools/forms/finding_type.py
+msgid "Unique ID within OpenKAT, for this type"
+msgstr ""
+
+#: tools/forms/finding_type.py
+msgid "Title"
+msgstr ""
+
+#: tools/forms/finding_type.py
+msgid "Give the finding type a fitting title"
+msgstr ""
+
+#: tools/forms/finding_type.py
+msgid "Describe the finding type"
+msgstr ""
+
+#: tools/forms/finding_type.py
+msgid "Risk"
+msgstr ""
+
+#: tools/forms/finding_type.py
+msgid "Solution"
+msgstr ""
+
+#: tools/forms/finding_type.py
+msgid "How can this be solved?"
+msgstr ""
+
+#: tools/forms/finding_type.py
+msgid "Describe how this type of finding can be solved"
+msgstr ""
+
+#: tools/forms/finding_type.py
+msgid "References"
+msgstr ""
+
+#: tools/forms/finding_type.py
+msgid "Please give some references on the solution"
+msgstr ""
+
+#: tools/forms/finding_type.py
+msgid "Please give sources and references on the suggested solution"
+msgstr ""
+
+#: tools/forms/finding_type.py
+msgid "Impact description"
+msgstr ""
+
+#: tools/forms/finding_type.py
+msgid "Describe the solutions impact"
+msgstr ""
+
+#: tools/forms/finding_type.py
+msgid "Solution chance"
+msgstr ""
+
+#: tools/forms/finding_type.py
+msgid "Solution impact"
+msgstr ""
+
+#: tools/forms/finding_type.py
+msgid "Solution effort"
+msgstr ""
+
+#: tools/forms/finding_type.py
+msgid "ID should start with "
+msgstr ""
+
+#: tools/forms/finding_type.py
+msgid "Finding type already exists"
+msgstr ""
+
+#: tools/forms/finding_type.py
+msgid "Click to select one of the available options"
+msgstr ""
+
+#: tools/forms/finding_type.py
+#: rocky/templates/partials/finding_occurrence_definition_list.html
+msgid "Proof"
+msgstr ""
+
+#: tools/forms/finding_type.py
+msgid "Provide evidence of your finding"
+msgstr ""
+
+#: tools/forms/finding_type.py
+msgid "Describe your finding"
+msgstr ""
+
+#: tools/forms/finding_type.py
+msgid "Reproduce finding"
+msgstr ""
+
+#: tools/forms/finding_type.py
+msgid "Please explain how to reproduce your finding"
+msgstr ""
+
+#: tools/forms/finding_type.py tools/forms/upload_raw.py
+msgid "Date/Time (UTC)"
+msgstr ""
+
+#: tools/forms/finding_type.py tools/forms/upload_raw.py
+msgid "Doc! I'm from the future, I'm here to take you back!"
+msgstr ""
+
+#: tools/forms/finding_type.py
+msgid "OOI doesn't exist"
+msgstr ""
+
+#: tools/forms/findings.py
+msgid "Show non-muted findings"
+msgstr ""
+
+#: tools/forms/findings.py
+msgid "Show muted findings"
+msgstr ""
+
+#: tools/forms/findings.py
+msgid "Show muted and non-muted findings"
+msgstr ""
+
+#: tools/forms/findings.py
+msgid "Filter by severity"
+msgstr ""
+
+#: tools/forms/findings.py
+msgid "Filter by muted findings"
+msgstr ""
+
+#: tools/forms/findings.py tools/forms/ooi_form.py tools/forms/scheduler.py
+msgid "Search"
+msgstr ""
+
+#: tools/forms/findings.py
+msgid "Object ID contains (case sensitive)"
+msgstr ""
+
+#: tools/forms/ooi.py
+msgid "Filter types"
+msgstr ""
+
+#: tools/forms/ooi.py
+msgid "Clearance Level"
+msgstr ""
+
+#: tools/forms/ooi.py
+msgid "Next scan"
+msgstr ""
+
+#: tools/forms/ooi.py
+msgid "Show objects that don't meet the Boefjes scan level."
+msgstr ""
+
+#: tools/forms/ooi.py
+msgid "Show Boefjes that exceed the objects clearance level."
+msgstr ""
+
+#: tools/forms/ooi.py
+msgid ""
+"All the boefjes with a scan level below or equal to the clearance level will "
+"be allowed to scan this object."
+msgstr ""
+
+#: tools/forms/ooi.py
+msgid "Expires by (UTC)"
+msgstr ""
+
+#: tools/forms/ooi_form.py
+msgid "option"
+msgstr ""
+
+#: tools/forms/ooi_form.py
+#, python-brace-format
+msgid "Optionally choose a {option_label}"
+msgstr ""
+
+#: tools/forms/ooi_form.py
+#, python-brace-format
+msgid "Please choose a {option_label}"
+msgstr ""
+
+#: tools/forms/ooi_form.py
+msgid "Filter by clearance level"
+msgstr ""
+
+#: tools/forms/ooi_form.py
+msgid "Filter by clearance type"
+msgstr ""
+
+#: tools/forms/scheduler.py
+msgid "From"
+msgstr ""
+
+#: tools/forms/scheduler.py
+msgid "To"
+msgstr ""
+
+#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+msgid "Cancelled"
+msgstr ""
+
+#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+msgid "Completed"
+msgstr ""
+
+#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+msgid "Dispatched"
+msgstr ""
+
+#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+msgid "Failed"
+msgstr ""
+
+#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+msgid "Queued"
+msgstr ""
+
+#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+msgid "Running"
+msgstr ""
+
+#: tools/forms/scheduler.py
+msgid "Search by object name"
+msgstr ""
+
+#: tools/forms/scheduler.py
+msgid "The selected date is in the future. Please select a different date."
+msgstr ""
+
+#: tools/forms/settings.py
+msgid "--- Show all ----"
+msgstr ""
+
+#: tools/forms/settings.py
+msgid "recommendation"
+msgstr ""
+
+#: tools/forms/settings.py
+msgid "low"
+msgstr ""
+
+#: tools/forms/settings.py
+msgid "medium"
+msgstr ""
+
+#: tools/forms/settings.py
+msgid "high"
+msgstr ""
+
+#: tools/forms/settings.py
+msgid "very high"
+msgstr ""
+
+#: tools/forms/settings.py
+msgid "critical"
+msgstr ""
+
+#: tools/forms/settings.py
+msgid "quickfix"
+msgstr ""
+
+#: tools/forms/settings.py
+msgid "Declared"
+msgstr ""
+
+#: tools/forms/settings.py
+msgid "Inherited"
+msgstr ""
+
+#: tools/forms/settings.py
+msgid "Empty"
+msgstr ""
+
+#: tools/forms/settings.py
+msgid "Add one finding type ID per line."
+msgstr ""
+
+#: tools/forms/settings.py
+msgid "Add the date and time of your finding (UTC)"
+msgstr ""
+
+#: tools/forms/settings.py
+msgid "Add the date and time of when the raw file was generated (UTC)"
+msgstr ""
+
+#: tools/forms/settings.py
+msgid ""
+"OpenKAT stores a time indication with every observation, so it is possible "
+"to see the status of your network through time. Select a datetime to change "
+"the view to represent that moment in time."
+msgstr ""
+
+#: tools/forms/settings.py
+msgid ""
+"<p>The name of the Docker image. For example: <i>'ghcr.io/minvws/openkat/"
+"nmap'</i>. In OpenKAT, all Boefjes with the same container image will be "
+"seen as 'variants' and will be shown together on the Boefje detail page. </"
+"p> "
+msgstr ""
+
+#: tools/forms/settings.py
+msgid ""
+"A description of the Boefje explaining in short what it can do. This will "
+"both be displayed inside the KAT-alogus and on the Boefje details page."
+msgstr ""
+
+#: tools/forms/settings.py
+msgid ""
+"Select the object type(s) that your Boefje consumes. To select multiple "
+"objects, press and hold the 'ctrl'/'command' key and then click the items "
+"you want to select. "
+msgstr ""
+
+#: tools/forms/settings.py
+msgid ""
+"<p>If any other settings are needed for your Boefje, add these as a JSON "
+"Schema, otherwise, leave the field empty or 'null'.</p> <p> This JSON is "
+"used as the basis for a form for the user. When the user enables this Boefje "
+"they can get the option to give extra information. For example, it can "
+"contain an API key that the script requires.</p> <p>More information about "
+"what the schema.json file looks like can be found <a href='https://docs."
+"openkat.nl/developer_documentation/development_tutorial/creating_a_boefje."
+"html'> here</a>.</p> "
+msgstr ""
+
+#: tools/forms/settings.py
+msgid ""
+"<p>Add a set of mime types that are produced by this Boefje, separated by "
+"commas. For example: <i>'text/html'</i>, <i>'image/jpeg'</i> or <i>'boefje/"
+"{boefje-id}'</i></p> <p>These output mime types will be shown on the Boefje "
+"detail page as information for other users. </p> "
+msgstr ""
+
+#: tools/forms/settings.py
+msgid ""
+"<p>Select a clearance level for your Boefje. For more information about the "
+"different clearance levels please check the <a href='https://docs.openkat.nl/"
+"manual/usermanual.html#scan-levels-clearance-indemnities'> documentation</a>."
+"</p> "
+msgstr ""
+
+#: tools/forms/settings.py
+msgid ""
+"Choose when this Boefje will scan objects. It can run on a given interval or "
+"it can run every time an object has been created or changed. "
+msgstr ""
+
+#: tools/forms/settings.py
+msgid "Depth of the tree."
+msgstr ""
+
+#: tools/forms/upload_csv.py
+msgid "Only CSV file supported"
+msgstr ""
+
+#: tools/forms/upload_csv.py
+msgid "File could not be decoded"
+msgstr ""
+
+#: tools/forms/upload_csv.py
+msgid "No file selected"
+msgstr ""
+
+#: tools/forms/upload_csv.py
+msgid "The uploaded file is empty."
+msgstr ""
+
+#: tools/forms/upload_csv.py
+msgid "The number of columns do not meet the requirements."
+msgstr ""
+
+#: tools/forms/upload_csv.py
+msgid "OOI Type in CSV does not meet the criteria."
+msgstr ""
+
+#: tools/forms/upload_csv.py
+msgid "An error has occurred during the parsing of the csv file:"
+msgstr ""
+
+#: tools/forms/upload_csv.py
+msgid "Upload CSV file"
+msgstr ""
+
+#: tools/forms/upload_csv.py
+msgid "Only accepts CSV file."
+msgstr ""
+
+#: tools/forms/upload_oois.py rocky/templates/partials/explanations.html
+msgid "Object Type"
+msgstr ""
+
+#: tools/forms/upload_oois.py
+msgid "Choose a type of which objects are added."
+msgstr ""
+
+#: tools/forms/upload_raw.py
+msgid "Mime types"
+msgstr ""
+
+#: tools/forms/upload_raw.py
+msgid ""
+"<p>Add a set of mime types, separated by commas, for example:</"
+"p><p><i>\"text/html, image/jpeg\"</i> or <i>\"boefje/dns-records\"</i>.</"
+"p><p>Mime types are used to match the correct normalizer to a raw file. When "
+"the mime type \"boefje/dns-records\" is added, the normalizer expects the "
+"raw file to contain dns scan information.</p>"
+msgstr ""
+
+#: tools/forms/upload_raw.py rocky/templates/partials/ooi_list_toolbar.html
+#: rocky/templates/upload_raw.html
+msgid "Upload raw file"
+msgstr ""
+
+#: tools/forms/upload_raw.py
+msgid "Input or Scan OOI"
+msgstr ""
+
+#: tools/forms/upload_raw.py
+msgid "Click to select one of the available options, or type one yourself"
+msgstr ""
+
+#: tools/forms/upload_raw.py
+msgid "OOI doesn't exist, try another valid time"
+msgstr ""
+
+#: tools/models.py
+msgid ""
+"A short code containing only lower-case unicode letters, numbers, hyphens or "
+"underscores that will be used in URLs and paths."
+msgstr ""
+
+#: tools/models.py
+msgid ""
+"This organization code is reserved by OpenKAT and cannot be used. Choose "
+"another organization code."
+msgstr ""
+
+#: tools/models.py
+msgid "new"
+msgstr ""
+
+#: tools/templatetags/ooi_extra.py
+msgid "Unknown user"
+msgstr ""
+
+#: tools/view_helpers.py rocky/templates/header.html
+#: rocky/templates/organizations/organization_member_list.html
+#: rocky/views/organization_member_edit.py
+msgid "Members"
+msgstr ""
+
+#: rocky/forms.py
+msgid "Current status"
+msgstr ""
+
+#: rocky/forms.py rocky/templates/organizations/organization_member_list.html
+msgid "Active"
+msgstr ""
+
+#: rocky/forms.py rocky/templates/organizations/organization_member_list.html
+msgid "New"
+msgstr ""
+
+#: rocky/forms.py
+msgid "Account status"
+msgstr ""
+
+#: rocky/forms.py
+msgid "Not blocked"
+msgstr ""
+
+#: rocky/messaging.py
+msgid ""
+"You have trusted this member with a clearance level of L{}. This member "
+"needs at least a clearance level of L{} in order to do a proper onboarding. "
+"Edit this member and change the clearance level if necessary."
+msgstr ""
+
+#: rocky/paginator.py
+msgid "That page number is not an integer"
+msgstr ""
+
+#: rocky/paginator.py
+msgid "That page number is less than 1"
+msgstr ""
+
+#: rocky/paginator.py
+msgid "That page contains no results"
+msgstr ""
+
+#: rocky/scheduler.py
+msgid ""
+"The Scheduler has an unexpected error. Check the Scheduler logs for further "
+"details."
+msgstr ""
+
+#: rocky/scheduler.py
+msgid "Could not connect to Scheduler. Service is possibly down."
+msgstr ""
+
+#: rocky/scheduler.py
+msgid "Your request could not be validated."
+msgstr ""
+
+#: rocky/scheduler.py
+msgid "Task could not be found."
+msgstr ""
+
+#: rocky/scheduler.py
+msgid ""
+"Scheduler is receiving too many requests. Increase SCHEDULER_PQ_MAXSIZE or "
+"wait for task to finish."
+msgstr ""
+
+#: rocky/scheduler.py
+msgid "Bad request. Your request could not be interpreted by the Scheduler."
+msgstr ""
+
+#: rocky/scheduler.py
+msgid "The Scheduler has received a conflict. Your task is already in queue."
+msgstr ""
+
+#: rocky/scheduler.py
+msgid "A HTTPError occurred. See Scheduler logs for more info."
+msgstr ""
+
+#: rocky/scheduler.py
+msgid "Schedule list: "
+msgstr ""
+
+#: rocky/scheduler.py
+msgid "Task list: "
+msgstr ""
+
+#: rocky/settings.py
+msgid "Blue light"
+msgstr ""
+
+#: rocky/settings.py
+msgid "Blue medium"
+msgstr ""
+
+#: rocky/settings.py
+msgid "Blue dark"
+msgstr ""
+
+#: rocky/settings.py
+msgid "Green light"
+msgstr ""
+
+#: rocky/settings.py
+msgid "Green medium"
+msgstr ""
+
+#: rocky/settings.py
+msgid "Green dark"
+msgstr ""
+
+#: rocky/settings.py
+msgid "Yellow light"
+msgstr ""
+
+#: rocky/settings.py
+msgid "Yellow medium"
+msgstr ""
+
+#: rocky/settings.py
+msgid "Yellow dark"
+msgstr ""
+
+#: rocky/settings.py
+msgid "Orange light"
+msgstr ""
+
+#: rocky/settings.py
+msgid "Orange medium"
+msgstr ""
+
+#: rocky/settings.py
+msgid "Orange dark"
+msgstr ""
+
+#: rocky/settings.py
+msgid "Red light"
+msgstr ""
+
+#: rocky/settings.py
+msgid "Red medium"
+msgstr ""
+
+#: rocky/settings.py
+msgid "Red dark"
+msgstr ""
+
+#: rocky/settings.py
+msgid "Violet light"
+msgstr ""
+
+#: rocky/settings.py
+msgid "Violet medium"
+msgstr ""
+
+#: rocky/settings.py
+msgid "Violet dark"
+msgstr ""
+
+#: rocky/settings.py
+msgid "Plain"
+msgstr ""
+
+#: rocky/settings.py
+msgid "Solid"
+msgstr ""
+
+#: rocky/settings.py
+msgid "Dashed"
+msgstr ""
+
+#: rocky/settings.py
+msgid "Dotted"
+msgstr ""
+
+#: rocky/templates/403.html
+msgid "Error code 403: Unauthorized"
+msgstr ""
+
+#: rocky/templates/403.html
+msgid "Your account is not authorized to access this page or organization."
+msgstr ""
+
+#: rocky/templates/403.html
+msgid "Please contact your system administrator."
+msgstr ""
+
+#: rocky/templates/403.html rocky/templates/404.html
+msgid "You may want to go back to the"
+msgstr ""
+
+#: rocky/templates/403.html rocky/templates/404.html
+msgid "Crisis Room"
+msgstr ""
+
+#: rocky/templates/404.html
+msgid "Error code 404: Page not found"
+msgstr ""
+
+#: rocky/templates/404.html
+msgid ""
+"The page you wanted to see or the file you wanted to view was not found."
+msgstr ""
+
+#: rocky/templates/admin/base.html
+msgid "Skip to main content"
+msgstr ""
+
+#: rocky/templates/admin/base.html
+msgid "Welcome,"
+msgstr ""
+
+#: rocky/templates/admin/base.html
+msgid "View site"
+msgstr ""
+
+#: rocky/templates/admin/base.html
+msgid "Documentation"
+msgstr ""
+
+#: rocky/templates/admin/base.html
+msgid "Change password"
+msgstr ""
+
+#: rocky/templates/admin/base.html
+msgid "Log out"
+msgstr ""
+
+#: rocky/templates/admin/base.html rocky/templates/header.html
+msgid "Breadcrumbs"
+msgstr ""
+
+#: rocky/templates/admin/base.html rocky/templates/admin/change_form.html
+#: rocky/templates/admin/change_list.html
+#: rocky/templates/admin/delete_confirmation.html
+#: rocky/templates/admin/delete_selected_confirmation.html
+msgid "Home"
+msgstr ""
+
+#: rocky/templates/admin/change_form.html
+#, python-format
+msgid "Add %(name)s"
+msgstr ""
+
+#: rocky/templates/admin/change_form.html
+#: rocky/templates/admin/change_list.html
+msgid "Please correct the error below."
+msgid_plural "Please correct the errors below."
+msgstr[0] ""
+msgstr[1] ""
+
+#: rocky/templates/admin/change_list.html
+msgid "Filter"
+msgstr ""
+
+#: rocky/templates/admin/change_list.html
+msgid "Hide counts"
+msgstr ""
+
+#: rocky/templates/admin/change_list.html
+msgid "Show counts"
+msgstr ""
+
+#: rocky/templates/admin/change_list.html
+msgid "Clear all filters"
+msgstr ""
+
+#: rocky/templates/admin/delete_confirmation.html
+#, python-format
+msgid ""
+"Deleting the %(object_name)s '%(escaped_object)s' would result in deleting "
+"related objects, but your account doesn't have permission to delete the "
+"following types of objects"
+msgstr ""
+
+#: rocky/templates/admin/delete_confirmation.html
+#, python-format
+msgid ""
+"Deleting the %(object_name)s '%(escaped_object)s' would require deleting the "
+"following protected related objects"
+msgstr ""
+
+#: rocky/templates/admin/delete_confirmation.html
+#, python-format
+msgid ""
+"Are you sure you want to delete the %(object_name)s \"%(escaped_object)s\"? "
+"All of the following related items will be deleted"
+msgstr ""
+
+#: rocky/templates/admin/delete_confirmation.html
+#: rocky/templates/admin/delete_selected_confirmation.html
+msgid "Yes, I’m sure"
+msgstr ""
+
+#: rocky/templates/admin/delete_confirmation.html
+#: rocky/templates/admin/delete_selected_confirmation.html
+msgid "No, take me back"
+msgstr ""
+
+#: rocky/templates/admin/delete_selected_confirmation.html
+msgid "Delete multiple objects"
+msgstr ""
+
+#: rocky/templates/admin/delete_selected_confirmation.html
+#, python-format
+msgid ""
+"Deleting the selected %(objects_name)s would result in deleting related "
+"objects, but your account doesn't have permission to delete the following "
+"types of objects"
+msgstr ""
+
+#: rocky/templates/admin/delete_selected_confirmation.html
+#, python-format
+msgid ""
+"Deleting the selected %(objects_name)s would require deleting the following "
+"protected related objects"
+msgstr ""
+
+#: rocky/templates/admin/delete_selected_confirmation.html
+#, python-format
+msgid ""
+"Are you sure you want to delete the selected %(objects_name)s? All of the "
+"following objects and their related items will be deleted"
+msgstr ""
+
+#: rocky/templates/admin/popup_response.html
+msgid "Popup closing…"
+msgstr ""
+
+#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
+#: rocky/templates/header.html
+msgid "Close menu"
+msgstr ""
+
+#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
+#: rocky/templates/header.html
+msgid "Main navigation"
+msgstr ""
+
+#: rocky/templates/dashboard_client.html
+msgid "Indemnifications"
+msgstr ""
+
+#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
+#: rocky/templates/partials/secondary-menu.html
+msgid "Logout"
+msgstr ""
+
+#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
+msgid "Welcome"
+msgstr ""
+
+#: rocky/templates/dashboard_client.html rocky/templates/dashboard_redteam.html
+msgid "User overview"
+msgstr ""
+
+#: rocky/templates/dashboard_redteam.html
+#: rocky/templates/partials/notifications_block.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid "warning"
+msgstr ""
+
+#: rocky/templates/dashboard_redteam.html
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+#: rocky/templates/partials/notifications_block.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid "Warning:"
+msgstr ""
+
+#: rocky/templates/dashboard_redteam.html
+msgid "Organization code missing"
+msgstr ""
+
+#: rocky/templates/finding_type_add.html
+#: rocky/templates/partials/findings_list_toolbar.html
+#: rocky/views/finding_type_add.py
+msgid "Add finding type"
+msgstr ""
+
+#: rocky/templates/finding_type_add.html
+msgid "Finding Type"
+msgstr ""
+
+#: rocky/templates/findings/finding_add.html
+#: rocky/templates/oois/ooi_detail_findings_list.html
+#: rocky/templates/oois/ooi_findings.html
+#: rocky/templates/partials/findings_list_toolbar.html
+#: rocky/views/finding_add.py
+msgid "Add finding"
+msgstr ""
+
+#: rocky/templates/findings/finding_list.html
+msgid "Findings "
+msgstr ""
+
+#: rocky/templates/findings/finding_list.html
+#, python-format
+msgid ""
+"An overview of all findings OpenKAT found for organization "
+"<strong>%(organization_name)s</strong>. Each finding relates to an object. "
+"Click a finding for additional information."
+msgstr ""
+
+#: rocky/templates/findings/finding_list.html
+#, python-format
+msgid "Showing %(length)s of %(total)s findings"
+msgstr ""
+
+#: rocky/templates/findings/finding_list.html
+#: rocky/templates/partials/mute_findings_modal.html
+msgid "Mute findings"
+msgstr ""
+
+#: rocky/templates/findings/finding_list.html
+msgid "Unmute findings"
+msgstr ""
+
+#: rocky/templates/findings/findings_filter.html
+#: rocky/templates/partials/elements/ooi_list_settings_form.html
+#: rocky/templates/tasks/partials/task_filter.html
+msgid "Set filters"
+msgstr ""
+
+#: rocky/templates/findings/findings_filter.html
+#: rocky/templates/partials/elements/ooi_list_settings_form.html
+#: rocky/templates/tasks/partials/task_filter.html
+msgid "Clear filters"
+msgstr ""
+
+#: rocky/templates/footer.html rocky/views/privacy_statement.py
+msgid "Privacy Statement"
+msgstr ""
+
+#: rocky/templates/forms/json_schema_form.html
+msgid "Fill out this form to answer the Question (again):"
+msgstr ""
+
+#: rocky/templates/graph-d3.html
+msgid ""
+"Click a circle to collapse / expand the tree, click the text to view the "
+"tree from that OOI and hover over the text to see details."
+msgstr ""
+
+#: rocky/templates/graph-d3.html
+msgid "Tree graph"
+msgstr ""
+
+#: rocky/templates/header.html
+msgid "Menu"
+msgstr ""
+
+#: rocky/templates/header.html
+msgid "OpenKAT logo, go to the homepage of OpenKAT"
+msgstr ""
+
+#: rocky/templates/header.html rocky/templates/tasks/ooi_detail_task_list.html
+#: rocky/templates/tasks/partials/tasks_overview_header.html
+#: rocky/templates/tasks/plugin_detail_task_list.html
+#: rocky/views/task_detail.py rocky/views/tasks.py
+msgid "Tasks"
+msgstr ""
+
+#: rocky/templates/health.html
+msgid "Health Checks"
+msgstr ""
+
+#: rocky/templates/health.html
+msgid "Health checks"
+msgstr ""
+
+#: rocky/templates/health.html
+msgid "Additional"
+msgstr ""
+
+#: rocky/templates/indemnification_present.html
+msgid "Indemnification"
+msgstr ""
+
+#: rocky/templates/indemnification_present.html
+msgid ""
+"Indemnification on the organization present. You may now add objects and "
+"start scans."
+msgstr ""
+
+#: rocky/templates/indemnification_present.html
+msgid "Go to Objects"
+msgstr ""
+
+#: rocky/templates/indemnification_present.html
+msgid "Go to"
+msgstr ""
+
+#: rocky/templates/landing_page.html
+msgid "Welcome to OpenKAT"
+msgstr ""
+
+#: rocky/templates/landing_page.html
+msgid "Kwetsbaarheden Analyse Tool"
+msgstr ""
+
+#: rocky/templates/landing_page.html
+msgid "What is OpenKAT?"
+msgstr ""
+
+#: rocky/templates/landing_page.html
+msgid ""
+"OpenKAT is a vulnerability analysis tool. An Open Source-project developed "
+"by the Ministry of Health, Welfare and Sport to make your and our world "
+"safer."
+msgstr ""
+
+#: rocky/templates/landing_page.html
+msgid "OpenKAT sees"
+msgstr ""
+
+#: rocky/templates/landing_page.html
+msgid ""
+"Dozens of tools are integrated in OpenKAT to view the world (digital and "
+"analog)."
+msgstr ""
+
+#: rocky/templates/landing_page.html
+msgid "Our motto is therefore: I see, I see, what you do not see."
+msgstr ""
+
+#: rocky/templates/landing_page.html
+msgid "OpenKAT knows"
+msgstr ""
+
+#: rocky/templates/landing_page.html
+msgid ""
+"OpenKAT does not forget (just like that), and can be queried without "
+"scanning again. Also about a historical situation."
+msgstr ""
+
+#: rocky/templates/landing_page.html
+msgid "OpenKAT is secure"
+msgstr ""
+
+#: rocky/templates/landing_page.html
+msgid ""
+"Forensically secured storage of evidence is one of the basic ingredients of "
+"OpenKAT."
+msgstr ""
+
+#: rocky/templates/landing_page.html
+msgid "OpenKAT is sweet"
+msgstr ""
+
+#: rocky/templates/landing_page.html
+msgid ""
+"OpenKAT thinks about privacy, and stores what is necessary, within the rules "
+"of your organization and the law."
+msgstr ""
+
+#: rocky/templates/landing_page.html
+msgid "A wide playing field"
+msgstr ""
+
+#: rocky/templates/landing_page.html
+msgid ""
+"OpenKAT makes a copy of the actual reality by means of the integrated tools. "
+"Within this copy you can search for answers to countless security and policy "
+"questions. Expected and unexpected changes in the world are made visible, "
+"and where necessary reported or made known directly to the right people."
+msgstr ""
+
+#: rocky/templates/legal/privacy_statement.html
+msgid "OpenKAT Privacy Statement"
+msgstr ""
+
+#: rocky/templates/legal/privacy_statement.html
+msgid ""
+"OpenKAT is dedicated to protecting the confidentiality and privacy of "
+"information entrusted to it. As part of this fundamental obligation, OpenKAT "
+"is committed to the appropriate protection and use of personal information "
+"(sometimes referred to as \"personal data\", \"personally identifiable "
+"information\" or \"PII\") that has been collected online."
+msgstr ""
+
+#: rocky/templates/oois/error.html
+msgid "Object List"
+msgstr ""
+
+#: rocky/templates/oois/error.html
+msgid "An error occurred. Please contact a system administrator."
+msgstr ""
+
+#: rocky/templates/oois/ooi_add.html
+#, python-format
+msgid "Add a %(display_type)s"
+msgstr ""
+
+#: rocky/templates/oois/ooi_add.html
+msgid ""
+"Here you can add the asset of the client. Findings can be added to these in "
+"the findings page."
+msgstr ""
+
+#: rocky/templates/oois/ooi_add.html
+#, python-format
+msgid "Add %(display_type)s"
+msgstr ""
+
+#: rocky/templates/oois/ooi_add_type_select.html
+#: rocky/templates/oois/ooi_detail_add_related_object.html
+#: rocky/templates/partials/elements/ooi_add_type_select_form.html
+#: rocky/templates/partials/ooi_list_toolbar.html rocky/views/ooi_add.py
+msgid "Add object"
+msgstr ""
+
+#: rocky/templates/oois/ooi_add_type_select.html
+msgid "Select the type of object you want to create."
+msgstr ""
+
+#: rocky/templates/oois/ooi_delete.html
+#, python-format
+msgid "Delete %(primary_key)s"
+msgstr ""
+
+#: rocky/templates/oois/ooi_delete.html
+msgid "Are you sure?"
+msgstr ""
+
+#: rocky/templates/oois/ooi_delete.html
+#, python-format
+msgid "Here you can delete the %(display_type)s."
+msgstr ""
+
+#: rocky/templates/oois/ooi_delete.html
+msgid "To be deleted object(s)"
+msgstr ""
+
+#: rocky/templates/oois/ooi_delete.html
+#: rocky/templates/partials/elements/ooi_tree_condensed_table.html
+msgid "Key"
+msgstr ""
+
+#: rocky/templates/oois/ooi_delete.html
+#: rocky/templates/partials/ooi_detail_toolbar.html
+#, python-format
+msgid "Delete %(display_type)s"
+msgstr ""
+
+#: rocky/templates/oois/ooi_delete.html
+msgid "Deletion not possible for types: KATFindingType and CVEFindingType"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail.html
+msgid "using boefjes"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail.html
+#: rocky/templates/organizations/organization_settings.html
+msgid "indemnification warning"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail.html
+#, python-format
+msgid ""
+"<strong>Warning:</strong> There is no indemnification for this organization. "
+"Go to the <a href=\"%(organization_settings)s\">organization settings page</"
+"a> to add one."
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail.html
+msgid "Permission warning"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail.html
+msgid ""
+"<strong>Warning:</strong> You don't have the proper permission at the "
+"organizational level to scan objects. Contact your administrator."
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail.html
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Scan warning"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail.html
+#, python-format
+msgid ""
+"<strong>Warning:</strong> You are not allowed to scan this OOI. Your maximum "
+"clearance level is %(member_clearance_level)s and this OOI has level "
+"%(boefje_scan_level)s. Go to your <a href=\"%(account_details)s\">account "
+"details</a> to manage your clearance level."
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail.html rocky/templates/scan.html
+msgid "Boefjes overview"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail.html
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+#: rocky/templates/scan.html rocky/templates/tasks/boefjes.html
+#: rocky/templates/tasks/normalizers.html
+msgid "Boefje"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail.html rocky/templates/scan.html
+msgid "Scan profile"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail.html
+msgid "Unable to start scan. See the warning for more details."
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail.html
+msgid "Start scan"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail.html
+msgid "There are no boefjes enabled to scan an OOI of type"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail.html
+msgid "See"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail.html
+msgid "to find and enable boefjes that can scan within the current level."
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail_add_related_object.html
+#: rocky/templates/partials/ooi_detail_related_object.html
+msgid "Add related object"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail_add_related_object.html
+#: rocky/templates/oois/ooi_detail_object.html
+msgid "Object details"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail_add_related_object.html
+#: rocky/templates/partials/elements/ooi_add_type_select_form.html
+msgid "Object type"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail_add_related_object.html
+#: rocky/templates/partials/elements/ooi_add_type_select_form.html
+msgid "Choose an object type to add"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail_add_related_object.html
+#: rocky/templates/partials/elements/ooi_add_type_select_form.html
+msgid "Select an object type to add."
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail_findings_list.html
+msgid "Overview of findings for"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail_findings_list.html
+msgid "Score"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail_findings_list.html
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid "Finding details"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail_findings_overview.html
+msgid "Overview of the number of findings and their severity found on"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail_findings_overview.html
+msgid ""
+"Findings can occur multiple times. To give better insight the following "
+"table shows the number of unique findings found as well as the number of "
+"occurrences."
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail_findings_overview.html
+msgid "See finding details"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail_findings_overview.html
+msgid "Total findings"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail_object.html
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Inactive"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail_origins_declarations.html
+msgid "Declarations"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail_origins_inference.html
+msgid "Inferred by"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail_origins_inference.html
+msgid "Bit"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail_origins_inference.html
+msgid "Parameters"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+msgid "Last observed by"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+msgid "Task ID"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+msgid "When"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+#: rocky/templates/tasks/normalizers.html
+msgid "Normalizer"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+msgid "This scan was manually created."
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+msgid "The boefje has since been deleted or disabled."
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+msgid "No Raw file could be found, this might point to an error in OpenKAT"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Warning"
+msgstr ""
+
+#: rocky/templates/oois/ooi_edit.html
+#, python-format
+msgid "Edit %(type)s: %(ooi_human_readable)s"
+msgstr ""
+
+#: rocky/templates/oois/ooi_edit.html
+msgid "Primary key fields cannot be edited."
+msgstr ""
+
+#: rocky/templates/oois/ooi_edit.html
+#, python-format
+msgid "Save %(display_type)s"
+msgstr ""
+
+#: rocky/templates/oois/ooi_findings.html
+msgid "Currently no findings have been identified for OOI"
+msgstr ""
+
+#: rocky/templates/oois/ooi_list.html
+#, python-format
+msgid ""
+"An overview of objects found for organization <strong>%(organization_name)s</"
+"strong>. Objects can be added manually or by running Boefjes. Click an "
+"object for additional information."
+msgstr ""
+
+#: rocky/templates/oois/ooi_list.html
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Edit clearance level"
+msgstr ""
+
+#: rocky/templates/oois/ooi_mute_finding.html
+msgid "Mute finding:"
+msgstr ""
+
+#: rocky/templates/oois/ooi_mute_finding.html
+msgid "Give a reason below why you want to mute this finding."
+msgstr ""
+
+#: rocky/templates/oois/ooi_mute_finding.html
+#: rocky/templates/partials/mute_findings_modal.html
+#: rocky/templates/partials/ooi_detail_toolbar.html
+msgid "Mute finding"
+msgstr ""
+
+#: rocky/templates/oois/ooi_mute_finding.html
+msgid "Mute"
+msgstr ""
+
+#: rocky/templates/oois/ooi_page_tabs.html
+msgid "List of views for OOI"
+msgstr ""
+
+#: rocky/templates/oois/ooi_past_due_warning.html
+msgid "This object is past due"
+msgstr ""
+
+#: rocky/templates/oois/ooi_past_due_warning.html
+msgid "This object is past due and has been deleted"
+msgstr ""
+
+#: rocky/templates/oois/ooi_past_due_warning.html
+msgid ""
+"This object is past due. You are viewing the object state in a past state."
+msgstr ""
+
+#: rocky/templates/oois/ooi_past_due_warning.html
+msgid ""
+"You will not be able to add Findings or other OOI's to past due objects."
+msgstr ""
+
+#: rocky/templates/oois/ooi_past_due_warning.html
+#: rocky/templates/partials/hyperlink_ooi_id.html
+#, python-format
+msgid "Show details for %(name)s"
+msgstr ""
+
+#: rocky/templates/oois/ooi_past_due_warning.html
+msgid "View the current state"
+msgstr ""
+
+#: rocky/templates/oois/ooi_past_due_warning.html
+msgid ""
+"You will not be able to add Findings or other OOI's, this object has been "
+"deleted and is no longer available."
+msgstr ""
+
+#: rocky/templates/oois/ooi_summary.html
+msgid "Summary for"
+msgstr ""
+
+#: rocky/templates/oois/ooi_summary.html
+msgid "Below you can see findings that were found for"
+msgstr ""
+
+#: rocky/templates/oois/ooi_summary.html
+msgid "and direct  children of this"
+msgstr ""
+
+#: rocky/templates/oois/ooi_summary.html
+msgid "This"
+msgstr ""
+
+#: rocky/templates/oois/ooi_summary.html
+msgid "tree view"
+msgstr ""
+
+#: rocky/templates/oois/ooi_summary.html
+msgid "of the"
+msgstr ""
+
+#: rocky/templates/oois/ooi_summary.html
+msgid "shows the same objects."
+msgstr ""
+
+#: rocky/templates/organizations/organization_add.html
+msgid ""
+"Please enter the following organization details. These details can be edited "
+"within the organization page within OpenKAT when necessary."
+msgstr ""
+
+#: rocky/templates/organizations/organization_edit.html
+msgid "Edit organization"
+msgstr ""
+
+#: rocky/templates/organizations/organization_edit.html
+msgid "Save organization"
+msgstr ""
+
+#: rocky/templates/organizations/organization_list.html
+msgid "An overview of all organizations you are a member of."
+msgstr ""
+
+#: rocky/templates/organizations/organization_list.html
+msgid "Add new organization"
+msgstr ""
+
+#: rocky/templates/organizations/organization_list.html
+#, python-format
+msgid ""
+"\n"
+"                            Showing %(total)s organizations\n"
+"                        "
+msgstr ""
+
+#: rocky/templates/organizations/organization_list.html
+msgid "Organization overview:"
+msgstr ""
+
+#: rocky/templates/organizations/organization_list.html
+#: rocky/templates/organizations/organization_settings.html
+msgid "Tags"
+msgstr ""
+
+#: rocky/templates/organizations/organization_list.html
+msgid "There were no organizations found for your user account"
+msgstr ""
+
+#: rocky/templates/organizations/organization_list.html
+msgid "Actions to perform for all of your organizations."
+msgstr ""
+
+#: rocky/templates/organizations/organization_list.html
+#: rocky/templates/organizations/organization_settings.html
+msgid "Rerun all bits"
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_add.html
+msgid "Change account type"
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_add_header.html
+#: rocky/views/organization_member_add.py
+msgid "Add member"
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_add_header.html
+#, python-format
+msgid ""
+"Creating a new member of organization <strong>%(organization)s</strong>. For "
+"detailed information about the different account types, check the <a "
+"href=\"https://docs.openkat.nl/basics/users-and-organisations.html#users\" "
+"target=\"_blank\" rel=\"noopener\">documentation</a>."
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_edit.html
+#: rocky/views/organization_member_edit.py
+msgid "Edit member"
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_edit.html
+msgid "Save member"
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_list.html
+#, python-format
+msgid "An overview of members of <strong>%(organization_name)s</strong>."
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Add member(s)"
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Manually"
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Upload a CSV"
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_list.html
+#, python-format
+msgid ""
+"\n"
+"                        Showing %(total)s members\n"
+"                    "
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Member overview:"
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Role"
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Assigned clearance level"
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_list.html
+msgid "Super user"
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_upload.html
+#: rocky/views/organization_member_add.py
+msgid "Add members"
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_upload.html
+#, python-format
+msgid ""
+"To upload multiple members at once, you can upload a CSV file or you can <a "
+"href=\"%(download_url)s\">download the template</a>."
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_upload.html
+msgid "To create a custom CSV file, make sure it meets the following criteria:"
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_upload.html
+msgid "Upload"
+msgstr ""
+
+#: rocky/templates/organizations/organization_settings.html
+#, python-format
+msgid ""
+"An overview of general information and settings for "
+"<strong>%(organization_name)s</strong>."
+msgstr ""
+
+#: rocky/templates/organizations/organization_settings.html
+msgid ""
+"<strong>Warning:</strong> Indemnification is not set for this organization."
+msgstr ""
+
+#: rocky/templates/organizations/organization_settings.html
+#: rocky/views/indemnification_add.py
+msgid "Add indemnification"
+msgstr ""
+
+#: rocky/templates/partials/current_config.html
+msgid "Current configuration"
+msgstr ""
+
+#: rocky/templates/partials/delete_ooi_modal.html
+msgid "Delete objects"
+msgstr ""
+
+#: rocky/templates/partials/delete_ooi_modal.html
+msgid ""
+"Are you sure you want to delete all the selected objects? The history of the "
+"deleted objects will still be available."
+msgstr ""
+
+#: rocky/templates/partials/edit_ooi_clearance_level_modal.html
+msgid "Edit clearance level settings"
+msgstr ""
+
+#: rocky/templates/partials/edit_ooi_clearance_level_modal.html
+msgid "You are editing clearance level of all the selected objects."
+msgstr ""
+
+#: rocky/templates/partials/edit_ooi_clearance_level_modal.html
+msgid "Switching between declare and inherit"
+msgstr ""
+
+#: rocky/templates/partials/edit_ooi_clearance_level_modal.html
+msgid ""
+"Clearance levels can be automatically inherited or you can manually declare "
+"the clearance level for an object. Switching to inherit clearance level will "
+"also recalculate the clearance levels of objects that inherit from these "
+"clearance levels."
+msgstr ""
+
+#: rocky/templates/partials/elements/ooi_detail_settings.html
+msgid "Observed at"
+msgstr ""
+
+#: rocky/templates/partials/elements/ooi_detail_settings.html
+#: rocky/templates/partials/elements/ooi_report_settings.html
+msgid "Show settings"
+msgstr ""
+
+#: rocky/templates/partials/elements/ooi_detail_settings.html
+#: rocky/templates/partials/elements/ooi_report_settings.html
+msgid "Hide settings"
+msgstr ""
+
+#: rocky/templates/partials/elements/ooi_list_settings_form.html
+msgid "Toggle all OOI types"
+msgstr ""
+
+#: rocky/templates/partials/elements/ooi_tree_condensed_table.html
+msgid "Children"
+msgstr ""
+
+#: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
+#, python-format
+msgid "Show details for %(object_id)s, with %(child_count)s children."
+msgstr ""
+
+#: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
+#, python-format
+msgid ""
+"Show tree for %(object_id)s with only children of type %(object_ooi_type)s"
+msgstr ""
+
+#: rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
+#, python-format
+msgid "Unfold %(object_id)s with %(child_count)s children"
+msgstr ""
+
+#: rocky/templates/partials/elements/ooi_tree_table.html
+msgid "go to:"
+msgstr ""
+
+#: rocky/templates/partials/elements/ooi_tree_table.html
+msgid "Go to detailpage"
+msgstr ""
+
+#: rocky/templates/partials/elements/ooi_tree_table.html
+msgid "detail"
+msgstr ""
+
+#: rocky/templates/partials/elements/ooi_tree_table.html
+msgid "Go to tree view"
+msgstr ""
+
+#: rocky/templates/partials/elements/ooi_tree_table.html
+msgid "tree"
+msgstr ""
+
+#: rocky/templates/partials/elements/ooi_tree_table.html
+msgid "Go to graph view"
+msgstr ""
+
+#: rocky/templates/partials/elements/ooi_tree_table.html
+msgid "graph"
+msgstr ""
+
+#: rocky/templates/partials/explanations.html
+msgid "Clearance level inheritance"
+msgstr ""
+
+#: rocky/templates/partials/explanations.html
+msgid "OOI"
+msgstr ""
+
+#: rocky/templates/partials/explanations.html
+msgid "This OOI"
+msgstr ""
+
+#: rocky/templates/partials/explanations.html
+msgid "Origin"
+msgstr ""
+
+#: rocky/templates/partials/explanations.html
+msgid "declared"
+msgstr ""
+
+#: rocky/templates/partials/explanations.html
+msgid "inherited from ↓"
+msgstr ""
+
+#: rocky/templates/partials/explanations.html
+msgid "Show clearance level inheritance"
+msgstr ""
+
+#: rocky/templates/partials/finding_occurrence_definition_list.html
+msgid "Reproduction"
+msgstr ""
+
+#: rocky/templates/partials/form/checkbox_group_table_form.html
+msgid "Please enable plugin to start scanning."
+msgstr ""
+
+#: rocky/templates/partials/form/field_input.html
+msgid "Not set"
+msgstr ""
+
+#: rocky/templates/partials/form/field_input.html
+msgid "Forgot email"
+msgstr ""
+
+#: rocky/templates/partials/form/field_input.html
+msgid "Forgot password"
+msgstr ""
+
+#: rocky/templates/partials/form/field_input_errors.html
+#: rocky/templates/partials/notifications_block.html
+msgid "error"
+msgstr ""
+
+#: rocky/templates/partials/form/field_input_errors.html
+#: rocky/templates/partials/form/form_errors.html
+#: rocky/templates/partials/notifications_block.html
+msgid "Error:"
+msgstr ""
+
+#: rocky/templates/partials/form/field_input_help_text.html
+msgid "Open explanation"
+msgstr ""
+
+#: rocky/templates/partials/form/field_input_help_text.html
+msgid "Close explanation"
+msgstr ""
+
+#: rocky/templates/partials/form/field_input_help_text.html
+#: rocky/templates/partials/notifications_block.html
+#: rocky/templates/two_factor/core/login.html
+msgid "Explanation:"
+msgstr ""
+
+#: rocky/templates/partials/form/indemnification_add_form.html
+msgid ""
+"Performing security scans against assets is generally only allowed if you "
+"have permission to scan those assets. Certain scans might also have a "
+"negative impact on (your) assets. Therefore it is important to know and be "
+"aware of the impact of security scans."
+msgstr ""
+
+#: rocky/templates/partials/form/indemnification_add_form.html
+msgid ""
+"An organization indemnification is required before you can use OpenKAT. With "
+"the indemnification you declare that you, as a person, can be held "
+"accountable."
+msgstr ""
+
+#: rocky/templates/partials/form/indemnification_add_form.html
+msgid "Set an indemnification"
+msgstr ""
+
+#: rocky/templates/partials/hyperlink_ooi_type.html
+#, python-format
+msgid "Only show objects of type %(type)s"
+msgstr ""
+
+#: rocky/templates/partials/list_filters.html
+msgid "Hide filter options"
+msgstr ""
+
+#: rocky/templates/partials/list_filters.html
+msgid "Show filter options"
+msgstr ""
+
+#: rocky/templates/partials/list_paginator.html
+msgid "List pagination"
+msgstr ""
+
+#: rocky/templates/partials/list_paginator.html
+msgid "Previous Page"
+msgstr ""
+
+#: rocky/templates/partials/list_paginator.html
+msgid "Previous"
+msgstr ""
+
+#: rocky/templates/partials/list_paginator.html
+msgid "Five Pages Back"
+msgstr ""
+
+#: rocky/templates/partials/list_paginator.html
+#: rocky/templates/partials/pagination.html
+msgid "Page"
+msgstr ""
+
+#: rocky/templates/partials/list_paginator.html
+msgid "Current"
+msgstr ""
+
+#: rocky/templates/partials/list_paginator.html
+msgid "Five Pages Forward"
+msgstr ""
+
+#: rocky/templates/partials/list_paginator.html
+msgid "Next Page"
+msgstr ""
+
+#: rocky/templates/partials/list_paginator.html
+msgid "Next"
+msgstr ""
+
+#: rocky/templates/partials/mute_findings_modal.html
+msgid "You are muting the selected findings."
+msgstr ""
+
+#: rocky/templates/partials/mute_findings_modal.html
+msgid "Reason:"
+msgstr ""
+
+#: rocky/templates/partials/mute_findings_modal.html
+msgid "Expires by (UTC):"
+msgstr ""
+
+#: rocky/templates/partials/notifications_block.html
+msgid "Confirmation:"
+msgstr ""
+
+#: rocky/templates/partials/ooi_detail_related_object.html
+msgid "No related object known for"
+msgstr ""
+
+#: rocky/templates/partials/ooi_detail_toolbar.html
+msgid "Generate Report"
+msgstr ""
+
+#: rocky/templates/partials/ooi_detail_toolbar.html
+#, python-format
+msgid "Edit %(display_type)s"
+msgstr ""
+
+#: rocky/templates/partials/ooi_head.html
+msgid "Data from:"
+msgstr ""
+
+#: rocky/templates/partials/ooi_head.html
+msgid "(Now)"
+msgstr ""
+
+#: rocky/templates/partials/ooi_list_toolbar.html
+msgid "Scan for objects"
+msgstr ""
+
+#: rocky/templates/partials/ooi_list_toolbar.html
+#: rocky/templates/upload_csv.html rocky/views/upload_csv.py
+msgid "Upload CSV"
+msgstr ""
+
+#: rocky/templates/partials/ooi_list_toolbar.html
+msgid "Export"
+msgstr ""
+
+#: rocky/templates/partials/ooi_list_toolbar.html
+msgid "Download as CSV"
+msgstr ""
+
+#: rocky/templates/partials/ooi_report_findings_block.html
+#, python-format
+msgid "%(total)s findings on %(name)s"
+msgstr ""
+
+#: rocky/templates/partials/ooi_report_findings_block_table.html
+#, python-format
+msgid "Findings for %(type)s %(name)s on %(observed_at)s:"
+msgstr ""
+
+#: rocky/templates/partials/ooi_report_findings_block_table.html
+msgid "Open finding details"
+msgstr ""
+
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+#, python-format
+msgid "Details of %(object_id)s"
+msgstr ""
+
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid ""
+"The severity of this findingtype has not (yet) been determined by the data "
+"source. This situation requires manual investigation of the severity."
+msgstr ""
+
+#: rocky/templates/partials/ooi_report_findings_block_table_expanded_row.html
+msgid "Total occurrences"
+msgstr ""
+
+#: rocky/templates/partials/ooi_tree_toolbar_bottom.html
+msgid "Tree - dense view"
+msgstr ""
+
+#: rocky/templates/partials/ooi_tree_toolbar_bottom.html
+msgid "Tree - table view"
+msgstr ""
+
+#: rocky/templates/partials/organization_member_list_filters.html
+msgid "Update List"
+msgstr ""
+
+#: rocky/templates/partials/organization_properties_table.html
+msgid "Organization name"
+msgstr ""
+
+#: rocky/templates/partials/organization_properties_table.html
+msgid "Organization code"
+msgstr ""
+
+#: rocky/templates/partials/organizations_menu_dropdown.html
+msgid "Select organization"
+msgstr ""
+
+#: rocky/templates/partials/organizations_menu_dropdown.html
+msgid "All organizations"
+msgstr ""
+
+#: rocky/templates/partials/page-meta.html
+msgid "Logged in as:"
+msgstr ""
+
+#: rocky/templates/partials/pagination.html
+msgid "of"
+msgstr ""
+
+#: rocky/templates/partials/pagination.html
+msgid "first"
+msgstr ""
+
+#: rocky/templates/partials/pagination.html
+msgid "previous"
+msgstr ""
+
+#: rocky/templates/partials/pagination.html
+msgid "next"
+msgstr ""
+
+#: rocky/templates/partials/pagination.html
+msgid "last"
+msgstr ""
+
+#: rocky/templates/partials/secondary-menu.html
+msgid "User navigation"
+msgstr ""
+
+#: rocky/templates/partials/secondary-menu.html
+msgid "Close user navigation"
+msgstr ""
+
+#: rocky/templates/partials/secondary-menu.html
+msgid "My organizations"
+msgstr ""
+
+#: rocky/templates/partials/secondary-menu.html
+msgid "Profile"
+msgstr ""
+
+#: rocky/templates/partials/skip-to-content.html
+msgid "Go to content"
+msgstr ""
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid ""
+"The clearance level determines the level of boefje scans allowed on this "
+"object. An object inherits its clearance level from neighbouring objects. "
+"This means that the clearance level might stay the same, increase or "
+"decrease, depending on other declared clearance levels."
+msgstr ""
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Empty clearance level explanation"
+msgstr ""
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Empty:"
+msgstr ""
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid ""
+"This object has a clearance level of \"empty\". This means that this object "
+"has no clearance level."
+msgstr ""
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Indemnification warning"
+msgstr ""
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Indemnification is not set for this organization."
+msgstr ""
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Go to the"
+msgstr ""
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "organization settings page"
+msgstr ""
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "to add one."
+msgstr ""
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Set clearance level warning"
+msgstr ""
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid ""
+"You don't have permissions to set the clearance level. Contact your "
+"administrator."
+msgstr ""
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+#, python-format
+msgid ""
+"You are not allowed to set the clearance level of this OOI. Your maximum "
+"clearance level is %(member_clearance_level)s and this OOI has level "
+"%(boefje_scan_level)s."
+msgstr ""
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Go to your"
+msgstr ""
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "account details"
+msgstr ""
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "to manage your clearance level."
+msgstr ""
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Current clearance level"
+msgstr ""
+
+#: rocky/templates/tasks/boefje_task_detail.html
+msgid ""
+"An overview of the boefje task, the input OOI and the RAW data it generated."
+msgstr ""
+
+#: rocky/templates/tasks/boefje_task_detail.html
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Download meta and raw data"
+msgstr ""
+
+#: rocky/templates/tasks/boefje_task_detail.html
+msgid "Download meta data"
+msgstr ""
+
+#: rocky/templates/tasks/boefje_task_detail.html
+msgid "Input object"
+msgstr ""
+
+#: rocky/templates/tasks/boefjes.html
+msgid "There are no tasks for boefjes."
+msgstr ""
+
+#: rocky/templates/tasks/boefjes.html
+msgid "List of tasks for boefjes."
+msgstr ""
+
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/reports.html
+msgid "Organization Code"
+msgstr ""
+
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
+#: rocky/templates/tasks/ooi_detail_task_list.html
+#: rocky/templates/tasks/plugin_detail_task_list.html
+msgid "Created date"
+msgstr ""
+
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
+#: rocky/templates/tasks/reports.html
+msgid "Modified date"
+msgstr ""
+
+#: rocky/templates/tasks/normalizers.html
+msgid "There are no tasks for normalizers."
+msgstr ""
+
+#: rocky/templates/tasks/normalizers.html
+msgid "List of tasks for normalizers."
+msgstr ""
+
+#: rocky/templates/tasks/normalizers.html
+msgid "Boefje input OOI"
+msgstr ""
+
+#: rocky/templates/tasks/normalizers.html
+msgid "Manually added"
+msgstr ""
+
+#: rocky/templates/tasks/ooi_detail_task_list.html
+msgid "There have been no tasks."
+msgstr ""
+
+#: rocky/templates/tasks/partials/stats.html
+msgid "Task statistics - Last 24 hours"
+msgstr ""
+
+#: rocky/templates/tasks/partials/stats.html
+msgid "All times in UTC, blocks of 1 hour."
+msgstr ""
+
+#: rocky/templates/tasks/partials/stats.html
+msgid "Timeslot"
+msgstr ""
+
+#: rocky/templates/tasks/partials/stats.html
+msgid "Could not load stats, Scheduler error."
+msgstr ""
+
+#: rocky/templates/tasks/partials/tab_navigation.html
+msgid "List of tasks"
+msgstr ""
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Loading..."
+msgstr ""
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Yielded objects"
+msgstr ""
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Yielded raw files"
+msgstr ""
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Reschedule"
+msgstr ""
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Download task data"
+msgstr ""
+
+#: rocky/templates/tasks/partials/tasks_overview_header.html
+#, python-format
+msgid ""
+"An overview of the tasks for <strong>%(organization)s</strong>. Tasks are "
+"divided in Boefjes, Normalizers and Reports. Boefjes scan objects and "
+"Normalizers dispatch on the output mime-type. Additionally, there is a "
+"Report tasks. This task aggregates and presents findings from both Boefjes "
+"and Normalizers."
+msgstr ""
+
+#: rocky/templates/tasks/plugin_detail_task_list.html
+msgid "There are no tasks for"
+msgstr ""
+
+#: rocky/templates/tasks/plugin_detail_task_list.html
+msgid "List of tasks for"
+msgstr ""
+
+#: rocky/templates/tasks/reports.html
+msgid "There are no tasks for reports."
+msgstr ""
+
+#: rocky/templates/tasks/reports.html
+msgid "List of tasks for reports."
+msgstr ""
+
+#: rocky/templates/tasks/reports.html
+msgid "Recipe ID"
+msgstr ""
+
+#: rocky/templates/two_factor/_wizard_actions.html
+msgid "Log in"
+msgstr ""
+
+#: rocky/templates/two_factor/_wizard_actions.html
+msgid "Authenticate"
+msgstr ""
+
+#: rocky/templates/two_factor/core/backup_tokens.html
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Backup Tokens"
+msgstr ""
+
+#: rocky/templates/two_factor/core/backup_tokens.html
+msgid ""
+"Backup tokens can be used when your primary and backup phone numbers aren't "
+"available. The backup tokens below can be used for login verification. If "
+"you've used up all your backup tokens, you can generate a new set of backup "
+"tokens. Only the backup tokens shown below will be valid."
+msgstr ""
+
+#: rocky/templates/two_factor/core/backup_tokens.html
+msgid "Print these tokens and keep them somewhere safe."
+msgstr ""
+
+#: rocky/templates/two_factor/core/backup_tokens.html
+msgid "You don't have any backup codes yet."
+msgstr ""
+
+#: rocky/templates/two_factor/core/backup_tokens.html
+msgid "Generate Tokens"
+msgstr ""
+
+#: rocky/templates/two_factor/core/backup_tokens.html
+#: rocky/templates/two_factor/core/setup_complete.html
+msgid "Back to Account Security"
+msgstr ""
+
+#: rocky/templates/two_factor/core/login.html
+msgid "You are logged in."
+msgstr ""
+
+#: rocky/templates/two_factor/core/login.html
+msgid "Two factor authentication is enabled for your account."
+msgstr ""
+
+#: rocky/templates/two_factor/core/login.html
+msgid ""
+"Two factor authentication is not enabled for your account. Enable it to "
+"continue."
+msgstr ""
+
+#: rocky/templates/two_factor/core/login.html
+msgid "Setup two factor authentication"
+msgstr ""
+
+#: rocky/templates/two_factor/core/login.html
+msgid "Credentials"
+msgstr ""
+
+#: rocky/templates/two_factor/core/login.html
+msgid ""
+"Use this form for entering backup tokens for logging in. These tokens have "
+"been generated for you to print and keep safe. Please enter one of these "
+"backup tokens to login to your account."
+msgstr ""
+
+#: rocky/templates/two_factor/core/login.html
+msgid "As a last resort, you can use a backup token:"
+msgstr ""
+
+#: rocky/templates/two_factor/core/login.html
+msgid "Use Backup Token"
+msgstr ""
+
+#: rocky/templates/two_factor/core/otp_required.html
+msgid "Permission Denied"
+msgstr ""
+
+#: rocky/templates/two_factor/core/otp_required.html
+msgid ""
+"The page you requested, enforces users to verify using two-factor "
+"authentication for security reasons. You need to enable these security "
+"features in order to access this page."
+msgstr ""
+
+#: rocky/templates/two_factor/core/otp_required.html
+#: rocky/templates/two_factor/profile/profile.html
+msgid ""
+"Two-factor authentication is not enabled for your account. Enable two-factor "
+"authentication for enhanced account security."
+msgstr ""
+
+#: rocky/templates/two_factor/core/otp_required.html
+#: rocky/templates/two_factor/core/setup.html
+#: rocky/templates/two_factor/core/setup_complete.html
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Enable Two-Factor Authentication"
+msgstr ""
+
+#: rocky/templates/two_factor/core/phone_register.html
+msgid "Add Backup Phone"
+msgstr ""
+
+#: rocky/templates/two_factor/core/phone_register.html
+msgid ""
+"You'll be adding a backup phone number to your account. This number will be "
+"used if your primary method of registration is not available."
+msgstr ""
+
+#: rocky/templates/two_factor/core/phone_register.html
+msgid ""
+"We've sent a token to your phone number. Please enter the token you've "
+"received."
+msgstr ""
+
+#: rocky/templates/two_factor/core/setup.html
+msgid ""
+"To start using a token generator, please use your smartphone to scan the QR "
+"code below or use the setup key. For example, use GoogleAuthenticator. Then, "
+"enter the token generated by the app."
+msgstr ""
+
+#: rocky/templates/two_factor/core/setup.html
+msgid "QR code"
+msgstr ""
+
+#: rocky/templates/two_factor/core/setup.html
+msgid "Setup key"
+msgstr ""
+
+#: rocky/templates/two_factor/core/setup.html
+msgid ""
+"The secret key is a 32 characters representation of the QR code. There are 2 "
+"options to setup the two factor authtentication. You can scan the QR code "
+"above or you can insert this key using the secret key option of the "
+"authenticator app."
+msgstr ""
+
+#: rocky/templates/two_factor/core/setup_complete.html
+msgid "Congratulations, you've successfully enabled two-factor authentication."
+msgstr ""
+
+#: rocky/templates/two_factor/core/setup_complete.html
+msgid "Start using OpenKAT"
+msgstr ""
+
+#: rocky/templates/two_factor/core/setup_complete.html
+msgid ""
+"However, it might happen that you don't have access to your primary token "
+"device. To enable account recovery, add a phone number."
+msgstr ""
+
+#: rocky/templates/two_factor/core/setup_complete.html
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Add Phone Number"
+msgstr ""
+
+#: rocky/templates/two_factor/profile/disable.html
+msgid "Disable Two-factor Authentication"
+msgstr ""
+
+#: rocky/templates/two_factor/profile/disable.html
+msgid ""
+"You are about to disable two-factor authentication. This weakens your "
+"account security, are you sure?"
+msgstr ""
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Account Security"
+msgstr ""
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Tokens will be generated by your token generator."
+msgstr ""
+
+#: rocky/templates/two_factor/profile/profile.html
+#, python-format
+msgid "Primary method: %(primary)s"
+msgstr ""
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Tokens will be generated by your YubiKey."
+msgstr ""
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Backup Phone Numbers"
+msgstr ""
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid ""
+"If your primary method is not available, we are able to send backup tokens "
+"to the phone numbers listed below."
+msgstr ""
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Unregister"
+msgstr ""
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid ""
+"If you don't have any device with you, you can access your account using "
+"backup tokens."
+msgstr ""
+
+#: rocky/templates/two_factor/profile/profile.html
+#, python-format
+msgid "You have only one backup token remaining."
+msgid_plural "You have %(counter)s backup tokens remaining."
+msgstr[0] ""
+msgstr[1] ""
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Show Codes"
+msgstr ""
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid "Disable Two-Factor Authentication"
+msgstr ""
+
+#: rocky/templates/two_factor/profile/profile.html
+msgid ""
+"However we strongly discourage you to do so, you can also disable two-factor "
+"authentication for your account."
+msgstr ""
+
+#: rocky/templates/two_factor/twilio/sms_message.html
+#, python-format
+msgid "Your OTP token is %(token)s"
+msgstr ""
+
+#: rocky/templates/upload_csv.html
+msgid "Automate the creation of multiple objects by uploading a CSV file."
+msgstr ""
+
+#: rocky/templates/upload_csv.html
+msgid "These are the criteria for CSV upload:"
+msgstr ""
+
+#: rocky/templates/upload_raw.html
+msgid "Automate the creation of multiple objects by uploading a raw file."
+msgstr ""
+
+#: rocky/templates/upload_raw.html
+msgid ""
+"An input OOI can be selected for the normalizer to attach newly yielded OOIs "
+"to. If no input OOI was used for the raw file, a placeholder ExternalScan "
+"OOI can be used. ExternalScan OOIs can be created from the objects page. "
+"When a new version of the raw file is generated, the same ExternalScan OOI "
+"should be chosen to ensure that old results are overwritten."
+msgstr ""
+
+#: rocky/templates/upload_raw.html rocky/views/upload_raw.py
+msgid "Upload raw"
+msgstr ""
+
+#: rocky/views/bytes_raw.py
+msgid "Getting raw data failed."
+msgstr ""
+
+#: rocky/views/bytes_raw.py
+msgid "The task does not have any raw data."
+msgstr ""
+
+#: rocky/views/finding_list.py rocky/views/ooi_list.py
+msgid "Unknown action."
+msgstr ""
+
+#: rocky/views/health.py
+msgid "Beautified"
+msgstr ""
+
+#: rocky/views/indemnification_add.py
+msgid "Indemnification successfully set."
+msgstr ""
+
+#: rocky/views/mixins.py
+msgid "The selected date is in the future."
+msgstr ""
+
+#: rocky/views/mixins.py
+msgid "Can not parse date, falling back to show current date."
+msgstr ""
+
+#: rocky/views/mixins.py
+#, python-format
+msgid "Could not load origins for OOI: %s from octopoes"
+msgstr ""
+
+#: rocky/views/mixins.py
+msgid "Could not load normalizer metas from bytes"
+msgstr ""
+
+#: rocky/views/mixins.py
+#, python-format
+msgid "Could not load boefje %s from katalogus"
+msgstr ""
+
+#: rocky/views/mixins.py
+msgid "You do not have the permission to add items to a dashboard."
+msgstr ""
+
+#: rocky/views/mixins.py
+msgid "Dashboard item has been added."
+msgstr ""
+
+#: rocky/views/ooi_add.py
+#, python-format
+msgid "Add %(ooi_type)s"
+msgstr ""
+
+#: rocky/views/ooi_detail.py
+msgid ""
+"Cannot set clearance level. It must be provided and must be a valid number."
+msgstr ""
+
+#: rocky/views/ooi_detail.py
+msgid "Only Question OOIs can be answered."
+msgstr ""
+
+#: rocky/views/ooi_detail.py
+msgid "Question has been answered."
+msgstr ""
+
+#: rocky/views/ooi_detail_related_object.py
+msgid " (as "
+msgstr ""
+
+#: rocky/views/ooi_findings.py
+msgid "Object findings"
+msgstr ""
+
+#: rocky/views/ooi_list.py
+msgid "No OOIs selected."
+msgstr ""
+
+#: rocky/views/ooi_list.py
+#, python-format
+msgid ""
+"Could not raise clearance levels to L%s. Indemnification not present at "
+"organization %s."
+msgstr ""
+
+#: rocky/views/ooi_list.py
+#, python-format
+msgid ""
+"Could not raise clearance level to L%s. You were trusted a clearance level "
+"of L%s. Contact your administrator to receive a higher clearance."
+msgstr ""
+
+#: rocky/views/ooi_list.py
+#, python-format
+msgid ""
+"Could not raise clearance level to L%s. You acknowledged a clearance level "
+"of L%s. Please accept the clearance level below to proceed."
+msgstr ""
+
+#: rocky/views/ooi_list.py
+msgid "An error occurred while saving clearance levels."
+msgstr ""
+
+#: rocky/views/ooi_list.py
+msgid "One of the OOI's doesn't exist"
+msgstr ""
+
+#: rocky/views/ooi_list.py
+#, python-format
+msgid "Successfully set scan profile to %s for %d OOIs."
+msgstr ""
+
+#: rocky/views/ooi_list.py
+msgid "An error occurred while setting clearance levels to inherit."
+msgstr ""
+
+#: rocky/views/ooi_list.py
+msgid ""
+"An error occurred while setting clearance levels to inherit: one of the OOIs "
+"doesn't exist."
+msgstr ""
+
+#: rocky/views/ooi_list.py
+#, python-format
+msgid "Successfully set %d OOI(s) clearance level to inherit."
+msgstr ""
+
+#: rocky/views/ooi_list.py
+msgid "An error occurred while deleting oois."
+msgstr ""
+
+#: rocky/views/ooi_list.py
+msgid "An error occurred while deleting OOIs: one of the OOIs doesn't exist."
+msgstr ""
+
+#: rocky/views/ooi_list.py
+#, python-format
+msgid ""
+"Successfully deleted %d ooi(s). Note: Bits can recreate objects "
+"automatically."
+msgstr ""
+
+#: rocky/views/ooi_mute.py
+msgid "Please select at least one finding."
+msgstr ""
+
+#: rocky/views/ooi_mute.py
+msgid "Finding(s) successfully unmuted."
+msgstr ""
+
+#: rocky/views/ooi_mute.py
+msgid "Finding(s) successfully muted."
+msgstr ""
+
+#: rocky/views/ooi_tree.py
+msgid "Tree Visualisation"
+msgstr ""
+
+#: rocky/views/ooi_tree.py
+msgid "Graph Visualisation"
+msgstr ""
+
+#: rocky/views/ooi_view.py
+msgid "Observed_at: "
+msgstr ""
+
+#: rocky/views/ooi_view.py
+msgid "OOI types: "
+msgstr ""
+
+#: rocky/views/ooi_view.py
+msgid "Clearance level: "
+msgstr ""
+
+#: rocky/views/ooi_view.py
+msgid "Clearance type: "
+msgstr ""
+
+#: rocky/views/ooi_view.py
+msgid "Searching for: "
+msgstr ""
+
+#: rocky/views/organization_add.py
+msgid "Setup"
+msgstr ""
+
+#: rocky/views/organization_add.py
+msgid "Organization added successfully."
+msgstr ""
+
+#: rocky/views/organization_add.py
+msgid "You are not allowed to add organizations."
+msgstr ""
+
+#: rocky/views/organization_edit.py
+#, python-format
+msgid "Organization %s successfully updated."
+msgstr ""
+
+#: rocky/views/organization_member_add.py
+msgid "Add column titles, followed by each object on a new line."
+msgstr ""
+
+#: rocky/views/organization_member_add.py
+msgid "The columns are: "
+msgstr ""
+
+#: rocky/views/organization_member_add.py
+msgid "Clearance levels should be between -1 and 4."
+msgstr ""
+
+#: rocky/views/organization_member_add.py
+msgid "Account type can be one of: "
+msgstr ""
+
+#: rocky/views/organization_member_add.py
+msgid "Member added successfully."
+msgstr ""
+
+#: rocky/views/organization_member_add.py
+msgid "The csv file is missing required columns"
+msgstr ""
+
+#: rocky/views/organization_member_add.py
+#, python-brace-format
+msgid "Invalid account type: '{account_type}'"
+msgstr ""
+
+#: rocky/views/organization_member_add.py
+#, python-brace-format
+msgid "Invalid data for: '{email}'"
+msgstr ""
+
+#: rocky/views/organization_member_add.py
+#, python-brace-format
+msgid "Invalid email address: '{email}'"
+msgstr ""
+
+#: rocky/views/organization_member_add.py
+msgid "Successfully processed users from csv."
+msgstr ""
+
+#: rocky/views/organization_member_add.py
+msgid "Error parsing the csv file. Please verify its contents."
+msgstr ""
+
+#: rocky/views/organization_member_edit.py
+#, python-format
+msgid "Member %s successfully updated."
+msgstr ""
+
+#: rocky/views/organization_member_edit.py
+#, python-format
+msgid ""
+"The updated trusted clearance level of L%s is lower then the member's "
+"acknowledged clearance level of L%s. This member only has clearance for "
+"level L%s. For this reason the acknowledged clearance level has been set at "
+"the same level as trusted clearance level."
+msgstr ""
+
+#: rocky/views/organization_member_edit.py
+msgid ""
+"You have trusted this member with a higher trusted level than member "
+"acknowledged. Member must first accept this level to use it."
+msgstr ""
+
+#: rocky/views/organization_member_list.py
+#, python-format
+msgid "Blocked member %s successfully."
+msgstr ""
+
+#: rocky/views/organization_member_list.py
+#, python-format
+msgid "Unblocked member %s successfully."
+msgstr ""
+
+#: rocky/views/organization_settings.py
+#, python-brace-format
+msgid "Recalculated {number_of_bits} bits. Duration: {duration}"
+msgstr ""
+
+#: rocky/views/page_actions.py
+msgid "Could not process your request, action required."
+msgstr ""
+
+#: rocky/views/scan_profile.py
+msgid ""
+"Cannot set clearance level. The clearance type must be inherited or declared."
+msgstr ""
+
+#: rocky/views/scans.py
+msgid "Scans"
+msgstr ""
+
+#: rocky/views/scheduler.py
+msgid "Your report has been scheduled."
+msgstr ""
+
+#: rocky/views/scheduler.py
+msgid ""
+"Your task is scheduled and will soon be started in the background. Results "
+"will be added to the object list when they are in. It may take some time, a "
+"refresh of the page may be needed to show the results."
+msgstr ""
+
+#: rocky/views/tasks.py
+#, python-brace-format
+msgid "Fetching tasks failed: no connection with scheduler: {error}"
+msgstr ""
+
+#: rocky/views/tasks.py
+msgid "All Tasks"
+msgstr ""
+
+#: rocky/views/upload_csv.py
+msgid "Add column titles. Followed by each object on a new line."
+msgstr ""
+
+#: rocky/views/upload_csv.py
+msgid ""
+"For URL object type, a column 'raw' with URL values is required, starting "
+"with http:// or https://, optionally a second column 'network' is supported "
+msgstr ""
+
+#: rocky/views/upload_csv.py
+msgid ""
+"For Hostname object type, a column with 'name' values is required, "
+"optionally a second column 'network' is supported "
+msgstr ""
+
+#: rocky/views/upload_csv.py
+msgid ""
+"For IPAddressV4 and IPAddressV6 object types, a column of 'address' is "
+"required, optionally a second column 'network' is supported "
+msgstr ""
+
+#: rocky/views/upload_csv.py
+msgid ""
+"Clearance levels can be controlled by a column 'clearance' taking numerical "
+"values 0, 1, 2, 3, and 4 for the corresponding clearance level (other values "
+"are ignored) "
+msgstr ""
+
+#: rocky/views/upload_csv.py
+msgid "Object(s) could not be created for row number(s): "
+msgstr ""
+
+#: rocky/views/upload_csv.py
+msgid "Object(s) successfully added."
+msgstr ""
+
+#: rocky/views/upload_raw.py
+#, python-format
+msgid "Raw file could not be uploaded to Bytes: status code %d"
+msgstr ""
+
+#: rocky/views/upload_raw.py
+#, python-format
+msgid "Raw file could not be uploaded to Bytes: %s"
+msgstr ""
+
+#: rocky/views/upload_raw.py
+msgid "Raw file successfully added."
+msgstr ""

--- a/rocky/rocky/settings.py
+++ b/rocky/rocky/settings.py
@@ -341,7 +341,7 @@ LANG_INFO = locale.LANG_INFO.copy()
 LANG_INFO.update(EXTRA_LANG_INFO)
 locale.LANG_INFO = LANG_INFO
 
-LANGUAGES = [("en", "en"), ("nl", "nl"), ("pap", "pap"), ("it", "it"), ("fy", "fy")]
+LANGUAGES = [("en", "en"), ("nl", "nl"), ("pap", "pap"), ("it", "it"), ("fy", "fy"), ("pl", "pl")]
 
 if env.bool("PIRATE", False):
     LANGUAGE_CODE = "en@pirate"


### PR DESCRIPTION
## Summary
- add Polish (pl) to the supported OpenKAT languages
- add a fully populated initial Polish gettext catalog based on the current template

## Validation
- msgfmt --statistics --check-format -c -o /tmp/openkat-pl.mo rocky/rocky/locale/pl/LC_MESSAGES/django.po
- msgattrib --untranslated rocky/rocky/locale/pl/LC_MESSAGES/django.po
- custom placeholder/newline consistency check for msgid/msgstr and plural forms

Note: this is an initial machine-generated Polish translation and should be reviewed in Weblate for wording quality.