### PR TITLE
Follow-up on #5284: rename, docstring, regression test

### DIFF
--- a/octopoes/octopoes/core/service.py
+++ b/octopoes/octopoes/core/service.py
@@ -570,7 +570,7 @@ class OctopoesService:
 
         neighbour_paths = get_paths_to_neighbours(reference.class_type)
 
-        eligible_paths = {path for path in neighbour_paths if path._path_can_inherit_level(required_level)}
+        eligible_paths = {path for path in neighbour_paths if path.path_can_inherit_level(required_level)}
 
         if not eligible_paths:
             return inheritance_chain

--- a/octopoes/octopoes/models/path.py
+++ b/octopoes/octopoes/models/path.py
@@ -157,7 +157,7 @@ class Path:
     def __repr__(self) -> str:
         return str(self)
 
-    def _path_can_inherit_level(self, required_level: int) -> bool:
+    def path_can_inherit_level(self, required_level: int) -> bool:
         max_inheritance_level = get_max_scan_level_inheritance(self.segments[0])
 
         return max_inheritance_level is not None and max_inheritance_level >= required_level
@@ -207,7 +207,7 @@ def get_max_scan_level_inheritance(segment: Segment) -> int | None:
 
 @cache
 def get_max_scan_level_issuance(segment: Segment) -> int | None:
-    """This does not change during runtime as the models are static and as such can be cached."""
+    """Return the maximum level transferable while tracing issuance."""
     if segment.direction == Direction.INCOMING:
         if segment.target_type is None:
             raise ValueError("Direction cannot be incoming if target type is None")

--- a/octopoes/tests/test_scan_profile_inheritance_path.py
+++ b/octopoes/tests/test_scan_profile_inheritance_path.py
@@ -26,3 +26,52 @@ def test_scan_profile_inheritance_duplicate_neighbour_paths(
     assert chain[-1].scan_profile_type == ScanProfileType.DECLARED  # resolves, no ValueError
     # highest-edge-wins (the reversed() bug): levels toward the source are non-decreasing
     assert [s.level for s in chain] == sorted(s.level for s in chain)
+
+
+def test_scan_profile_inheritance_no_path_going_down(
+    octopoes_service,
+    ooi_repository,
+    scan_profile_repository,
+    valid_time,
+    dns_zone,
+    hostname,
+    ipaddressv4,
+    resolved_hostname,
+):
+    # Reproduces issue #5283: a ResolvedHostname at L2 has two outgoing edges:
+    #   - hostname  -> Hostname (max_inherit=4) — the real inheritance path
+    #   - address   -> IPAddress (max_inherit=0) — cannot transfer any level
+    # Declare L2 on both DNSZone (so Hostname inherits L2) and IPAddressV4.
+    # The old code did not pre-filter the address path and would pick the
+    # IPAddress (DECLARED, but inherited_level=0) via the declared shortcut,
+    # producing a chain that goes L2 -> L0 — "down" instead of "up".
+    # The fix pre-filters paths by path_can_inherit_level(required_level),
+    # so the address edge (max_inherit=0 < 2) is never considered.
+    octopoes = octopoes_service
+    octopoes.ooi_repository = ooi_repository
+    octopoes.scan_profile_repository = scan_profile_repository
+    octopoes.scan_profile_repository.save(None, DeclaredScanProfile(reference=dns_zone.reference, level=2), valid_time)
+    octopoes.scan_profile_repository.save(
+        None, DeclaredScanProfile(reference=ipaddressv4.reference, level=2), valid_time
+    )
+
+    octopoes.recalculate_scan_profiles(valid_time)
+    ooi = octopoes.get_ooi(resolved_hostname.reference, valid_time)
+    assert ooi.scan_profile.level == 2  # ResolvedHostname inherits L2
+
+    start_section = InheritanceSection(
+        reference=ooi.reference,
+        level=ooi.scan_profile.level,
+        inherited_level=None,
+        scan_profile_type=ooi.scan_profile.scan_profile_type,
+    )
+
+    chain = octopoes_service.get_scan_profile_inheritance(resolved_hostname.reference, valid_time, [start_section])
+
+    # The chain must reach a DECLARED source without going through the IPAddress
+    # (whose edge has max_inherit=0 and would show up as L0 in the old code).
+    assert chain[-1].scan_profile_type == ScanProfileType.DECLARED
+    assert chain[-1].reference == dns_zone.reference  # the actual declared source
+    assert len(chain) == 3  # ResolvedHostname -> Hostname -> DNSZone
+    # Levels never go down — the original "path going down" bug
+    assert [s.level for s in chain] == sorted(s.level for s in chain)


### PR DESCRIPTION
## Summary

Three small follow-ups from the PR #5284 review:

1. **Rename `_path_can_inherit_level` → `path_can_inherit_level`** — the method is called from outside the `Path` class (in `service.py`), so the leading underscore was misleading.

2. **Fix `get_max_scan_level_issuance` docstring** — was still describing the caching implementation detail while its sibling `get_max_scan_level_inheritance` was updated to describe semantics. Now both are consistent.

3. **Add `test_scan_profile_inheritance_no_path_going_down`** — a regression test for the original issue #5283 ("path going down"). A `ResolvedHostname` at L2 has an outgoing edge to `IPAddress` with `max_inherit=0`. The old code did not pre-filter this edge and would pick the IPAddress (DECLARED but `inherited_level=0`) via the declared shortcut, producing a chain that goes L2 → L0. The test verifies the chain reaches the DNSZone (the actual declared source) through the Hostname instead.

### Verification

- The new test **passes** on the fixed code (head of this PR)
- The new test **fails** on the pre-fix code (`c504237e0^`) with `AssertionError: assert Reference('IPAddressV4|internet|192.0.2.1') == Reference('DNSZone|internet|example.com')` — confirming it pins the actual "path going down" bug
- Both tests in the file pass: `2 passed`
- `ruff check` and `ruff format --check` clean

#### Test plan
- [ ] CI `test (3.10–3.13)` green on octopoes
- [ ] CI `pre-commit` green

Generated with [Devin](https://devin.ai)