### PR TITLE
Allow superusers to grant and revoke superuser access in Rocky

### DIFF
--- a/docs/source/installation-and-deployment/events-and-logging.rst
+++ b/docs/source/installation-and-deployment/events-and-logging.rst
@@ -61,6 +61,7 @@ Event code Model              Routing key            Description                
 900111     TOTPDevice         account_change         2FA is removed.                             D
 900112     TOTPDevice         account_change         2FA is updated.                             U
 900113     KATUser            account_change         Superuser access is granted.                U
+900114     KATUser            account_change         Superuser access is revoked.                U
 900201     Organization       organization_change    A new organization is created.              C
 900202     Organization       organization_change    Organization information changed.           U
 900203     Organization       organization_change    Organization is removed.                    D

--- a/docs/source/installation-and-deployment/events-and-logging.rst
+++ b/docs/source/installation-and-deployment/events-and-logging.rst
@@ -60,6 +60,7 @@ Event code Model              Routing key            Description                
 900110     KATUser            account_change         A user is deleted.                          D
 900111     TOTPDevice         account_change         2FA is removed.                             D
 900112     TOTPDevice         account_change         2FA is updated.                             U
+900113     KATUser            account_change         Superuser access is granted.                U
 900201     Organization       organization_change    A new organization is created.              C
 900202     Organization       organization_change    Organization information changed.           U
 900203     Organization       organization_change    Organization is removed.                    D

--- a/docs/source/installation-and-deployment/users-and-organizations.rst
+++ b/docs/source/installation-and-deployment/users-and-organizations.rst
@@ -17,6 +17,10 @@ Users
 
 OpenKAT knows four types of users: the client, the red team user, the admin and the superuser. In OpenKAT, permissions utilise a stacked model. This means that a higher permission level includes all lower permissions of the lower levels. The client is a 'read only' type of user, the red teamer is a researcher who can start scans. The admin is an administrative user who can do user management etc, the superuser has the ability to do everything.
 
+Superuser access is global and applies to every organization in an OpenKAT installation. An existing superuser can grant this access to another active account by opening the organization's member overview, editing the member, and selecting ``Grant superuser access`` under ``Global account access``. Rocky shows the installation-wide impact for confirmation before applying the change. Organization admins and other account types cannot grant superuser access.
+
+Rocky cannot revoke superuser access. To revoke it, open the account under :guilabel:`Accounts` > :guilabel:`Users` in Django administration, clear both :guilabel:`Superuser status` and :guilabel:`Staff status`, and save the account.
+
 Rights and functions per user type
 ----------------------------------
 

--- a/docs/source/installation-and-deployment/users-and-organizations.rst
+++ b/docs/source/installation-and-deployment/users-and-organizations.rst
@@ -19,7 +19,7 @@ OpenKAT knows four types of users: the client, the red team user, the admin and 
 
 Superuser access is global and applies to every organization in an OpenKAT installation. An existing superuser can grant this access to another active account by opening the organization's member overview, editing the member, and selecting ``Grant superuser access`` under ``Global account access``. Rocky shows the installation-wide impact for confirmation before applying the change. Organization admins and other account types cannot grant superuser access.
 
-Rocky cannot revoke superuser access. To revoke it, open the account under :guilabel:`Accounts` > :guilabel:`Users` in Django administration, clear both :guilabel:`Superuser status` and :guilabel:`Staff status`, and save the account.
+An existing superuser can revoke this access again from the same member edit page by selecting ``Revoke superuser access``. Rocky refuses to revoke the last active superuser in an installation to prevent lockout; promote another account first, or revoke via Django administration. To revoke superuser access outside Rocky, open the account under :guilabel:`Accounts` > :guilabel:`Users` in Django administration, clear both :guilabel:`Superuser status` and :guilabel:`Staff status`, and save the account.
 
 Rights and functions per user type
 ----------------------------------

--- a/rocky/rocky/locale/django.pot
+++ b/rocky/rocky/locale/django.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-24 20:14+0000\n"
+"POT-Creation-Date: 2026-08-19 13:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -590,6 +590,7 @@ msgstr ""
 #: rocky/templates/organizations/organization_edit.html
 #: rocky/templates/organizations/organization_member_edit.html
 #: rocky/templates/organizations/organization_member_grant_superuser.html
+#: rocky/templates/organizations/organization_member_revoke_superuser.html
 #: rocky/templates/partials/delete_ooi_modal.html
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 #: rocky/templates/partials/mute_findings_modal.html
@@ -931,6 +932,7 @@ msgstr ""
 #: reports/templates/report_overview/scheduled_reports_table.html
 #: reports/templates/summary/selected_plugins.html
 #: rocky/templates/findings/finding_list.html
+#: rocky/templates/oois/ooi_detail_origins_observations.html
 #: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
 #: rocky/templates/tasks/ooi_detail_task_list.html
 #: rocky/templates/tasks/plugin_detail_task_list.html
@@ -946,6 +948,7 @@ msgstr ""
 #: reports/templates/report_overview/scheduled_reports_table.html
 #: reports/templates/summary/selected_plugins.html
 #: rocky/templates/findings/finding_list.html
+#: rocky/templates/oois/ooi_detail_origins_observations.html
 #: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
 #: rocky/templates/tasks/ooi_detail_task_list.html
 #: rocky/templates/tasks/plugin_detail_task_list.html
@@ -6058,6 +6061,47 @@ msgstr ""
 msgid "Warning"
 msgstr ""
 
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Loading..."
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Normalizer task"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Consuming Raw file"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Yielded objects"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Yielded raw files for task"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+#: rocky/templates/tasks/boefje_task_detail.html
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Download meta and raw data"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Origin boefje task"
+msgstr ""
+
+#: rocky/templates/oois/ooi_detail_origins_observations.html
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "See all similar tasks"
+msgstr ""
+
 #: rocky/templates/oois/ooi_edit.html
 #, python-format
 msgid "Edit %(type)s: %(ooi_human_readable)s"
@@ -6112,21 +6156,13 @@ msgid "List of views for OOI"
 msgstr ""
 
 #: rocky/templates/oois/ooi_past_due_warning.html
-msgid "This object is past due"
-msgstr ""
-
-#: rocky/templates/oois/ooi_past_due_warning.html
-msgid "This object is past due and has been deleted"
+msgid "You are looking at a historic view of this object."
 msgstr ""
 
 #: rocky/templates/oois/ooi_past_due_warning.html
 msgid ""
-"This object is past due. You are viewing the object state in a past state."
-msgstr ""
-
-#: rocky/templates/oois/ooi_past_due_warning.html
-msgid ""
-"You will not be able to add Findings or other OOI's to past due objects."
+"You are looking at a historic view of this object which has been deleted in "
+"the current timeline"
 msgstr ""
 
 #: rocky/templates/oois/ooi_past_due_warning.html
@@ -6264,6 +6300,12 @@ msgid ""
 msgstr ""
 
 #: rocky/templates/organizations/organization_member_edit.html
+#: rocky/templates/organizations/organization_member_revoke_superuser.html
+#: rocky/views/organization_member_superuser.py
+msgid "Revoke superuser access"
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_edit.html
 #: rocky/templates/organizations/organization_member_grant_superuser.html
 #: rocky/views/organization_member_superuser.py
 msgid "Grant superuser access"
@@ -6295,52 +6337,6 @@ msgstr ""
 msgid ""
 "Only continue when this person is authorized to administer the entire "
 "installation."
-msgstr ""
-
-#: rocky/templates/organizations/organization_member_edit.html
-#: rocky/templates/organizations/organization_member_revoke_superuser.html
-#: rocky/views/organization_member_superuser.py
-msgid "Revoke superuser access"
-msgstr ""
-
-#: rocky/templates/organizations/organization_member_revoke_superuser.html
-#, python-format
-msgid ""
-"You are about to revoke <strong>%(email)s</strong>'s unrestricted access to "
-"every organization and all administrative functionality in this OpenKAT "
-"installation."
-msgstr ""
-
-#: rocky/templates/organizations/organization_member_revoke_superuser.html
-msgid "This removes a global account permission, not an organization role."
-msgstr ""
-
-#: rocky/templates/organizations/organization_member_revoke_superuser.html
-msgid "The account will keep its organization membership and organization role."
-msgstr ""
-
-#: rocky/templates/organizations/organization_member_revoke_superuser.html
-msgid ""
-"Only continue when this person should no longer administer the entire "
-"installation."
-msgstr ""
-
-#: rocky/views/organization_member_superuser.py
-#, python-format
-msgid "%(email)s does not have superuser access."
-msgstr ""
-
-#: rocky/views/organization_member_superuser.py
-#, python-format
-msgid ""
-"Revoking superuser access from %(email)s would leave this installation "
-"without any active superuser. Promote another account first, or revoke it "
-"via Django administration."
-msgstr ""
-
-#: rocky/views/organization_member_superuser.py
-#, python-format
-msgid "Superuser access revoked from %(email)s."
 msgstr ""
 
 #: rocky/templates/organizations/organization_member_list.html
@@ -6382,6 +6378,29 @@ msgstr ""
 
 #: rocky/templates/organizations/organization_member_list.html
 msgid "Super user"
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_revoke_superuser.html
+#, python-format
+msgid ""
+"You are about to revoke <strong>%(email)s</strong>'s unrestricted access to "
+"every organization and all administrative functionality in this OpenKAT "
+"installation."
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_revoke_superuser.html
+msgid "This removes a global account permission, not an organization role."
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_revoke_superuser.html
+msgid ""
+"The account will keep its organization membership and organization role."
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_revoke_superuser.html
+msgid ""
+"Only continue when this person should no longer administer the entire "
+"installation."
 msgstr ""
 
 #: rocky/templates/organizations/organization_member_upload.html
@@ -6900,11 +6919,6 @@ msgid ""
 msgstr ""
 
 #: rocky/templates/tasks/boefje_task_detail.html
-#: rocky/templates/tasks/partials/task_actions.html
-msgid "Download meta and raw data"
-msgstr ""
-
-#: rocky/templates/tasks/boefje_task_detail.html
 msgid "Download meta data"
 msgstr ""
 
@@ -7000,35 +7014,7 @@ msgid "List of tasks"
 msgstr ""
 
 #: rocky/templates/tasks/partials/task_actions.html
-msgid "Loading..."
-msgstr ""
-
-#: rocky/templates/tasks/partials/task_actions.html
-msgid "Normalizer task"
-msgstr ""
-
-#: rocky/templates/tasks/partials/task_actions.html
 msgid "Processing input from Boefje task"
