### PR TITLE
Add check-cookie bit assessing Cookie OOI security attributes

### DIFF
--- a/boefjes/boefjes/plugins/kat_kat_finding_types/kat_finding_types.json
+++ b/boefjes/boefjes/plugins/kat_kat_finding_types/kat_finding_types.json
@@ -661,5 +661,13 @@
     "risk": "low",
     "impact": "Ambiguous cookie parsing can mask security attributes or allow smuggling of unintended values; the cookie may behave differently across browsers, proxies and security tooling.",
     "recommendation": "Emit syntactically valid Set-Cookie headers: a named cookie whose Domain matches the origin, with a valid Expires date, an integer Max-Age, a Path starting with '/', and a SameSite of Strict, Lax or None."
+  },
+  "KAT-INSECURE-COOKIE": {
+    "name": "Insecure cookie configuration",
+    "description": "A cookie is set without one or more recommended security attributes (Secure, HttpOnly, SameSite), or violates the requirements of its __Host-/__Secure- name prefix.",
+    "source": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie",
+    "risk": "medium",
+    "impact": "A cookie without the Secure attribute may be sent over an unencrypted connection and intercepted. Without HttpOnly the cookie is readable by client-side scripts, so an XSS flaw can steal it. Without a restrictive SameSite value the cookie is sent with cross-site requests, enabling CSRF. For session cookies this can lead to session hijacking.",
+    "recommendation": "Set the Secure and HttpOnly attributes on all cookies, and set SameSite to Strict or Lax (use None only together with Secure when cross-site use is required)."
   }
 }

--- a/octopoes/bits/check_cookie/bit.py
+++ b/octopoes/bits/check_cookie/bit.py
@@ -1,0 +1,6 @@
+from bits.definitions import BitDefinition
+from octopoes.models.ooi.web import Cookie
+
+BIT = BitDefinition(
+    id="check-cookie", consumes=Cookie, parameters=[], module="bits.check_cookie.check_cookie", min_scan_level=1
+)

--- a/octopoes/bits/check_cookie/check_cookie.py
+++ b/octopoes/bits/check_cookie/check_cookie.py
@@ -1,0 +1,45 @@
+from collections.abc import Iterator
+from typing import Any
+
+from octopoes.models import OOI
+from octopoes.models.ooi.findings import Finding, KATFindingType
+from octopoes.models.ooi.web import Cookie
+
+
+def run(cookie: Cookie, additional_oois: list, config: dict[str, Any]) -> Iterator[OOI]:
+    """Assess the security attributes of a parsed Cookie.
+
+    The attributes are already parsed onto the Cookie OOI by the headers
+    normalizer (RFC 6265 5.2), so this bit only inspects fields — no string
+    parsing. The issue list is emitted in a fixed order so repeated runs
+    produce a byte-identical Finding.
+    """
+    issues = []
+
+    if not cookie.secure_only:
+        issues.append("the Secure attribute is not set, so the cookie may be sent over an unencrypted connection")
+
+    if not cookie.http_only:
+        issues.append("the HttpOnly attribute is not set, so client-side scripts can read the cookie (XSS risk)")
+
+    if cookie.same_site is None:
+        issues.append("no valid SameSite attribute is set, so the cookie is sent with cross-site requests (CSRF risk)")
+    elif cookie.same_site == "None" and not cookie.secure_only:
+        issues.append("SameSite=None is set without the Secure attribute; modern browsers reject such cookies")
+
+    # https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-19#section-4.1.3
+    if cookie.name.startswith("__Host-") and not (cookie.secure_only and cookie.host_only and cookie.path == "/"):
+        issues.append("the __Host- name prefix requires the Secure attribute, no Domain attribute and Path=/")
+    elif cookie.name.startswith("__Secure-") and not cookie.secure_only:
+        issues.append("the __Secure- name prefix requires the Secure attribute")
+
+    if not issues:
+        return
+
+    finding_type = KATFindingType(id="KAT-INSECURE-COOKIE")
+    yield finding_type
+    yield Finding(
+        finding_type=finding_type.reference,
+        ooi=cookie.reference,
+        description="Insecure cookie configuration: " + "; ".join(issues) + ".",
+    )

