### PR TITLE
Add regression guard for the tagulous python serializer

### DIFF
--- a/rocky/tests/test_tagulous_serializer.py
+++ b/rocky/tests/test_tagulous_serializer.py
@@ -1,0 +1,25 @@
+from unittest.mock import patch
+
+from django.core import serializers
+
+
+def test_tagulous_python_serializer_roundtrip(organization):
+    """Regression guard for the Django/tagulous serializer coupling (#5319).
+
+    settings.SERIALIZATION_MODULES routes the "python" serializer through
+    tagulous, which monkeypatches a private Django deserializer hook at import
+    time (_get_model on Django <= 5.1, Deserializer._get_model_from_node on
+    5.2+). Nothing else in the test suite loads this serializer, so an
+    incompatible Django/tagulous combination (e.g. Django 5.2 with tagulous
+    2.1.1) only surfaced during the native build. This roundtrip fails loudly
+    on such a combination.
+    """
+    with patch("katalogus.client.KATalogusClient"), patch("rocky.signals.OctopoesAPIConnector"):
+        organization.tags = ["roundtrip"]
+        organization.save()
+
+    data = serializers.serialize("python", [organization])
+    assert data[0]["fields"]["tags"] == ["roundtrip"]
+
+    restored = list(serializers.deserialize("python", data))
+    assert restored[0].object.code == organization.code


### PR DESCRIPTION
### Changes

Adds the regression test suggested in the #5319 review: a `serialize("python")` → `deserialize` round-trip of a tagged `Organization`.

**Why this test:** `settings.SERIALIZATION_MODULES` routes the `python` serializer through tagulous, which monkeypatches a private Django deserializer hook at import time (`_get_model` on Django ≤ 5.1, `Deserializer._get_model_from_node` on 5.2+). Nothing else in the test suite loads this serializer, so an incompatible Django/tagulous combination is invisible to CI — on #5319 the whole `test` matrix stayed green while `make kat` hard-failed at `build-rocky-native` (`loaddata` is the only thing that imported it). This test makes that class of breakage fail in the unit suite instead.

**Verified both directions** in the rocky CI Docker image:
- Django 5.2.17 + tagulous 2.2.2 (current main pins): **passes**
- Django 5.2.17 + tagulous 2.1.1 (the combination that broke #5319): **fails** with exactly the original error — `AttributeError: module 'django.core.serializers.python' has no attribute '_get_model'`

### Issue link

Follow-up to #5319 (regression guard requested in the QA review there).

### QA notes

`cd rocky && make utest` — the new test is `tests/test_tagulous_serializer.py`. External org signals (katalogus/octopoes) are patched the same way `create_organization` in `conftest.py` does.

---

### Code Checklist

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [x] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.