### PR TITLE
Add organization user activity logs

### DIFF
--- a/rocky/account/mixins.py
+++ b/rocky/account/mixins.py
@@ -16,7 +16,6 @@ from katalogus.client import KATalogus, get_katalogus
 from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from tools.models import Indemnification, Organization, OrganizationMember
-from tools.view_helpers import get_ooi_url
 
 from octopoes.connector.octopoes import OctopoesAPIConnector
 from octopoes.models import OOI, DeclaredScanProfile, Reference, ScanLevel
@@ -184,8 +183,7 @@ class OrganizationView(ContextMixin, View):
             organization=self.organization,
             action=AuditLog.Action.CLEARANCE_LEVEL_CHANGED,
             object_type=ooi_reference.class_,
-            object_label=ooi_reference.human_readable,
-            object_url=get_ooi_url("ooi_detail", ooi_reference, self.organization.code),
+            object_pk=ooi_reference,
         )
 
         return True

--- a/rocky/account/mixins.py
+++ b/rocky/account/mixins.py
@@ -3,6 +3,7 @@ from functools import cached_property
 
 import structlog
 import structlog.contextvars
+from crisis_room.models import AuditLog
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import PermissionRequiredMixin
@@ -15,6 +16,7 @@ from katalogus.client import KATalogus, get_katalogus
 from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from tools.models import Indemnification, Organization, OrganizationMember
+from tools.view_helpers import get_ooi_url
 
 from octopoes.connector.octopoes import OctopoesAPIConnector
 from octopoes.models import OOI, DeclaredScanProfile, Reference, ScanLevel
@@ -177,6 +179,14 @@ class OrganizationView(ContextMixin, View):
             sync=True,
         )
         logger.info("Declared scan profile created", event_code="800010", ooi=ooi_reference, level=level)
+        AuditLog.record(
+            user=self.request.user,
+            organization=self.organization,
+            action=AuditLog.Action.CLEARANCE_LEVEL_CHANGED,
+            object_type=ooi_reference.class_,
+            object_label=ooi_reference.human_readable,
+            object_url=get_ooi_url("ooi_detail", ooi_reference, self.organization.code),
+        )
 
         return True
 
@@ -191,6 +201,13 @@ class OrganizationView(ContextMixin, View):
             sync=True,
         )
         logger.info("Declared scan profiles created", event_code="800010", ooi_count=len(ooi_references), level=level)
+        AuditLog.record(
+            user=self.request.user,
+            organization=self.organization,
+            action=AuditLog.Action.CLEARANCE_LEVEL_CHANGED,
+            object_type="OOI",
+            object_label=str(_("%(count)s objects to L%(level)s")) % {"count": len(ooi_references), "level": level},
+        )
 
         return True
 

--- a/rocky/crisis_room/migrations/0009_auditlog.py
+++ b/rocky/crisis_room/migrations/0009_auditlog.py
@@ -34,8 +34,8 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("object_type", models.CharField(blank=True, max_length=64)),
-                ("object_label", models.CharField(blank=True, max_length=512)),
-                ("object_url", models.CharField(blank=True, max_length=2048)),
+                ("object_label", models.TextField(blank=True, default="")),
+                ("object_pk", models.TextField(blank=True, default="")),
                 ("created_at", models.DateTimeField(auto_now_add=True, db_index=True)),
                 (
                     "actor",
@@ -53,7 +53,7 @@ class Migration(migrations.Migration):
             options={
                 "ordering": ["-created_at"],
                 "indexes": [
-                    models.Index(fields=["organization", "-created_at"], name="crisis_room_organiz_875530_idx")
+                    models.Index(fields=["organization", "-created_at"], name="audit_log_org_created_idx")
                 ],
             },
         )

--- a/rocky/crisis_room/migrations/0009_auditlog.py
+++ b/rocky/crisis_room/migrations/0009_auditlog.py
@@ -1,0 +1,60 @@
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("crisis_room", "0008_alter_dashboard_organization"),
+        ("tools", "0047_alter_organization_code_alter_organization_name"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="AuditLog",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("actor_label", models.CharField(max_length=254)),
+                (
+                    "action",
+                    models.CharField(
+                        choices=[
+                            ("indemnification_set", "Set indemnification"),
+                            ("object_added", "Added object"),
+                            ("object_updated", "Updated object"),
+                            ("object_deleted", "Deleted object"),
+                            ("clearance_level_changed", "Changed clearance level"),
+                            ("plugin_enabled", "Enabled plugin"),
+                            ("plugin_disabled", "Disabled plugin"),
+                            ("plugin_settings_changed", "Changed plugin settings"),
+                            ("plugin_settings_deleted", "Deleted plugin settings"),
+                        ],
+                        max_length=32,
+                    ),
+                ),
+                ("object_type", models.CharField(blank=True, max_length=64)),
+                ("object_label", models.CharField(blank=True, max_length=512)),
+                ("object_url", models.CharField(blank=True, max_length=2048)),
+                ("created_at", models.DateTimeField(auto_now_add=True, db_index=True)),
+                (
+                    "actor",
+                    models.ForeignKey(
+                        null=True, on_delete=django.db.models.deletion.SET_NULL, to=settings.AUTH_USER_MODEL
+                    ),
+                ),
+                (
+                    "organization",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, related_name="audit_logs", to="tools.organization"
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["-created_at"],
+                "indexes": [
+                    models.Index(fields=["organization", "-created_at"], name="crisis_room_organiz_875530_idx")
+                ],
+            },
+        )
+    ]

--- a/rocky/crisis_room/migrations/0009_auditlog.py
+++ b/rocky/crisis_room/migrations/0009_auditlog.py
@@ -52,9 +52,7 @@ class Migration(migrations.Migration):
             ],
             options={
                 "ordering": ["-created_at"],
-                "indexes": [
-                    models.Index(fields=["organization", "-created_at"], name="audit_log_org_created_idx")
-                ],
+                "indexes": [models.Index(fields=["organization", "-created_at"], name="audit_log_org_created_idx")],
             },
         )
     ]

--- a/rocky/crisis_room/models.py
+++ b/rocky/crisis_room/models.py
@@ -3,6 +3,7 @@ from typing import Any, Literal, TypedDict
 from urllib.parse import urlencode
 
 import structlog
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models, transaction
@@ -13,6 +14,53 @@ from django.utils.translation import gettext_lazy as _
 from tools.models import Organization
 
 logger = structlog.get_logger(__name__)
