### PR TITLE
Fix vulnerability report HTTP header findings

### DIFF
--- a/rocky/reports/report_types/vulnerability_report/report.py
+++ b/rocky/reports/report_types/vulnerability_report/report.py
@@ -4,12 +4,23 @@ from datetime import datetime
 from typing import Any, TypedDict
 
 from django.utils.translation import gettext_lazy as _
-
 from octopoes.models import Reference
 from octopoes.models.ooi.dns.zone import Hostname
 from octopoes.models.ooi.findings import Finding, FindingType, KATFindingType, RiskLevelSeverity
 from octopoes.models.ooi.network import IPAddressV4, IPAddressV6
+
 from reports.report_types.definitions import Report
+
+PORT_FINDINGS_PATH = "IPAddress.<address[is IPPort].<ooi[is Finding]"
+SOFTWARE_INSTANCE_FINDINGS_PATH = (
+    "IPAddress.<address [is ResolvedHostname].hostname.<netloc [is HostnameHTTPURL]"
+    ".<ooi [is SoftwareInstance].<ooi [is Finding]"
+)
+HTTP_HEADER_FINDINGS_PATH = (
+    "IPAddress.<address[is IPPort].<ip_port [is IPService].<ip_service [is Website]"
+    ".<website [is HTTPResource].<resource [is HTTPHeader].<ooi [is Finding]"
+)
+FINDING_PATHS = (PORT_FINDINGS_PATH, SOFTWARE_INSTANCE_FINDINGS_PATH, HTTP_HEADER_FINDINGS_PATH)
 
 
 class FindingsData(TypedDict):
@@ -130,57 +141,59 @@ class VulnerabilityReport(Report):
 
         return result
 
+    @staticmethod
+    def is_included_vulnerability(finding: Finding) -> bool:
+        """Keep the report's existing policy of excluding KAT compliance findings."""
+        return finding.finding_type.class_type != KATFindingType
+
     def get_findings(self, input_oois: Iterable[Reference], valid_time: datetime) -> dict:
         ips_by_input_ooi = self.to_ips(input_oois, valid_time)
-        all_ips = list({ip for key, ips in ips_by_input_ooi.items() for ip in ips})
+        all_ips = list(dict.fromkeys(ip for ips in ips_by_input_ooi.values() for ip in ips))
 