-msgstr ""
-
-#: rocky/templates/tasks/partials/task_actions.html
-msgid "Consuming Raw file"
-msgstr ""
-
-#: rocky/templates/tasks/partials/task_actions.html
-msgid "Yielded objects"
-msgstr ""
-
-#: rocky/templates/tasks/partials/task_actions.html
-msgid "Yielded raw files for task"
-msgstr ""
-
-#: rocky/templates/tasks/partials/task_actions.html
-msgid "Origin boefje task"
-msgstr ""
-
-#: rocky/templates/tasks/partials/task_actions.html
-msgid "See all similar tasks"
 msgstr ""
 
 #: rocky/templates/tasks/partials/task_actions.html
@@ -7624,6 +7610,31 @@ msgstr ""
 #: rocky/views/organization_member_superuser.py
 #, python-format
 msgid "Superuser access granted to %(email)s."
+msgstr ""
+
+#: rocky/views/organization_member_superuser.py
+#, python-format
+msgid ""
+"%(email)s does not have superuser access but still has Django administration "
+"access; revoke that via Django administration."
+msgstr ""
+
+#: rocky/views/organization_member_superuser.py
+#, python-format
+msgid "%(email)s does not have superuser access."
+msgstr ""
+
+#: rocky/views/organization_member_superuser.py
+#, python-format
+msgid ""
+"Revoking superuser access from %(email)s would leave this installation "
+"without any active superuser. Promote another account first, or revoke it "
+"via Django administration."
+msgstr ""
+
+#: rocky/views/organization_member_superuser.py
+#, python-format
+msgid "Superuser access revoked from %(email)s."
 msgstr ""
 
 #: rocky/views/organization_settings.py

--- a/rocky/rocky/locale/django.pot
+++ b/rocky/rocky/locale/django.pot
@@ -7370,6 +7370,10 @@ msgid "Dashboard item has been added."
 msgstr ""
 
 #: rocky/views/ooi_add.py
+msgid "Type select"
+msgstr ""
+
+#: rocky/views/ooi_add.py
 #, python-format
 msgid "Add %(ooi_type)s"
 msgstr ""

--- a/rocky/rocky/locale/django.pot
+++ b/rocky/rocky/locale/django.pot
@@ -6283,9 +6283,8 @@ msgstr ""
 
 #: rocky/templates/organizations/organization_member_grant_superuser.html
 msgid ""
-"Rocky cannot revoke this permission. To revoke it, open this account under "
-"Accounts > Users in Django administration, clear both Superuser status and "
-"Staff status, and save."
+"Superuser access can be revoked again from the same member edit page, or via "
+"Django administration."
 msgstr ""
 
 #: rocky/templates/organizations/organization_member_grant_superuser.html
@@ -6296,6 +6295,52 @@ msgstr ""
 msgid ""
 "Only continue when this person is authorized to administer the entire "
 "installation."
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_edit.html
+#: rocky/templates/organizations/organization_member_revoke_superuser.html
+#: rocky/views/organization_member_superuser.py
+msgid "Revoke superuser access"
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_revoke_superuser.html
+#, python-format
+msgid ""
+"You are about to revoke <strong>%(email)s</strong>'s unrestricted access to "
+"every organization and all administrative functionality in this OpenKAT "
+"installation."
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_revoke_superuser.html
+msgid "This removes a global account permission, not an organization role."
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_revoke_superuser.html
+msgid "The account will keep its organization membership and organization role."
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_revoke_superuser.html
+msgid ""
+"Only continue when this person should no longer administer the entire "
+"installation."
+msgstr ""
+
+#: rocky/views/organization_member_superuser.py
+#, python-format
+msgid "%(email)s does not have superuser access."
+msgstr ""
+
+#: rocky/views/organization_member_superuser.py
+#, python-format
+msgid ""
+"Revoking superuser access from %(email)s would leave this installation "
+"without any active superuser. Promote another account first, or revoke it "
+"via Django administration."
+msgstr ""
+
+#: rocky/views/organization_member_superuser.py
+#, python-format
+msgid "Superuser access revoked from %(email)s."
 msgstr ""
 
 #: rocky/templates/organizations/organization_member_list.html

--- a/rocky/rocky/locale/django.pot
+++ b/rocky/rocky/locale/django.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-12 11:17+0000\n"
+"POT-Creation-Date: 2026-07-24 20:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -589,6 +589,7 @@ msgstr ""
 #: rocky/templates/oois/ooi_mute_finding.html
 #: rocky/templates/organizations/organization_edit.html
 #: rocky/templates/organizations/organization_member_edit.html
+#: rocky/templates/organizations/organization_member_grant_superuser.html
 #: rocky/templates/partials/delete_ooi_modal.html
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 #: rocky/templates/partials/mute_findings_modal.html
@@ -930,7 +931,6 @@ msgstr ""
 #: reports/templates/report_overview/scheduled_reports_table.html
 #: reports/templates/summary/selected_plugins.html
 #: rocky/templates/findings/finding_list.html
-#: rocky/templates/oois/ooi_detail_origins_observations.html
 #: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
 #: rocky/templates/tasks/ooi_detail_task_list.html
 #: rocky/templates/tasks/plugin_detail_task_list.html
@@ -946,7 +946,6 @@ msgstr ""
 #: reports/templates/report_overview/scheduled_reports_table.html
 #: reports/templates/summary/selected_plugins.html
 #: rocky/templates/findings/finding_list.html
-#: rocky/templates/oois/ooi_detail_origins_observations.html
 #: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
 #: rocky/templates/tasks/ooi_detail_task_list.html
 #: rocky/templates/tasks/plugin_detail_task_list.html
@@ -5223,6 +5222,7 @@ msgstr ""
 #: tools/view_helpers.py rocky/templates/header.html
 #: rocky/templates/organizations/organization_member_list.html
 #: rocky/views/organization_member_edit.py
+#: rocky/views/organization_member_superuser.py
 msgid "Members"
 msgstr ""
 
@@ -6058,47 +6058,6 @@ msgstr ""
 msgid "Warning"
 msgstr ""
 
-#: rocky/templates/oois/ooi_detail_origins_observations.html
-#: rocky/templates/tasks/partials/task_actions.html
-msgid "Loading..."
-msgstr ""
-
-#: rocky/templates/oois/ooi_detail_origins_observations.html
-#: rocky/templates/tasks/partials/task_actions.html
-msgid "Normalizer task"
-msgstr ""
-
-#: rocky/templates/oois/ooi_detail_origins_observations.html
-#: rocky/templates/tasks/partials/task_actions.html
-msgid "Consuming Raw file"
-msgstr ""
-
-#: rocky/templates/oois/ooi_detail_origins_observations.html
-#: rocky/templates/tasks/partials/task_actions.html
-msgid "Yielded objects"
-msgstr ""
-
-#: rocky/templates/oois/ooi_detail_origins_observations.html
-#: rocky/templates/tasks/partials/task_actions.html
-msgid "Yielded raw files for task"
-msgstr ""
-
-#: rocky/templates/oois/ooi_detail_origins_observations.html
-#: rocky/templates/tasks/boefje_task_detail.html
-#: rocky/templates/tasks/partials/task_actions.html
-msgid "Download meta and raw data"
-msgstr ""
-
-#: rocky/templates/oois/ooi_detail_origins_observations.html
-#: rocky/templates/tasks/partials/task_actions.html
-msgid "Origin boefje task"
-msgstr ""
-
-#: rocky/templates/oois/ooi_detail_origins_observations.html
-#: rocky/templates/tasks/partials/task_actions.html
-msgid "See all similar tasks"
-msgstr ""
-
 #: rocky/templates/oois/ooi_edit.html
 #, python-format
 msgid "Edit %(type)s: %(ooi_human_readable)s"
@@ -6153,13 +6112,21 @@ msgid "List of views for OOI"
 msgstr ""
 
 #: rocky/templates/oois/ooi_past_due_warning.html
-msgid "You are looking at a historic view of this object."
+msgid "This object is past due"
+msgstr ""
+
+#: rocky/templates/oois/ooi_past_due_warning.html
+msgid "This object is past due and has been deleted"
 msgstr ""
 
 #: rocky/templates/oois/ooi_past_due_warning.html
 msgid ""
-"You are looking at a historic view of this object which has been deleted in "
-"the current timeline"
+"This object is past due. You are viewing the object state in a past state."
+msgstr ""
+
+#: rocky/templates/oois/ooi_past_due_warning.html
+msgid ""
+"You will not be able to add Findings or other OOI's to past due objects."
 msgstr ""
 
 #: rocky/templates/oois/ooi_past_due_warning.html
@@ -6278,11 +6245,57 @@ msgstr ""
 
 #: rocky/templates/organizations/organization_member_edit.html
 #: rocky/views/organization_member_edit.py
+#: rocky/views/organization_member_superuser.py
 msgid "Edit member"
 msgstr ""
 
 #: rocky/templates/organizations/organization_member_edit.html
 msgid "Save member"
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_edit.html
+msgid "Global account access"
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_edit.html
+msgid ""
+"Superuser access applies to every organization and all administrative "
+"functionality in this OpenKAT installation."
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_edit.html
+#: rocky/templates/organizations/organization_member_grant_superuser.html
+#: rocky/views/organization_member_superuser.py
+msgid "Grant superuser access"
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_grant_superuser.html
+#, python-format
+msgid ""
+"You are about to grant <strong>%(email)s</strong> unrestricted access to "
+"every organization and all administrative functionality in this OpenKAT "
+"installation."
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_grant_superuser.html
+msgid "This is a global account permission, not an organization role."
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_grant_superuser.html
+msgid ""
+"Rocky cannot revoke this permission. To revoke it, open this account under "
+"Accounts > Users in Django administration, clear both Superuser status and "
+"Staff status, and save."
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_grant_superuser.html
+msgid "Open this account in Django administration"
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_grant_superuser.html
+msgid ""
+"Only continue when this person is authorized to administer the entire "
+"installation."
 msgstr ""
 
 #: rocky/templates/organizations/organization_member_list.html
@@ -6842,6 +6855,11 @@ msgid ""
 msgstr ""
 
 #: rocky/templates/tasks/boefje_task_detail.html
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Download meta and raw data"
+msgstr ""
+
+#: rocky/templates/tasks/boefje_task_detail.html
 msgid "Download meta data"
 msgstr ""
 
