### PR TITLE
Fix kat_crt_sh crash on wildcard and email certificate identities

### DIFF
--- a/boefjes/boefjes/plugins/kat_crt_sh/normalize.py
+++ b/boefjes/boefjes/plugins/kat_crt_sh/normalize.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import logging
 from collections.abc import Iterable
 
 from dateutil.parser import parse
@@ -8,6 +9,25 @@ from boefjes.normalizer_models import NormalizerOutput
 from octopoes.models.ooi.certificate import X509Certificate
 from octopoes.models.ooi.dns.zone import Hostname
 from octopoes.models.ooi.network import Network
+
+logger = logging.getLogger(__name__)
+
+
+def _clean_identity(identity: str) -> str | None:
+    """Normalise a crt.sh certificate identity into a valid hostname, or None.
+
+    crt.sh's ``common_name`` and ``name_value`` can contain wildcard identities
+    (``*.example.com``) and rfc822 (email) identities (``admin@example.com``).
+    Neither is a valid Hostname: ``*`` and ``@`` are rejected by the Hostname
+    validator. Left unchecked, a single such identity raises a ValidationError
+    that aborts the whole normalizer run and drops every hostname and
+    certificate found in the scan (the runner materializes the generator, so an
+    exception discards everything already yielded).
+    """
+    name = identity.strip().lstrip(".*")
+    if not name or "@" in name:
+        return None
+    return name
 
 
 def run(input_ooi: dict, raw: bytes) -> Iterable[NormalizerOutput]:
@@ -25,13 +45,18 @@ def run(input_ooi: dict, raw: bytes) -> Iterable[NormalizerOutput]:
         # walk over all name_value parts (possibly just one, possibly more)
         names = certificate["name_value"].lower().splitlines()
         for name in names:
-            if not name.endswith(current):
-                # todo: do we want to hint other unrelated hostnames using the same certificate / and this possibly
-                #  the same private keys for tls?
-                pass
-            if name not in unique_domains:
-                yield Hostname(name=name, network=network_reference)
-                unique_domains.add(name)
+            # todo: do we want to hint other unrelated hostnames using the same certificate / and this possibly
+            #  the same private keys for tls?
+            name = _clean_identity(name)
+            if name is None or name in unique_domains:
+                continue
+            try:
+                hostname = Hostname(name=name, network=network_reference)
+            except ValueError:
+                logger.debug("Skipping invalid crt.sh identity %r", name)
+                continue
+            yield hostname
+            unique_domains.add(name)
 
         # Yield only current certs.
         expires_in = parse(certificate["not_after"]).astimezone(datetime.timezone.utc) - datetime.datetime.now(
@@ -49,5 +74,9 @@ def run(input_ooi: dict, raw: bytes) -> Iterable[NormalizerOutput]:
         # walk over the common_name. which might be unrelated to the requested domain, or it might be a parent domain
         # which our dns Boefje should also have picked up.
         # wildcards also trigger here, and won't be visible from a DNS query
-        if common_name.endswith(current) or common_name not in unique_domains:
-            yield Hostname(name=common_name, network=network_reference)
+        common_identity = _clean_identity(common_name)
+        if common_identity is not None and (common_identity.endswith(current) or common_identity not in unique_domains):
+            try:
+                yield Hostname(name=common_identity, network=network_reference)
+            except ValueError:
+                logger.debug("Skipping invalid crt.sh common_name %r", common_name)

--- a/boefjes/tests/plugins/test_crt_sh.py
+++ b/boefjes/tests/plugins/test_crt_sh.py
@@ -1,0 +1,51 @@
+import json
+
+from boefjes.plugins.kat_crt_sh.normalize import run
+from octopoes.models.ooi.certificate import X509Certificate
+from octopoes.models.ooi.dns.zone import Hostname
+
+input_ooi = {"hostname": {"name": "example.com"}}
+
+
+def _raw(common_name: str, name_value: str) -> bytes:
+    return json.dumps(
+        [
+            {
+                "common_name": common_name,
+                "name_value": name_value,
+                "not_before": "2020-01-01T00:00:00",
+                "not_after": "2999-01-01T00:00:00",
+                "issuer_name": "C=US, O=Example CA",
+                "serial_number": "0a1b",
+            }
+        ]
+    ).encode()
+
+
+def test_crt_sh_normalizer_wildcard_and_email_identities_do_not_crash():
+    # crt.sh name_value routinely contains wildcard and email identities. These
+    # are not valid Hostnames; before the fix a single one raised a
+    # ValidationError that aborted the run and dropped every hostname and
+    # certificate of the scan.
+    raw = _raw("*.example.com", "*.example.com\nexample.com\nadmin@example.com\nwww.example.com")
+
+    oois = list(run(input_ooi, raw))
+
+    hostname_names = {o.name for o in oois if isinstance(o, Hostname)}
+    # Wildcard is stripped to the bare domain, the plain names survive...
+    assert "example.com" in hostname_names
+    assert "www.example.com" in hostname_names
+    # ...and no invalid identity leaks through.
+    assert not any("*" in name or "@" in name for name in hostname_names)
+    # The certificate itself is still yielded.
+    assert any(isinstance(o, X509Certificate) for o in oois)
+
+
+def test_crt_sh_normalizer_only_invalid_identities_still_yields_certificate():
+    raw = _raw("*.example.com", "*.example.com\nsupport@example.com")
+
+    oois = list(run(input_ooi, raw))
+
+    # The wildcard collapses onto example.com; the email is skipped; the cert survives.
+    assert {o.name for o in oois if isinstance(o, Hostname)} == {"example.com"}
+    assert any(isinstance(o, X509Certificate) for o in oois)

--- a/boefjes/tests/plugins/test_crt_sh.py
+++ b/boefjes/tests/plugins/test_crt_sh.py
@@ -32,11 +32,9 @@ def test_crt_sh_normalizer_wildcard_and_email_identities_do_not_crash():
     oois = list(run(input_ooi, raw))
 
     hostname_names = {o.name for o in oois if isinstance(o, Hostname)}
-    # Wildcard is stripped to the bare domain, the plain names survive...
-    assert "example.com" in hostname_names
-    assert "www.example.com" in hostname_names
-    # ...and no invalid identity leaks through.
-    assert not any("*" in name or "@" in name for name in hostname_names)
+    # Wildcard is stripped to the bare domain, the plain names survive, and no
+    # invalid identity (containing '*' or '@') leaks through.
+    assert hostname_names == {"example.com", "www.example.com"}
     # The certificate itself is still yielded.
     assert any(isinstance(o, X509Certificate) for o in oois)
 


### PR DESCRIPTION
## What

crt.sh's `name_value` and `common_name` routinely contain wildcard identities (`*.example.com`) and rfc822 (email) identities (`admin@example.com`). Neither is a valid `Hostname`: the `*` and `@` are rejected by the Hostname validator. The normalizer yielded these verbatim, so a single such identity raised a `ValidationError`. Because the normalizer runner materializes the result generator, that exception aborts the **whole** normalizer and drops **every hostname and certificate** found in the scan.

## Fix

Normalise each identity through a small `_clean_identity` helper before constructing a `Hostname`: strip the wildcard prefix (as `common_name` already did via `lstrip(".*")`) and skip email identities. A defensive `try/except ValueError` around the `Hostname` construction ensures any other malformed identity from this untrusted third-party source can no longer abort the run.

## Test

`boefjes/tests/plugins/test_crt_sh.py`: a `name_value` mixing wildcard, email and plain identities no longer crashes; the wildcard collapses onto the bare domain, plain names survive, email identities are skipped, and the certificate is still yielded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)