-        port_finding_types = self.group_finding_types_by_source(
-            self.octopoes_api_connector.query_many(
-                "IPAddress.<address[is IPPort].<ooi[is Finding].finding_type", valid_time, all_ips
-            )
-        )
-        software_instance_finding_types = self.group_finding_types_by_source(
-            self.octopoes_api_connector.query_many(
-                "IPAddress.<address [is ResolvedHostname].hostname.<netloc [is HostnameHTTPURL]"
-                ".<ooi [is SoftwareInstance].<ooi [is Finding].finding_type",
-                valid_time,
-                all_ips,
-            )
-        )
-        port_findings = self.group_finding_types_by_source(
-            self.octopoes_api_connector.query_many(
-                "IPAddress.<address[is IPPort].<ooi[is Finding]", valid_time, all_ips
-            )
-        )
-        software_instance_findings = self.group_finding_types_by_source(
-            self.octopoes_api_connector.query_many(
-                "IPAddress.<address [is ResolvedHostname].hostname.<netloc [is HostnameHTTPURL]"
-                ".<ooi [is SoftwareInstance].<ooi [is Finding]",
-                valid_time,
-                all_ips,
-            )
+        findings_by_path = [
+            self.group_by_source(self.octopoes_api_connector.query_many(path, valid_time, all_ips))
+            for path in FINDING_PATHS
+        ]
+        findings_by_ip: dict[Reference, list[Finding]] = {}
+
+        for ip in all_ips:
+            # A finding can be reachable through more than one relation path. Deduplicate it before
+            # counting occurrences, and create a fresh collection for every IP to prevent findings
+            # from one address leaking into the next address in the report.
+            unique_findings = {
+                finding.reference: finding
+                for grouped_findings in findings_by_path
+                for finding in grouped_findings.get(str(ip), [])
+                if isinstance(finding, Finding) and self.is_included_vulnerability(finding)
+            }
+            findings_by_ip[ip] = list(unique_findings.values())
+
+        finding_type_references = {finding.finding_type for findings in findings_by_ip.values() for finding in findings}
+        finding_types_by_reference = (
+            self.octopoes_api_connector.load_objects_bulk(finding_type_references, valid_time, with_scan_profiles=False)
+            if finding_type_references
+            else {}
         )
 
         result = {}
         for input_ooi, ip_references in ips_by_input_ooi.items():
             findings_data = {}
-            all_finding_types = []
-            aggregated_findings = []
 
             for ip in ip_references:
-                found_finding_types = port_finding_types.get(ip, []) + software_instance_finding_types.get(ip, [])
+                findings = []
+                finding_types = []
 
-                for finding_type in found_finding_types:
-                    if finding_type.reference.class_type != KATFindingType:
-                        all_finding_types.append(finding_type)
+                for finding in findings_by_ip.get(ip, []):
+                    finding_type = finding_types_by_reference.get(finding.finding_type)
+                    if not isinstance(finding_type, FindingType):
+                        continue
 
-                findings = port_findings.get(ip, []) + software_instance_findings.get(ip, [])
+                    findings.append(finding)
+                    # Keep one finding type entry per finding: collect_data uses this list to count
+                    # occurrences, then deduplicates it for rendering.
+                    finding_types.append(finding_type)
 
-                for finding in findings:
-                    if finding.finding_type.class_type != KATFindingType:
-                        aggregated_findings.append(finding)
-
-                findings_data[ip] = {"finding_types": all_finding_types, "findings": aggregated_findings}
+                findings_data[ip] = {"finding_types": finding_types, "findings": findings}
 
             result[input_ooi] = findings_data
 

--- a/rocky/reports/report_types/vulnerability_report/report.py
+++ b/rocky/reports/report_types/vulnerability_report/report.py
@@ -4,11 +4,11 @@ from datetime import datetime
 from typing import Any, TypedDict
 
 from django.utils.translation import gettext_lazy as _
+
 from octopoes.models import Reference
 from octopoes.models.ooi.dns.zone import Hostname
 from octopoes.models.ooi.findings import Finding, FindingType, KATFindingType, RiskLevelSeverity
 from octopoes.models.ooi.network import IPAddressV4, IPAddressV6
-
 from reports.report_types.definitions import Report
 
 PORT_FINDINGS_PATH = "IPAddress.<address[is IPPort].<ooi[is Finding]"

--- a/rocky/tests/conftest.py
+++ b/rocky/tests/conftest.py
@@ -1396,6 +1396,11 @@ class MockOctopoesAPIConnector:
     ) -> Paginated[OOIType]:
         return Paginated[OOIType](items=list(self.oois.values()), count=len(self.oois))
 
+    def load_objects_bulk(
+        self, references: set[Reference], valid_time: datetime, with_scan_profiles: bool = True
+    ) -> dict[Reference, OOIType]:
+        return {reference: self.oois[reference] for reference in references if reference in self.oois}
+
 
 @pytest.fixture
 def mock_octopoes_api_connector(valid_time):

--- a/rocky/tests/integration/test_reports.py
+++ b/rocky/tests/integration/test_reports.py
@@ -1,17 +1,18 @@
 from dataclasses import asdict
 
+from octopoes.api.models import Declaration
+from octopoes.connector.octopoes import OctopoesAPIConnector
+from octopoes.models import Reference
+from octopoes.models.ooi.findings import CVEFindingType, Finding, KATFindingType, RiskLevelSeverity
+from octopoes.models.ooi.reports import ReportData
 from reports.report_types.aggregate_organisation_report.report import AggregateOrganisationReport
 from reports.report_types.definitions import MultiReport, Report
 from reports.report_types.multi_organization_report.report import MultiOrganizationReport, collect_report_data
 from reports.report_types.systems_report.report import SystemReport, SystemType
+from reports.report_types.vulnerability_report.report import VulnerabilityReport
 from reports.report_types.web_system_report.report import WebSystemReport
 from reports.runner.report_runner import aggregate_reports
 