@@ -6937,7 +6955,35 @@ msgid "List of tasks"
 msgstr ""
 
 #: rocky/templates/tasks/partials/task_actions.html
+msgid "Loading..."
+msgstr ""
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Normalizer task"
+msgstr ""
+
+#: rocky/templates/tasks/partials/task_actions.html
 msgid "Processing input from Boefje task"
+msgstr ""
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Consuming Raw file"
+msgstr ""
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Yielded objects"
+msgstr ""
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Yielded raw files for task"
+msgstr ""
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Origin boefje task"
+msgstr ""
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "See all similar tasks"
 msgstr ""
 
 #: rocky/templates/tasks/partials/task_actions.html
@@ -7293,10 +7339,6 @@ msgid "Dashboard item has been added."
 msgstr ""
 
 #: rocky/views/ooi_add.py
-msgid "Type select"
-msgstr ""
-
-#: rocky/views/ooi_add.py
 #, python-format
 msgid "Add %(ooi_type)s"
 msgstr ""
@@ -7522,6 +7564,21 @@ msgstr ""
 #: rocky/views/organization_member_list.py
 #, python-format
 msgid "Unblocked member %s successfully."
+msgstr ""
+
+#: rocky/views/organization_member_superuser.py
+#, python-format
+msgid "%(email)s is inactive and cannot be granted superuser access."
+msgstr ""
+
+#: rocky/views/organization_member_superuser.py
+#, python-format
+msgid "%(email)s already has superuser access."
+msgstr ""
+
+#: rocky/views/organization_member_superuser.py
+#, python-format
+msgid "Superuser access granted to %(email)s."
 msgstr ""
 
 #: rocky/views/organization_settings.py

--- a/rocky/rocky/locale/django.pot
+++ b/rocky/rocky/locale/django.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-28 14:22+0000\n"
+"POT-Creation-Date: 2026-07-24 20:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -589,6 +589,7 @@ msgstr ""
 #: rocky/templates/oois/ooi_mute_finding.html
 #: rocky/templates/organizations/organization_edit.html
 #: rocky/templates/organizations/organization_member_edit.html
+#: rocky/templates/organizations/organization_member_grant_superuser.html
 #: rocky/templates/partials/delete_ooi_modal.html
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 #: rocky/templates/partials/mute_findings_modal.html
@@ -1662,7 +1663,7 @@ msgstr ""
 msgid "Latest plugin settings"
 msgstr ""
 
-#: katalogus/templates/katalogus_settings.html
+#: katalogus/templates/katalogus_settings.html tools/forms/scheduler.py
 #: rocky/templates/tasks/ooi_detail_task_list.html
 msgid "Plugin"
 msgstr ""
@@ -4868,7 +4869,7 @@ msgstr ""
 msgid "Filter by muted findings"
 msgstr ""
 
-#: tools/forms/findings.py tools/forms/ooi_form.py tools/forms/scheduler.py
+#: tools/forms/findings.py tools/forms/ooi_form.py
 msgid "Search"
 msgstr ""
 
@@ -4961,11 +4962,45 @@ msgid "Running"
 msgstr ""
 
 #: tools/forms/scheduler.py
+msgid "Search (in OOI)"
+msgstr ""
+
+#: tools/forms/scheduler.py
 msgid "Search by object name"
 msgstr ""
 
 #: tools/forms/scheduler.py
-msgid "The selected date is in the future. Please select a different date."
+msgid "Input OOI"
+msgstr ""
+
+#: tools/forms/scheduler.py
+msgid "Select specific object"
+msgstr ""
+
+#: tools/forms/scheduler.py
+msgid "Search by plugin"
+msgstr ""
+
+#: tools/forms/scheduler.py
+msgid "Task id"
+msgstr ""
+
+#: tools/forms/scheduler.py
+msgid "Search by task ID"
+msgstr ""
+
+#: tools/forms/scheduler.py
+#, python-format
+msgid ""
+"The selected date (%s) is in the future. Please select a different date."
+msgstr ""
+
+#: tools/forms/scheduler.py
+msgid "'from'"
+msgstr ""
+
+#: tools/forms/scheduler.py
+msgid "'to'"
 msgstr ""
 
 #: tools/forms/settings.py
@@ -5187,6 +5222,7 @@ msgstr ""
 #: tools/view_helpers.py rocky/templates/header.html
 #: rocky/templates/organizations/organization_member_list.html
 #: rocky/views/organization_member_edit.py
+#: rocky/views/organization_member_superuser.py
 msgid "Members"
 msgstr ""
 
@@ -6209,11 +6245,57 @@ msgstr ""
 
 #: rocky/templates/organizations/organization_member_edit.html
 #: rocky/views/organization_member_edit.py
+#: rocky/views/organization_member_superuser.py
 msgid "Edit member"
 msgstr ""
 
 #: rocky/templates/organizations/organization_member_edit.html
 msgid "Save member"
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_edit.html
+msgid "Global account access"
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_edit.html
+msgid ""
+"Superuser access applies to every organization and all administrative "
+"functionality in this OpenKAT installation."
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_edit.html
+#: rocky/templates/organizations/organization_member_grant_superuser.html
+#: rocky/views/organization_member_superuser.py
+msgid "Grant superuser access"
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_grant_superuser.html
+#, python-format
+msgid ""
+"You are about to grant <strong>%(email)s</strong> unrestricted access to "
+"every organization and all administrative functionality in this OpenKAT "
+"installation."
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_grant_superuser.html
+msgid "This is a global account permission, not an organization role."
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_grant_superuser.html
+msgid ""
+"Rocky cannot revoke this permission. To revoke it, open this account under "
+"Accounts > Users in Django administration, clear both Superuser status and "
+"Staff status, and save."
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_grant_superuser.html
+msgid "Open this account in Django administration"
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_grant_superuser.html
+msgid ""
+"Only continue when this person is authorized to administer the entire "
+"installation."
 msgstr ""
 
 #: rocky/templates/organizations/organization_member_list.html
@@ -6808,6 +6890,30 @@ msgstr ""
 msgid "Modified date"
 msgstr ""
 
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
+msgid "Filter on this plugin"
+msgstr ""
+
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
+msgid "Add filter on this plugin"
+msgstr ""
+
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/partials/stats.html
+msgid "Filter on this status"
+msgstr ""
+
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/partials/stats.html
+msgid "Add filter on this status"
+msgstr ""
+
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
+msgid "Filter on this ooi"
+msgstr ""
+
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
+msgid "Add filter on this ooi"
+msgstr ""
+
 #: rocky/templates/tasks/normalizers.html
 msgid "There are no tasks for normalizers."
 msgstr ""
@@ -6853,15 +6959,39 @@ msgid "Loading..."
 msgstr ""
 
 #: rocky/templates/tasks/partials/task_actions.html
+msgid "Normalizer task"
+msgstr ""
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Processing input from Boefje task"
+msgstr ""
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Consuming Raw file"
+msgstr ""
+
+#: rocky/templates/tasks/partials/task_actions.html
 msgid "Yielded objects"
 msgstr ""
 
 #: rocky/templates/tasks/partials/task_actions.html
-msgid "Yielded raw files"
+msgid "Yielded raw files for task"
+msgstr ""
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Origin boefje task"
+msgstr ""
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "See all similar tasks"
 msgstr ""
 
 #: rocky/templates/tasks/partials/task_actions.html
 msgid "Reschedule"
+msgstr ""
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Related Normalizer tasks"
 msgstr ""
 
 #: rocky/templates/tasks/partials/task_actions.html
@@ -7155,6 +7285,10 @@ msgid "Upload raw"
 msgstr ""
 
 #: rocky/views/bytes_raw.py
+msgid "Getting raw data failed, No such meta."
+msgstr ""
+
+#: rocky/views/bytes_raw.py
 msgid "Getting raw data failed."
 msgstr ""
 
@@ -7432,6 +7566,21 @@ msgstr ""
 msgid "Unblocked member %s successfully."
 msgstr ""
 
+#: rocky/views/organization_member_superuser.py
+#, python-format
+msgid "%(email)s is inactive and cannot be granted superuser access."
+msgstr ""
+
+#: rocky/views/organization_member_superuser.py
+#, python-format
+msgid "%(email)s already has superuser access."
+msgstr ""
+
+#: rocky/views/organization_member_superuser.py
+#, python-format
+msgid "Superuser access granted to %(email)s."
+msgstr ""
+
 #: rocky/views/organization_settings.py
 #, python-brace-format
 msgid "Recalculated {number_of_bits} bits. Duration: {duration}"
@@ -7451,14 +7600,14 @@ msgid "Scans"
 msgstr ""
 
 #: rocky/views/scheduler.py
-msgid "Your report has been scheduled."
-msgstr ""
-
-#: rocky/views/scheduler.py
 msgid ""
 "Your task is scheduled and will soon be started in the background. Results "
 "will be added to the object list when they are in. It may take some time, a "
 "refresh of the page may be needed to show the results."
+msgstr ""
+
+#: rocky/views/scheduler.py
+msgid "Your report has been scheduled."
 msgstr ""
 
 #: rocky/views/tasks.py

--- a/rocky/rocky/locale/django.pot
+++ b/rocky/rocky/locale/django.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-19 13:43+0000\n"
+"POT-Creation-Date: 2026-09-10 09:00+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4163,7 +4163,8 @@ msgid "Low"
 msgstr ""
 
 #: reports/templates/partials/report_severity_totals_table.html
-#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+#: tools/forms/scheduler.py rocky/scheduler.py
+#: rocky/templates/tasks/partials/stats.html
 msgid "Pending"
 msgstr ""
 
@@ -4940,27 +4941,33 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+#: tools/forms/scheduler.py rocky/scheduler.py
+#: rocky/templates/tasks/partials/stats.html
 msgid "Cancelled"
 msgstr ""
 
-#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+#: tools/forms/scheduler.py rocky/scheduler.py
+#: rocky/templates/tasks/partials/stats.html
 msgid "Completed"
 msgstr ""
 
-#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+#: tools/forms/scheduler.py rocky/scheduler.py
+#: rocky/templates/tasks/partials/stats.html
 msgid "Dispatched"
 msgstr ""
 
-#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+#: tools/forms/scheduler.py rocky/scheduler.py
+#: rocky/templates/tasks/partials/stats.html
 msgid "Failed"
 msgstr ""
 
-#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+#: tools/forms/scheduler.py rocky/scheduler.py
+#: rocky/templates/tasks/partials/stats.html
 msgid "Queued"
 msgstr ""
 