+
+
+class AuditLog(models.Model):
+    class Action(models.TextChoices):
+        INDEMNIFICATION_SET = "indemnification_set", _("Set indemnification")
+        OBJECT_ADDED = "object_added", _("Added object")
+        OBJECT_UPDATED = "object_updated", _("Updated object")
+        OBJECT_DELETED = "object_deleted", _("Deleted object")
+        CLEARANCE_LEVEL_CHANGED = "clearance_level_changed", _("Changed clearance level")
+        PLUGIN_ENABLED = "plugin_enabled", _("Enabled plugin")
+        PLUGIN_DISABLED = "plugin_disabled", _("Disabled plugin")
+        PLUGIN_SETTINGS_CHANGED = "plugin_settings_changed", _("Changed plugin settings")
+        PLUGIN_SETTINGS_DELETED = "plugin_settings_deleted", _("Deleted plugin settings")
+
+    organization = models.ForeignKey(Organization, on_delete=models.CASCADE, related_name="audit_logs")
+    actor = models.ForeignKey(settings.AUTH_USER_MODEL, null=True, on_delete=models.SET_NULL)
+    actor_label = models.CharField(max_length=254)
+    action = models.CharField(max_length=32, choices=Action.choices)
+    object_type = models.CharField(blank=True, max_length=64)
+    object_label = models.CharField(blank=True, max_length=512)
+    object_url = models.CharField(blank=True, max_length=2048)
+    created_at = models.DateTimeField(auto_now_add=True, db_index=True)
+
+    class Meta:
+        ordering = ["-created_at"]
+        indexes = [models.Index(fields=["organization", "-created_at"], name="crisis_room_organiz_875530_idx")]
+
+    @classmethod
+    def record(
+        cls,
+        *,
+        user,
+        organization: Organization,
+        action: Any,
+        object_type: str = "",
+        object_label: str = "",
+        object_url: str = "",
+    ) -> "AuditLog":
+        return cls.objects.create(
+            organization=organization,
+            actor=user if user.is_authenticated else None,
+            actor_label=user.get_username() if user.is_authenticated else str(_("System")),
+            action=action,
+            object_type=object_type,
+            object_label=object_label,
+            object_url=object_url,
+        )
 
 
 class Dashboard(models.Model):

--- a/rocky/crisis_room/models.py
+++ b/rocky/crisis_room/models.py
@@ -11,7 +11,9 @@ from django.db.models.query_utils import Q
 from django.db.models.signals import post_delete, pre_save
 from django.dispatch import receiver
 from django.utils.translation import gettext_lazy as _
+from octopoes.models.reference import Reference
 from tools.models import Organization
+from tools.view_helpers import get_ooi_url
 
 logger = structlog.get_logger(__name__)
 
@@ -33,13 +35,13 @@ class AuditLog(models.Model):
     actor_label = models.CharField(max_length=254)
     action = models.CharField(max_length=32, choices=Action.choices)
     object_type = models.CharField(blank=True, max_length=64)
-    object_label = models.CharField(blank=True, max_length=512)
-    object_url = models.CharField(blank=True, max_length=2048)
+    object_label = models.TextField(blank=True, default="")
+    object_pk = models.TextField(blank=True, default="")
     created_at = models.DateTimeField(auto_now_add=True, db_index=True)
 
     class Meta:
         ordering = ["-created_at"]
-        indexes = [models.Index(fields=["organization", "-created_at"], name="crisis_room_organiz_875530_idx")]
+        indexes = [models.Index(fields=["organization", "-created_at"], name="audit_log_org_created_idx")]
 
     @classmethod
     def record(
@@ -50,7 +52,7 @@ class AuditLog(models.Model):
         action: Any,
         object_type: str = "",
         object_label: str = "",
-        object_url: str = "",
+        object_pk: str = "",
     ) -> "AuditLog":
         return cls.objects.create(
             organization=organization,
@@ -59,8 +61,27 @@ class AuditLog(models.Model):
             action=action,
             object_type=object_type,
             object_label=object_label,
-            object_url=object_url,
+            object_pk=object_pk,
         )
+
+    def get_object_label(self) -> str:
+        """Infer the display label from the stored PK for OOI actions;
+        fall back to the stored label for non-OOI actions (plugins, etc.)."""
+        if self.object_pk:
+            try:
+                return Reference.from_str(self.object_pk).human_readable
+            except Exception:
+                return self.object_pk
+        return self.object_label
+
+    def get_object_url(self) -> str:
+        """Construct the detail URL at read time from the stored PK."""
+        if not self.object_pk:
+            return ""
+        try:
+            return get_ooi_url("ooi_detail", self.object_pk, self.organization.code)
+        except Exception:
+            return ""
 
 
 class Dashboard(models.Model):

--- a/rocky/crisis_room/models.py
+++ b/rocky/crisis_room/models.py
@@ -11,7 +11,7 @@ from django.db.models.query_utils import Q
 from django.db.models.signals import post_delete, pre_save
 from django.dispatch import receiver
 from django.utils.translation import gettext_lazy as _
-from octopoes.models.reference import Reference
+from octopoes.models import Reference
 from tools.models import Organization
 from tools.view_helpers import get_ooi_url
 

--- a/rocky/crisis_room/models.py
+++ b/rocky/crisis_room/models.py
@@ -11,9 +11,10 @@ from django.db.models.query_utils import Q
 from django.db.models.signals import post_delete, pre_save
 from django.dispatch import receiver
 from django.utils.translation import gettext_lazy as _
-from octopoes.models import Reference
 from tools.models import Organization
 from tools.view_helpers import get_ooi_url
+
+from octopoes.models import Reference
 
 logger = structlog.get_logger(__name__)
 

--- a/rocky/crisis_room/models.py
+++ b/rocky/crisis_room/models.py
@@ -54,16 +54,22 @@ class AuditLog(models.Model):
         object_type: str = "",
         object_label: str = "",
         object_pk: str = "",
