### PR TITLE
Fix kat_external_db discarding one section when the other key is missing

### DIFF
--- a/boefjes/boefjes/plugins/kat_external_db/normalize.py
+++ b/boefjes/boefjes/plugins/kat_external_db/normalize.py
@@ -31,6 +31,22 @@ def follow_path_in_dict(path, path_dict):
     return path_dict
 
 
+def follow_list_path_in_dict(path, path_dict):
+    """Return the list found at path, or an empty list when the path is absent.
+
+    The ip_addresses and domains sections must be imported independently: the
+    runner materializes the result generator, so a KeyError raised while
+    iterating one section discards every OOI already yielded by the other. A
+    response with only domains (or only ip_addresses) must still import what it
+    does contain.
+    """
+    try:
+        return follow_path_in_dict(path=path, path_dict=path_dict)
+    except KeyError:
+        logging.warning("Path %s not found in results, skipping that section.", path)
+        return []
+
+
 def get_indemnification_level(path_dict):
     """Return indemnification level from metadata or default."""
     try:
@@ -49,7 +65,7 @@ def run(input_ooi: dict, raw: bytes) -> Iterable[NormalizerOutput]:
     network = Network(name=input_ooi["name"])
     addresses_count, blocks_count, hostnames_count = 0, 0, 0
 
-    for address_item in follow_path_in_dict(path=IP_ADDRESS_LIST_PATH, path_dict=results):
+    for address_item in follow_list_path_in_dict(path=IP_ADDRESS_LIST_PATH, path_dict=results):
         interface = ip_interface(follow_path_in_dict(path=IP_ADDRESS_ITEM_PATH, path_dict=address_item))
         indemnification_level = get_indemnification_level(path_dict=address_item)
         address, mask_str = interface.with_prefixlen.split("/")
@@ -74,7 +90,7 @@ def run(input_ooi: dict, raw: bytes) -> Iterable[NormalizerOutput]:
             yield DeclaredScanProfile(reference=block.reference, level=indemnification_level)
             blocks_count += 1
 
-    for hostname_data in follow_path_in_dict(path=DOMAIN_LIST_PATH, path_dict=results):
+    for hostname_data in follow_list_path_in_dict(path=DOMAIN_LIST_PATH, path_dict=results):
         hostname = Hostname(
             name=follow_path_in_dict(path=DOMAIN_ITEM_PATH, path_dict=hostname_data), network=network.reference
         )

--- a/boefjes/tests/plugins/test_external_db.py
+++ b/boefjes/tests/plugins/test_external_db.py
@@ -1,0 +1,37 @@
+import json
+
+from boefjes.plugins.kat_external_db.normalize import run
+from octopoes.models.ooi.dns.zone import Hostname
+from octopoes.models.ooi.network import IPAddressV4
+
+input_ooi = {"name": "internet"}
+
+
+def test_external_db_imports_ip_addresses_when_domains_missing():
+    # A response with only ip_addresses used to raise KeyError on the domains
+    # loop, discarding every IP already yielded (the runner materializes the
+    # generator). The IPs must survive.
+    raw = json.dumps({"ip_addresses": [{"address": "1.2.3.4"}]}).encode()
+
+    oois = list(run(input_ooi, raw))
+
+    assert any(isinstance(o, IPAddressV4) and str(o.address) == "1.2.3.4" for o in oois)
+
+
+def test_external_db_imports_domains_when_ip_addresses_missing():
+    # A response with only domains used to raise KeyError on the ip_addresses
+    # loop before any domain was reached, yielding nothing at all.
+    raw = json.dumps({"domains": [{"name": "example.com"}]}).encode()
+
+    oois = list(run(input_ooi, raw))
+
+    assert any(isinstance(o, Hostname) and o.name == "example.com" for o in oois)
+
+
+def test_external_db_imports_both_sections():
+    raw = json.dumps({"ip_addresses": [{"address": "1.2.3.4"}], "domains": [{"name": "example.com"}]}).encode()
+
+    oois = list(run(input_ooi, raw))
+
+    assert any(isinstance(o, IPAddressV4) for o in oois)
+    assert any(isinstance(o, Hostname) for o in oois)


### PR DESCRIPTION
## What

`kat_external_db` reads the `ip_addresses` and `domains` lists with `follow_path_in_dict`, which raises `KeyError` when a key is absent. Because the normalizer runner materializes the result generator, a `KeyError` on the domains loop **discards every IP address already yielded**, and a response without `ip_addresses` yields nothing at all even when it does contain `domains`.

## Fix

Add `follow_list_path_in_dict`, which returns an empty list (and logs a warning) when a list path is absent, so the two sections import independently. A response containing only one of the two sections now imports what it has.

## Test

`boefjes/tests/plugins/test_external_db.py`: only-ip_addresses, only-domains, and both-sections inputs all import their content without crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)