### PR TITLE
Follow same-resource redirects in webpage analysis

### DIFF
--- a/boefjes/boefjes/plugins/kat_webpage_analysis/main.py
+++ b/boefjes/boefjes/plugins/kat_webpage_analysis/main.py
@@ -73,7 +73,6 @@ def run(boefje_meta: dict) -> list[tuple[set, bytes | str]]:
 
 def do_request(hostname: str, session: Session, uri: str, useragent: str):
     headers = {"Host": hostname, "User-Agent": useragent}
-    response = session.get(uri, headers=headers, verify=False, allow_redirects=False)
 
     # Follow a redirect only when it points back to the same resource — the
     # server canonicalising the URL (e.g. dropping the explicit :443, or a
@@ -84,8 +83,15 @@ def do_request(hostname: str, session: Session, uri: str, useragent: str):
     # as a 301: the oois_in_headers bit turns its Location into a URL that is
     # discovered and scanned as its own resource, so following it here would
     # only duplicate that detection onto the wrong resource.
-    seen = {uri}
-    while response.is_redirect and len(seen) <= MAX_SAME_RESOURCE_REDIRECTS:
+    target = uri
+    seen: set[str] = set()
+    while True:
+        response = session.get(target, headers=headers, verify=False, allow_redirects=False)
+        seen.add(target)
+
+        if not response.is_redirect or len(seen) > MAX_SAME_RESOURCE_REDIRECTS:
+            break
+
         location = response.headers.get("location")
         if not location:
             break
@@ -93,9 +99,6 @@ def do_request(hostname: str, session: Session, uri: str, useragent: str):
         target = urljoin(response.url, location)
         if target in seen or not is_same_resource(uri, target):
             break
-
-        seen.add(target)
-        response = session.get(target, headers=headers, verify=False, allow_redirects=False)
 
     return response
 

--- a/boefjes/boefjes/plugins/kat_webpage_analysis/main.py
+++ b/boefjes/boefjes/plugins/kat_webpage_analysis/main.py
@@ -2,7 +2,7 @@ import ipaddress
 import json
 import mimetypes
 from os import getenv
-from urllib.parse import urlparse, urlunsplit
+from urllib.parse import urljoin, urlparse, urlunsplit
 
 import requests
 from forcediphttpsadapter.adapters import ForcedIPHTTPSAdapter
@@ -12,6 +12,10 @@ from requests import Session
 from boefjes.plugins.kat_webpage_analysis.har.requests import create_har_object
 
 ALLOWED_CONTENT_TYPES = mimetypes.types_map.values()
+
+DEFAULT_PORTS = {"http": 80, "https": 443}
+# Cap on same-resource redirect hops (see do_request).
+MAX_SAME_RESOURCE_REDIRECTS = 5
 
 
 def run(boefje_meta: dict) -> list[tuple[set, bytes | str]]:
@@ -26,8 +30,10 @@ def run(boefje_meta: dict) -> list[tuple[set, bytes | str]]:
     session = requests.Session()
 
     if url_parts.scheme == "https":
-        # Adapter is available, use it regardless of Python version
-        base_url = urlunsplit((url_parts.scheme, url_parts.netloc, "", "", ""))
+        # Adapter is available, use it regardless of Python version. Mount on
+        # scheme://host without the port so a same-resource redirect that drops
+        # the explicit :443 (see do_request) still resolves through the pinned IP.
+        base_url = urlunsplit((url_parts.scheme, url_parts.hostname or url_parts.netloc, "", "", ""))
         session.mount(base_url, ForcedIPHTTPSAdapter(dest_ip=ip))
     else:
         # Fall back to old hack-ip-into-url behavior, for either https with no adapter, or http.
@@ -66,11 +72,46 @@ def run(boefje_meta: dict) -> list[tuple[set, bytes | str]]:
 
 
 def do_request(hostname: str, session: Session, uri: str, useragent: str):