-    ) -> "AuditLog":
-        return cls.objects.create(
-            organization=organization,
-            actor=user if user.is_authenticated else None,
-            actor_label=user.get_username() if user.is_authenticated else str(_("System")),
-            action=action,
-            object_type=object_type,
-            object_label=object_label,
-            object_pk=object_pk,
-        )
+    ) -> "AuditLog | None":
+        """Best-effort audit logging: a failure here must never break the
+        primary action it records."""
+        try:
+            return cls.objects.create(
+                organization=organization,
+                actor=user if user.is_authenticated else None,
+                actor_label=user.get_username() if user.is_authenticated else str(_("System")),
+                action=action,
+                object_type=object_type,
+                object_label=object_label,
+                object_pk=object_pk,
+            )
+        except Exception:
+            logger.exception("Failed to record audit log entry", action=action)
+            return None
 
     def get_object_label(self) -> str:
         """Infer the display label from the stored PK for OOI actions;
@@ -76,11 +82,15 @@ class AuditLog(models.Model):
         return self.object_label
 
     def get_object_url(self) -> str:
-        """Construct the detail URL at read time from the stored PK."""
+        """Construct the detail URL at read time from the stored PK.
+        Include the event's created_at as valid_time so the link points to
+        the object state at the time of the event."""
         if not self.object_pk:
             return ""
         try:
-            return get_ooi_url("ooi_detail", self.object_pk, self.organization.code)
+            return get_ooi_url(
+                "ooi_detail", self.object_pk, self.organization.code, valid_time=self.created_at.isoformat()
+            )
         except Exception:
             return ""
 

--- a/rocky/crisis_room/templates/audit_log.html
+++ b/rocky/crisis_room/templates/audit_log.html
@@ -17,7 +17,7 @@
 
                 {% endif %}
                 <h2>{% translate "Activity log" %}</h2>
-                <p>{% translate "The 50 most recent recorded user actions are shown below." %}</p>
+                <p>{% translate "Recent recorded user actions are shown below." %}</p>
                 {% if audit_logs %}
                     <div class="horizontal-scroll">
                         <table class="nowrap">
@@ -43,9 +43,9 @@
                                         {% if not organization %}<td>{{ entry.organization.name }}</td>{% endif %}
                                         <td>{{ entry.get_action_display }}</td>
                                         <td>
-                                            {% if entry.object_url %}<a href="{{ entry.object_url }}">{% endif %}
-                                                {{ entry.object_label|default:"—" }}
-                                                {% if entry.object_url %}</a>{% endif %}
+                                            {% if entry.object_pk %}<a href="{{ entry.get_object_url }}">{% endif %}
+                                                {{ entry.get_object_label|default:"—" }}
+                                                {% if entry.object_pk %}</a>{% endif %}
                                             {% if entry.object_type %}<span class="nota-bene">{{ entry.object_type }}</span>{% endif %}
                                         </td>
                                     </tr>

--- a/rocky/crisis_room/templates/audit_log.html
+++ b/rocky/crisis_room/templates/audit_log.html
@@ -1,0 +1,62 @@
+{% extends "layouts/base.html" %}
+
+{% load i18n %}
+
+{% block content %}
+    {% include "header.html" %}
+
+    <main id="main-content">
+        <section>
+            <div>
+                <h1>{% translate "Crisis room" %}</h1>
+                {% if organization %}
+                    {% include "organization_crisis_room_header.html" with active="activity" %}
+
+                {% else %}
+                    {% include "crisis_room_header.html" with active="activity" %}
+
+                {% endif %}
+                <h2>{% translate "Activity log" %}</h2>
+                <p>{% translate "The 50 most recent recorded user actions are shown below." %}</p>
+                {% if audit_logs %}
+                    <div class="horizontal-scroll">
+                        <table class="nowrap">
+                            <caption class="visually-hidden">{% translate "Recent user actions" %}</caption>
+                            <thead>
+                                <tr>
+                                    <th scope="col">{% translate "Date and time" %}</th>
+                                    <th scope="col">{% translate "User" %}</th>
+                                    {% if not organization %}
+                                        <th scope="col">{% translate "Organization" %}</th>
+                                    {% endif %}
+                                    <th scope="col">{% translate "Action" %}</th>
+                                    <th scope="col">{% translate "Object" %}</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for entry in audit_logs %}
+                                    <tr>
+                                        <td>
+                                            <time datetime="{{ entry.created_at|date:'c' }}">{{ entry.created_at|date:"SHORT_DATETIME_FORMAT" }}</time>
+                                        </td>
+                                        <td>{{ entry.actor_label }}</td>
+                                        {% if not organization %}<td>{{ entry.organization.name }}</td>{% endif %}
+                                        <td>{{ entry.get_action_display }}</td>
+                                        <td>
+                                            {% if entry.object_url %}<a href="{{ entry.object_url }}">{% endif %}
+                                                {{ entry.object_label|default:"—" }}
+                                                {% if entry.object_url %}</a>{% endif %}
+                                            {% if entry.object_type %}<span class="nota-bene">{{ entry.object_type }}</span>{% endif %}
+                                        </td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                {% else %}
+                    <p>{% translate "No user actions have been recorded yet." %}</p>
+                {% endif %}
+            </div>
+        </section>
+    </main>
+{% endblock content %}

--- a/rocky/crisis_room/templates/crisis_room_header.html
+++ b/rocky/crisis_room/templates/crisis_room_header.html
@@ -6,6 +6,9 @@
             <li {% if active == "findings" %}aria-current="page"{% endif %}>
                 <a href="{% url 'crisis_room' %}">{% translate "Findings" %}</a>
             </li>
+            <li {% if active == "activity" %}aria-current="page"{% endif %}>
+                <a href="{% url 'crisis_room_audit_log' %}">{% translate "Activity log" %}</a>
+            </li>
         </ul>
     </nav>
 </div>

--- a/rocky/crisis_room/templates/organization_crisis_room_header.html
+++ b/rocky/crisis_room/templates/organization_crisis_room_header.html
@@ -9,6 +9,9 @@
                 <a href="{% url "organization_crisis_room" organization_code=dashboard.organization.code id=dashboard.id %}">{{ dashboard.name }}</a>
             </li>
         {% endfor %}
+        <li {% if active == "activity" %}aria-current="page"{% endif %}>
+            <a href="{% url 'organization_crisis_room_audit_log' organization.code %}">{% translate "Activity log" %}</a>
+        </li>
         {% if organization_member.can_add_dashboard %}
             <li>
                 <a href="#new-dashboard">+ {% translate "Add dashboard" %}</a>

--- a/rocky/crisis_room/urls.py
+++ b/rocky/crisis_room/urls.py
@@ -2,5 +2,8 @@ from django.urls import path
 
 from . import views
 
-# Crisis room overview (non-org-scope) url
-urlpatterns = [path("", views.CrisisRoomView.as_view(), name="crisis_room")]
+# Crisis room overview (non-org-scope) urls
+urlpatterns = [
+    path("", views.CrisisRoomView.as_view(), name="crisis_room"),
+    path("logs/", views.AuditLogView.as_view(), name="crisis_room_audit_log"),
+]

--- a/rocky/crisis_room/urls.py
+++ b/rocky/crisis_room/urls.py
@@ -5,5 +5,5 @@ from . import views
 # Crisis room overview (non-org-scope) urls
 urlpatterns = [
     path("", views.CrisisRoomView.as_view(), name="crisis_room"),
-    path("logs/", views.AuditLogView.as_view(), name="crisis_room_audit_log"),
+    path("auditlog/", views.AuditLogView.as_view(), name="crisis_room_audit_log"),
 ]

--- a/rocky/crisis_room/urls_org.py
+++ b/rocky/crisis_room/urls_org.py
@@ -7,6 +7,7 @@ from . import views
 # is provided by the mount point and does not need to be captured here.
 urlpatterns = [
     path("", views.OrganizationsCrisisRoomLandingView.as_view(), name="organization_crisis_room_landing"),
+    path("logs/", views.OrganizationAuditLogView.as_view(), name="organization_crisis_room_audit_log"),
     path("<int:id>/", views.OrganizationsCrisisRoomView.as_view(), name="organization_crisis_room"),
     path("add/", views.AddDashboardView.as_view(), name="add_dashboard"),
     path("update-item/", views.UpdateDashboardItemView.as_view(), name="update_dashboard_item"),

--- a/rocky/crisis_room/urls_org.py
+++ b/rocky/crisis_room/urls_org.py
@@ -7,7 +7,7 @@ from . import views
 # is provided by the mount point and does not need to be captured here.
 urlpatterns = [
     path("", views.OrganizationsCrisisRoomLandingView.as_view(), name="organization_crisis_room_landing"),
-    path("logs/", views.OrganizationAuditLogView.as_view(), name="organization_crisis_room_audit_log"),
+    path("auditlog/", views.OrganizationAuditLogView.as_view(), name="organization_crisis_room_audit_log"),
     path("<int:id>/", views.OrganizationsCrisisRoomView.as_view(), name="organization_crisis_room"),
     path("add/", views.AddDashboardView.as_view(), name="add_dashboard"),
     path("update-item/", views.UpdateDashboardItemView.as_view(), name="update_dashboard_item"),

--- a/rocky/crisis_room/views.py
+++ b/rocky/crisis_room/views.py
@@ -16,6 +16,7 @@ from django.http.request import HttpRequest
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.text import slugify
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import TemplateView
 from django.views.generic.edit import FormView
 from httpx import HTTPStatusError, ReadTimeout
@@ -24,7 +25,7 @@ from reports.report_types.findings_report.report import SEVERITY_OPTIONS
 from tools.forms.ooi_form import _EXCLUDED_OOI_TYPES
 
 from crisis_room.forms import AddDashboardForm
-from crisis_room.models import MAX_POSITION, Dashboard, DashboardItem
+from crisis_room.models import MAX_POSITION, AuditLog, Dashboard, DashboardItem
 from octopoes.config.settings import DEFAULT_SCAN_LEVEL_FILTER, DEFAULT_SCAN_PROFILE_TYPE_FILTER
 from octopoes.connector.octopoes import OctopoesAPIConnector
 from octopoes.models import Reference, ScanLevel, ScanProfileType
@@ -329,6 +330,20 @@ class CrisisRoomView(TemplateView):
         return context
 
 
+class AuditLogView(TemplateView):
+    """Recent user actions for every organization the user may access."""
+
+    template_name = "audit_log.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["audit_logs"] = AuditLog.objects.filter(
+            organization__in=self.request.user.organizations
+        ).select_related("organization")[:50]
+        context["breadcrumbs"] = [{"url": reverse("crisis_room_audit_log"), "text": _("Activity log")}]
+        return context
+
+
 class OrganizationsCrisisRoomLandingView(OrganizationView, TemplateView):
     template_name = "organization_crisis_room.html"
 
@@ -347,6 +362,26 @@ class OrganizationsCrisisRoomLandingView(OrganizationView, TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["add_dashboard_form"] = AddDashboardForm
+        return context
+
+
+class OrganizationAuditLogView(OrganizationView, TemplateView):
+    """Recent user actions for one organization."""
+
+    template_name = "audit_log.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["dashboards"] = Dashboard.objects.filter(organization=self.organization)
+        context["audit_logs"] = AuditLog.objects.filter(organization=self.organization)[:50]
+        context["breadcrumbs"] = [
+            {
+                "url": reverse(
+                    "organization_crisis_room_audit_log", kwargs={"organization_code": self.organization.code}
+                ),
+                "text": _("Activity log"),
+            }
+        ]
         return context
 
 

--- a/rocky/crisis_room/views.py
+++ b/rocky/crisis_room/views.py
@@ -9,6 +9,7 @@ from account.mixins import OrganizationView
 from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
+from django.core.paginator import Paginator
 from django.db import IntegrityError
 from django.db.models.manager import BaseManager
 from django.http import HttpResponse
@@ -334,12 +335,14 @@ class AuditLogView(TemplateView):
     """Recent user actions for every organization the user may access."""
 
     template_name = "audit_log.html"
+    paginate_by = 50
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["audit_logs"] = AuditLog.objects.filter(
-            organization__in=self.request.user.organizations
-        ).select_related("organization")[:50]
+        page_number = self.request.GET.get("page", 1)
+        logs = AuditLog.objects.filter(organization__in=self.request.user.organizations).select_related("organization")
+        paginator = Paginator(logs, self.paginate_by)
+        context["audit_logs"] = paginator.page(page_number)
         context["breadcrumbs"] = [{"url": reverse("crisis_room_audit_log"), "text": _("Activity log")}]
         return context
 
@@ -369,11 +372,15 @@ class OrganizationAuditLogView(OrganizationView, TemplateView):
     """Recent user actions for one organization."""
 
     template_name = "audit_log.html"
+    paginate_by = 50
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["dashboards"] = Dashboard.objects.filter(organization=self.organization)
-        context["audit_logs"] = AuditLog.objects.filter(organization=self.organization)[:50]
+        page_number = self.request.GET.get("page", 1)
+        logs = AuditLog.objects.filter(organization=self.organization)
+        paginator = Paginator(logs, self.paginate_by)
+        context["audit_logs"] = paginator.page(page_number)
         context["breadcrumbs"] = [
             {
                 "url": reverse(

--- a/rocky/katalogus/views/plugin_enable_disable.py
+++ b/rocky/katalogus/views/plugin_enable_disable.py
@@ -75,8 +75,4 @@ class PluginEnableDisableView(SinglePluginView):
             action=action,
             object_type=self.plugin.type.title(),
             object_label=self.plugin.name,
-            object_url=reverse(
-                "boefje_detail" if self.plugin.type == "boefje" else "normalizer_detail",
-                kwargs={"organization_code": self.organization.code, "plugin_id": self.plugin.id},
-            ),
         )

--- a/rocky/katalogus/views/plugin_enable_disable.py
+++ b/rocky/katalogus/views/plugin_enable_disable.py
@@ -1,4 +1,7 @@
+from typing import Any
+
 import structlog
+from crisis_room.models import AuditLog
 from django.contrib import messages
 from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import redirect
@@ -17,6 +20,7 @@ class PluginEnableDisableView(SinglePluginView):
 
         if plugin_state == "True":
             self.katalogus_client.disable_plugin(self.plugin)
+            self.record_action(AuditLog.Action.PLUGIN_DISABLED)
             messages.add_message(
                 self.request,
                 messages.WARNING,
@@ -29,6 +33,7 @@ class PluginEnableDisableView(SinglePluginView):
 
         if self.plugin.can_scan(self.organization_member):
             self.katalogus_client.enable_plugin(self.plugin)
+            self.record_action(AuditLog.Action.PLUGIN_ENABLED)
             messages.add_message(
                 self.request, messages.SUCCESS, _("{} '{}' enabled.").format(self.plugin.type.title(), self.plugin.name)
             )
@@ -62,3 +67,16 @@ class PluginEnableDisableView(SinglePluginView):
             )
 
         return redirect(reverse("katalogus", kwargs={"organization_code": self.organization.code}))
+
+    def record_action(self, action: Any) -> None:
+        AuditLog.record(
+            user=self.request.user,
+            organization=self.organization,
+            action=action,
+            object_type=self.plugin.type.title(),
+            object_label=self.plugin.name,
+            object_url=reverse(
+                "boefje_detail" if self.plugin.type == "boefje" else "normalizer_detail",
+                kwargs={"organization_code": self.organization.code, "plugin_id": self.plugin.id},
+            ),
+        )

--- a/rocky/katalogus/views/plugin_settings_add.py
+++ b/rocky/katalogus/views/plugin_settings_add.py
@@ -1,5 +1,8 @@
+from typing import Any
+
 import structlog
 from account.mixins import OrganizationPermissionRequiredMixin
+from crisis_room.models import AuditLog
 from django.contrib import messages
 from django.shortcuts import redirect
 from django.urls import reverse
@@ -48,6 +51,7 @@ class PluginSettingsAddView(OrganizationPermissionRequiredMixin, SinglePluginVie
 
         try:
             self.katalogus_client.upsert_plugin_settings(self.plugin.id, form.cleaned_data)
+            self.record_action(AuditLog.Action.PLUGIN_SETTINGS_CHANGED)
             messages.add_message(self.request, messages.SUCCESS, _("Added settings for '{}'").format(self.plugin.name))
         except HTTPError:
             messages.add_message(self.request, messages.ERROR, _("Failed adding settings"))
@@ -56,6 +60,7 @@ class PluginSettingsAddView(OrganizationPermissionRequiredMixin, SinglePluginVie
         if "add-enable" in self.request.POST:
             try:
                 self.katalogus_client.enable_plugin(self.plugin)
+                self.record_action(AuditLog.Action.PLUGIN_ENABLED)
             except HTTPError:
                 messages.add_message(self.request, messages.ERROR, _("Enabling {} failed").format(self.plugin.name))
                 return redirect(self.get_success_url())
@@ -101,3 +106,13 @@ class PluginSettingsAddView(OrganizationPermissionRequiredMixin, SinglePluginVie
 
     def add_error_notification(self, message):
         messages.add_message(self.request, messages.ERROR, message)
+
+    def record_action(self, action: Any) -> None:
+        AuditLog.record(
+            user=self.request.user,
+            organization=self.organization,
+            action=action,
+            object_type=self.plugin.type.title(),
+            object_label=self.plugin.name,
+            object_url=self.get_success_url(),
+        )

--- a/rocky/katalogus/views/plugin_settings_add.py
+++ b/rocky/katalogus/views/plugin_settings_add.py
@@ -114,5 +114,4 @@ class PluginSettingsAddView(OrganizationPermissionRequiredMixin, SinglePluginVie
             action=action,
             object_type=self.plugin.type.title(),
             object_label=self.plugin.name,
-            object_url=self.get_success_url(),
         )

--- a/rocky/katalogus/views/plugin_settings_delete.py
+++ b/rocky/katalogus/views/plugin_settings_delete.py
@@ -1,5 +1,6 @@
 import structlog
 from account.mixins import OrganizationPermissionRequiredMixin
+from crisis_room.models import AuditLog
 from django.contrib import messages
 from django.http import HttpResponseRedirect
 from django.urls import reverse
@@ -59,6 +60,14 @@ class PluginSettingsDeleteView(OrganizationPermissionRequiredMixin, SinglePlugin
     def delete(self, request, *args, **kwargs):
         try:
             self.katalogus_client.delete_plugin_settings(self.plugin.id)
+            AuditLog.record(
+                user=request.user,
+                organization=self.organization,
+                action=AuditLog.Action.PLUGIN_SETTINGS_DELETED,
+                object_type=self.plugin.type.title(),
+                object_label=self.plugin.name,
+                object_url=self.get_success_url(),
+            )
             messages.add_message(
                 request, messages.SUCCESS, _("Settings for plugin {} successfully deleted.").format(self.plugin.name)
             )

--- a/rocky/katalogus/views/plugin_settings_delete.py
+++ b/rocky/katalogus/views/plugin_settings_delete.py
@@ -66,7 +66,6 @@ class PluginSettingsDeleteView(OrganizationPermissionRequiredMixin, SinglePlugin
                 action=AuditLog.Action.PLUGIN_SETTINGS_DELETED,
                 object_type=self.plugin.type.title(),
                 object_label=self.plugin.name,
-                object_url=self.get_success_url(),
             )
             messages.add_message(
                 request, messages.SUCCESS, _("Settings for plugin {} successfully deleted.").format(self.plugin.name)

--- a/rocky/rocky/locale/django.pot
+++ b/rocky/rocky/locale/django.pot
@@ -254,6 +254,11 @@ msgid "Backup token"
 msgstr ""
 
 #: account/mixins.py
+#, python-format
+msgid "%(count)s objects to L%(level)s"
+msgstr ""
+
+#: account/mixins.py
 msgid "Clearance level has been set."
 msgstr ""
 
@@ -346,7 +351,7 @@ msgstr ""
 msgid "Member type"
 msgstr ""
 
-#: account/templates/account_detail.html
+#: account/templates/account_detail.html crisis_room/templates/audit_log.html
 #: crisis_room/templates/partials/crisis_room_findings_table.html
 #: rocky/templates/tasks/normalizers.html
 msgid "Organization"
@@ -665,6 +670,46 @@ msgid "Finding (Z-A)"
 msgstr ""
 
 #: crisis_room/models.py
+msgid "Set indemnification"
+msgstr ""
+
+#: crisis_room/models.py
+msgid "Added object"
+msgstr ""
+
+#: crisis_room/models.py
+msgid "Updated object"
+msgstr ""
+
+#: crisis_room/models.py
+msgid "Deleted object"
+msgstr ""
+
+#: crisis_room/models.py
+msgid "Changed clearance level"
+msgstr ""
+
+#: crisis_room/models.py
+msgid "Enabled plugin"
+msgstr ""
+
+#: crisis_room/models.py
+msgid "Disabled plugin"
+msgstr ""
+
+#: crisis_room/models.py
+msgid "Changed plugin settings"
+msgstr ""
+
+#: crisis_room/models.py
+msgid "Deleted plugin settings"
+msgstr ""
+
+#: crisis_room/models.py
+msgid "System"
+msgstr ""
+
+#: crisis_room/models.py
 msgid "Findings Dashboard"
 msgstr ""
 
@@ -707,10 +752,48 @@ msgstr ""
 msgid "Max dashboard items reached."
 msgstr ""
 
-#: crisis_room/templates/crisis_room.html
+#: crisis_room/templates/audit_log.html crisis_room/templates/crisis_room.html
 #: crisis_room/templates/organization_crisis_room.html
 #: rocky/templates/header.html
 msgid "Crisis room"
+msgstr ""
+
+#: crisis_room/templates/audit_log.html
+#: crisis_room/templates/crisis_room_header.html
+#: crisis_room/templates/organization_crisis_room_header.html
+#: crisis_room/views.py
+msgid "Activity log"
+msgstr ""
+
+#: crisis_room/templates/audit_log.html
+msgid "The 50 most recent recorded user actions are shown below."
+msgstr ""
+
+#: crisis_room/templates/audit_log.html
+msgid "Recent user actions"
+msgstr ""
+
+#: crisis_room/templates/audit_log.html
+msgid "Date and time"
+msgstr ""
+
+#: crisis_room/templates/audit_log.html
+msgid "User"
+msgstr ""
+
+#: crisis_room/templates/audit_log.html
+msgid "Action"
+msgstr ""
+
+#: crisis_room/templates/audit_log.html
+#: katalogus/templates/change_clearance_level.html
+#: reports/templates/report_overview/report_history_table.html
+#: reports/templates/summary/ooi_selection.html rocky/views/mixins.py
+msgid "Object"
+msgstr ""
+
+#: crisis_room/templates/audit_log.html
+msgid "No user actions have been recorded yet."
 msgstr ""
 
 #: crisis_room/templates/crisis_room.html
@@ -1602,12 +1685,6 @@ msgstr ""
 #: reports/report_types/aggregate_organisation_report/appendix.html
 #: reports/templates/summary/report_asset_overview.html
 msgid "Selected objects"
-msgstr ""
-
-#: katalogus/templates/change_clearance_level.html
-#: reports/templates/report_overview/report_history_table.html
-#: reports/templates/summary/ooi_selection.html rocky/views/mixins.py
-msgid "Object"
 msgstr ""
 
 #: katalogus/templates/change_clearance_level.html
@@ -7266,6 +7343,10 @@ msgstr ""
 
 #: rocky/views/health.py
 msgid "Beautified"
+msgstr ""
+
+#: rocky/views/indemnification_add.py
+msgid "Scanning indemnification"
 msgstr ""
 
 #: rocky/views/indemnification_add.py

--- a/rocky/rocky/locale/django.pot
+++ b/rocky/rocky/locale/django.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-03 09:10+0000\n"
+"POT-Creation-Date: 2026-09-10 09:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -4238,7 +4238,8 @@ msgid "Low"
 msgstr ""
 
 #: reports/templates/partials/report_severity_totals_table.html
-#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+#: tools/forms/scheduler.py rocky/scheduler.py
+#: rocky/templates/tasks/partials/stats.html
 msgid "Pending"
 msgstr ""
 
@@ -5015,27 +5016,33 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+#: tools/forms/scheduler.py rocky/scheduler.py
+#: rocky/templates/tasks/partials/stats.html
 msgid "Cancelled"
 msgstr ""
 
-#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+#: tools/forms/scheduler.py rocky/scheduler.py
+#: rocky/templates/tasks/partials/stats.html
 msgid "Completed"
 msgstr ""
 
-#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+#: tools/forms/scheduler.py rocky/scheduler.py
+#: rocky/templates/tasks/partials/stats.html
 msgid "Dispatched"
 msgstr ""
 
-#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+#: tools/forms/scheduler.py rocky/scheduler.py
+#: rocky/templates/tasks/partials/stats.html
 msgid "Failed"
 msgstr ""
 
-#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+#: tools/forms/scheduler.py rocky/scheduler.py
+#: rocky/templates/tasks/partials/stats.html
 msgid "Queued"
 msgstr ""
 
-#: tools/forms/scheduler.py rocky/templates/tasks/partials/stats.html
+#: tools/forms/scheduler.py rocky/scheduler.py
+#: rocky/templates/tasks/partials/stats.html
 msgid "Running"
 msgstr ""
 
@@ -6815,6 +6822,16 @@ msgstr ""
 
 #: rocky/templates/partials/pagination.html
 msgid "last"
+msgstr ""
+
+#: rocky/templates/partials/scan_level_indicator.html
+#, python-format
+msgid "Scan level %(level)s"
+msgstr ""
+
+#: rocky/templates/partials/scan_level_indicator.html
+#, python-format
+msgid "Clearance level %(level)s"
 msgstr ""
 
 #: rocky/templates/partials/secondary-menu.html

--- a/rocky/rocky/locale/django.pot
+++ b/rocky/rocky/locale/django.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-03 13:50+0000\n"
+"POT-Creation-Date: 2026-09-03 09:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -766,7 +766,7 @@ msgid "Activity log"
 msgstr ""
 
 #: crisis_room/templates/audit_log.html
-msgid "The 50 most recent recorded user actions are shown below."
+msgid "Recent recorded user actions are shown below."
 msgstr ""
 
 #: crisis_room/templates/audit_log.html
@@ -6815,16 +6815,6 @@ msgstr ""
 
 #: rocky/templates/partials/pagination.html
 msgid "last"
-msgstr ""
-
-#: rocky/templates/partials/scan_level_indicator.html
-#, python-format
-msgid "Scan level %(level)s"
-msgstr ""
-
-#: rocky/templates/partials/scan_level_indicator.html
-#, python-format
-msgid "Clearance level %(level)s"
 msgstr ""
 
 #: rocky/templates/partials/secondary-menu.html

--- a/rocky/rocky/views/indemnification_add.py
+++ b/rocky/rocky/views/indemnification_add.py
@@ -15,7 +15,9 @@ class IndemnificationAddView(OrganizationPermissionRequiredMixin, OrganizationVi
     permission_required = "tools.add_indemnification"
 
     def post(self, request, *args, **kwargs):
-        _, created = Indemnification.objects.get_or_create(user=self.request.user, organization=self.organization)
+        _indemnification, created = Indemnification.objects.get_or_create(
+            user=self.request.user, organization=self.organization
+        )
         if created:
             AuditLog.record(
                 user=self.request.user,

--- a/rocky/rocky/views/indemnification_add.py
+++ b/rocky/rocky/views/indemnification_add.py
@@ -1,5 +1,6 @@
 from account.forms import IndemnificationAddForm
 from account.mixins import OrganizationPermissionRequiredMixin, OrganizationView
+from crisis_room.models import AuditLog
 from django.contrib import messages
 from django.urls import reverse_lazy
 from django.urls.base import reverse
@@ -14,7 +15,15 @@ class IndemnificationAddView(OrganizationPermissionRequiredMixin, OrganizationVi
     permission_required = "tools.add_indemnification"
 
     def post(self, request, *args, **kwargs):
-        Indemnification.objects.get_or_create(user=self.request.user, organization=self.organization)
+        _, created = Indemnification.objects.get_or_create(user=self.request.user, organization=self.organization)
+        if created:
+            AuditLog.record(
+                user=self.request.user,
+                organization=self.organization,
+                action=AuditLog.Action.INDEMNIFICATION_SET,
+                object_type="Indemnification",
+                object_label=str(_("Scanning indemnification")),
+            )
         self.add_success_notification()
         return super().post(request, *args, **kwargs)
 

--- a/rocky/rocky/views/ooi_delete.py
+++ b/rocky/rocky/views/ooi_delete.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 
 from account.mixins import OrganizationPermissionRequiredMixin
+from crisis_room.models import AuditLog
 from django.http import HttpResponseRedirect
 from django.urls import reverse_lazy
 from django.utils.translation import gettext_lazy as _
@@ -20,6 +21,13 @@ class OOIDeleteView(OrganizationPermissionRequiredMixin, SingleOOIMixin, Templat
 
     def delete(self, request):
         self.octopoes_api_connector.delete(self.ooi.reference, valid_time=datetime.now(timezone.utc), sync=True)
+        AuditLog.record(
+            user=request.user,
+            organization=self.organization,
+            action=AuditLog.Action.OBJECT_DELETED,
+            object_type=self.ooi.get_ooi_type(),
+            object_label=self.ooi.human_readable,
+        )
         return HttpResponseRedirect(self.get_success_url())
 
     # Add support for browsers which only accept GET and POST for now.

--- a/rocky/rocky/views/ooi_delete.py
+++ b/rocky/rocky/views/ooi_delete.py
@@ -26,7 +26,7 @@ class OOIDeleteView(OrganizationPermissionRequiredMixin, SingleOOIMixin, Templat
             organization=self.organization,
             action=AuditLog.Action.OBJECT_DELETED,
             object_type=self.ooi.get_ooi_type(),
-            object_label=self.ooi.human_readable,
+            object_pk=self.ooi.primary_key,
         )
         return HttpResponseRedirect(self.get_success_url())
 

--- a/rocky/rocky/views/ooi_view.py
+++ b/rocky/rocky/views/ooi_view.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 from typing import Literal
 
+from crisis_room.models import AuditLog
 from django.forms import Form
 from django.http import Http404
 from django.shortcuts import redirect
@@ -214,6 +215,14 @@ class BaseOOIFormView(SingleOOIMixin, FormView):
             new_ooi = self.ooi_class.model_validate(form.cleaned_data)
             create_ooi(
                 self.octopoes_api_connector, self.bytes_client, new_ooi, datetime.now(timezone.utc), end_valid_time
+            )
+            AuditLog.record(
+                user=self.request.user,
+                organization=self.organization,
+                action=(AuditLog.Action.OBJECT_UPDATED if hasattr(self, "ooi") else AuditLog.Action.OBJECT_ADDED),
+                object_type=new_ooi.get_ooi_type(),
+                object_label=new_ooi.human_readable,
+                object_url=get_ooi_url("ooi_detail", new_ooi.primary_key, self.organization.code),
             )
             return redirect(self.get_ooi_success_url(new_ooi))
         except ValidationError as exception:

--- a/rocky/rocky/views/ooi_view.py
+++ b/rocky/rocky/views/ooi_view.py
@@ -221,8 +221,7 @@ class BaseOOIFormView(SingleOOIMixin, FormView):
                 organization=self.organization,
                 action=(AuditLog.Action.OBJECT_UPDATED if hasattr(self, "ooi") else AuditLog.Action.OBJECT_ADDED),
                 object_type=new_ooi.get_ooi_type(),
-                object_label=new_ooi.human_readable,
-                object_url=get_ooi_url("ooi_detail", new_ooi.primary_key, self.organization.code),
+                object_pk=new_ooi.primary_key,
             )
             return redirect(self.get_ooi_success_url(new_ooi))
         except ValidationError as exception:

--- a/rocky/rocky/views/ooi_view.py
+++ b/rocky/rocky/views/ooi_view.py
@@ -219,7 +219,7 @@ class BaseOOIFormView(SingleOOIMixin, FormView):
             AuditLog.record(
                 user=self.request.user,
                 organization=self.organization,
-                action=(AuditLog.Action.OBJECT_UPDATED if hasattr(self, "ooi") else AuditLog.Action.OBJECT_ADDED),
+                action=AuditLog.Action.OBJECT_UPDATED if getattr(self, "ooi", None) else AuditLog.Action.OBJECT_ADDED,
                 object_type=new_ooi.get_ooi_type(),
                 object_pk=new_ooi.primary_key,
             )

--- a/rocky/tests/katalogus/test_katalogus_plugin_add.py
+++ b/rocky/tests/katalogus/test_katalogus_plugin_add.py
@@ -1,3 +1,4 @@
+from crisis_room.models import AuditLog
 from django.urls import reverse
 from katalogus.views.plugin_settings_add import PluginSettingsAddView
 from pytest_django.asserts import assertContains, assertNotContains
@@ -51,6 +52,9 @@ def test_plugin_settings_add(rf, superuser_member, mock_mixins_katalogus, plugin
 
     assert response.status_code == 302
     assert list(request._messages).pop().message == "Added settings for 'TestBoefje'"
+    audit_log = AuditLog.objects.get()
+    assert audit_log.action == AuditLog.Action.PLUGIN_SETTINGS_CHANGED
+    assert audit_log.object_label == "TestBoefje"
 
 
 def test_plugin_settings_add_no_required(

--- a/rocky/tests/objects/test_objects_add.py
+++ b/rocky/tests/objects/test_objects_add.py
@@ -2,6 +2,7 @@ import json
 import uuid
 from unittest.mock import Mock
 
+from crisis_room.models import AuditLog
 from django import forms
 from pytest_django.asserts import assertContains
 from tools.forms.ooi_form import generate_select_ooi_field
@@ -36,6 +37,10 @@ def test_add_ooi(rf, client_member, mock_organization_view_octopoes, mock_bytes_
 
     assert expected_fragment.items() <= actual[0].items()
     assert mock_organization_view_octopoes().save_declaration.call_count == 1
+    audit_log = AuditLog.objects.get()
+    assert audit_log.actor == client_member.user
+    assert audit_log.action == AuditLog.Action.OBJECT_ADDED
+    assert audit_log.object_label == "testnetwork"
 
 
 def test_add_bad_schema(rf, client_member):

--- a/rocky/tests/objects/test_objects_add.py
+++ b/rocky/tests/objects/test_objects_add.py
@@ -40,7 +40,7 @@ def test_add_ooi(rf, client_member, mock_organization_view_octopoes, mock_bytes_
     audit_log = AuditLog.objects.get()
     assert audit_log.actor == client_member.user
     assert audit_log.action == AuditLog.Action.OBJECT_ADDED
-    assert audit_log.object_label == "testnetwork"
+    assert audit_log.object_pk == "Network|testnetwork"
 
 
 def test_add_bad_schema(rf, client_member):

--- a/rocky/tests/test_audit_log.py
+++ b/rocky/tests/test_audit_log.py
@@ -11,8 +11,7 @@ def test_organization_audit_log(rf, client_member):
         organization=client_member.organization,
         action=AuditLog.Action.OBJECT_ADDED,
         object_type="Network",
-        object_label="internet",
-        object_url="/objects/internet/",
+        object_pk="Network|internet",
     )
 
     request = setup_request(rf.get("organization_crisis_room_audit_log"), client_member.user)
@@ -22,7 +21,8 @@ def test_organization_audit_log(rf, client_member):
     assertContains(response, "Activity log")
     assertContains(response, client_member.user.email)
     assertContains(response, "Added object")
-    assertContains(response, 'href="/objects/internet/"')
+    # The URL is constructed at read time from the stored PK.
+    assertContains(response, "Network|internet")
 
 
 def test_general_audit_log_only_shows_accessible_organizations(rf, client_member, organization_b):

--- a/rocky/tests/test_audit_log.py
+++ b/rocky/tests/test_audit_log.py
@@ -1,0 +1,47 @@
+from crisis_room.models import AuditLog
+from crisis_room.views import AuditLogView, OrganizationAuditLogView
+from pytest_django.asserts import assertContains, assertNotContains
+
+from tests.conftest import setup_request
+
+
+def test_organization_audit_log(rf, client_member):
+    AuditLog.record(
+        user=client_member.user,
+        organization=client_member.organization,
+        action=AuditLog.Action.OBJECT_ADDED,
+        object_type="Network",
+        object_label="internet",
+        object_url="/objects/internet/",
+    )
+
+    request = setup_request(rf.get("organization_crisis_room_audit_log"), client_member.user)
+    response = OrganizationAuditLogView.as_view()(request, organization_code=client_member.organization.code)
+
+    assert response.status_code == 200
+    assertContains(response, "Activity log")
+    assertContains(response, client_member.user.email)
+    assertContains(response, "Added object")
+    assertContains(response, 'href="/objects/internet/"')
+
+
+def test_general_audit_log_only_shows_accessible_organizations(rf, client_member, organization_b):
+    AuditLog.record(
+        user=client_member.user,
+        organization=client_member.organization,
+        action=AuditLog.Action.PLUGIN_ENABLED,
+        object_label="Visible plugin",
+    )
+    AuditLog.record(
+        user=client_member.user,
+        organization=organization_b,
+        action=AuditLog.Action.PLUGIN_ENABLED,
+        object_label="Hidden plugin",
+    )
+
+    request = setup_request(rf.get("crisis_room_audit_log"), client_member.user)
+    response = AuditLogView.as_view()(request)
+
+    assert response.status_code == 200
+    assertContains(response, "Visible plugin")
+    assertNotContains(response, "Hidden plugin")

--- a/rocky/tests/test_audit_log.py
+++ b/rocky/tests/test_audit_log.py
@@ -21,8 +21,10 @@ def test_organization_audit_log(rf, client_member):
     assertContains(response, "Activity log")
     assertContains(response, client_member.user.email)
     assertContains(response, "Added object")
+    # The label is inferred from the stored PK at read time.
+    assertContains(response, "internet")
     # The URL is constructed at read time from the stored PK.
-    assertContains(response, "Network|internet")
+    assertContains(response, "ooi_id=Network")
 
 
 def test_general_audit_log_only_shows_accessible_organizations(rf, client_member, organization_b):

--- a/rocky/tests/test_organization.py
+++ b/rocky/tests/test_organization.py
@@ -1,12 +1,13 @@
 from unittest.mock import patch
 
 import pytest
+from crisis_room.models import AuditLog
 from django.contrib.auth.models import Permission
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.urls import reverse
 from httpx import RequestError
 from pytest_django.asserts import assertContains, assertNotContains
-from tools.models import DENY_ORGANIZATION_CODES, Organization
+from tools.models import DENY_ORGANIZATION_CODES, Indemnification, Organization
 
 from rocky.views.indemnification_add import IndemnificationAddView
 from rocky.views.organization_add import OrganizationAddView
@@ -325,6 +326,21 @@ def test_edit_organization_indemnification(rf, redteam_member, client_member):
         IndemnificationAddView.as_view()(
             request_client, organization_code=client_member.organization.code, pk=client_member.organization.id
         )
+
+
+def test_add_organization_indemnification(rf, admin_member):
+    Indemnification.objects.filter(user=admin_member.user, organization=admin_member.organization).delete()
+    request = setup_request(
+        rf.post("indemnification_add", {"may_scan": "on", "am_authorized": "on"}), admin_member.user
+    )
+
+    response = IndemnificationAddView.as_view()(request, organization_code=admin_member.organization.code)
+
+    assert response.status_code == 302
+    assert Indemnification.objects.filter(user=admin_member.user, organization=admin_member.organization).exists()
+    audit_log = AuditLog.objects.get()
+    assert audit_log.action == AuditLog.Action.INDEMNIFICATION_SET
+    assert audit_log.object_label == "Scanning indemnification"
 
 
 def test_admin_rights_edits_organization(rf, admin_member):


### PR DESCRIPTION
## Summary
Split out from #5305 per review: this PR contains the organization-scoped activity logs (audit log views) and the indemnification onboarding crash fix that the activity logging introduced.

- Add organization-scoped activity logs for successful user actions without storing plugin setting values
- Expose the latest activity in both the general and organization crisis rooms
- Fix the indemnification onboarding crash: the `Indemnification.objects.get_or_create()` result was assigned to `_`, shadowing Django's translation helper before the new audit-log label was translated. Creating a first indemnification raised `TypeError: 'Indemnification' object is not callable`. The unused result variable is renamed so the translation helper stays callable, with a regression test.

The rate-limiting work moves to a separate PR (#5313).

Closes #1437.
Closes #5308.

#### Test plan
- [x] Indemnification regression tests: 2 passed
- [x] Rocky audit-log tests added (`test_audit_log.py`)
- [x] pre-commit on changed files

Generated with [Devin](https://devin.ai)