### PR TITLE
Fix 500 on object list for ImageMetadata with a HostnameHTTPURL resource

### DIFF
--- a/octopoes/octopoes/models/ooi/web.py
+++ b/octopoes/octopoes/models/ooi/web.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Literal
 
-from pydantic import AnyUrl
+from pydantic import AnyUrl, ValidationError
 
 from octopoes.models import OOI, PrimaryKeyToken, Reference
 from octopoes.models.ooi.certificate import X509Certificate
@@ -228,8 +228,10 @@ class ImageMetadata(OOI):
             address = t.resource.website.ip_service.ip_port.address.address
 
             return f"{web_url} @ {address}"
-        except IndexError:
-            # try parsing reference as a HostnameHTTPURL instead
+        except (IndexError, ValidationError):
+            # The resource is a HostnameHTTPURL, not an HTTPResource: its primary key
+            # has too few tokens for the HTTPResource token tree, which raises
+            # IndexError on the old tokenizer and ValidationError on the pydantic one.
             tokenized = HostnameHTTPURL.get_tokenized_primary_key(reference.natural_key)
             port = f":{tokenized.port}" if tokenized.port else ""
             return f"{tokenized.scheme}://{tokenized.netloc.name}{port}{tokenized.path}"

--- a/octopoes/tests/test_web_human_readable.py
+++ b/octopoes/tests/test_web_human_readable.py
@@ -1,0 +1,13 @@
+from octopoes.models import Reference
+from octopoes.models.ooi.web import ImageMetadata
+
+
+def test_imagemetadata_human_readable_with_hostname_http_url_resource():
+    # check_images (webpage-capture / webpage-analysis screenshots) produces
+    # ImageMetadata(resource=<HostnameHTTPURL>), whose primary key has fewer tokens
+    # than an HTTPResource. format_reference_human_readable must fall back to
+    # HostnameHTTPURL parsing rather than raising a pydantic ValidationError, which
+    # would 500 the object list wherever such an ImageMetadata is rendered.
+    reference = Reference.from_str("ImageMetadata|https|internet|example.com|443|/")
+
+    assert ImageMetadata.format_reference_human_readable(reference) == "https://example.com:443/"


### PR DESCRIPTION
### What

`ImageMetadata.format_reference_human_readable` first tries to tokenize the reference as an `HTTPResource`, and falls back to parsing it as a `HostnameHTTPURL`. The `check_images` normalizer stores the `resource` as a `HostnameHTTPURL` (`Reference.from_str(input_ooi["primary_key"])` where the boefje input is a `HostnameHTTPURL`/`IPAddressHTTPURL`), whose primary key has far fewer tokens than an `HTTPResource`.

The fallback only caught `IndexError`, but the pydantic-based tokenizer raises `pydantic.ValidationError` when the token tree is too short. So the exception propagated instead of falling back, and **any object-list page that rendered such an `ImageMetadata` returned a 500** (`21 validation errors for PrimaryKeyToken` in `rocky.views.ooi_list.OOIListView`). This is easy to hit: enable `webpage-capture` (or any screenshot flow feeding `check_images`) and open the Objects list.

### Fix

Catch `ValidationError` alongside `IndexError` so the existing `HostnameHTTPURL` fallback is reached. One import + one `except`. Behaviour for genuine `HTTPResource`-shaped references is unchanged.

### Reproduction / verification

Against a live stack (`ImageMetadata|https|internet|hasecon.nl|443|/`):

- **Before:** `format_reference_human_readable(...)` raises `pydantic_core.ValidationError` → Objects list 500 on the page containing the ImageMetadata.
- **After:** returns `https://hasecon.nl:443/`; Objects list pages 1, 2 and the `ooi_type=ImageMetadata` filter all render `200`.

### Test

Added `octopoes/tests/test_web_human_readable.py`, which asserts the human-readable rendering of an `ImageMetadata` with a `HostnameHTTPURL` resource. It fails on `main` (`ValidationError`) and passes with this change (revert-test verified).

Pre-existing bug — not introduced by any open PR; surfaced while running `webpage-capture` locally.