-from octopoes.api.models import Declaration
-from octopoes.connector.octopoes import OctopoesAPIConnector
-from octopoes.models import Reference
-from octopoes.models.ooi.findings import Finding, KATFindingType, RiskLevelSeverity
-from octopoes.models.ooi.reports import ReportData
 from tests.integration.conftest import seed_system
 
 
@@ -91,6 +92,34 @@ def test_system_report(octopoes_api_connector: OctopoesAPIConnector, valid_time)
     }
 
 
+def test_vulnerability_report_includes_http_header_finding_only_under_observed_ip(
+    octopoes_api_connector: OctopoesAPIConnector, valid_time
+):
+    system = seed_system(octopoes_api_connector, valid_time)
+    finding_type = CVEFindingType(
+        id="CVE-2021-41773",
+        risk_score=9.8,
+        risk_severity=RiskLevelSeverity.CRITICAL,
+        description="Apache path traversal and file disclosure",
+    )
+    finding = Finding(finding_type=finding_type.reference, ooi=system["headers"][0].reference)
+    octopoes_api_connector.save_declaration(Declaration(ooi=finding_type, valid_time=valid_time))
+    octopoes_api_connector.save_declaration(Declaration(ooi=finding, valid_time=valid_time))
+
+    input_ooi = Reference.from_str("Hostname|test|example.com")
+    data = VulnerabilityReport(octopoes_api_connector).collect_data([input_ooi], valid_time)[input_ooi]
+    ipv4 = "IPAddressV4|test|192.0.2.3"
+    ipv6 = "IPAddressV6|test|3e4d:64a2:cb49:bd48:a1ba:def3:d15d:9230"
+
+    assert data[ipv4]["vulnerabilities"]["CVE-2021-41773"]["cvss"] == {
+        "class": "critical",
+        "score": 9.8,
+        "severity": "Critical",
+    }
+    assert data[ipv4]["vulnerabilities"]["CVE-2021-41773"]["occurrences"] == 1
+    assert "CVE-2021-41773" not in data[ipv6]["vulnerabilities"]
+
+
 def test_aggregate_report(octopoes_api_connector: OctopoesAPIConnector, valid_time, hostname_oois, organization):
     seed_system(octopoes_api_connector, valid_time)
 
