### PR TITLE
Give the dnssec boefje a clear error when drill fails

### DIFF
--- a/boefjes/boefjes/plugins/kat_dnssec/main.py
+++ b/boefjes/boefjes/plugins/kat_dnssec/main.py
@@ -1,12 +1,28 @@
 import re
 import subprocess
 
+# ldns exit code for LDNS_STATUS_NETWORK_ERR ("Could not send or receive, because of network error").
+# drill -T queries the root and authoritative nameservers directly, so this is what drill exits with
+# when the scanner's network only allows DNS through a local resolver.
+LDNS_NETWORK_ERR = 20
+
 
 def run_drill(domain: str, record_type: str) -> bytes:
     cmd = ["/usr/bin/drill", "-DT", domain, record_type]
 
     output = subprocess.run(cmd, capture_output=True)
-    output.check_returncode()
+    if output.returncode != 0:
+        stderr = output.stderr.decode(errors="replace").strip()
+        message = f"drill exited with status {output.returncode} for {domain} ({record_type})"
+        if stderr:
+            message += f": {stderr}"
+        if output.returncode == LDNS_NETWORK_ERR:
+            message += (
+                ". DNSSEC tracing (drill -T) queries the root and authoritative nameservers directly, "
+                "so outbound UDP and TCP port 53 to arbitrary hosts must be allowed; "
+                "a resolver-only egress policy is not enough."
+            )
+        raise RuntimeError(message)
 
     return output.stdout
 

--- a/boefjes/boefjes/plugins/kat_dnssec/main.py
+++ b/boefjes/boefjes/plugins/kat_dnssec/main.py
@@ -3,7 +3,7 @@ import subprocess
 
 # ldns exit code for LDNS_STATUS_NETWORK_ERR ("Could not send or receive, because of network error").
 # drill -T queries the root and authoritative nameservers directly, so this is what drill exits with
-# when the scanner's network only allows DNS through a local resolver.
+# when those direct queries go unanswered, whatever the cause (connectivity, routing, egress filtering).
 LDNS_NETWORK_ERR = 20
 
 
@@ -18,9 +18,10 @@ def run_drill(domain: str, record_type: str) -> bytes:
             message += f": {stderr}"
         if output.returncode == LDNS_NETWORK_ERR:
             message += (
-                ". DNSSEC tracing (drill -T) queries the root and authoritative nameservers directly, "
-                "so outbound UDP and TCP port 53 to arbitrary hosts must be allowed; "
-                "a resolver-only egress policy is not enough."
+                ". DNSSEC tracing (drill -T) queries the root and authoritative nameservers directly and "
+                "got no answer. This points at a connectivity problem rather than the domain's DNSSEC state: "
+                "for example local network loss, a routing problem towards the nameservers, or an egress "
+                "policy that only allows DNS through a local resolver."
             )
         raise RuntimeError(message)
 

--- a/boefjes/tests/plugins/test_dnssec.py
+++ b/boefjes/tests/plugins/test_dnssec.py
@@ -1,7 +1,45 @@
+import subprocess
+
+import pytest
+
+from boefjes.plugins.kat_dnssec import main as dnssec_main
 from boefjes.plugins.kat_dnssec.normalize import run
 from octopoes.models.ooi.dns.zone import Hostname
 from octopoes.models.ooi.network import Network
 from tests.loading import get_dummy_data
+
+
+def fake_drill(returncode: int, stdout: bytes = b"", stderr: bytes = b""):
+    def fake_run(cmd, capture_output):
+        return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr=stderr)
+
+    return fake_run
+
+
+def test_boefje_drill_success_returns_raw_output(monkeypatch):
+    monkeypatch.setattr(dnssec_main.subprocess, "run", fake_drill(0, stdout=b"[T] example.org. 3600 IN A 192.0.2.1\n"))
+
+    output = dnssec_main.run({"arguments": {"input": {"name": "example.org"}}})
+
+    assert output == [({"openkat/dnssec-output"}, b"[T] example.org. 3600 IN A 192.0.2.1\n")]
+
+
+def test_boefje_drill_network_error_gives_clear_message(monkeypatch):
+    monkeypatch.setattr(
+        dnssec_main.subprocess,
+        "run",
+        fake_drill(20, stderr=b"Error sending query: Could not send or receive, because of network error\n"),
+    )
+
+    with pytest.raises(RuntimeError, match="outbound UDP and TCP port 53"):
+        dnssec_main.run({"arguments": {"input": {"name": "example.org"}}})
+
+
+def test_boefje_drill_failure_includes_stderr(monkeypatch):
+    monkeypatch.setattr(dnssec_main.subprocess, "run", fake_drill(1, stderr=b"Error: error sending query\n"))
+
+    with pytest.raises(RuntimeError, match=r"status 1 for example\.org \(A\): Error: error sending query"):
+        dnssec_main.run({"arguments": {"input": {"name": "example.org"}}})
 
 
 def test_dnssec_unsigned():

--- a/boefjes/tests/plugins/test_dnssec.py
+++ b/boefjes/tests/plugins/test_dnssec.py
@@ -31,7 +31,7 @@ def test_boefje_drill_network_error_gives_clear_message(monkeypatch):
         fake_drill(20, stderr=b"Error sending query: Could not send or receive, because of network error\n"),
     )
 
-    with pytest.raises(RuntimeError, match="outbound UDP and TCP port 53"):
+    with pytest.raises(RuntimeError, match="connectivity problem rather than the domain's DNSSEC state"):
         dnssec_main.run({"arguments": {"input": {"name": "example.org"}}})
 
 


### PR DESCRIPTION
### Changes

On a production install we hit this on every dnssec scan:

```
subprocess.CalledProcessError: Command '['/usr/bin/drill', '-DT', 'dvwa.cloud', 'A']' returned non-zero exit status 20.
```

Exit status 20 is ldns' `LDNS_STATUS_NETWORK_ERR` ("Could not send or receive, because of network error"), which `do_secure_trace` propagates as drill's exit code. The actual cause was the host's egress policy: DNS was only allowed through the provider's resolvers, while `drill -DT` by design queries the root and authoritative nameservers **directly** — a resolver-only network can never run this boefje. None of that is visible in the bare `CalledProcessError`, because `check_returncode()` throws away drill's stderr.

This PR keeps the failure a failure (the scan genuinely couldn't run) but makes it actionable:

* `run_drill` now raises a `RuntimeError` containing drill's exit status, the domain/record type, and drill's stderr (e.g. `Error sending query: Could not send or receive, because of network error`).
* For exit code 20 specifically, the message explains that DNSSEC tracing needs outbound UDP and TCP port 53 to arbitrary hosts and that a resolver-only egress policy is not enough.
* Unit tests for the success passthrough, the network-error message, and the generic failure path.

Verified that drill communicates DNSSEC verdicts via stdout markers (`[S]/[B]/[T]/[U]`) and exits 0 even for bogus domains (checked live against `dnssec-failed.org` and `bogus.dnssec.works`), so a non-zero exit is always an operational error, never a DNSSEC verdict — raising on any non-zero exit remains correct and the normalizer contract is untouched.

Note for existing installs: this lives inside the boefje OCI image, so it takes effect when `openkat-dns-sec` is next rebuilt/published.

### Issue link

No issue; small hardening fix from a production incident (drill exit 20 on an egress-restricted host).

### QA notes

- Enable the `dns-sec` boefje on a hostname with working egress: scan completes, raw `openkat/dnssec-output` unchanged.
- To see the new behaviour, run the boefje somewhere without direct outbound DNS: the task now fails with the explanatory message instead of a bare `CalledProcessError`.