### PR TITLE
Remove dead ooi-types json_script block from the graph template

### DIFF
--- a/rocky/rocky/templates/graph-d3.html
+++ b/rocky/rocky/templates/graph-d3.html
@@ -31,7 +31,6 @@
 {% endblock content %}
 {% block html_at_end_body %}
     {{ block.super }}
-    {{ ooi_types|json_script:"ooi-types" }}
     {{ graph_tree|json_script:"tree-data" }}
     <script src="{% static "js/checkboxToggler.js" %}" nonce="{{ request.csp_nonce }}"></script>
     <script src="{% static "dist/imports/graph.js" %}" nonce="{{ request.csp_nonce }}"></script>


### PR DESCRIPTION
### Changes

One-line follow-up to #5324. The old `graph-render.js` was the only consumer of the `#ooi-types` JSON block and was removed there; the bundled `graph-d3.js` only reads `#tree-data` (colors come from `colorForOoi()` directly). The block was serializing the full `ooi_types` context into every graph page render with no reader left — `grep -rn "ooi-types" rocky/` now returns only this template line.

The server-side `ooi_types` context stays (the tree settings form uses it); only the client-side JSON dump goes.

### Issue link

Follow-up to #5324 / #5322 (surfaced by a post-merge review pass on that diff).

### QA notes

- `pytest tests/objects/test_objects_graph.py` in the rocky CI container: 2 passed (graph renders + hydration regression test).
- pre-commit (djLint et al.) green on the template.

---

### Code Checklist

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made. *(pure dead-code removal; existing graph tests cover the page)*
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.
