### PR TITLE
Guard that the Playwright base image and PLAYWRIGHT_VERSION stay in sync

### DIFF
--- a/.github/scripts/check_playwright_version_pin.py
+++ b/.github/scripts/check_playwright_version_pin.py
@@ -8,8 +8,15 @@ ecosystem bumps only the `FROM` tag + digest — it cannot touch the `ARG` — s
 silently leaves the package and browser behind at the old version (PR #5334). This
 guard makes that drift a red `pre-commit` check instead of a no-op "upgrade".
 
-Runs as a pre-commit hook over boefje.Dockerfile paths; a Dockerfile without both a
-Playwright base image and a PLAYWRIGHT_VERSION arg is ignored.
+Scope: a Dockerfile is checked when it references a Playwright base image or declares
+`PLAYWRIGHT_VERSION`; anything else is ignored. The check is fail-closed — if such a
+file is present but a version can't be parsed from both the `FROM` tag and the `ARG`,
+that is an error, not a skip, so a reformat that outruns these regexes can't silently
+disable the guard.
+
+Boundary: this compares the human-readable `:vX.Y.Z` tag against the arg. It does not
+resolve the `@sha256:` digest to a version (that needs a registry pull); Dependabot is
+relied on to keep the tag and digest consistent.
 """
 
 from __future__ import annotations
@@ -18,22 +25,35 @@ import re
 import sys
 from pathlib import Path
 
+# A Playwright base image, capturing the tag version. Matches `.../playwright:vX.Y.Z`.
 FROM_RE = re.compile(r"^FROM\s+\S*/playwright:v(\d+\.\d+\.\d+)", re.MULTILINE)
-ARG_RE = re.compile(r"^ARG\s+PLAYWRIGHT_VERSION=(\d+\.\d+\.\d+)", re.MULTILINE)
+# The value-bearing PLAYWRIGHT_VERSION arg (quotes optional; a bare redeclare has none).
+ARG_RE = re.compile(r"""^ARG\s+PLAYWRIGHT_VERSION=["']?(\d+\.\d+\.\d+)["']?""", re.MULTILINE)
+# Markers that put a Dockerfile in scope even if a version can't be parsed (fail-closed).
+PLAYWRIGHT_FROM_MARKER = re.compile(r"^FROM\s+\S*playwright\b", re.MULTILINE)
+ARG_MARKER = re.compile(r"^ARG\s+PLAYWRIGHT_VERSION\b", re.MULTILINE)
 
 
 def check(path: str) -> str | None:
     text = Path(path).read_text(encoding="utf-8")
 
+    if not PLAYWRIGHT_FROM_MARKER.search(text) and not ARG_MARKER.search(text):
+        return None  # not a Playwright-pinned Dockerfile
+
     from_versions = FROM_RE.findall(text)
     arg_versions = ARG_RE.findall(text)
     if not from_versions or not arg_versions:
-        return None  # not a version-pinned Playwright Dockerfile
-
-    base, arg = from_versions[0], arg_versions[0]
-    if base != arg:
         return (
-            f"{path}: Playwright base image v{base} does not match "
+            f"{path}: pins Playwright but a vX.Y.Z version could not be parsed from both the "
+            f"FROM tag and ARG PLAYWRIGHT_VERSION. Keep both in the pinned `:vX.Y.Z` / "
+            f"`PLAYWRIGHT_VERSION=X.Y.Z` form so the version stays machine-verifiable."
+        )
+
+    arg = arg_versions[0]
+    mismatched = sorted({version for version in from_versions if version != arg})
+    if mismatched:
+        return (
+            f"{path}: Playwright base image v{'/v'.join(mismatched)} does not match "
             f"ARG PLAYWRIGHT_VERSION={arg}. Bump the FROM tag, its digest and "
             f"PLAYWRIGHT_VERSION together (Dependabot only bumps the FROM tag)."
         )

--- a/.github/scripts/check_playwright_version_pin.py
+++ b/.github/scripts/check_playwright_version_pin.py
@@ -8,8 +8,10 @@ ecosystem bumps only the `FROM` tag + digest — it cannot touch the `ARG` — s
 silently leaves the package and browser behind at the old version (PR #5334). This
 guard makes that drift a red `pre-commit` check instead of a no-op "upgrade".
 
-Scope: a Dockerfile is checked when it references a Playwright base image or declares
-`PLAYWRIGHT_VERSION`; anything else is ignored. The check is fail-closed — if such a
+Scope: the pre-commit hook targets `kat_webpage_capture/boefje.Dockerfile` (the only
+Playwright-pinned image today; add a path when another appears). The script itself stays
+general — a file it is handed is checked when it references a Playwright base image or
+declares `PLAYWRIGHT_VERSION`, and ignored otherwise. The check is fail-closed: if such a
 file is present but a version can't be parsed from both the `FROM` tag and the `ARG`,
 that is an error, not a skip, so a reformat that outruns these regexes can't silently
 disable the guard.

--- a/.github/scripts/check_playwright_version_pin.py
+++ b/.github/scripts/check_playwright_version_pin.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Fail if a Dockerfile's Playwright base-image tag and PLAYWRIGHT_VERSION drift.
+
+A Playwright boefje image pins the base by `FROM …/playwright:vX.Y.Z-…` and the npm
+package + browser by `ARG PLAYWRIGHT_VERSION=X.Y.Z`; they must be the same version
+(see kat_webpage_capture/boefje.Dockerfile and PR #5333). Dependabot's docker
+ecosystem bumps only the `FROM` tag + digest — it cannot touch the `ARG` — so a bump
+silently leaves the package and browser behind at the old version (PR #5334). This
+guard makes that drift a red `pre-commit` check instead of a no-op "upgrade".
+
+Runs as a pre-commit hook over boefje.Dockerfile paths; a Dockerfile without both a
+Playwright base image and a PLAYWRIGHT_VERSION arg is ignored.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+FROM_RE = re.compile(r"^FROM\s+\S*/playwright:v(\d+\.\d+\.\d+)", re.MULTILINE)
+ARG_RE = re.compile(r"^ARG\s+PLAYWRIGHT_VERSION=(\d+\.\d+\.\d+)", re.MULTILINE)
+
+
+def check(path: str) -> str | None:
+    text = Path(path).read_text(encoding="utf-8")
+
+    from_versions = FROM_RE.findall(text)
+    arg_versions = ARG_RE.findall(text)
+    if not from_versions or not arg_versions:
+        return None  # not a version-pinned Playwright Dockerfile
+
+    base, arg = from_versions[0], arg_versions[0]
+    if base != arg:
+        return (
+            f"{path}: Playwright base image v{base} does not match "
+            f"ARG PLAYWRIGHT_VERSION={arg}. Bump the FROM tag, its digest and "
+            f"PLAYWRIGHT_VERSION together (Dependabot only bumps the FROM tag)."
+        )
+    return None
+
+
+def main(argv: list[str]) -> int:
+    exit_code = 0
+    for path in argv[1:]:
+        error = check(path)
+        if error:
+            sys.stderr.write(error + "\n")
+            exit_code = 1
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -194,3 +194,11 @@ repos:
           ^rocky/assets/vendors |
           ^docs/source/_static
           )
+
+  - repo: local
+    hooks:
+      - id: playwright-version-pin
+        name: Playwright base image tag must match PLAYWRIGHT_VERSION
+        entry: python3 .github/scripts/check_playwright_version_pin.py
+        language: system
+        files: boefje\.Dockerfile$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -201,4 +201,4 @@ repos:
         name: Playwright base image tag must match PLAYWRIGHT_VERSION
         entry: python3 .github/scripts/check_playwright_version_pin.py
         language: system
-        files: boefje\.Dockerfile$
+        files: ^boefjes/boefjes/plugins/kat_webpage_capture/boefje\.Dockerfile$


### PR DESCRIPTION
### What

`kat_webpage_capture/boefje.Dockerfile` pins Playwright in two places that must stay on the same version:

- the base image, by `FROM …/playwright:vX.Y.Z-noble@sha256:…` (tag + digest)
- the npm package and its browser, by `ARG PLAYWRIGHT_VERSION=X.Y.Z` (drives `npm install -g playwright@…` + `playwright install`)

#5333 documented the invariant in a comment ("bump the base tag, the digest and `PLAYWRIGHT_VERSION` together") and set up a Dependabot docker entry for this file. But Dependabot's docker ecosystem only bumps image *references* — the `FROM` tag and digest — and cannot touch the `ARG`. So the first bump it produced, #5334, moves the base to `v1.62.1-noble` while `PLAYWRIGHT_VERSION` stays `1.53.0`: the image still builds and the `playwright --version` / screenshot guards still pass (they check the npm package against `PLAYWRIGHT_VERSION`, both `1.53.0`), so it merges green while upgrading nothing and double-downloading browsers. (Confirmed on #5334, which already carries a manual "bump PLAYWRIGHT_VERSION to 1.62.1" commit — exactly the fix this guard would have demanded automatically.)

### Change

A `repo: local` pre-commit hook (`.github/scripts/check_playwright_version_pin.py`) that fails when the `FROM …/playwright:vX.Y.Z` tag and `ARG PLAYWRIGHT_VERSION=X.Y.Z` disagree. Per review the hook's `files:` is scoped to `kat_webpage_capture/boefje.Dockerfile` (the only Playwright-pinned image today); add a path when a second one appears. The script itself stays general and fail-closed — handed a file, it checks it when it references a Playwright base image or declares `PLAYWRIGHT_VERSION`, and errors (not skips) if a version can't be parsed from both, so a reformat can't silently disable it.

It runs inside the `pre-commit` CI job, which runs on every PR including Dependabot's, so drift turns that check **red**. Whether a red `pre-commit` also *blocks* the merge depends on the branch-protection required-checks config — @underdarknl, could you confirm `pre-commit` is in the required set? If it isn't, this is still a clear signal on the PR (and Dependabot auto-merge is off), just not a hard gate; happy to note that either way.

### Verification

- Current `main` Dockerfile (both `1.53.0`) → hook **Passed**.
- Simulated #5334 drift (`FROM v1.62.1-noble`, `ARG …=1.53.0`) → exit 1: `Playwright base image v1.62.1 does not match ARG PLAYWRIGHT_VERSION=1.53.0. Bump the FROM tag, its digest and PLAYWRIGHT_VERSION together …`
- After scoping: hook runs on `kat_webpage_capture/boefje.Dockerfile`, **skips** other `boefje.Dockerfile`s (e.g. `kat_nmap_tcp`).
- Edge cases pass: quoted `ARG PLAYWRIGHT_VERSION="1.53.0"` → ok; marker present but unparseable version → fail-closed; non-Playwright Dockerfile → skip. `ruff`, `ruff-format`, `mypy`, `vulture`, `codespell` green on the script.