### PR TITLE
Run Wappalyzer over the browser capture HAR

### DIFF
--- a/boefjes/boefjes/plugins/kat_wappalyzer/_analysis.py
+++ b/boefjes/boefjes/plugins/kat_wappalyzer/_analysis.py
@@ -1,0 +1,102 @@
+"""Shared Wappalyzer analysis: turn a HAR into Software / SoftwareInstance OOIs.
+
+Used by both the `kat_wappalyzer` normalizer (static requests HAR from
+webpage-analysis) and the `kat_wappalyzer_capture` normalizer (Playwright browser
+HAR from webpage-capture). The caller passes the reference the SoftwareInstances
+should attach to, so no OOIs are minted for third-party hosts the page loaded.
+"""
+
+from collections.abc import Iterable
+from pathlib import Path
+from typing import cast
+
+import httpx
+from tanimachi import (
+    Categories,
+    Fingerprints,
+    Groups,
+    Har,
+    Wappalyzer,
+    analyze_css,
+    analyze_headers,
+    analyze_scripts,
+    analyze_url,
+    schemas,
+)
+from tanimachi.wappalyzer import (
+    Detection,
+    HarWrapper,
+    analyze_cookies,
+    analyze_dom,
+    analyze_html,
+    analyze_meta,
+    is_html,
+)
+
+from boefjes.normalizer_models import NormalizerOutput
+from boefjes.plugins.kat_wappalyzer.utils import replace_cpe_version
+from octopoes.models import Reference
+from octopoes.models.ooi.software import Software, SoftwareInstance
+
+DATA_DIRECTORY = Path(__file__).parent / "data"
+
+
+def software_from_har(raw: bytes, target: Reference) -> Iterable[NormalizerOutput]:
+    """Yield Software + SoftwareInstance(ooi=target) for each Wappalyzer detection."""
+    fingerprints = Fingerprints.model_validate_pattern(DATA_DIRECTORY.joinpath("technologies/*.json").as_posix())
+    categories = Categories.model_validate_file(DATA_DIRECTORY.joinpath("categories.json"))
+    groups = Groups.model_validate_file(DATA_DIRECTORY.joinpath("groups.json"))
+    httpx.HTTPTransport()
+    har = Har.model_validate_json(raw)
+
+    wappalyzer = Wappalyzer(fingerprints, categories=categories, groups=groups)
+
+    analyzes = [analyze_scripts, analyze_css]
+
+    # is_html() only checks the Content-Type header; a redirect / Content-Length: 0
+    # response can be text/html with no body, so har.html raises inside
+    # analyze_html / analyze_dom / analyze_meta / analyze_script_src_in_html.
+    first_entry = har.log.entries[0] if har.log.entries else None
+    if first_entry and is_html(first_entry) and first_entry.response.content.text:
+        analyzes.extend(
+            [
+                analyze_headers,
+                analyze_url,
+                analyze_cookies,
+                analyze_meta,
+                analyze_html,
+                analyze_dom,
+                analyze_script_src_in_html,
+            ]
+        )
+
+    detections = cast(list[Detection], wappalyzer.analyze(har, analyzes=analyzes))
+
+    for detection in detections:
+        version = None
+        cpe = detection.fingerprint.cpe
+        if detection.pattern.version:
+            version = detection.pattern.regex.search(detection.value).expand(detection.pattern.version)
+
+        if cpe is not None and version is not None:
+            cpe = replace_cpe_version(cpe, version)
+
+        software = Software(name=detection.fingerprint.id, version=version, cpe=cpe)
+        yield software
+        yield SoftwareInstance(ooi=target, software=software.reference)
+
+
+# analyze_scripts is used to check javascript files, therefore we need another analyzer that analyzes the script
+# source in the html
+def analyze_script_src_in_html(har: HarWrapper, fingerprint: schemas.Fingerprint) -> list[Detection]:
+    detections: list[Detection] = []
+
+    for pattern in fingerprint.script_src:
+        try:
+            if pattern.regex.search(har.html):
+                detections.append(
+                    Detection(url=har.url, fingerprint=fingerprint, app_type="html", pattern=pattern, value=har.html)
+                )
+        except ValueError:  # no html found
+            return []
+    return detections