-#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+#: tools/forms/scheduler.py rocky/scheduler.py
+#: rocky/templates/tasks/partials/stats.html
 msgid "Running"
 msgstr ""
 
@@ -5832,7 +5839,7 @@ msgstr ""
 #: rocky/templates/oois/ooi_add_type_select.html
 #: rocky/templates/oois/ooi_detail_add_related_object.html
 #: rocky/templates/partials/elements/ooi_add_type_select_form.html
-#: rocky/templates/partials/ooi_list_toolbar.html rocky/views/ooi_add.py
+#: rocky/templates/partials/ooi_list_toolbar.html
 msgid "Add object"
 msgstr ""
 
@@ -7604,6 +7611,13 @@ msgstr ""
 #: rocky/views/organization_member_superuser.py
 #, python-format
 msgid "%(email)s is inactive and cannot be granted superuser access."
+msgstr ""
+
+#: rocky/views/organization_member_superuser.py
+#, python-format
+msgid ""
+"%(email)s is blocked in this organization and cannot be granted superuser "
+"access."
 msgstr ""
 
 #: rocky/views/organization_member_superuser.py

--- a/rocky/rocky/templates/organizations/organization_member_edit.html
+++ b/rocky/rocky/templates/organizations/organization_member_edit.html
@@ -22,6 +22,18 @@
                 </form>
             </div>
         </section>
+        {% if request.user.is_superuser and object.user.is_active and not object.user.is_superuser %}
+            <section>
+                <div>
+                    <h2>{% translate "Global account access" %}</h2>
+                    <p>
+                        {% translate "Superuser access applies to every organization and all administrative functionality in this OpenKAT installation." %}
+                    </p>
+                    <a class="button ghost destructive"
+                       href="{% url 'organization_member_grant_superuser' organization.code object.id %}">{% translate "Grant superuser access" %}</a>
+                </div>
+            </section>
+        {% endif %}
     </main>
 {% endblock content %}
 {% block html_at_end_body %}

--- a/rocky/rocky/templates/organizations/organization_member_edit.html
+++ b/rocky/rocky/templates/organizations/organization_member_edit.html
@@ -22,17 +22,30 @@
                 </form>
             </div>
         </section>
-        {% if request.user.is_superuser and object.user.is_active and not object.user.is_superuser %}
-            <section>
-                <div>
-                    <h2>{% translate "Global account access" %}</h2>
-                    <p>
-                        {% translate "Superuser access applies to every organization and all administrative functionality in this OpenKAT installation." %}
-                    </p>
-                    <a class="button ghost destructive"
-                       href="{% url 'organization_member_grant_superuser' organization.code object.id %}">{% translate "Grant superuser access" %}</a>
-                </div>
-            </section>
+        {% if request.user.is_superuser %}
+            {% if object.user.is_superuser %}
+                <section>
+                    <div>
+                        <h2>{% translate "Global account access" %}</h2>
+                        <p>
+                            {% translate "Superuser access applies to every organization and all administrative functionality in this OpenKAT installation." %}
+                        </p>
+                        <a class="button ghost destructive"
+                           href="{% url 'organization_member_revoke_superuser' organization.code object.id %}">{% translate "Revoke superuser access" %}</a>
+                    </div>
+                </section>
+            {% elif object.user.is_active %}
+                <section>
+                    <div>
+                        <h2>{% translate "Global account access" %}</h2>
+                        <p>
+                            {% translate "Superuser access applies to every organization and all administrative functionality in this OpenKAT installation." %}
+                        </p>
+                        <a class="button ghost destructive"
+                           href="{% url 'organization_member_grant_superuser' organization.code object.id %}">{% translate "Grant superuser access" %}</a>
+                    </div>
+                </section>
+            {% endif %}
         {% endif %}
     </main>
 {% endblock content %}

--- a/rocky/rocky/templates/organizations/organization_member_edit.html
+++ b/rocky/rocky/templates/organizations/organization_member_edit.html
@@ -23,7 +23,7 @@
             </div>
         </section>
         {% if request.user.is_superuser %}
-            {% if object.user.is_superuser %}
+            {% if object.user.is_superuser and can_revoke_superuser %}
                 <section>
                     <div>
                         <h2>{% translate "Global account access" %}</h2>
@@ -34,7 +34,7 @@
                            href="{% url 'organization_member_revoke_superuser' organization.code object.id %}">{% translate "Revoke superuser access" %}</a>
                     </div>
                 </section>
-            {% elif object.user.is_active %}
+            {% elif object.user.is_active and not object.blocked %}
                 <section>
                     <div>
                         <h2>{% translate "Global account access" %}</h2>

--- a/rocky/rocky/templates/organizations/organization_member_grant_superuser.html
+++ b/rocky/rocky/templates/organizations/organization_member_grant_superuser.html
@@ -1,0 +1,36 @@
+{% extends "layouts/base.html" %}
+
+{% load i18n %}
+
+{% block content %}
+    {% include "header.html" %}
+
+    <main id="main-content">
+        <section>
+            <div>
+                <h1>{% translate "Grant superuser access" %}</h1>
+                <div class="warning" role="alert">
+                    <p>
+                        {% blocktranslate with email=member.user.email trimmed %}
+                            You are about to grant <strong>{{ email }}</strong> unrestricted access to every organization and all administrative functionality in this OpenKAT installation.
+                        {% endblocktranslate %}
+                    </p>
+                    <p>
+                        {% translate "This is a global account permission, not an organization role." %}
+                        {% translate "Rocky cannot revoke this permission. To revoke it, open this account under Accounts > Users in Django administration, clear both Superuser status and Staff status, and save." %}
+                    </p>
+                    <a href="{% url 'admin:account_katuser_change' member.user.id %}">{% translate "Open this account in Django administration" %}</a>
+                </div>
+                <p>{% translate "Only continue when this person is authorized to administer the entire installation." %}</p>
+                <form method="post">
+                    {% csrf_token %}
+                    <div class="button-container">
+                        <button type="submit" class="destructive">{% translate "Grant superuser access" %}</button>
+                        <a class="button ghost"
+                           href="{% url 'organization_member_edit' organization.code member.id %}">{% translate "Cancel" %}</a>
+                    </div>
+                </form>
+            </div>
+        </section>
+    </main>
+{% endblock content %}

--- a/rocky/rocky/templates/organizations/organization_member_revoke_superuser.html
+++ b/rocky/rocky/templates/organizations/organization_member_revoke_superuser.html
@@ -8,24 +8,24 @@
     <main id="main-content">
         <section>
             <div>
-                <h1>{% translate "Grant superuser access" %}</h1>
+                <h1>{% translate "Revoke superuser access" %}</h1>
                 <div class="warning" role="alert">
                     <p>
                         {% blocktranslate with email=member.user.email trimmed %}
-                            You are about to grant <strong>{{ email }}</strong> unrestricted access to every organization and all administrative functionality in this OpenKAT installation.
+                            You are about to revoke <strong>{{ email }}</strong>'s unrestricted access to every
+                            organization and all administrative functionality in this OpenKAT installation.
                         {% endblocktranslate %}
                     </p>
                     <p>
-                        {% translate "This is a global account permission, not an organization role." %}
-                        {% translate "Superuser access can be revoked again from the same member edit page, or via Django administration." %}
+                        {% translate "This removes a global account permission, not an organization role." %}
+                        {% translate "The account will keep its organization membership and organization role." %}
                     </p>
-                    <a href="{% url 'admin:account_katuser_change' member.user.id %}">{% translate "Open this account in Django administration" %}</a>
                 </div>
-                <p>{% translate "Only continue when this person is authorized to administer the entire installation." %}</p>
+                <p>{% translate "Only continue when this person should no longer administer the entire installation." %}</p>
                 <form method="post">
                     {% csrf_token %}
                     <div class="button-container">
-                        <button type="submit" class="destructive">{% translate "Grant superuser access" %}</button>
+                        <button type="submit" class="destructive">{% translate "Revoke superuser access" %}</button>
                         <a class="button ghost"
                            href="{% url 'organization_member_edit' organization.code member.id %}">{% translate "Cancel" %}</a>
                     </div>

--- a/rocky/rocky/urls.py
+++ b/rocky/rocky/urls.py
@@ -34,6 +34,7 @@ from rocky.views.organization_member_add import (
 )
 from rocky.views.organization_member_edit import OrganizationMemberEditView
 from rocky.views.organization_member_list import OrganizationMemberListView
+from rocky.views.organization_member_superuser import GrantSuperuserAccessView
 from rocky.views.organization_settings import OrganizationSettingsView
 from rocky.views.privacy_statement import PrivacyStatementView
 from rocky.views.scan_profile import ScanProfileDetailView
@@ -114,6 +115,11 @@ urlpatterns += i18n_patterns(
         "<organization_code>/members/edit/<int:pk>/",
         OrganizationMemberEditView.as_view(),
         name="organization_member_edit",
+    ),
+    path(
+        "<organization_code>/members/<int:pk>/grant-superuser/",
+        GrantSuperuserAccessView.as_view(),
+        name="organization_member_grant_superuser",
     ),
     path("<organization_code>/health/v1/", HealthChecks.as_view(), name="health_beautified"),
     path("<organization_code>/objects/", OOIListView.as_view(), name="ooi_list"),

--- a/rocky/rocky/urls.py
+++ b/rocky/rocky/urls.py
@@ -34,7 +34,7 @@ from rocky.views.organization_member_add import (
 )
 from rocky.views.organization_member_edit import OrganizationMemberEditView
 from rocky.views.organization_member_list import OrganizationMemberListView
-from rocky.views.organization_member_superuser import GrantSuperuserAccessView
+from rocky.views.organization_member_superuser import GrantSuperuserAccessView, RevokeSuperuserAccessView
 from rocky.views.organization_settings import OrganizationSettingsView
 from rocky.views.privacy_statement import PrivacyStatementView
 from rocky.views.scan_profile import ScanProfileDetailView
@@ -121,6 +121,11 @@ urlpatterns += i18n_patterns(
         "<organization_code>/members/<int:pk>/grant-superuser/",
         GrantSuperuserAccessView.as_view(),
         name="organization_member_grant_superuser",
+    ),
+    path(
+        "<organization_code>/members/<int:pk>/revoke-superuser/",
+        RevokeSuperuserAccessView.as_view(),
+        name="organization_member_revoke_superuser",
     ),
     path("<organization_code>/health/v1/", HealthChecks.as_view(), name="health_beautified"),
     path("<organization_code>/objects/", OOIListView.as_view(), name="ooi_list"),