-    response = session.get(
-        uri, headers={"Host": hostname, "User-Agent": useragent}, verify=False, allow_redirects=False
-    )
+    headers = {"Host": hostname, "User-Agent": useragent}
+    response = session.get(uri, headers=headers, verify=False, allow_redirects=False)
+
+    # Follow a redirect only when it points back to the same resource — the
+    # server canonicalising the URL (e.g. dropping the explicit :443, or a
+    # cache/security warm-up that 301s "/" to itself). Without this the HAR
+    # captures an empty redirect body and every body-based analysis (Wappalyzer
+    # CMS/tech detection, image extraction) sees nothing. A redirect to a
+    # *different* URL (apex->www, http->https, /->/other) is deliberately left
+    # as a 301: the oois_in_headers bit turns its Location into a URL that is
+    # discovered and scanned as its own resource, so following it here would
+    # only duplicate that detection onto the wrong resource.
+    seen = {uri}
+    while response.is_redirect and len(seen) <= MAX_SAME_RESOURCE_REDIRECTS:
+        location = response.headers.get("location")
+        if not location:
+            break
+
+        target = urljoin(response.url, location)
+        if target in seen or not is_same_resource(uri, target):
+            break
+
+        seen.add(target)
+        response = session.get(target, headers=headers, verify=False, allow_redirects=False)
 
     return response
+
+
+def is_same_resource(url: str, other: str) -> bool:
+    left, right = urlparse(url), urlparse(other)
+
+    def port(parts):
+        return parts.port or DEFAULT_PORTS.get(parts.scheme)
+
+    return (
+        left.scheme == right.scheme
+        and left.hostname == right.hostname
+        and port(left) == port(right)
+        and (left.path or "/") == (right.path or "/")
+    )
 
 
 def get_uri(input_: dict) -> str:

--- a/boefjes/tests/plugins/test_webpage_analysis_redirects.py
+++ b/boefjes/tests/plugins/test_webpage_analysis_redirects.py
@@ -1,0 +1,104 @@
+from boefjes.plugins.kat_webpage_analysis.main import do_request, is_same_resource
+
+
+class FakeResponse:
+    def __init__(self, status_code, url, location=None, body=b""):
+        self.status_code = status_code
+        self.url = url
+        self.headers = {"location": location} if location else {}
+        self.content = body
+
+    @property
+    def is_redirect(self):
+        return 300 <= self.status_code < 400 and "location" in self.headers
+
+
+class FakeSession:
+    """Returns the queued response whose url matches the requested url."""
+
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.requested = []
+
+    def get(self, url, **kwargs):
+        self.requested.append(url)
+        for response in self.responses:
+            if response.url == url:
+                return response
+        raise AssertionError(f"unexpected request to {url}")
+
+
+def test_follows_canonical_same_resource_redirect_dropping_default_port():
+    # The boefje requests the URL with an explicit :443; the server canonicalises
+    # to the port-less form. Same resource -> follow and return the real body.
+    session = FakeSession(
+        [
+            FakeResponse(301, "https://example.com:443/", location="https://example.com/"),
+            FakeResponse(200, "https://example.com/", body=b"<html>real</html>"),
+        ]
+    )
+
+    response = do_request("example.com:443", session, "https://example.com:443/", "OpenKAT")
+
+    assert response.status_code == 200
+    assert response.content == b"<html>real</html>"
+    assert session.requested == ["https://example.com:443/", "https://example.com/"]
+
+
+def test_follows_self_redirect_ignoring_query():
+    # A cache/security warm-up 301 to the same path with a marker query.
+    session = FakeSession(
+        [
+            FakeResponse(302, "https://example.com:443/", location="https://example.com:443/?nocache=1"),
+            FakeResponse(200, "https://example.com:443/?nocache=1", body=b"<html>ok</html>"),
+        ]
+    )
+
+    response = do_request("example.com:443", session, "https://example.com:443/", "OpenKAT")
+
+    assert response.status_code == 200
+
+
+def test_does_not_follow_cross_url_redirect():
+    # apex -> www is a different resource; leave the 301 so the target is
+    # discovered and scanned separately. Only one request is made.
+    session = FakeSession([FakeResponse(301, "https://example.com:443/", location="https://www.example.com/")])
+
+    response = do_request("example.com:443", session, "https://example.com:443/", "OpenKAT")
+
+    assert response.status_code == 301
+    assert session.requested == ["https://example.com:443/"]
+
+
+def test_does_not_follow_http_to_https_redirect():
+    session = FakeSession([FakeResponse(301, "http://example.com:80/", location="https://example.com/")])
+
+    response = do_request("example.com:80", session, "http://example.com:80/", "OpenKAT")
+
+    assert response.status_code == 301
+
+
+def test_redirect_loop_is_bounded():
+    responses = [
+        FakeResponse(301, f"https://example.com:443/?n={n}", location=f"https://example.com:443/?n={n + 1}")
+        for n in range(10)
+    ]
+    session = FakeSession(
+        [FakeResponse(301, "https://example.com:443/", location="https://example.com:443/?n=0")] + responses
+    )
+
+    response = do_request("example.com:443", session, "https://example.com:443/", "OpenKAT")
+
+    # Bounded: does not loop forever, returns the last redirect it stopped at.
+    assert response.is_redirect
+    assert len(session.requested) <= 1 + 5
+
+
+def test_is_same_resource():
+    assert is_same_resource("https://a.com:443/", "https://a.com/")
+    assert is_same_resource("http://a.com:80/", "http://a.com/")
+    assert is_same_resource("https://a.com/", "https://a.com/?x=1")
+    assert not is_same_resource("https://a.com/", "https://www.a.com/")
+    assert not is_same_resource("http://a.com/", "https://a.com/")
+    assert not is_same_resource("https://a.com/", "https://a.com/other")
+    assert not is_same_resource("https://a.com:443/", "https://a.com:8443/")


