### PR TITLE
Backport RDO workflow permission hardening to release-1.18

### DIFF
--- a/.github/workflows/build-rdo-package.yml
+++ b/.github/workflows/build-rdo-package.yml
@@ -16,6 +16,9 @@ env:
 jobs:
   build:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      packages: write
     strategy:
       matrix:
         python_version: ["3.10", "3.11"]


### PR DESCRIPTION
## Summary

- add explicit job-level permissions to the RDO package workflow
- limit the workflow token to `contents: write` and `packages: write`
- align the affected release branch with the hardening already present on `main`

## Why

Without an explicit permissions block, the workflow inherits broader default token permissions and is reported by zizmor as `excessive-permissions`.

Part of #5217.

## Validation

- `actionlint .github/workflows/build-rdo-package.yml`
- zizmor 1.28.0: no `excessive-permissions` finding
- branch-native pre-commit hooks for the changed workflow
- `git diff --check`