--- a/rocky/rocky/urls.py
+++ b/rocky/rocky/urls.py
@@ -34,6 +34,7 @@ from rocky.views.organization_member_add import (
 )
 from rocky.views.organization_member_edit import OrganizationMemberEditView
 from rocky.views.organization_member_list import OrganizationMemberListView
+from rocky.views.organization_member_superuser import GrantSuperuserAccessView
 from rocky.views.organization_settings import OrganizationSettingsView
 from rocky.views.privacy_statement import PrivacyStatementView
 from rocky.views.scan_profile import ScanProfileDetailView
@@ -115,6 +116,11 @@ urlpatterns += i18n_patterns(
         "<organization_code>/members/edit/<int:pk>/",
         OrganizationMemberEditView.as_view(),
         name="organization_member_edit",
+    ),
+    path(
+        "<organization_code>/members/<int:pk>/grant-superuser/",
+        GrantSuperuserAccessView.as_view(),
+        name="organization_member_grant_superuser",
     ),
     path("<organization_code>/health/v1/", HealthChecks.as_view(), name="health_beautified"),
     path("<organization_code>/objects/", OOIListView.as_view(), name="ooi_list"),

--- a/rocky/rocky/views/organization_member_edit.py
+++ b/rocky/rocky/views/organization_member_edit.py
@@ -2,6 +2,7 @@ import structlog
 from account.forms import OrganizationMemberEditForm
 from account.mixins import OrganizationPermissionRequiredMixin, OrganizationView
 from django.contrib import messages
+from django.contrib.auth import get_user_model
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.urls.base import reverse
 from django.utils.translation import gettext_lazy as _
@@ -9,6 +10,7 @@ from django.views.generic import UpdateView
 from tools.models import GROUP_CLIENT, OrganizationMember
 
 logger = structlog.get_logger(__name__)
+User = get_user_model()
 
 
 class OrganizationMemberEditView(
@@ -60,6 +62,10 @@ class OrganizationMemberEditView(
                 "text": _("Edit member"),
             },
         ]
+
+        if self.object.user.is_superuser:
+            active_superuser_count = User.objects.filter(is_superuser=True, is_active=True).count()
+            context["can_revoke_superuser"] = active_superuser_count > 1
 
         return context
 

--- a/rocky/rocky/views/organization_member_superuser.py
+++ b/rocky/rocky/views/organization_member_superuser.py
@@ -56,10 +56,7 @@ class SuperuserAccessView(UserPassesTestMixin, OrganizationView, TemplateView):
                 ),
                 "text": _("Edit member"),
             },
-            {
-                "url": self.request.path,
-                "text": self.action_label,
-            },
+            {"url": self.request.path, "text": self.action_label},
         ]
         return context
 
@@ -126,23 +123,34 @@ class RevokeSuperuserAccessView(SuperuserAccessView):
             target_member = get_object_or_404(
                 OrganizationMember.objects.select_for_update(), pk=kwargs["pk"], organization=self.organization
             )
+            # Lock the full set of active superusers (in pk order) before the
+            # target row, so two concurrent revokes serialise on the set instead
+            # of deadlocking: both transactions lock the same rows in the same
+            # order, so the second waits for the first to commit before counting.
+            active_superusers = list(
+                User.objects.select_for_update().filter(is_superuser=True, is_active=True).order_by("pk")
+            )
             target_user = User.objects.select_for_update().get(pk=target_member.user_id)
             previous_is_superuser = target_user.is_superuser
             previous_is_staff = target_user.is_staff
 
             if not previous_is_superuser:
-                messages.warning(request, _("%(email)s does not have superuser access.") % {"email": target_user.email})
+                if previous_is_staff:
+                    messages.warning(
+                        request,
+                        _(
+                            "%(email)s does not have superuser access but still has Django administration "
+                            "access; revoke that via Django administration."
+                        )
+                        % {"email": target_user.email},
+                    )
+                else:
+                    messages.warning(
+                        request, _("%(email)s does not have superuser access.") % {"email": target_user.email}
+                    )
                 return HttpResponseRedirect(self.get_success_url())
 
