### PR TITLE
Introduce an update to the task DB migration that makes sure the uniq…

### DIFF
--- a/mula/scheduler/storage/migrations/versions/0011_add_more_indexes.py
+++ b/mula/scheduler/storage/migrations/versions/0011_add_more_indexes.py
@@ -24,10 +24,27 @@ def upgrade():
     op.create_index("ix_schedules_scheduler_id", "schedules", ["scheduler_id"], unique=False)
     op.execute(
         """
+        WITH duplicate_active_tasks AS (
+            SELECT id
+            FROM (
+                SELECT
+                    id,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY schedule_id
+                        ORDER BY created_at DESC, id DESC
+                    ) AS row_number
+                FROM tasks
+                WHERE status IN ('PENDING', 'QUEUED', 'DISPATCHED', 'RUNNING')
+                  AND schedule_id IS NOT NULL
+            ) ranked
+            WHERE row_number > 1
+        )
         UPDATE tasks
         SET status = 'FAILED'
-        WHERE status IN ('PENDING', 'QUEUED', 'DISPATCHED', 'RUNNING')
-          AND created_at < NOW() - INTERVAL '1 day'
+        WHERE id IN (
+            SELECT id
+            FROM duplicate_active_tasks
+        )
         """
     )
     op.create_index(

--- a/mula/scheduler/storage/migrations/versions/0011_add_more_indexes.py
+++ b/mula/scheduler/storage/migrations/versions/0011_add_more_indexes.py
@@ -22,6 +22,14 @@ def upgrade():
     op.create_index("ix_schedules_hash", "schedules", ["hash"], unique=False)
     op.create_index("ix_schedules_organisation", "schedules", ["organisation"], unique=False)
     op.create_index("ix_schedules_scheduler_id", "schedules", ["scheduler_id"], unique=False)
+    op.execute(
+        """
+        UPDATE tasks
+        SET status = 'FAILED'
+        WHERE status IN ('PENDING', 'QUEUED', 'DISPATCHED', 'RUNNING')
+          AND created_at < NOW() - INTERVAL '1 day'
+        """
+    )
     op.create_index(
         "ix_tasks_active_per_schedule",
         "tasks",


### PR DESCRIPTION
…ue contraint actually can be added. this sets old hanging jobs to failed.

### Changes

We noticed an uncompleted migration on the mula DB at one of our users. This was due to a bunch of uncompleted 'handing' tasks in their task list, which made the new unique contraint on those statuses impossible.
This change adds an update query which sets all handing jobs (older than 1 day) to FAILED. allowing the new index to be added

### QA notes

Insert some old tasks, or flip some successful old tasks from SUCCES to PENDING, after this the migration should fail without this update query, and complete successfully with this new update query.

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [x] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [x] Tickets have been created for newly discovered issues.
- [x] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [x] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/developer-documentation/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/developer-documentation/contributor/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/developer-documentation/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/developer-documentation/contributor/templates/pull_request_template_review_qa.md) into your comment.
