### PR TITLE
Pin Playwright in the webpage-capture image so it stops breaking

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,10 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+  # Track the pinned Playwright base image so the webpage-capture boefje does not
+  # silently rot on new Playwright releases (#3916). Bump the digest here and the
+  # PLAYWRIGHT_VERSION arg in the Dockerfile together.
+  - package-ecosystem: "docker"
+    directory: "/boefjes/boefjes/plugins/kat_webpage_capture"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/containerized_boefjes.yml
+++ b/.github/workflows/containerized_boefjes.yml
@@ -21,6 +21,7 @@ on:
       - boefjes/boefjes/plugins/kat_nuclei_cve/**
       - boefjes/boefjes/plugins/kat_nuclei_exposed_panels/**
       - boefjes/boefjes/plugins/kat_nuclei_take_over/**
+      - boefjes/boefjes/plugins/kat_webpage_capture/**
       - boefjes/images/**
       - .github/workflows/containerized_boefjes.yml
 

--- a/boefjes/boefjes/plugins/kat_webpage_capture/boefje.Dockerfile
+++ b/boefjes/boefjes/plugins/kat_webpage_capture/boefje.Dockerfile
@@ -1,4 +1,18 @@
-FROM mcr.microsoft.com/playwright:v1.53.0-noble
+# PLAYWRIGHT_VERSION pins the Playwright npm package and, via `playwright install`
+# below, the browser it downloads. The base image is pinned by tag + digest so it
+# is immutable and Dependabot-trackable (a plain tag can't be, see #3261). The
+# digest is authoritative (Docker ignores the tag when a digest is present), so on
+# a version bump update the base tag, the digest and PLAYWRIGHT_VERSION together.
+ARG PLAYWRIGHT_VERSION=1.53.0
+FROM mcr.microsoft.com/playwright:v1.53.0-noble@sha256:c30040b375c6daebbc1997818ea5889e74a26916c7837e0354cfa1de30fafbed
+
+# Redeclare so the RUN below (a new build stage scope) can use it.
+ARG PLAYWRIGHT_VERSION
+
+# Install browsers into the path the runtime reads, not root's cache. Set before
+# `playwright install` so a bumped PLAYWRIGHT_VERSION downloads the matching
+# browser where capture actually looks for it, independent of what the base baked.
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends software-properties-common &&  \
@@ -6,7 +20,15 @@ RUN apt-get update && \
     apt-get update &&  \
     apt-get install -y --no-install-recommends python3.13 python3.13-venv && \
     python3.13 -m ensurepip --upgrade && \
-    npx playwright install --with-deps chromium
+    # Install the pinned Playwright and let IT fetch the exactly-matching browser.
+    # Never use `npx playwright` at runtime: with no local package installed it
+    # fetches the LATEST Playwright, which then wants a browser revision the image
+    # never baked, so every capture fails on the next Playwright release (#3916).
+    npm install -g "playwright@${PLAYWRIGHT_VERSION}" && \
+    playwright install --with-deps chromium && \
+    # Build-time guardrail (this image is built in CI): fail the build if the
+    # installed Playwright is not the pinned version. -F: match a fixed string.
+    playwright --version | grep -qF "Version ${PLAYWRIGHT_VERSION}"
 
 ARG BOEFJES_API=http://boefje:8000
 ENV BOEFJES_API=$BOEFJES_API
@@ -19,6 +41,14 @@ RUN --mount=type=cache,target=/root/.cache pip3 install --upgrade pip &&  \
 
 USER nonroot
 
+# Regression guard for #3916: launch the pinned browser exactly as the boefje
+# runs it (as nonroot, from /ms-playwright) and take a real screenshot. A version
+# drift, a browser installed to the wrong path, or a sandbox/permission problem
+# fails the image build here instead of every capture at runtime. about:blank
+# needs no network. The webpage-capture image is built in containerized_boefjes,
+# so this runs in CI (its pull_request paths include this plugin).
+RUN playwright screenshot about:blank /tmp/smoke.png && rm -f /tmp/smoke.png
+
 COPY ./boefjes/worker ./worker
 COPY ./boefjes/logging.json logging.json
 
@@ -27,6 +57,5 @@ CMD []
 
 ARG OCI_IMAGE=docker.underdark.nl/librekat/openkat-webpage-capture:latest
 ENV OCI_IMAGE=$OCI_IMAGE
-ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 
 COPY ./boefjes/plugins/kat_webpage_capture ./kat_webpage_capture

--- a/boefjes/boefjes/plugins/kat_webpage_capture/main.py
+++ b/boefjes/boefjes/plugins/kat_webpage_capture/main.py
@@ -17,8 +17,10 @@ class WebpageCaptureException(Exception):
 
 def build_playwright_command(webpage: str, browser: str, tmp_path: str) -> list[str]:
     """Returns playwright command including webpage, browser and locations for image, har and storage."""
+    # Call the pinned Playwright binary directly, never `npx playwright`: with no
+    # local package, npx fetches the latest Playwright at runtime, which then wants
+    # a browser revision the image never baked, breaking every capture (#3916).
     return [
-        "/usr/bin/npx",
         "playwright",
         "screenshot",
         "-b",

--- a/boefjes/tests/plugins/test_webpage_capture.py
+++ b/boefjes/tests/plugins/test_webpage_capture.py
@@ -1,0 +1,21 @@
+from boefjes.plugins.kat_webpage_capture.main import build_playwright_command
+
+
+def test_command_calls_pinned_binary_not_npx(tmp_path):
+    # Regression for #3916: `npx playwright` fetches the latest Playwright at
+    # runtime, which breaks against the browser baked into the image. The command
+    # must invoke the pinned, installed binary directly.
+    command = build_playwright_command("https://example.com/", "chromium", str(tmp_path / "output"))
+
+    assert command[0] == "playwright"
+    assert not any("npx" in part for part in command)
+
+
+def test_command_captures_har_screenshot_and_storage(tmp_path):
+    base = str(tmp_path / "output")
+    command = build_playwright_command("https://example.com/", "chromium", base)
+
+    assert command[:3] == ["playwright", "screenshot", "-b"]
+    assert f"--save-har={base}.har.zip" in command
+    assert f"--save-storage={base}.json" in command
+    assert command[-2:] == ["https://example.com/", f"{base}.png"]


### PR DESCRIPTION
### Changes

`kat_webpage_capture` ran `["/usr/bin/npx", "playwright", "screenshot", …]` with **no Playwright package installed** in the image, so `npx` fetched the **latest** Playwright from npm at run time. That version wants a browser revision the image never baked, so every capture container exited 1 — breaking in 2024 (v1.46→1.49) and again now (v1.53→1.62). Re-confirmed live 2026-08-18: 6/6 capture tasks failed.

The fix stops the runtime fetch and locks the package to the browser, following the same `ARG` pin as `kat_nuclei_cve`:

- **`PLAYWRIGHT_VERSION` build arg** pins `npm install -g playwright@<ver>`; the pinned Playwright then installs the exactly-matching browser into `PLAYWRIGHT_BROWSERS_PATH=/ms-playwright` (set **before** the install), so runtime always finds the browser its Playwright expects — independent of what the base image baked. (At 1.53.0 the pinned package actually needs chromium-1178 while the base bakes chromium-1208, so this ordering is load-bearing.)
- **Base pinned by concrete tag + digest** (`mcr.microsoft.com/playwright:v1.53.0-noble@sha256:…`) — immutable and Dependabot-parseable (addresses #3261). The digest is authoritative; bump tag, digest and `PLAYWRIGHT_VERSION` together.
- **`main.py` calls the pinned `playwright` binary directly**, not `npx` — the runtime fetch is gone.
- **Dependabot docker entry** for the capture Dockerfile so the base is bumped deliberately, with CI.

### Regression coverage

The reason this rotted for ~21 months is that nothing exercised capture in CI. Two guards now pin the fix:

- **Unit test** (`test_webpage_capture.py`): the command invokes the installed binary, not `npx` — fails if `main.py` is reverted. Runs in the boefjes `Tests` job.
- **Build-time capture smoke** in the Dockerfile: after `USER nonroot`, `RUN playwright screenshot about:blank` launches the pinned browser exactly as the boefje does. A version drift, a browser at the wrong path, or a sandbox/permission problem **fails the image build** instead of every capture at runtime — this would have caught both the 2024 and 2026 breakage. `containerized_boefjes` builds this image, and I added `kat_webpage_capture` to its `pull_request` paths so the smoke gates capture PRs (including Dependabot base-image bumps), not just post-merge builds.

### Issue link

Closes #3916 (approved approach per @underdarknl in the thread).

### Demo

Built the fixed image and ran the exact capture command via the pinned binary:

```
$ docker run --entrypoint playwright openkat-webpage-capture:fix \
    screenshot -b chromium --full-page --ignore-https-errors \
    --save-har=/out/o.har.zip --save-storage=/out/o.json https://hasecon.nl/ /out/o.png
Navigating to https://hasecon.nl/
Capturing screenshot into /out/o.png            # exit 0
```

Produces `o.png` (458 KB), `o.har.zip` (104 KB browser HAR: `har.har` + resource bodies), `o.json`. The build itself passed the `playwright --version` guard and the `about:blank` capture smoke; the browser installs to `/ms-playwright` (chromium-1178, matching the pinned package).

### QA notes

- Image builds locally including both build-time guards (version + `about:blank` capture).
- Functional: a real capture against a live site produces screenshot + HAR + storage (above).
- Unit tests: `boefjes/tests/plugins/test_webpage_capture.py` green; pre-commit green.

### Scope / follow-ups

- Kept to "capture works + stays working". The browser HAR this produces unblocks running Wappalyzer over it for the tech/version-detection gap (#4447) — separate PR.
- Per @underdarknl on #3916: Playwright renders and loads referenced third-party hosts/URLs (and redirect targets) that don't pass OpenKAT's per-OOI scan levels. Not introduced here (inherent to Playwright), but it matters for the #4447 follow-up (which would mint OOIs for uncleared hosts). Documented on #3916; carried into the Niveau-1 design.
- Related open ticket #1559 (feed Playwright an `HTTPResource` + specific IP) folds into that same follow-up.

---

### Code Checklist

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [x] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.
- [x] For any non-trivial functionality, I have added integration and/or end-to-end tests.