--- a/octopoes/tests/test_bit_cookie.py
+++ b/octopoes/tests/test_bit_cookie.py
@@ -1,0 +1,63 @@
+from bits.check_cookie.check_cookie import run
+
+from octopoes.models import Reference
+from octopoes.models.ooi.web import Cookie
+
+DOMAIN = Reference.from_str("Hostname|internet|example.com")
+
+
+def _cookie(**kwargs):
+    kwargs.setdefault("name", "sid")
+    return Cookie(domain=DOMAIN, **kwargs)
+
+
+def _findings(cookie):
+    return [result for result in run(cookie, [], {}) if result.object_type == "Finding"]
+
+
+def test_fully_secure_cookie_is_clean():
+    assert _findings(_cookie(secure_only=True, http_only=True, same_site="Lax")) == []
+
+
+def test_bare_cookie_reports_all_three_attributes():
+    (finding,) = _findings(_cookie())
+    assert "Secure attribute is not set" in finding.description
+    assert "HttpOnly attribute is not set" in finding.description
+    assert "SameSite attribute is set" in finding.description
+
+
+def test_only_missing_secure_is_reported():
+    (finding,) = _findings(_cookie(http_only=True, same_site="Strict"))
+    assert "Secure attribute is not set" in finding.description
+    assert "HttpOnly" not in finding.description
+
+
+def test_samesite_none_without_secure_is_flagged():
+    (finding,) = _findings(_cookie(http_only=True, same_site="None"))
+    assert "SameSite=None" in finding.description
+
+
+def test_samesite_none_with_secure_is_allowed():
+    assert _findings(_cookie(secure_only=True, http_only=True, same_site="None")) == []
+
+
+def test_host_prefix_with_non_root_path_is_flagged():
+    cookie = _cookie(name="__Host-sid", path="/app", secure_only=True, http_only=True, same_site="Lax")
+    (finding,) = _findings(cookie)
+    assert "__Host-" in finding.description
+
+
+def test_host_prefix_satisfied_is_clean():
+    cookie = _cookie(name="__Host-sid", path="/", secure_only=True, http_only=True, same_site="Lax")
+    assert _findings(cookie) == []
+
+
+def test_secure_prefix_requires_secure():
+    (finding,) = _findings(_cookie(name="__Secure-sid", http_only=True, same_site="Lax"))
+    assert "__Secure-" in finding.description
+
+
+def test_finding_is_deterministic():
+    first = _findings(_cookie())[0]
+    second = _findings(_cookie())[0]
+    assert first.model_dump() == second.model_dump()


### PR DESCRIPTION
### Changes

**Rewritten on top of the merged Cookie OOI (#5331)** — this is phase 2 of the #213 plan, replacing this PR's earlier Set-Cookie header-string approach, per @underdarknl's note that the string bit was superseded by the Cookie model. The branch was rebuilt from current `main`; the old string-parsing implementation is gone.

Adds a `check-cookie` bit that consumes the parsed `Cookie` OOI and yields one `KAT-INSECURE-COOKIE` finding (risk medium) per insecure cookie. No string parsing — the headers normalizer already parsed the attributes onto the object, and the canonical Set-Cookie header value is redacted anyway.

Checks:
- missing **Secure** (cookie may travel over an unencrypted connection)
- missing **HttpOnly** (readable by client-side scripts → XSS)
- no valid **SameSite** value (sent with cross-site requests → CSRF)
- **SameSite=None without Secure** (rejected by modern browsers)
- **`__Host-` prefix** without Secure + host-only + `Path=/`, and **`__Secure-` prefix** without Secure (RFC 6265bis §4.1.3)

The issue list is emitted in a fixed order, so repeated observations produce a byte-identical Finding — same determinism guarantee as the Cookie OOI itself (#213's churn goal).

### Issue link

Phase 2 of the plan on #213 (phase 1 = #5331, merged). Does not close #213 (phase 3, the use-case normalizers, remains).

### QA notes

- Unit tests: `octopoes/tests/test_bit_cookie.py` — 9 cases (clean cookie, each missing attribute, SameSite=None ±Secure, both name prefixes, determinism), green in the octopoes container.
- Bit discovery verified: `get_bit_definitions()` picks up `check-cookie` (consumes `Cookie`, min_scan_level 1).
- **Functional, verified live on a full stack:** uploaded a `Set-Cookie: sid=tok123; Path=/` headers raw via bytes → headers normalizer minted `Cookie|sid|internet|apache.dvwa.cloud|/` → scan level 4 inherited from the hostname → the bit derived `Finding|Cookie|…|KAT-INSECURE-COOKIE` listing all three missing attributes. Findings page and Cookie detail page render (200).

---

### Code Checklist

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [x] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.