### PR DESCRIPTION
### Changes

`kat_webpage_analysis` requests each URL with an explicit port (`get_uri` always appends `:443`/`:80`) and runs with `allow_redirects=False`. When a server **canonicalises the URL** (a 301 from `https://host:443/` to `https://host/`) or a cache/security layer 301s a URL **to itself**, the stored HAR captures only the empty redirect body. Every body-based analysis then sees nothing for that resource — most visibly **Wappalyzer**, which yields zero technology/CMS detections, and image extraction.

`do_request` now follows a redirect **only when its target is the same resource** — same scheme, host and path, with default ports normalised and query/fragment ignored — capped at a few hops. A redirect to a *different* URL (apex→www, http→https, `/`→`/other`) is still returned as the 301: the `oois_in_headers` bit turns its `Location` into a `URL` that is discovered and scanned as its own resource, so following it here would only duplicate that detection onto the wrong resource. The forced-IP HTTPS adapter is now mounted on `scheme://host` (without the port) so a followed port-less URL still resolves through the pinned IP.

### Issue link

Related to #4447 (OpenKAT detecting less software than the Wappalyzer browser plugin). This is one contributing cause — any scanned URL that returns a redirect at scan time gets no technology detection at all — but not the whole of #4447 (which also covers version-regex gaps and JS-rendered software the raw-HTML pipeline can't see), so this does not close it.

### Demo / how it was found

Live on `https://hasecon.nl` (a WordPress site). The first scan produced **zero** `Software` for it. The stored HAR showed why:

```
req=https://hasecon.nl:443/   status=301  Location=https://hasecon.nl/   (same resource, empty body)
```

Its LiteSpeed cache/security layer served a transient canonical 301 on the first OpenKAT hit. Feeding a body-carrying HAR of the same page through the real Wappalyzer normalizer detects **WordPress** (`cpe:2.3:a:wordpress:wordpress`) plus LiteSpeed Cache, RankMath SEO, jQuery, Google Analytics/Tag Manager, CookieYes — 11 `SoftwareInstance`s. With this change, the same-resource 301 is followed to the 200 body so that detection is not lost.

### QA notes

- Unit tests: `boefjes/tests/plugins/test_webpage_analysis_redirects.py` (7 cases) exercise `do_request` with a mock session — the exact stored-HAR scenario (`:443`→port-less canonical redirect) is `test_follows_canonical_same_resource_redirect_dropping_default_port`, plus self-redirect-with-query, non-following of apex→www and http→https, a bounded redirect loop, and `is_same_resource`. `test_bodyimage.py` (existing `main.run` tests) still pass — 10 passed, no regressions. pre-commit green.
- The live trigger is transient (hasecon's cache warmed and now returns 200), so an on-demand live repro of the *followed* 200 isn't stable; the stored HAR captured the failing scenario and the unit tests pin the fix for it.

---

### Code Checklist

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [x] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.