--- a/boefjes/boefjes/plugins/kat_wappalyzer/analysis.py
+++ b/boefjes/boefjes/plugins/kat_wappalyzer/analysis.py
@@ -10,7 +10,6 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import cast
 
-import httpx
 from tanimachi import (
     Categories,
     Fingerprints,
@@ -46,7 +45,6 @@ def software_from_har(raw: bytes, target: Reference) -> Iterable[NormalizerOutpu
     fingerprints = Fingerprints.model_validate_pattern(DATA_DIRECTORY.joinpath("technologies/*.json").as_posix())
     categories = Categories.model_validate_file(DATA_DIRECTORY.joinpath("categories.json"))
     groups = Groups.model_validate_file(DATA_DIRECTORY.joinpath("groups.json"))
-    httpx.HTTPTransport()
     har = Har.model_validate_json(raw)
 
     wappalyzer = Wappalyzer(fingerprints, categories=categories, groups=groups)
@@ -76,12 +74,17 @@ def software_from_har(raw: bytes, target: Reference) -> Iterable[NormalizerOutpu
         version = None
         cpe = detection.fingerprint.cpe
         if detection.pattern.version:
-            version = detection.pattern.regex.search(detection.value).expand(detection.pattern.version)
+            # A version template does not guarantee the pattern captured a version
+            # (the match can be None, or the group empty); guard so one odd
+            # detection cannot crash the whole run.
+            match = detection.pattern.regex.search(detection.value)
+            if match:
+                version = match.expand(detection.pattern.version)
 
-        if cpe is not None and version is not None:
+        if cpe is not None and version:
             cpe = replace_cpe_version(cpe, version)
 
-        software = Software(name=detection.fingerprint.id, version=version, cpe=cpe)
+        software = Software(name=detection.fingerprint.id, version=version or None, cpe=cpe)
         yield software
         yield SoftwareInstance(ooi=target, software=software.reference)
 

--- a/boefjes/boefjes/plugins/kat_wappalyzer/har_zip.py
+++ b/boefjes/boefjes/plugins/kat_wappalyzer/har_zip.py
@@ -23,6 +23,11 @@ def har_from_playwright_zip(raw: bytes) -> bytes:
         return raw
 
     with zipfile.ZipFile(io.BytesIO(raw)) as archive:
+        # A zip that is not a Playwright HAR archive (no `har.har` member) is
+        # neither shape we handle; pass it through instead of raising KeyError.
+        if "har.har" not in archive.namelist():
+            return raw
+
         har = json.loads(archive.read("har.har"))
 
         for entry in har.get("log", {}).get("entries", []):
@@ -35,6 +40,19 @@ def har_from_playwright_zip(raw: bytes) -> bytes:
             # A referenced body missing from the archive should not abort the
             # whole analysis; the entry is simply left without a body.
             with contextlib.suppress(KeyError):
-                content["text"] = archive.read(file_name).decode(errors="ignore")
+                content["text"] = _decode_body(archive.read(file_name))
 
     return json.dumps(har).encode()
+
+
+def _decode_body(body: bytes) -> str:
+    """Decode a response body without losing bytes on non-UTF-8 pages.
+
+    Wappalyzer matches (mostly ASCII) regexes over the body, so dropping bytes
+    with errors="ignore" could hide a detection on a latin-1/utf-16 page. Fall
+    back to latin-1, which never raises and maps every byte 1:1.
+    """
+    try:
+        return body.decode()
+    except UnicodeDecodeError:
+        return body.decode("latin-1")

--- a/boefjes/boefjes/plugins/kat_wappalyzer/har_zip.py
+++ b/boefjes/boefjes/plugins/kat_wappalyzer/har_zip.py
@@ -1,0 +1,40 @@
+"""Read a Playwright browser HAR for the Wappalyzer analysis.
+
+`kat_webpage_capture` runs `playwright screenshot --save-har=<file>.zip`, which
+writes a ZIP archive: the HAR document lives in `har.har`, and every response
+body is stored as a separate file referenced by `content._file` rather than
+inline `content.text`. tanimachi's `Har.model_validate_json` reads
+`content.text`, so the bodies have to be inlined before analysis.
+"""
+
+import contextlib
+import io
+import json
+import zipfile
+
+
+def har_from_playwright_zip(raw: bytes) -> bytes:
+    """Return a HAR JSON (bytes) with response bodies inlined into content.text.
+
+    Accepts either a Playwright `.zip` HAR archive or a plain (already inline)
+    HAR document, so callers do not have to know which shape they were given.
+    """
+    if not zipfile.is_zipfile(io.BytesIO(raw)):
+        return raw
+
+    with zipfile.ZipFile(io.BytesIO(raw)) as archive:
+        har = json.loads(archive.read("har.har"))
+
+        for entry in har.get("log", {}).get("entries", []):
+            content = entry.get("response", {}).get("content", {})
+            file_name = content.pop("_file", None)
+
+            if not file_name or content.get("text"):
+                continue
+
+            # A referenced body missing from the archive should not abort the
+            # whole analysis; the entry is simply left without a body.
+            with contextlib.suppress(KeyError):
+                content["text"] = archive.read(file_name).decode(errors="ignore")
+
+    return json.dumps(har).encode()

--- a/boefjes/boefjes/plugins/kat_wappalyzer/normalize.py
+++ b/boefjes/boefjes/plugins/kat_wappalyzer/normalize.py
@@ -1,36 +1,10 @@
 from collections.abc import Iterable
-from pathlib import Path
-from typing import cast
-
-import httpx
-from tanimachi import (
-    Categories,
-    Fingerprints,
-    Groups,
-    Har,
-    Wappalyzer,
-    analyze_css,
-    analyze_headers,
-    analyze_scripts,
-    analyze_url,
-    schemas,
-)
-from tanimachi.wappalyzer import (
-    Detection,
-    HarWrapper,
-    analyze_cookies,
-    analyze_dom,
-    analyze_html,
-    analyze_meta,
-    is_html,
-)
 
 from boefjes.normalizer_models import NormalizerOutput
-from boefjes.plugins.kat_wappalyzer.utils import replace_cpe_version
+from boefjes.plugins.kat_wappalyzer._analysis import software_from_har
 from octopoes.models import Reference
 from octopoes.models.ooi.dns.zone import Hostname
 from octopoes.models.ooi.network import Network
-from octopoes.models.ooi.software import Software, SoftwareInstance
 from octopoes.models.ooi.web import HostnameHTTPURL
 
 
@@ -49,61 +23,4 @@ def run(input_ooi: dict, raw: bytes) -> Iterable[NormalizerOutput]:
         path=tokenized_weburl["path"],
     )
 
-    data_directory = Path(__file__).parent / "data"
-    fingerprints = Fingerprints.model_validate_pattern(data_directory.joinpath("technologies/*.json").as_posix())
-    categories = Categories.model_validate_file(data_directory.joinpath("categories.json"))
-    groups = Groups.model_validate_file(data_directory.joinpath("groups.json"))
-    httpx.HTTPTransport()
-    har = Har.model_validate_json(raw)
-
-    wappalyzer = Wappalyzer(fingerprints, categories=categories, groups=groups)
-
-    analyzes = [analyze_scripts, analyze_css]
-
-    # is_html() only checks the Content-Type header; a redirect / Content-Length: 0
-    # response can be text/html with no body, so har.html raises inside
-    # analyze_html / analyze_dom / analyze_meta / analyze_script_src_in_html.
-    first_entry = har.log.entries[0] if har.log.entries else None
-    if first_entry and is_html(first_entry) and first_entry.response.content.text:
-        analyzes.extend(
-            [
-                analyze_headers,
-                analyze_url,
-                analyze_cookies,
-                analyze_meta,
-                analyze_html,
-                analyze_dom,
-                analyze_script_src_in_html,
-            ]
-        )
-
-    detections = cast(list[Detection], wappalyzer.analyze(har, analyzes=analyzes))
-
-    for detection in detections:
-        version = None
-        cpe = detection.fingerprint.cpe
-        if detection.pattern.version:
-            version = detection.pattern.regex.search(detection.value).expand(detection.pattern.version)
-
-        if cpe is not None and version is not None:
-            cpe = replace_cpe_version(cpe, version)
-
-        software = Software(name=detection.fingerprint.id, version=version, cpe=cpe)
-        software_instance = SoftwareInstance(ooi=web_url.reference, software=software.reference)
-        yield from [software, software_instance]
-
-
-# analyze_scripts is used to check javascript files, therefore we need another analyzer that analyzes the script
-# source in the html
-def analyze_script_src_in_html(har: HarWrapper, fingerprint: schemas.Fingerprint) -> list[Detection]:
-    detections: list[Detection] = []
-
-    for pattern in fingerprint.script_src:
-        try:
-            if pattern.regex.search(har.html):
-                detections.append(
-                    Detection(url=har.url, fingerprint=fingerprint, app_type="html", pattern=pattern, value=har.html)
-                )
-        except ValueError:  # no html found
-            return []
-    return detections
+    yield from software_from_har(raw, web_url.reference)

--- a/boefjes/boefjes/plugins/kat_wappalyzer/normalize.py
+++ b/boefjes/boefjes/plugins/kat_wappalyzer/normalize.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterable
 
 from boefjes.normalizer_models import NormalizerOutput
-from boefjes.plugins.kat_wappalyzer._analysis import software_from_har
+from boefjes.plugins.kat_wappalyzer.analysis import software_from_har
 from octopoes.models import Reference
 from octopoes.models.ooi.dns.zone import Hostname
 from octopoes.models.ooi.network import Network

--- a/boefjes/boefjes/plugins/kat_wappalyzer_capture/normalize.py
+++ b/boefjes/boefjes/plugins/kat_wappalyzer_capture/normalize.py
@@ -1,0 +1,15 @@
+from collections.abc import Iterable
+
+from boefjes.normalizer_models import NormalizerOutput
+from boefjes.plugins.kat_wappalyzer._analysis import software_from_har
+from boefjes.plugins.kat_wappalyzer.har_zip import har_from_playwright_zip
+from octopoes.models import Reference
+
+
+def run(input_ooi: dict, raw: bytes) -> Iterable[NormalizerOutput]:
+    # webpage-capture consumes a HostnameHTTPURL / IPAddressHTTPURL, so the input
+    # OOI is the URL the SoftwareInstances attach to directly. The browser HAR is
+    # a Playwright zip; har_from_playwright_zip inlines its bodies for tanimachi.
+    target = Reference.from_str(input_ooi["primary_key"])
+
+    yield from software_from_har(har_from_playwright_zip(raw), target)

--- a/boefjes/boefjes/plugins/kat_wappalyzer_capture/normalize.py
+++ b/boefjes/boefjes/plugins/kat_wappalyzer_capture/normalize.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterable
 
 from boefjes.normalizer_models import NormalizerOutput
-from boefjes.plugins.kat_wappalyzer._analysis import software_from_har
+from boefjes.plugins.kat_wappalyzer.analysis import software_from_har
 from boefjes.plugins.kat_wappalyzer.har_zip import har_from_playwright_zip
 from octopoes.models import Reference
 

--- a/boefjes/boefjes/plugins/kat_wappalyzer_capture/normalizer.json
+++ b/boefjes/boefjes/plugins/kat_wappalyzer_capture/normalizer.json
@@ -1,0 +1,12 @@
+{
+  "id": "kat_wappalyzer_capture_normalize",
+  "name": "Wappalyzer (browser capture)",
+  "description": "Detects software and versions with Wappalyzer over the Playwright browser HAR from webpage-capture, catching resources loaded after JavaScript that the static webpage-analysis HAR misses.",
+  "consumes": [
+    "application/har+json"
+  ],
+  "produces": [
+    "Software",
+    "SoftwareInstance"
+  ]
+}

--- a/boefjes/tests/integration/test_api.py
+++ b/boefjes/tests/integration/test_api.py
@@ -171,7 +171,8 @@ def test_add_normalizer(test_client, organisation):
     assert response.status_code == 201
 
     response = test_client.get(f"/v1/organisations/{organisation.id}/plugins/?plugin_type=normalizer")
-    assert len(response.json()) != 0
+    assert response.status_code == 200
+    assert len(response.json()) > 0
 
     response = test_client.get(f"/v1/organisations/{organisation.id}/plugins/test_normalizer")
     assert response.json() == normalizer.model_dump(mode="json")

--- a/boefjes/tests/plugins/test_wappalyzer_capture.py
+++ b/boefjes/tests/plugins/test_wappalyzer_capture.py
@@ -21,15 +21,9 @@ def test_attaches_software_and_versions_to_the_input_url():
     instances = [o for o in results if o.object_type == "SoftwareInstance"]
 
     assert software, "expected Wappalyzer detections"
+    # Scan-level scoping (per #3916 discussion): every SoftwareInstance attaches to
+    # the input URL and nothing else — no OOI is minted for a third-party host the
+    # page loaded resources from.
     assert instances and all(str(instance.ooi) == str(url.reference) for instance in instances)
     # Versions coming through is the whole point of running over the rendered HAR (#4447).
     assert any(o.version for o in software)
-
-
-def test_no_third_party_host_or_url_oois_are_minted():
-    # Scan-level scoping (per #3916 discussion): only Software/SoftwareInstance,
-    # never a Hostname/URL for a third-party host the page referenced.
-    url = _input_url()
-    results = list(run({"primary_key": str(url.reference)}, get_dummy_data("download_page_analysis.raw")))
-
-    assert {o.object_type for o in results} <= {"Software", "SoftwareInstance"}

--- a/boefjes/tests/plugins/test_wappalyzer_capture.py
+++ b/boefjes/tests/plugins/test_wappalyzer_capture.py
@@ -1,0 +1,35 @@
+from boefjes.plugins.kat_wappalyzer_capture.normalize import run
+from octopoes.models.ooi.dns.zone import Hostname
+from octopoes.models.ooi.network import Network
+from octopoes.models.ooi.web import HostnameHTTPURL
+from tests.loading import get_dummy_data
+
+
+def _input_url():
+    network = Network(name="internet")
+    hostname = Hostname(network=network.reference, name="mispo.es")
+    return HostnameHTTPURL(network=network.reference, netloc=hostname.reference, scheme="https", port=443, path="/")
+
+
+def test_attaches_software_and_versions_to_the_input_url():
+    # webpage-capture consumes a HostnameHTTPURL, so SoftwareInstances attach to it
+    # directly. A plain HAR is accepted as-is (zip handling is covered separately).
+    url = _input_url()
+    results = list(run({"primary_key": str(url.reference)}, get_dummy_data("download_page_analysis.raw")))
+
+    software = [o for o in results if o.object_type == "Software"]
+    instances = [o for o in results if o.object_type == "SoftwareInstance"]
+
+    assert software, "expected Wappalyzer detections"
+    assert instances and all(str(instance.ooi) == str(url.reference) for instance in instances)
+    # Versions coming through is the whole point of running over the rendered HAR (#4447).
+    assert any(o.version for o in software)
+
+
+def test_no_third_party_host_or_url_oois_are_minted():
+    # Scan-level scoping (per #3916 discussion): only Software/SoftwareInstance,
+    # never a Hostname/URL for a third-party host the page referenced.
+    url = _input_url()
+    results = list(run({"primary_key": str(url.reference)}, get_dummy_data("download_page_analysis.raw")))
+
+    assert {o.object_type for o in results} <= {"Software", "SoftwareInstance"}

--- a/boefjes/tests/plugins/test_wappalyzer_har_zip.py
+++ b/boefjes/tests/plugins/test_wappalyzer_har_zip.py
@@ -1,0 +1,49 @@
+import io
+import json
+import zipfile
+
+from boefjes.plugins.kat_wappalyzer.har_zip import har_from_playwright_zip
+
+
+def _playwright_har_zip(bodies: dict[str, str], entries: list[dict], *, extra_files: dict[str, str] | None = None):
+    """Build a Playwright-shaped HAR zip: `har.har` plus body files by `_file`."""
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr("har.har", json.dumps({"log": {"entries": entries}}))
+        for name, content in {**bodies, **(extra_files or {})}.items():
+            archive.writestr(name, content)
+    return buffer.getvalue()
+
+
+def _entry(file_name: str, mime: str = "text/html"):
+    return {"response": {"content": {"mimeType": mime, "_file": file_name}}}
+
+
+def test_inlines_file_bodies_into_content_text():
+    raw = _playwright_har_zip(
+        bodies={"a.html": "<html>wp-content</html>", "b.css": "body{}"},
+        entries=[_entry("a.html"), _entry("b.css", "text/css")],
+    )
+
+    har = json.loads(har_from_playwright_zip(raw))
+    first, second = (e["response"]["content"] for e in har["log"]["entries"])
+
+    assert first["text"] == "<html>wp-content</html>"
+    assert "_file" not in first
+    assert second["text"] == "body{}"
+
+
+def test_missing_body_file_does_not_abort():
+    raw = _playwright_har_zip(bodies={}, entries=[_entry("gone.html")])
+
+    har = json.loads(har_from_playwright_zip(raw))
+    content = har["log"]["entries"][0]["response"]["content"]
+
+    assert "_file" not in content
+    assert "text" not in content
+
+
+def test_plain_har_is_passed_through_unchanged():
+    plain = json.dumps({"log": {"entries": []}}).encode()
+
+    assert har_from_playwright_zip(plain) == plain


### PR DESCRIPTION
### Changes

OpenKAT's tech detection already works — it just runs on the wrong data. `kat_wappalyzer` analyses the **static** `requests` HAR from `kat_webpage_analysis` (no JS executed, only the main document), so it detects software but often not versions and misses anything loaded after JavaScript. Meanwhile `kat_webpage_capture` (fixed in #5333) already produces a full **browser HAR** via Playwright — post-JS, every loaded resource — and nothing analysed it.

This adds a normalizer that runs the same Wappalyzer engine over that browser HAR:

- Extract the shared detection logic (`HAR → Software/SoftwareInstance`) out of `kat_wappalyzer/normalize.py` into `_analysis.software_from_har`, so both normalizers share one code path.
- New `kat_wappalyzer_capture` normalizer consuming `application/har+json`. It unzips the Playwright HAR (`har.har` + response bodies stored as `content._file`) via `har_zip.har_from_playwright_zip`, then runs the analysis.
- **Scan-level scoping** (per @underdarknl on #3916): SoftwareInstances attach to the input `HostnameHTTPURL`/`IPAddressHTTPURL` **only**; no `Hostname`/`URL` OOIs are minted for third-party hosts the browser loaded — the same footprint the existing normalizer already has, so nothing gets created for uncleared hosts.

Design + scope discussed on #4447.

### Demo / result

Ran the full pipeline in a live stack against `https://hasecon.nl` (WordPress): capture → browser HAR → this normalizer → **14 SoftwareInstances** on the site's URL. The browser HAR surfaces the server-side stack **with versions** that the static single-document HAR misses:

| From the browser HAR (new) | |
|---|---|
| Apache HTTP Server | **2.4.67** (cpe) |
| PHP | **8.3.31** (cpe) |
| Debian | OS |

…alongside WordPress, jQuery, LiteSpeed Cache, RankMath SEO, Google Analytics / Tag Manager / Fonts, CookieYes, Open Graph, RSS, Prototype.

### Honest limitation

The browser HAR is network traffic — it has the real loaded (versioned) resource URLs the static fetch misses, but not runtime JS variables like `jQuery.fn.jquery`. On sites that combine/minify JS (LiteSpeed strips the per-library versioned URLs) the JS-library version still won't come through; full parity with the browser Wappalyzer plugin would need running the Wappalyzer JS in-page (`page.evaluate`) — a separate, bigger step. This is the cheap 80%.

### Issue link

Part of #4447. Depends on #5333 (capture fix, merged).

### QA notes

- Unit tests: `test_wappalyzer_capture.py` (attaches Software + versions to the input URL, no third-party OOIs), `test_wappalyzer_har_zip.py` (zip → HAR inlining, missing-body resilience, plain-HAR passthrough). The existing `test_wappalyzer_normalizer.py` still passes — the refactor is behaviour-preserving. Full boefjes plugin suite: 138 passed. pre-commit green.
- Functional: verified live — the normalizer ran in the stack and produced the Software above; the fixed capture image (#5333) produces the browser HAR it consumes.

---

### Code Checklist

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [x] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.