-            # ponytail: last-superuser guard has a TOCTOU ceiling: two superusers
-            # revoking two *different* superusers concurrently can each see a
-            # remaining count of 1 and both proceed, leaving zero. A DB-level
-            # constraint or advisory lock forbidding zero active superusers is
-            # the upgrade path; until then recovery is `manage.py createsuperuser`.
-            remaining_active_superusers = (
-                User.objects.filter(is_superuser=True, is_active=True).exclude(pk=target_user.pk).count()
-            )
-            if remaining_active_superusers == 0:
+            if not any(other.pk != target_user.pk for other in active_superusers):
                 messages.warning(
                     request,
                     _(

--- a/rocky/rocky/views/organization_member_superuser.py
+++ b/rocky/rocky/views/organization_member_superuser.py
@@ -18,13 +18,18 @@ logger = structlog.get_logger(__name__)
 User = get_user_model()
 
 SUPERUSER_ACCESS_GRANTED_EVENT_CODE = "900113"
+SUPERUSER_ACCESS_REVOKED_EVENT_CODE = "900114"
 
 
-class GrantSuperuserAccessView(UserPassesTestMixin, OrganizationView, TemplateView):
-    """Grant installation-wide superuser access from an organization member page."""
+class SuperuserAccessView(UserPassesTestMixin, OrganizationView, TemplateView):
+    """Shared confirmation page base for granting/revoking installation-wide access.
 
-    template_name = "organizations/organization_member_grant_superuser.html"
+    The actor must already be a superuser; the target is resolved only after the
+    permission check so a non-superuser cannot probe membership IDs.
+    """
+
     raise_exception = True
+    action_label = ""
 
     @cached_property
     def member(self):
@@ -52,14 +57,21 @@ class GrantSuperuserAccessView(UserPassesTestMixin, OrganizationView, TemplateVi
                 "text": _("Edit member"),
             },
             {
-                "url": reverse(
-                    "organization_member_grant_superuser",
-                    kwargs={"organization_code": self.organization.code, "pk": self.member.id},
-                ),
-                "text": _("Grant superuser access"),
+                "url": self.request.path,
+                "text": self.action_label,
             },
         ]
         return context
+
+    def get_success_url(self):
+        return reverse("organization_member_list", kwargs={"organization_code": self.organization.code})
+
+
+class GrantSuperuserAccessView(SuperuserAccessView):
+    """Grant installation-wide superuser access from an organization member page."""
+
+    template_name = "organizations/organization_member_grant_superuser.html"
+    action_label = _("Grant superuser access")
 
     def post(self, request, *args, **kwargs):
         with transaction.atomic():
@@ -102,5 +114,62 @@ class GrantSuperuserAccessView(UserPassesTestMixin, OrganizationView, TemplateVi
         messages.success(request, _("Superuser access granted to %(email)s.") % {"email": target_user.email})
         return HttpResponseRedirect(self.get_success_url())
 
-    def get_success_url(self):
-        return reverse("organization_member_list", kwargs={"organization_code": self.organization.code})
+
+class RevokeSuperuserAccessView(SuperuserAccessView):
+    """Revoke installation-wide superuser access from an organization member page."""
+
+    template_name = "organizations/organization_member_revoke_superuser.html"
+    action_label = _("Revoke superuser access")
+
+    def post(self, request, *args, **kwargs):
+        with transaction.atomic():
+            target_member = get_object_or_404(
+                OrganizationMember.objects.select_for_update(), pk=kwargs["pk"], organization=self.organization
+            )
+            target_user = User.objects.select_for_update().get(pk=target_member.user_id)
+            previous_is_superuser = target_user.is_superuser
+            previous_is_staff = target_user.is_staff
+
+            if not previous_is_superuser:
+                messages.warning(request, _("%(email)s does not have superuser access.") % {"email": target_user.email})
+                return HttpResponseRedirect(self.get_success_url())
+
+            # ponytail: last-superuser guard has a TOCTOU ceiling: two superusers
+            # revoking two *different* superusers concurrently can each see a
+            # remaining count of 1 and both proceed, leaving zero. A DB-level
+            # constraint or advisory lock forbidding zero active superusers is
+            # the upgrade path; until then recovery is `manage.py createsuperuser`.
+            remaining_active_superusers = (
+                User.objects.filter(is_superuser=True, is_active=True).exclude(pk=target_user.pk).count()
+            )
+            if remaining_active_superusers == 0:
+                messages.warning(
+                    request,
+                    _(
+                        "Revoking superuser access from %(email)s would leave this installation without any "
+                        "active superuser. Promote another account first, or revoke it via Django administration."
+                    )
+                    % {"email": target_user.email},
+                )
+                return HttpResponseRedirect(self.get_success_url())
+
+            target_user.is_superuser = False
+            target_user.is_staff = False
+            target_user.save(update_fields=["is_superuser", "is_staff"])
+
+            audit_event = {
+                "event_code": SUPERUSER_ACCESS_REVOKED_EVENT_CODE,
+                "actor_id": request.user.id,
+                "actor_email": request.user.email,
+                "target_id": target_user.id,
+                "target_email": target_user.email,
+                "previous_is_superuser": previous_is_superuser,
+                "previous_is_staff": previous_is_staff,
+                "is_superuser": target_user.is_superuser,
+                "is_staff": target_user.is_staff,
+                "changed_at": datetime.now(timezone.utc).isoformat(),
+            }
+            transaction.on_commit(lambda: logger.info("Superuser access revoked", **audit_event))
+
+        messages.success(request, _("Superuser access revoked from %(email)s.") % {"email": target_user.email})
+        return HttpResponseRedirect(self.get_success_url())

--- a/rocky/rocky/views/organization_member_superuser.py
+++ b/rocky/rocky/views/organization_member_superuser.py
@@ -64,9 +64,7 @@ class GrantSuperuserAccessView(UserPassesTestMixin, OrganizationView, TemplateVi
     def post(self, request, *args, **kwargs):
         with transaction.atomic():
             target_member = get_object_or_404(
-                OrganizationMember.objects.select_for_update(),
-                pk=kwargs["pk"],
-                organization=self.organization,
+                OrganizationMember.objects.select_for_update(), pk=kwargs["pk"], organization=self.organization
             )
             target_user = User.objects.select_for_update().get(pk=target_member.user_id)
             previous_is_superuser = target_user.is_superuser

--- a/rocky/rocky/views/organization_member_superuser.py
+++ b/rocky/rocky/views/organization_member_superuser.py
@@ -1,0 +1,108 @@
+from datetime import datetime, timezone
+from functools import cached_property
+
+import structlog
+from account.mixins import OrganizationView
+from django.contrib import messages
+from django.contrib.auth import get_user_model
+from django.contrib.auth.mixins import UserPassesTestMixin
+from django.db import transaction
+from django.http import HttpResponseRedirect
+from django.shortcuts import get_object_or_404
+from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
+from django.views.generic import TemplateView
+from tools.models import OrganizationMember
+
+logger = structlog.get_logger(__name__)
+User = get_user_model()
+
+SUPERUSER_ACCESS_GRANTED_EVENT_CODE = "900113"
+
+
+class GrantSuperuserAccessView(UserPassesTestMixin, OrganizationView, TemplateView):
+    """Grant installation-wide superuser access from an organization member page."""
+
+    template_name = "organizations/organization_member_grant_superuser.html"
+    raise_exception = True
+
+    @cached_property
+    def member(self):
+        """Resolve the target only after the actor has passed the permission check."""
+        return get_object_or_404(
+            OrganizationMember.objects.select_related("user"), pk=self.kwargs["pk"], organization=self.organization
+        )
+
+    def test_func(self):
+        return self.request.user.is_superuser
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["member"] = self.member
+        context["breadcrumbs"] = [
+            {
+                "url": reverse("organization_member_list", kwargs={"organization_code": self.organization.code}),
+                "text": _("Members"),
+            },
+            {
+                "url": reverse(
+                    "organization_member_edit",
+                    kwargs={"organization_code": self.organization.code, "pk": self.member.id},
+                ),
+                "text": _("Edit member"),
+            },
+            {
+                "url": reverse(
+                    "organization_member_grant_superuser",
+                    kwargs={"organization_code": self.organization.code, "pk": self.member.id},
+                ),
+                "text": _("Grant superuser access"),
+            },
+        ]
+        return context
+
+    def post(self, request, *args, **kwargs):
+        with transaction.atomic():
+            target_member = get_object_or_404(
+                OrganizationMember.objects.select_for_update(),
+                pk=kwargs["pk"],
+                organization=self.organization,
+            )
+            target_user = User.objects.select_for_update().get(pk=target_member.user_id)
+            previous_is_superuser = target_user.is_superuser
+            previous_is_staff = target_user.is_staff
+
+            if not target_user.is_active:
+                messages.warning(
+                    request,
+                    _("%(email)s is inactive and cannot be granted superuser access.") % {"email": target_user.email},
+                )
+                return HttpResponseRedirect(self.get_success_url())
+
+            if previous_is_superuser and previous_is_staff:
+                messages.warning(request, _("%(email)s already has superuser access.") % {"email": target_user.email})
+                return HttpResponseRedirect(self.get_success_url())
+
+            target_user.is_superuser = True
+            target_user.is_staff = True
+            target_user.save(update_fields=["is_superuser", "is_staff"])
+
+            audit_event = {
+                "event_code": SUPERUSER_ACCESS_GRANTED_EVENT_CODE,
+                "actor_id": request.user.id,
+                "actor_email": request.user.email,
+                "target_id": target_user.id,
+                "target_email": target_user.email,
+                "previous_is_superuser": previous_is_superuser,
+                "previous_is_staff": previous_is_staff,
+                "is_superuser": target_user.is_superuser,
+                "is_staff": target_user.is_staff,
+                "changed_at": datetime.now(timezone.utc).isoformat(),
+            }
+            transaction.on_commit(lambda: logger.info("Superuser access granted", **audit_event))
+
+        messages.success(request, _("Superuser access granted to %(email)s.") % {"email": target_user.email})
+        return HttpResponseRedirect(self.get_success_url())
+
+    def get_success_url(self):
+        return reverse("organization_member_list", kwargs={"organization_code": self.organization.code})

--- a/rocky/rocky/views/organization_member_superuser.py
+++ b/rocky/rocky/views/organization_member_superuser.py
@@ -86,6 +86,14 @@ class GrantSuperuserAccessView(SuperuserAccessView):
                 )
                 return HttpResponseRedirect(self.get_success_url())
 
+            if target_member.blocked:
+                messages.warning(
+                    request,
+                    _("%(email)s is blocked in this organization and cannot be granted superuser access.")
+                    % {"email": target_user.email},
+                )
+                return HttpResponseRedirect(self.get_success_url())
+
             if previous_is_superuser and previous_is_staff:
                 messages.warning(request, _("%(email)s already has superuser access.") % {"email": target_user.email})
                 return HttpResponseRedirect(self.get_success_url())
@@ -162,8 +170,7 @@ class RevokeSuperuserAccessView(SuperuserAccessView):
                 return HttpResponseRedirect(self.get_success_url())
 
             target_user.is_superuser = False
-            target_user.is_staff = False
-            target_user.save(update_fields=["is_superuser", "is_staff"])
+            target_user.save(update_fields=["is_superuser"])
 
             audit_event = {
                 "event_code": SUPERUSER_ACCESS_REVOKED_EVENT_CODE,
@@ -180,4 +187,6 @@ class RevokeSuperuserAccessView(SuperuserAccessView):
             transaction.on_commit(lambda: logger.info("Superuser access revoked", **audit_event))
 
         messages.success(request, _("Superuser access revoked from %(email)s.") % {"email": target_user.email})
+        if target_user.pk == request.user.pk:
+            return HttpResponseRedirect(reverse("crisis_room"))
         return HttpResponseRedirect(self.get_success_url())

--- a/rocky/tests/test_members.py
+++ b/rocky/tests/test_members.py
@@ -7,10 +7,15 @@ from django.test import Client
 from django.urls import reverse
 from django_otp import DEVICE_ID_SESSION_KEY
 from pytest_django.asserts import assertContains, assertNotContains
-
 from rocky.views.organization_member_add import OrganizationMemberAddAccountTypeView, OrganizationMemberAddView
 from rocky.views.organization_member_edit import OrganizationMemberEditView
-from rocky.views.organization_member_superuser import SUPERUSER_ACCESS_GRANTED_EVENT_CODE, GrantSuperuserAccessView
+from rocky.views.organization_member_superuser import (
+    SUPERUSER_ACCESS_GRANTED_EVENT_CODE,
+    SUPERUSER_ACCESS_REVOKED_EVENT_CODE,
+    GrantSuperuserAccessView,
+    RevokeSuperuserAccessView,
+)
+
 from tests.conftest import setup_request
 
 
@@ -200,7 +205,7 @@ def test_superuser_can_view_grant_superuser_confirmation(rf, superuser_member, a
     assertContains(response, "Grant superuser access")
     assertContains(response, admin_member.user.email)
     assertContains(response, "unrestricted access to every organization")
-    assertContains(response, "clear both Superuser status and Staff status")
+    assertContains(response, "can be revoked again from the same member edit page")
     assertContains(response, reverse("admin:account_katuser_change", args=[admin_member.user.id]))
     assertContains(response, "csrfmiddlewaretoken")
 
@@ -239,14 +244,18 @@ def test_superuser_can_grant_superuser_access(
 def test_grant_superuser_access_does_not_log_a_rolled_back_change(
     rf, superuser_member, admin_member, log_output, django_capture_on_commit_callbacks
 ):
+    """A rolled-back grant emits no audit log: the view registers its log via
+    ``transaction.on_commit()``, and Django drops on_commit callbacks when the
+    enclosing transaction rolls back, so the logger must never fire."""
     log_output.entries.clear()
     request = setup_request(rf.post("organization_member_grant_superuser"), superuser_member.user)
 
-    with django_capture_on_commit_callbacks(execute=True), pytest.raises(RuntimeError), transaction.atomic():
+    with django_capture_on_commit_callbacks(execute=True), transaction.atomic():
         GrantSuperuserAccessView.as_view()(
             request, organization_code=admin_member.organization.code, pk=admin_member.id
         )
-        raise RuntimeError
+        # Force the enclosing transaction to roll back instead of committing.
+        transaction.set_rollback(True)
 
     admin_member.user.refresh_from_db()
     assert admin_member.user.is_superuser is False
@@ -348,6 +357,162 @@ def test_grant_superuser_access_requires_csrf(superuser_member, client_member):
     client_member.user.refresh_from_db()
     assert client_member.user.is_superuser is True
     assert client_member.user.is_staff is True
+
+
+def test_superuser_sees_revoke_superuser_action(rf, superuser_member, superuser_member_b):
+    request = setup_request(rf.get("organization_member_edit"), superuser_member.user)
+    response = OrganizationMemberEditView.as_view()(
+        request, organization_code=superuser_member_b.organization.code, pk=superuser_member_b.id
+    )
+
+    assertContains(response, "Global account access")
+    assertContains(
+        response,
+        reverse(
+            "organization_member_revoke_superuser",
+            kwargs={"organization_code": superuser_member_b.organization.code, "pk": superuser_member_b.id},
+        ),
+    )
+    assertNotContains(response, "Grant superuser access")
+
+
+def test_superuser_can_view_revoke_superuser_confirmation(rf, superuser_member, superuser_member_b):
+    request = setup_request(rf.get("organization_member_revoke_superuser"), superuser_member.user)
+    response = RevokeSuperuserAccessView.as_view()(
+        request, organization_code=superuser_member_b.organization.code, pk=superuser_member_b.id
+    )
+
+    assertContains(response, "Revoke superuser access")
+    assertContains(response, superuser_member_b.user.email.lower())
+    assertContains(response, "revoke")
+    assertContains(response, "csrfmiddlewaretoken")
+
+
+def test_superuser_can_revoke_superuser_access(
+    rf, superuser_member, superuser_member_b, log_output, django_capture_on_commit_callbacks
+):
+    log_output.entries.clear()
+    request = setup_request(rf.post("organization_member_revoke_superuser"), superuser_member.user)
+    with django_capture_on_commit_callbacks(execute=True):
+        response = RevokeSuperuserAccessView.as_view()(
+            request, organization_code=superuser_member_b.organization.code, pk=superuser_member_b.id
+        )
+
+    assert response.status_code == 302
+    assert response.url == reverse(
+        "organization_member_list", kwargs={"organization_code": superuser_member_b.organization.code}
+    )
+
+    superuser_member_b.user.refresh_from_db()
+    assert superuser_member_b.user.is_superuser is False
+    assert superuser_member_b.user.is_staff is False
+
+    audit_log = log_output.entries[-1]
+    assert audit_log["event"] == "Superuser access revoked"
+    assert audit_log["event_code"] == SUPERUSER_ACCESS_REVOKED_EVENT_CODE
+    assert audit_log["actor_id"] == superuser_member.user.id
+    assert audit_log["target_id"] == superuser_member_b.user.id
+    assert audit_log["previous_is_superuser"] is True
+    assert audit_log["is_superuser"] is False
+    assert audit_log["is_staff"] is False
+    assert audit_log["changed_at"]
+
+
+def test_revoke_superuser_access_does_not_log_a_rolled_back_change(
+    rf, superuser_member, superuser_member_b, log_output, django_capture_on_commit_callbacks
+):
+    """A rolled-back revoke emits no audit log: on_commit callbacks are dropped
+    when the enclosing transaction rolls back, so the logger never fires."""
+    log_output.entries.clear()
+    request = setup_request(rf.post("organization_member_revoke_superuser"), superuser_member.user)
+
+    with django_capture_on_commit_callbacks(execute=True), transaction.atomic():
+        RevokeSuperuserAccessView.as_view()(
+            request, organization_code=superuser_member_b.organization.code, pk=superuser_member_b.id
+        )
+        transaction.set_rollback(True)
+
+    superuser_member_b.user.refresh_from_db()
+    assert superuser_member_b.user.is_superuser is True
+    assert not any(entry.get("event") == "Superuser access revoked" for entry in log_output.entries)
+
+
+def test_revoke_superuser_access_is_idempotent(rf, superuser_member, admin_member, log_output):
+    log_output.entries.clear()
+    request = setup_request(rf.post("organization_member_revoke_superuser"), superuser_member.user)
+    response = RevokeSuperuserAccessView.as_view()(
+        request, organization_code=admin_member.organization.code, pk=admin_member.id
+    )
+
+    assert response.status_code == 302
+    admin_member.user.refresh_from_db()
+    assert admin_member.user.is_superuser is False
+    assert admin_member.user.is_staff is False
+    assert [str(message) for message in get_messages(request)] == [
+        f"{admin_member.user.email} does not have superuser access."
+    ]
+    assert not any(entry.get("event") == "Superuser access revoked" for entry in log_output.entries)
+
+
+def test_revoke_refuses_last_active_superuser(rf, superuser_member, log_output):
+    """Revoking the only active superuser would lock out the installation, so
+    Rocky refuses and leaves the account unchanged."""
+    log_output.entries.clear()
+    request = setup_request(rf.post("organization_member_revoke_superuser"), superuser_member.user)
+    response = RevokeSuperuserAccessView.as_view()(
+        request, organization_code=superuser_member.organization.code, pk=superuser_member.id
+    )
+
+    assert response.status_code == 302
+    superuser_member.user.refresh_from_db()
+    assert superuser_member.user.is_superuser is True
+    assert any(
+        "would leave this installation without any active superuser" in str(message)
+        for message in get_messages(request)
+    )
+    assert not any(entry.get("event") == "Superuser access revoked" for entry in log_output.entries)
+
+
+@pytest.mark.parametrize("actor_fixture", ["admin_member", "redteam_member", "client_member"])
+def test_non_superusers_cannot_revoke_superuser_access(rf, request, actor_fixture, superuser_member):
+    actor = request.getfixturevalue(actor_fixture)
+    view_request = setup_request(rf.post("organization_member_revoke_superuser"), actor.user)
+
+    with pytest.raises(PermissionDenied):
+        RevokeSuperuserAccessView.as_view()(
+            view_request, organization_code=superuser_member.organization.code, pk=superuser_member.id
+        )
+
+    superuser_member.user.refresh_from_db()
+    assert superuser_member.user.is_superuser is True
+
+
+def test_revoke_superuser_access_requires_csrf(superuser_member, superuser_member_b):
+    superuser_member.onboarded = True
+    superuser_member.save(update_fields=["onboarded"])
+    csrf_client = Client(enforce_csrf_checks=True)
+    csrf_client.force_login(superuser_member.user)
+    session = csrf_client.session
+    session[DEVICE_ID_SESSION_KEY] = superuser_member.user.staticdevice_set.get().persistent_id
+    session.save()
+    url = reverse(
+        "organization_member_revoke_superuser",
+        kwargs={"organization_code": superuser_member_b.organization.code, "pk": superuser_member_b.id},
+    )
+
+    response = csrf_client.get(url)
+    assert response.status_code == 200
+
+    response = csrf_client.post(url)
+    assert response.status_code == 403
+    superuser_member_b.user.refresh_from_db()
+    assert superuser_member_b.user.is_superuser is True
+
+    response = csrf_client.post(url, {"csrfmiddlewaretoken": csrf_client.cookies["csrftoken"].value})
+    assert response.status_code == 302
+    superuser_member_b.user.refresh_from_db()
+    assert superuser_member_b.user.is_superuser is False
+    assert superuser_member_b.user.is_staff is False
 
 
 def test_account_type_view_existence(rf, admin_member):

--- a/rocky/tests/test_members.py
+++ b/rocky/tests/test_members.py
@@ -7,6 +7,7 @@ from django.test import Client
 from django.urls import reverse
 from django_otp import DEVICE_ID_SESSION_KEY
 from pytest_django.asserts import assertContains, assertNotContains
+
 from rocky.views.organization_member_add import OrganizationMemberAddAccountTypeView, OrganizationMemberAddView
 from rocky.views.organization_member_edit import OrganizationMemberEditView
 from rocky.views.organization_member_superuser import (
@@ -15,7 +16,6 @@ from rocky.views.organization_member_superuser import (
     GrantSuperuserAccessView,
     RevokeSuperuserAccessView,
 )
-
 from tests.conftest import setup_request
 
 
@@ -384,7 +384,7 @@ def test_superuser_can_view_revoke_superuser_confirmation(rf, superuser_member, 
 
     assertContains(response, "Revoke superuser access")
     assertContains(response, superuser_member_b.user.email.lower())
-    assertContains(response, "revoke")
+    assertContains(response, "unrestricted access to every organization")
     assertContains(response, "csrfmiddlewaretoken")
 
 
@@ -450,6 +450,31 @@ def test_revoke_superuser_access_is_idempotent(rf, superuser_member, admin_membe
     assert admin_member.user.is_staff is False
     assert [str(message) for message in get_messages(request)] == [
         f"{admin_member.user.email} does not have superuser access."
+    ]
+    assert not any(entry.get("event") == "Superuser access revoked" for entry in log_output.entries)
+
+
+def test_revoke_warns_when_account_has_staff_access_without_superuser(rf, superuser_member, admin_member, log_output):
+    """An account with Django administration access but no superuser access is
+    not silently left as-is: Rocky points out the retained staff access so the
+    actor does not believe the revoke closed the administrative loop."""
+    admin_member.user.is_staff = True
+    admin_member.user.save(update_fields=["is_staff"])
+    log_output.entries.clear()
+    request = setup_request(rf.post("organization_member_revoke_superuser"), superuser_member.user)
+    response = RevokeSuperuserAccessView.as_view()(
+        request, organization_code=admin_member.organization.code, pk=admin_member.id
+    )
+
+    assert response.status_code == 302
+    admin_member.user.refresh_from_db()
+    assert admin_member.user.is_superuser is False
+    # is_staff is untouched: this flow only manages the superuser grant, not
+    # staff access set independently via Django administration.
+    assert admin_member.user.is_staff is True
+    assert [str(message) for message in get_messages(request)] == [
+        f"{admin_member.user.email} does not have superuser access but still has Django administration access; "
+        f"revoke that via Django administration."
     ]
     assert not any(entry.get("event") == "Superuser access revoked" for entry in log_output.entries)
 

--- a/rocky/tests/test_members.py
+++ b/rocky/tests/test_members.py
@@ -1,10 +1,16 @@
 import pytest
+from django.contrib.messages import get_messages
 from django.core.exceptions import PermissionDenied
+from django.db import transaction
 from django.http import Http404
+from django.test import Client
+from django.urls import reverse
+from django_otp import DEVICE_ID_SESSION_KEY
 from pytest_django.asserts import assertContains, assertNotContains
 
 from rocky.views.organization_member_add import OrganizationMemberAddAccountTypeView, OrganizationMemberAddView
 from rocky.views.organization_member_edit import OrganizationMemberEditView
+from rocky.views.organization_member_superuser import SUPERUSER_ACCESS_GRANTED_EVENT_CODE, GrantSuperuserAccessView
 from tests.conftest import setup_request
 
 
@@ -157,6 +163,191 @@ def test_admin_edits_redteamer_to_block(rf, admin_member, redteam_member):
 
     redteam_member.refresh_from_db()
     assert redteam_member.blocked is True
+
+
+def test_superuser_sees_grant_superuser_action(rf, superuser_member, admin_member):
+    request = setup_request(rf.get("organization_member_edit"), superuser_member.user)
+    response = OrganizationMemberEditView.as_view()(
+        request, organization_code=admin_member.organization.code, pk=admin_member.id
+    )
+
+    assertContains(response, "Global account access")
+    assertContains(
+        response,
+        reverse(
+            "organization_member_grant_superuser",
+            kwargs={"organization_code": admin_member.organization.code, "pk": admin_member.id},
+        ),
+    )
+
+
+def test_admin_does_not_see_grant_superuser_action(rf, admin_member, redteam_member):
+    request = setup_request(rf.get("organization_member_edit"), admin_member.user)
+    response = OrganizationMemberEditView.as_view()(
+        request, organization_code=redteam_member.organization.code, pk=redteam_member.id
+    )
+
+    assertNotContains(response, "Global account access")
+    assertNotContains(response, "Grant superuser access")
+
+
+def test_superuser_can_view_grant_superuser_confirmation(rf, superuser_member, admin_member):
+    request = setup_request(rf.get("organization_member_grant_superuser"), superuser_member.user)
+    response = GrantSuperuserAccessView.as_view()(
+        request, organization_code=admin_member.organization.code, pk=admin_member.id
+    )
+
+    assertContains(response, "Grant superuser access")
+    assertContains(response, admin_member.user.email)
+    assertContains(response, "unrestricted access to every organization")
+    assertContains(response, "clear both Superuser status and Staff status")
+    assertContains(response, reverse("admin:account_katuser_change", args=[admin_member.user.id]))
+    assertContains(response, "csrfmiddlewaretoken")
+
+
+def test_superuser_can_grant_superuser_access(
+    rf, superuser_member, admin_member, log_output, django_capture_on_commit_callbacks
+):
+    log_output.entries.clear()
+    request = setup_request(rf.post("organization_member_grant_superuser"), superuser_member.user)
+    with django_capture_on_commit_callbacks(execute=True):
+        response = GrantSuperuserAccessView.as_view()(
+            request, organization_code=admin_member.organization.code, pk=admin_member.id
+        )
+
+    assert response.status_code == 302
+    assert response.url == reverse(
+        "organization_member_list", kwargs={"organization_code": admin_member.organization.code}
+    )
+
+    admin_member.user.refresh_from_db()
+    assert admin_member.user.is_superuser is True
+    assert admin_member.user.is_staff is True
+
+    audit_log = log_output.entries[-1]
+    assert audit_log["event"] == "Superuser access granted"
+    assert audit_log["event_code"] == SUPERUSER_ACCESS_GRANTED_EVENT_CODE
+    assert audit_log["actor_id"] == superuser_member.user.id
+    assert audit_log["target_id"] == admin_member.user.id
+    assert audit_log["previous_is_superuser"] is False
+    assert audit_log["previous_is_staff"] is False
+    assert audit_log["is_superuser"] is True
+    assert audit_log["is_staff"] is True
+    assert audit_log["changed_at"]
+
+
+def test_grant_superuser_access_does_not_log_a_rolled_back_change(
+    rf, superuser_member, admin_member, log_output, django_capture_on_commit_callbacks
+):
+    log_output.entries.clear()
+    request = setup_request(rf.post("organization_member_grant_superuser"), superuser_member.user)
+
+    with django_capture_on_commit_callbacks(execute=True), pytest.raises(RuntimeError), transaction.atomic():
+        GrantSuperuserAccessView.as_view()(
+            request, organization_code=admin_member.organization.code, pk=admin_member.id
+        )
+        raise RuntimeError
+
+    admin_member.user.refresh_from_db()
+    assert admin_member.user.is_superuser is False
+    assert admin_member.user.is_staff is False
+    assert not any(entry.get("event") == "Superuser access granted" for entry in log_output.entries)
+
+
+@pytest.mark.parametrize("actor_fixture", ["admin_member", "redteam_member", "client_member"])
+def test_non_superusers_cannot_grant_superuser_access(rf, request, actor_fixture, redteam_member):
+    actor = request.getfixturevalue(actor_fixture)
+    view_request = setup_request(rf.post("organization_member_grant_superuser"), actor.user)
+
+    with pytest.raises(PermissionDenied):
+        GrantSuperuserAccessView.as_view()(
+            view_request, organization_code=redteam_member.organization.code, pk=redteam_member.id
+        )
+
+    redteam_member.user.refresh_from_db()
+    assert redteam_member.user.is_superuser is False
+    assert redteam_member.user.is_staff is False
+
+
+def test_non_superuser_cannot_determine_if_grant_target_exists(rf, admin_member, redteam_member):
+    existing_target = setup_request(rf.post("organization_member_grant_superuser"), admin_member.user)
+    missing_target = setup_request(rf.post("organization_member_grant_superuser"), admin_member.user)
+
+    with pytest.raises(PermissionDenied):
+        GrantSuperuserAccessView.as_view()(
+            existing_target, organization_code=redteam_member.organization.code, pk=redteam_member.id
+        )
+
+    with pytest.raises(PermissionDenied):
+        GrantSuperuserAccessView.as_view()(
+            missing_target, organization_code=redteam_member.organization.code, pk=redteam_member.id + 100_000
+        )
+
+
+def test_grant_superuser_access_is_idempotent(rf, superuser_member, superuser_member_b, log_output):
+    superuser_member_b.user.is_staff = True
+    superuser_member_b.user.save(update_fields=["is_staff"])
+    log_output.entries.clear()
+    request = setup_request(rf.post("organization_member_grant_superuser"), superuser_member.user)
+    response = GrantSuperuserAccessView.as_view()(
+        request, organization_code=superuser_member_b.organization.code, pk=superuser_member_b.id
+    )
+
+    assert response.status_code == 302
+    superuser_member_b.user.refresh_from_db()
+    assert superuser_member_b.user.is_superuser is True
+    assert superuser_member_b.user.is_staff is True
+    assert [str(message) for message in get_messages(request)] == [
+        f"{superuser_member_b.user.email} already has superuser access."
+    ]
+    assert not any(entry.get("event") == "Superuser access granted" for entry in log_output.entries)
+
+
+def test_inactive_user_cannot_be_granted_superuser_access(rf, superuser_member, admin_member):
+    admin_member.user.is_active = False
+    admin_member.user.save(update_fields=["is_active"])
+    request = setup_request(rf.post("organization_member_grant_superuser"), superuser_member.user)
+
+    response = GrantSuperuserAccessView.as_view()(
+        request, organization_code=admin_member.organization.code, pk=admin_member.id
+    )
+
+    assert response.status_code == 302
+    admin_member.user.refresh_from_db()
+    assert admin_member.user.is_superuser is False
+    assert admin_member.user.is_staff is False
+    assert [str(message) for message in get_messages(request)] == [
+        f"{admin_member.user.email} is inactive and cannot be granted superuser access."
+    ]
+
+
+def test_grant_superuser_access_requires_csrf(superuser_member, client_member):
+    superuser_member.onboarded = True
+    superuser_member.save(update_fields=["onboarded"])
+    csrf_client = Client(enforce_csrf_checks=True)
+    csrf_client.force_login(superuser_member.user)
+    session = csrf_client.session
+    session[DEVICE_ID_SESSION_KEY] = superuser_member.user.staticdevice_set.get().persistent_id
+    session.save()
+    url = reverse(
+        "organization_member_grant_superuser",
+        kwargs={"organization_code": client_member.organization.code, "pk": client_member.id},
+    )
+
+    response = csrf_client.get(url)
+    assert response.status_code == 200
+
+    response = csrf_client.post(url)
+    assert response.status_code == 403
+    client_member.user.refresh_from_db()
+    assert client_member.user.is_superuser is False
+    assert client_member.user.is_staff is False
+
+    response = csrf_client.post(url, {"csrfmiddlewaretoken": csrf_client.cookies["csrftoken"].value})
+    assert response.status_code == 302
+    client_member.user.refresh_from_db()
+    assert client_member.user.is_superuser is True
+    assert client_member.user.is_staff is True
 
 
 def test_account_type_view_existence(rf, admin_member):

--- a/rocky/tests/test_members.py
+++ b/rocky/tests/test_members.py
@@ -330,6 +330,24 @@ def test_inactive_user_cannot_be_granted_superuser_access(rf, superuser_member, 
     ]
 
 
+def test_blocked_member_cannot_be_granted_superuser_access(rf, superuser_member, admin_member):
+    admin_member.blocked = True
+    admin_member.save(update_fields=["blocked"])
+    request = setup_request(rf.post("organization_member_grant_superuser"), superuser_member.user)
+
+    response = GrantSuperuserAccessView.as_view()(
+        request, organization_code=admin_member.organization.code, pk=admin_member.id
+    )
+
+    assert response.status_code == 302
+    admin_member.user.refresh_from_db()
+    assert admin_member.user.is_superuser is False
+    assert admin_member.user.is_staff is False
+    assert [str(message) for message in get_messages(request)] == [
+        f"{admin_member.user.email} is blocked in this organization and cannot be granted superuser access."
+    ]
+
+
 def test_grant_superuser_access_requires_csrf(superuser_member, client_member):
     superuser_member.onboarded = True
     superuser_member.save(update_fields=["onboarded"])
@@ -416,6 +434,25 @@ def test_superuser_can_revoke_superuser_access(
     assert audit_log["is_superuser"] is False
     assert audit_log["is_staff"] is False
     assert audit_log["changed_at"]
+
+
+def test_revoke_preserves_independently_set_staff_access(
+    rf, superuser_member, superuser_member_b, django_capture_on_commit_callbacks
+):
+    """Revoke only clears is_superuser — is_staff set independently via Django
+    admin must survive the revoke (hasecon round-2, finding 2)."""
+    superuser_member_b.user.is_staff = True
+    superuser_member_b.user.save(update_fields=["is_staff"])
+    request = setup_request(rf.post("organization_member_revoke_superuser"), superuser_member.user)
+
+    with django_capture_on_commit_callbacks(execute=True):
+        RevokeSuperuserAccessView.as_view()(
+            request, organization_code=superuser_member_b.organization.code, pk=superuser_member_b.id
+        )
+
+    superuser_member_b.user.refresh_from_db()
+    assert superuser_member_b.user.is_superuser is False
+    assert superuser_member_b.user.is_staff is True
 
 
 def test_revoke_superuser_access_does_not_log_a_rolled_back_change(


### PR DESCRIPTION
## Summary

Supersedes #5267, addressing all three review points from @underdarkNL:

- **Unreachable test code**: rewrote the rolled-back-grant test to use `transaction.set_rollback(True)` instead of an unreachable `raise RuntimeError`, with a docstring explaining the intent.
- **Revoke superuser access**: adds `RevokeSuperuserAccessView` mirroring the grant flow, with a last-active-superuser guard to prevent installation lockout, audit event `900114`, a dedicated confirmation page, and a revoke link on the member edit page. The grant page and docs now reflect that Rocky can revoke the permission itself.
- **Confirmation dialog**: both grant and revoke open a dedicated confirmation page with `role="alert"` warning, target email, installation-wide impact, destructive confirm button, and cancel link — a11y-friendly without requiring JS.

### Changes from #5267

- `rocky/views/organization_member_superuser.py`: shared `SuperuserAccessView` base, new `RevokeSuperuserAccessView` with last-superuser guard
- `rocky/templates/organizations/organization_member_revoke_superuser.html`: new revoke confirmation page
- `rocky/templates/organizations/organization_member_edit.html`: show grant OR revoke link based on target status
- `rocky/templates/organizations/organization_member_grant_superuser.html`: updated text (Rocky can now revoke)
- `rocky/urls.py`: revoke URL
- `rocky/tests/test_members.py`: revoke tests (confirmation, success, rollback, idempotent, last-superuser guard, non-superuser denied, CSRF), fixed rollback test
- `docs/`: event 900114, updated users-and-organizations page
- `rocky/rocky/locale/django.pot`: revoke strings

#### Test plan

- [x] 38/38 `test_members.py` tests pass (PostgreSQL 15, Django 5.1)
- [x] ruff: 0 errors
- [x] djlint: 0 errors on all templates
- [ ] CI on this PR

Generated with [Devin](https://devin.ai)