@@ -149,7 +178,7 @@ def test_aggregate_report(octopoes_api_connector: OctopoesAPIConnector, valid_ti
     }
     assert data["ipv6"] == {"example.com": {"enabled": True, "systems": ["Dicom", "Mail", "Other", "Web"]}}
     assert data["vulnerabilities"]["IPAddressV4|test|192.0.2.3"]["summary"] == {
-        "total_findings": 6,
+        "total_findings": 3,
         "total_criticals": 0,
         "terms": ["CVE-2018-20677", "CVE-2019-8331", "RetireJS-jquerymigrate-f3a3"],
         "recommendations": [],
@@ -157,22 +186,22 @@ def test_aggregate_report(octopoes_api_connector: OctopoesAPIConnector, valid_ti
 
     v4_vulnerabilities = data["vulnerabilities"]["IPAddressV4|test|192.0.2.3"]
     assert v4_vulnerabilities["title"] == "192.0.2.3"
-    assert v4_vulnerabilities["vulnerabilities"]["CVE-2018-20677"]["occurrences"] == 2
-    assert v4_vulnerabilities["vulnerabilities"]["RetireJS-jquerymigrate-f3a3"]["occurrences"] == 2
-    assert v4_vulnerabilities["vulnerabilities"]["CVE-2019-8331"]["occurrences"] == 2
+    assert v4_vulnerabilities["vulnerabilities"]["CVE-2018-20677"]["occurrences"] == 1
+    assert v4_vulnerabilities["vulnerabilities"]["RetireJS-jquerymigrate-f3a3"]["occurrences"] == 1
+    assert v4_vulnerabilities["vulnerabilities"]["CVE-2019-8331"]["occurrences"] == 1
 
     v6_vulnerabilities = data["vulnerabilities"]["IPAddressV6|test|3e4d:64a2:cb49:bd48:a1ba:def3:d15d:9230"]
     assert v6_vulnerabilities["title"] == "3e4d:64a2:cb49:bd48:a1ba:def3:d15d:9230"
     assert v6_vulnerabilities["summary"] == {
-        "total_findings": 6,
+        "total_findings": 3,
         "total_criticals": 0,
         "terms": ["CVE-2018-20677", "CVE-2019-8331", "RetireJS-jquerymigrate-f3a3"],
         "recommendations": [],
     }
     assert v6_vulnerabilities["title"] == "3e4d:64a2:cb49:bd48:a1ba:def3:d15d:9230"
-    assert v6_vulnerabilities["vulnerabilities"]["CVE-2018-20677"]["occurrences"] == 2
-    assert v6_vulnerabilities["vulnerabilities"]["RetireJS-jquerymigrate-f3a3"]["occurrences"] == 2
-    assert v6_vulnerabilities["vulnerabilities"]["CVE-2019-8331"]["occurrences"] == 2
+    assert v6_vulnerabilities["vulnerabilities"]["CVE-2018-20677"]["occurrences"] == 1
+    assert v6_vulnerabilities["vulnerabilities"]["RetireJS-jquerymigrate-f3a3"]["occurrences"] == 1
+    assert v6_vulnerabilities["vulnerabilities"]["CVE-2019-8331"]["occurrences"] == 1
 
     assert data["basic_security"]["summary"]["Dicom"] == {
         "rpki": {"number_of_compliant": 1, "total": 1},

--- a/rocky/tests/integration/test_reports.py
+++ b/rocky/tests/integration/test_reports.py
@@ -1,10 +1,5 @@
 from dataclasses import asdict
 
-from octopoes.api.models import Declaration
-from octopoes.connector.octopoes import OctopoesAPIConnector
-from octopoes.models import Reference
-from octopoes.models.ooi.findings import CVEFindingType, Finding, KATFindingType, RiskLevelSeverity
-from octopoes.models.ooi.reports import ReportData
 from reports.report_types.aggregate_organisation_report.report import AggregateOrganisationReport
 from reports.report_types.definitions import MultiReport, Report
 from reports.report_types.multi_organization_report.report import MultiOrganizationReport, collect_report_data
@@ -13,6 +8,11 @@ from reports.report_types.vulnerability_report.report import VulnerabilityReport
 from reports.report_types.web_system_report.report import WebSystemReport
 from reports.runner.report_runner import aggregate_reports
 
+from octopoes.api.models import Declaration
+from octopoes.connector.octopoes import OctopoesAPIConnector
+from octopoes.models import Reference
+from octopoes.models.ooi.findings import CVEFindingType, Finding, KATFindingType, RiskLevelSeverity
+from octopoes.models.ooi.reports import ReportData
 from tests.integration.conftest import seed_system
 
 
@@ -92,9 +92,7 @@ def test_system_report(octopoes_api_connector: OctopoesAPIConnector, valid_time)
     }
 
 
-def test_vulnerability_report_includes_http_header_finding_only_under_observed_ip(
-    octopoes_api_connector: OctopoesAPIConnector, valid_time
-):
+def test_http_header_cve(octopoes_api_connector: OctopoesAPIConnector, valid_time):
     system = seed_system(octopoes_api_connector, valid_time)
     finding_type = CVEFindingType(
         id="CVE-2021-41773",

--- a/rocky/tests/reports/test_vulnerability_report.py
+++ b/rocky/tests/reports/test_vulnerability_report.py
@@ -1,20 +1,22 @@
-from reports.report_types.vulnerability_report.report import VulnerabilityReport
+from octopoes.models.ooi.findings import Finding
+from reports.report_types.vulnerability_report.report import (
+    FINDING_PATHS,
+    HTTP_HEADER_FINDINGS_PATH,
+    PORT_FINDINGS_PATH,
+    SOFTWARE_INSTANCE_FINDINGS_PATH,
+    VulnerabilityReport,
+)
+
+
+def finding_queries(*ip_references):
+    return {path: {ip: [] for ip in ip_references} for path in FINDING_PATHS}
 
 
 def test_vulnerability_report_no_findings(mock_octopoes_api_connector, valid_time, ipaddressv4):
     mock_octopoes_api_connector.oois = {ipaddressv4.reference: ipaddressv4}
-    mock_octopoes_api_connector.queries = {
-        "IPAddress.<address[is IPPort].<ooi[is Finding]": {ipaddressv4.reference: []},
-        "IPAddress.<address [is ResolvedHostname]"
-        ".hostname.<netloc [is HostnameHTTPURL].<ooi [is SoftwareInstance].<ooi [is Finding]": {
-            ipaddressv4.reference: []
-        },
-        "IPAddress.<address[is IPPort].<ooi[is Finding].finding_type": {ipaddressv4.reference: []},
-        "IPAddress.<address [is ResolvedHostname]"
-        ".hostname.<netloc [is HostnameHTTPURL].<ooi [is SoftwareInstance].<ooi [is Finding].finding_type": {
-            ipaddressv4.reference: []
-        },
-        "IPAddress.<address[is ResolvedHostname].hostname": {ipaddressv4.reference: []},
+    mock_octopoes_api_connector.queries = finding_queries(ipaddressv4.reference)
+    mock_octopoes_api_connector.queries["IPAddress.<address[is ResolvedHostname].hostname"] = {
+        ipaddressv4.reference: []
     }
 
     report = VulnerabilityReport(mock_octopoes_api_connector)
@@ -28,20 +30,17 @@ def test_vulnerability_report_no_findings(mock_octopoes_api_connector, valid_tim
 def test_vulnerability_report_single_finding(
     mock_octopoes_api_connector, valid_time, ipaddressv4, hostname, cve_finding_2019_8331, cve_finding_type_2019_8331
 ):
-    mock_octopoes_api_connector.oois = {hostname.reference: hostname}
-    mock_octopoes_api_connector.queries = {
-        "Hostname.<hostname[is ResolvedHostname].address": {hostname.reference: [ipaddressv4]},
-        "IPAddress.<address[is IPPort].<ooi[is Finding]": {ipaddressv4.reference: []},
-        "IPAddress.<address[is IPPort].<ooi[is Finding].finding_type": {ipaddressv4.reference: []},
-        "IPAddress.<address [is ResolvedHostname]"
-        ".hostname.<netloc [is HostnameHTTPURL].<ooi [is SoftwareInstance].<ooi [is Finding]": {
-            ipaddressv4.reference: [cve_finding_2019_8331]
-        },
-        "IPAddress.<address [is ResolvedHostname]"
-        ".hostname.<netloc [is HostnameHTTPURL].<ooi [is SoftwareInstance].<ooi [is Finding].finding_type": {
-            ipaddressv4.reference: [cve_finding_type_2019_8331]
-        },
+    mock_octopoes_api_connector.oois = {
+        hostname.reference: hostname,
+        cve_finding_type_2019_8331.reference: cve_finding_type_2019_8331,
     }
+    mock_octopoes_api_connector.queries = finding_queries(ipaddressv4.reference)
+    mock_octopoes_api_connector.queries["Hostname.<hostname[is ResolvedHostname].address"] = {
+        hostname.reference: [ipaddressv4]
+    }
+    mock_octopoes_api_connector.queries[SOFTWARE_INSTANCE_FINDINGS_PATH][ipaddressv4.reference] = [
+        cve_finding_2019_8331
+    ]
 
     report = VulnerabilityReport(mock_octopoes_api_connector)
 
@@ -50,6 +49,49 @@ def test_vulnerability_report_single_finding(
     assert data[str(ipaddressv4.reference)]["vulnerabilities"]["CVE-2019-8331"]["cvss"]["score"] == 6.1
     assert data[str(ipaddressv4.reference)]["summary"]["total_criticals"] == 0
     assert data[str(ipaddressv4.reference)]["summary"]["total_findings"] == 1
+
+
+def test_vulnerability_report_includes_http_header_finding(
+    mock_octopoes_api_connector, valid_time, ipaddressv4, hostname, cve_finding_2019_8331, cve_finding_type_2019_8331
+):
+    mock_octopoes_api_connector.oois = {
+        hostname.reference: hostname,
+        cve_finding_type_2019_8331.reference: cve_finding_type_2019_8331,
+    }
+    mock_octopoes_api_connector.queries = finding_queries(ipaddressv4.reference)
+    mock_octopoes_api_connector.queries["Hostname.<hostname[is ResolvedHostname].address"] = {
+        hostname.reference: [ipaddressv4]
+    }
+    mock_octopoes_api_connector.queries[HTTP_HEADER_FINDINGS_PATH][ipaddressv4.reference] = [cve_finding_2019_8331]
+
+    report = VulnerabilityReport(mock_octopoes_api_connector)
+
+    data = report.collect_data([hostname.reference], valid_time)[hostname.reference]
+
+    assert data[str(ipaddressv4.reference)]["vulnerabilities"]["CVE-2019-8331"]["cvss"]["score"] == 6.1
+    assert data[str(ipaddressv4.reference)]["summary"]["total_findings"] == 1
+
+
+def test_vulnerability_report_excludes_kat_findings(
+    mock_octopoes_api_connector, valid_time, ipaddressv4, finding_type_kat_no_spf
+):
+    kat_finding = Finding(ooi=ipaddressv4.reference, finding_type=finding_type_kat_no_spf.reference)
+    mock_octopoes_api_connector.oois = {
+        ipaddressv4.reference: ipaddressv4,
+        finding_type_kat_no_spf.reference: finding_type_kat_no_spf,
+    }
+    mock_octopoes_api_connector.queries = finding_queries(ipaddressv4.reference)
+    mock_octopoes_api_connector.queries["IPAddress.<address[is ResolvedHostname].hostname"] = {
+        ipaddressv4.reference: []
+    }
+    mock_octopoes_api_connector.queries[PORT_FINDINGS_PATH][ipaddressv4.reference] = [kat_finding]
+
+    report = VulnerabilityReport(mock_octopoes_api_connector)
+
+    data = report.collect_data([ipaddressv4.reference], valid_time)[ipaddressv4.reference]
+
+    assert data[str(ipaddressv4.reference)]["vulnerabilities"] == {}
+    assert data[str(ipaddressv4.reference)]["summary"]["total_findings"] == 0
 
 
 def test_vulnerability_report_finding_no_score(
@@ -62,20 +104,19 @@ def test_vulnerability_report_finding_no_score(
     cve_finding_no_score,
     cve_finding_type_no_score,
 ):
-    mock_octopoes_api_connector.oois = {hostname.reference: hostname}
-    mock_octopoes_api_connector.queries = {
-        "Hostname.<hostname[is ResolvedHostname].address": {hostname.reference: [ipaddressv4]},
-        "IPAddress.<address[is IPPort].<ooi[is Finding]": {ipaddressv4.reference: []},
-        "IPAddress.<address[is IPPort].<ooi[is Finding].finding_type": {ipaddressv4.reference: []},
-        "IPAddress.<address [is ResolvedHostname]"
-        ".hostname.<netloc [is HostnameHTTPURL].<ooi [is SoftwareInstance].<ooi [is Finding]": {
-            ipaddressv4.reference: [cve_finding_2023_38408, cve_finding_no_score]
-        },
-        "IPAddress.<address [is ResolvedHostname]"
-        ".hostname.<netloc [is HostnameHTTPURL].<ooi [is SoftwareInstance].<ooi [is Finding].finding_type": {
-            ipaddressv4.reference: [cve_finding_type_2023_38408, cve_finding_type_no_score]
-        },
+    mock_octopoes_api_connector.oois = {
+        hostname.reference: hostname,
+        cve_finding_type_2023_38408.reference: cve_finding_type_2023_38408,
+        cve_finding_type_no_score.reference: cve_finding_type_no_score,
     }
+    mock_octopoes_api_connector.queries = finding_queries(ipaddressv4.reference)
+    mock_octopoes_api_connector.queries["Hostname.<hostname[is ResolvedHostname].address"] = {
+        hostname.reference: [ipaddressv4]
+    }
+    mock_octopoes_api_connector.queries[SOFTWARE_INSTANCE_FINDINGS_PATH][ipaddressv4.reference] = [
+        cve_finding_2023_38408,
+        cve_finding_no_score,
+    ]
 
     report = VulnerabilityReport(mock_octopoes_api_connector)
 
@@ -97,20 +138,19 @@ def test_vulnerability_report_two_findings(
     cve_finding_2019_2019,
     cve_finding_type_2019_2019,
 ):
-    mock_octopoes_api_connector.oois = {hostname.reference: hostname}
-    mock_octopoes_api_connector.queries = {
-        "Hostname.<hostname[is ResolvedHostname].address": {hostname.reference: [ipaddressv4]},
-        "IPAddress.<address[is IPPort].<ooi[is Finding]": {ipaddressv4.reference: []},
-        "IPAddress.<address[is IPPort].<ooi[is Finding].finding_type": {ipaddressv4.reference: []},
-        "IPAddress.<address [is ResolvedHostname]"
-        ".hostname.<netloc [is HostnameHTTPURL].<ooi [is SoftwareInstance].<ooi [is Finding]": {
-            ipaddressv4.reference: [cve_finding_2019_8331, cve_finding_2019_2019]
-        },
-        "IPAddress.<address [is ResolvedHostname]"
-        ".hostname.<netloc [is HostnameHTTPURL].<ooi [is SoftwareInstance].<ooi [is Finding].finding_type": {
-            ipaddressv4.reference: [cve_finding_type_2019_8331, cve_finding_type_2019_2019]
-        },
+    mock_octopoes_api_connector.oois = {
+        hostname.reference: hostname,
+        cve_finding_type_2019_8331.reference: cve_finding_type_2019_8331,
+        cve_finding_type_2019_2019.reference: cve_finding_type_2019_2019,
     }
+    mock_octopoes_api_connector.queries = finding_queries(ipaddressv4.reference)
+    mock_octopoes_api_connector.queries["Hostname.<hostname[is ResolvedHostname].address"] = {
+        hostname.reference: [ipaddressv4]
+    }
+    mock_octopoes_api_connector.queries[SOFTWARE_INSTANCE_FINDINGS_PATH][ipaddressv4.reference] = [
+        cve_finding_2019_8331,
+        cve_finding_2019_2019,
+    ]
 
     report = VulnerabilityReport(mock_octopoes_api_connector)
 
@@ -119,19 +159,14 @@ def test_vulnerability_report_two_findings(
     findings = list(data[str(ipaddressv4.reference)]["vulnerabilities"].values())
     assert findings[0]["cvss"]["score"] > findings[1]["cvss"]["score"]
 
-    mock_octopoes_api_connector.queries = {
-        "Hostname.<hostname[is ResolvedHostname].address": {hostname.reference: [ipaddressv4]},
-        "IPAddress.<address[is IPPort].<ooi[is Finding]": {ipaddressv4.reference: []},
-        "IPAddress.<address[is IPPort].<ooi[is Finding].finding_type": {ipaddressv4.reference: []},
-        "IPAddress.<address [is ResolvedHostname]"
-        ".hostname.<netloc [is HostnameHTTPURL].<ooi [is SoftwareInstance].<ooi [is Finding]": {
-            ipaddressv4.reference: [cve_finding_2019_2019, cve_finding_2019_8331]
-        },
-        "IPAddress.<address [is ResolvedHostname]"
-        ".hostname.<netloc [is HostnameHTTPURL].<ooi [is SoftwareInstance].<ooi [is Finding].finding_type": {
-            ipaddressv4.reference: [cve_finding_type_2019_2019, cve_finding_type_2019_8331]
-        },
+    mock_octopoes_api_connector.queries = finding_queries(ipaddressv4.reference)
+    mock_octopoes_api_connector.queries["Hostname.<hostname[is ResolvedHostname].address"] = {
+        hostname.reference: [ipaddressv4]
     }
+    mock_octopoes_api_connector.queries[SOFTWARE_INSTANCE_FINDINGS_PATH][ipaddressv4.reference] = [
+        cve_finding_2019_2019,
+        cve_finding_2019_8331,
+    ]
 
     report = VulnerabilityReport(mock_octopoes_api_connector)
 
@@ -139,3 +174,44 @@ def test_vulnerability_report_two_findings(
 
     findings = list(data[str(ipaddressv4.reference)]["vulnerabilities"].values())
     assert findings[0]["cvss"]["score"] > findings[1]["cvss"]["score"]
+
+
+def test_vulnerability_report_keeps_findings_isolated_per_ip_and_deduplicates_paths(
+    mock_octopoes_api_connector,
+    valid_time,
+    hostname,
+    ipaddressv4,
+    ipaddressv6,
+    cve_finding_2019_8331,
+    cve_finding_type_2019_8331,
+    cve_finding_2023_38408,
+    cve_finding_type_2023_38408,
+):
+    mock_octopoes_api_connector.oois = {
+        hostname.reference: hostname,
+        cve_finding_type_2019_8331.reference: cve_finding_type_2019_8331,
+        cve_finding_type_2023_38408.reference: cve_finding_type_2023_38408,
+    }
+    mock_octopoes_api_connector.queries = finding_queries(ipaddressv4.reference, ipaddressv6.reference)
+    mock_octopoes_api_connector.queries["Hostname.<hostname[is ResolvedHostname].address"] = {
+        hostname.reference: [ipaddressv4, ipaddressv6]
+    }
+    # The IPv4 finding is deliberately reachable through two paths. It must still count once.
+    mock_octopoes_api_connector.queries[PORT_FINDINGS_PATH][ipaddressv4.reference] = [cve_finding_2019_8331]
+    mock_octopoes_api_connector.queries[SOFTWARE_INSTANCE_FINDINGS_PATH][ipaddressv4.reference] = [
+        cve_finding_2019_8331
+    ]
+    mock_octopoes_api_connector.queries[HTTP_HEADER_FINDINGS_PATH][ipaddressv6.reference] = [cve_finding_2023_38408]
+
+    report = VulnerabilityReport(mock_octopoes_api_connector)
+
+    data = report.collect_data([hostname.reference], valid_time)[hostname.reference]
+    ipv4_data = data[str(ipaddressv4.reference)]
+    ipv6_data = data[str(ipaddressv6.reference)]
+
+    assert set(ipv4_data["vulnerabilities"]) == {"CVE-2019-8331"}
+    assert ipv4_data["vulnerabilities"]["CVE-2019-8331"]["occurrences"] == 1
+    assert ipv4_data["summary"]["total_findings"] == 1
+    assert set(ipv6_data["vulnerabilities"]) == {"CVE-2023-38408"}
+    assert ipv6_data["vulnerabilities"]["CVE-2023-38408"]["occurrences"] == 1
+    assert ipv6_data["summary"]["total_findings"] == 1

--- a/rocky/tests/reports/test_vulnerability_report.py
+++ b/rocky/tests/reports/test_vulnerability_report.py
@@ -1,4 +1,3 @@
-from octopoes.models.ooi.findings import Finding
 from reports.report_types.vulnerability_report.report import (
     FINDING_PATHS,
     HTTP_HEADER_FINDINGS_PATH,
@@ -6,6 +5,8 @@ from reports.report_types.vulnerability_report.report import (
     SOFTWARE_INSTANCE_FINDINGS_PATH,
     VulnerabilityReport,
 )
+
+from octopoes.models.ooi.findings import Finding
 
 
 def finding_queries(*ip_references):


### PR DESCRIPTION
## Summary

- include vulnerability findings attached to `HTTPHeader` objects in the Vulnerability Report
- deduplicate findings that are reachable through multiple relation paths
- keep findings isolated per IP address so counts cannot leak between systems
- bulk-load finding types while preserving the existing exclusion of `KATFindingType`
- add unit and integration regression coverage for HTTP-header CVEs, deduplication, KAT filtering, and IPv4/IPv6 isolation

## Root cause

The report only queried findings attached directly below an IP port or below a software instance reached through a hostname. Findings attached to an HTTP header therefore had no relation path into the report. The existing aggregation also reused mutable lists between IP addresses, which could duplicate counts.

## Impact

CVE and other non-KAT vulnerability findings attached to HTTP headers are now shown under the IP address where the header was observed, with stable occurrence counts.

## Validation

- `7 passed` in the targeted Vulnerability Report test module on PostgreSQL
- repository-pinned pre-commit hooks passed for all changed Python files
- the generated integration-test organization code is 25 characters against a 32-character database limit
- all three Octopoes finding paths parsed and compiled to XTDB queries

This replaces #5257. Its branch could not be updated because the repository ruleset started requiring verified signatures after initial branch creation.

Closes #5203
