### PR TITLE
Make the CSP policy configurable from Rocky via an ask-csp-policy question

### DIFF
--- a/octopoes/bits/ask_csp_policy/ask_csp_policy.py
+++ b/octopoes/bits/ask_csp_policy/ask_csp_policy.py
@@ -1,0 +1,17 @@
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+from octopoes.models import OOI
+from octopoes.models.ooi.network import Network
+from octopoes.models.ooi.question import Question
+
+
+def run(input_ooi: Network, additional_oois: list, config: dict[str, Any]) -> Iterator[OOI]:
+    network = input_ooi
+
+    with (Path(__file__).parent / "question_schema.json").open() as f:
+        schema = json.load(f)
+
+    yield Question(ooi=network.reference, schema_id=schema["$id"], json_schema=json.dumps(schema))

--- a/octopoes/bits/ask_csp_policy/bit.py
+++ b/octopoes/bits/ask_csp_policy/bit.py
@@ -1,0 +1,6 @@
+from bits.definitions import BitDefinition
+from octopoes.models.ooi.network import Network
+
+BIT = BitDefinition(
+    id="ask-csp-policy", consumes=Network, parameters=[], min_scan_level=0, module="bits.ask_csp_policy.ask_csp_policy"
+)

--- a/octopoes/bits/ask_csp_policy/question_schema.json
+++ b/octopoes/bits/ask_csp_policy/question_schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "/bit/check-csp-policy",
+  "type": "object",
+  "default": {},
+  "Content Security Policy Configuration": "Root Schema",
+  "required": [],
+  "properties": {
+    "required_directives": {
+      "description": "Comma separated list of CSP directives that must be present in every policy",
+      "type": "string",
+      "default": "base-uri,frame-ancestors,default-src"
+    },
+    "deprecated_directives": {
+      "description": "Comma separated list of CSP directives that are reported as deprecated when present",
+      "type": "string",
+      "default": "block-all-mixed-content,prefetch-src,report-uri"
+    },
+    "forbidden_keywords": {
+      "description": "Comma separated list of CSP source keywords that are not accepted (without quotes)",
+      "type": "string",
+      "default": "unsafe-inline,unsafe-eval,unsafe-hashes"
+    },
+    "allowed_hosts": {
+      "description": "Comma separated allowlist of hosts that are accepted as CSP sources, e.g. cdn.example.com,*.trusted.example. Any other host in a policy is reported. Leave empty to accept every host.",
+      "type": "string",
+      "default": ""
+    }
+  }
+}

--- a/octopoes/bits/check_csp_policy/check_csp_policy.py
+++ b/octopoes/bits/check_csp_policy/check_csp_policy.py
@@ -42,6 +42,37 @@ def _is_host_wildcard(source: str) -> bool:
     return source == "*" or source.startswith("*.") or "://*" in source
 
 
+def _source_host(source: str) -> str | None:
+    """The lowercased host part of a host-source, or None for anything that is not a host-source:
+    quoted keywords/nonces/hashes (`'self'`, `'nonce-…'`), bare scheme sources (`https:`, `data:`)."""
+
+
+    if source.startswith("'"):
+        return None
+    if source.endswith(":") and "//" not in source:
+        return None
+    host = source
+    if "://" in host:
+        host = host.split("://", 1)[1]
+    host = host.split("/", 1)[0]
+    if ":" in host:
+        host = host.split(":", 1)[0]
+    return host.lower() if host else None
+
+
+def _host_is_allowed(host: str, allowed_hosts: list[str]) -> bool:
+    """True when the host matches an allowlist entry: exact, or a `*.suffix` entry matching the bare
+    suffix and any subdomain of it."""
+    for entry in allowed_hosts:
+        entry = entry.lower()
+        if entry.startswith("*."):
+            if host == entry[2:] or host.endswith(entry[1:]):
+                return True
+        elif host == entry:
+            return True
+    return False
+
+
 def _ip_is_global(source: str) -> bool:
     """False when the source contains a non-global (private/loopback/reserved/…) IP; True otherwise."""
     ip_str = NON_DECIMAL_FILTER.sub("", source)
@@ -60,8 +91,9 @@ def run(input_ooi: HTTPResource, additional_oois: list, config: dict[str, Any]) 
     Consumes an HTTPResource plus its headers and the structured CSPDirective/CSPSource OOIs produced by
     the parse-csp bit, so every check is a plain set/string operation — no backtracking regex and no
     whole-string substring matching, unlike the retired check_csp_header bit. Like that bit it skips
-    non-XSS-capable resources. The required/deprecated directive lists and forbidden keywords are
-    overridable by a Config OOI on the Network; the defaults reproduce the previous checks.
+    non-XSS-capable resources. The required/deprecated directive lists, forbidden keywords and an
+    optional host allowlist are configurable by a Config OOI on the Network (the ask-csp-policy
+    question); the defaults reproduce the previous checks, with no allowlist enforced.
     """
     header_by_key = {ooi.key.lower(): ooi for ooi in additional_oois if isinstance(ooi, HTTPHeader)}
 
@@ -111,6 +143,22 @@ def run(input_ooi: HTTPResource, additional_oois: list, config: dict[str, Any]) 
         findings.append(f"Forbidden CSP source keyword(s) used: {', '.join(forbidden_used)}.")
     if any(not _ip_is_global(source) for source in all_sources):
         findings.append("Private, local, reserved, multicast, loopback ips should not be allowed in the CSP settings.")
+
+    # Host allowlist (only when configured): any host-source outside the allowlist is reported.
+    # Wildcard sources are left to the wildcard check above so they are not reported twice.
+    allowed_hosts = [entry.lower() for entry in _as_list(config, "allowed_hosts", [])]
+    if allowed_hosts:
+        disallowed = sorted(
+            {
+                host
+                for source in all_sources
+                if not _is_host_wildcard(source)
+                and (host := _source_host(source)) is not None
+                and not _host_is_allowed(host, allowed_hosts)
+            }
+        )
+        if disallowed:
+            findings.append(f"CSP source host(s) not in the configured allowlist: {', '.join(disallowed)}.")
 
     # Required directives, plus the two fallback groups.
     for directive in required:

--- a/octopoes/tests/test_ask_csp_policy.py
+++ b/octopoes/tests/test_ask_csp_policy.py
@@ -1,0 +1,25 @@
+import json
+
+from bits.ask_csp_policy.ask_csp_policy import run
+
+from octopoes.models.ooi.network import Network
+from octopoes.models.ooi.question import Question
+
+
+def test_ask_csp_policy_yields_question_for_check_csp_policy_config():
+    results = list(run(Network(name="internet"), [], {}))
+
+    assert len(results) == 1
+    question = results[0]
+    assert isinstance(question, Question)
+    # The Config created from the answer takes its bit_id from the last schema id segment,
+    # so it must name the consuming bit exactly.
+    assert question.schema_id == "/bit/check-csp-policy"
+
+    schema = json.loads(question.json_schema)
+    assert set(schema["properties"]) == {
+        "required_directives",
+        "deprecated_directives",
+        "forbidden_keywords",
+        "allowed_hosts",
+    }

--- a/octopoes/tests/test_check_csp_policy.py
+++ b/octopoes/tests/test_check_csp_policy.py
@@ -147,3 +147,70 @@ def test_finding_is_anchored_to_the_csp_header():
     finding = next(o for o in results if isinstance(o, Finding))
     assert finding.ooi == csp_header.reference
     assert KATFindingType(id="KAT-CSP-VULNERABILITIES") in results
+
+
+STRICT_WITH_HOSTS = {
+    "default-src": ["'self'"],
+    "base-uri": ["'self'"],
+    "frame-ancestors": ["'none'"],
+    "style-src": ["https://cdn.example.com", "https://fonts.trusted.example/css/"],
+}
+
+
+def test_no_allowlist_config_accepts_any_host():
+    results, _ = _run(STRICT_WITH_HOSTS)
+
+    assert not any(isinstance(o, Finding) for o in results)
+
+
+def test_allowlist_reports_hosts_outside_it():
+    description = _description(_run(STRICT_WITH_HOSTS, config={"allowed_hosts": "cdn.example.com"})[0])
+
+    assert "CSP source host(s) not in the configured allowlist: fonts.trusted.example." in description
+
+
+def test_allowlist_accepts_exact_and_wildcard_entries():
+    results, _ = _run(STRICT_WITH_HOSTS, config={"allowed_hosts": "cdn.example.com,*.trusted.example"})
+
+    assert not any(isinstance(o, Finding) for o in results)
+
+
+def test_allowlist_ignores_keywords_schemes_and_nonces():
+    mapping = {
+        "default-src": ["'self'"],
+        "base-uri": ["'self'"],
+        "frame-ancestors": ["'none'"],
+        "img-src": ["data:"],
+        "script-src": ["'nonce-r4nd0m'", "'sha256-abc123'"],
+    }
+
+    results, _ = _run(mapping, config={"allowed_hosts": "cdn.example.com"})
+
+    assert not any(isinstance(o, Finding) for o in results)
+
+
+def test_allowlist_strips_scheme_port_and_path_and_ignores_case():
+    mapping = {
+        "default-src": ["'self'"],
+        "base-uri": ["'self'"],
+        "frame-ancestors": ["'none'"],
+        "style-src": ["https://CDN.Example.com:8443/styles/"],
+    }
+
+    results, _ = _run(mapping, config={"allowed_hosts": "cdn.example.com"})
+
+    assert not any(isinstance(o, Finding) for o in results)
+
+
+def test_allowlist_leaves_wildcard_sources_to_the_wildcard_check():
+    mapping = {
+        "default-src": ["'self'"],
+        "base-uri": ["'self'"],
+        "frame-ancestors": ["'none'"],
+        "style-src": ["*.evil.example"],
+    }
+
+    description = _description(_run(mapping, config={"allowed_hosts": "cdn.example.com"})[0])
+
+    assert "wildcard" in description
+    assert "allowlist" not in description


### PR DESCRIPTION
### Changes

Follow-up 1 of 2 on @underdarknl's post-merge comment on #5351 ("inhoudelijk had ik graag een CSP config meegenomen over wat er wel en niet geaccepteerd is"):

* **New `ask-csp-policy` question bit** (consumes `Network`, like the other ask-bits): yields a `Question` with schema id `/bit/check-csp-policy`, so the policy config can be filled in from Rocky's question flow instead of requiring a hand-declared `Config` OOI. It exposes the three existing keys (`required_directives`, `deprecated_directives`, `forbidden_keywords`) plus the new one below, with the current defaults pre-filled.
* **New `allowed_hosts` config for `check-csp-policy`**: a comma-separated allowlist of hosts that are accepted as CSP sources (exact entries or `*.suffix` entries). When configured, any host source outside the list yields a finding line; quoted keywords/nonces/hashes and bare scheme sources are exempt, and wildcard sources are left to the existing wildcard check so they are not reported twice. Scheme, port and path are stripped and matching is case-insensitive. **An empty allowlist (the default) keeps today's behaviour** — nothing changes for organisations that don't configure it.

This complements the existing `disallowed_csp_hostnames` bit (a blocklist on the raw header) with the "what *is* accepted" side Jan asked for, evaluated on the parsed sources.

The second follow-up (cleaning up objects left behind by removed bits, the `recalculate_bits` TODO) comes as a separate PR.

### Issue link

Follow-up on #5351 / #4330 (comment thread).

### QA notes

- Unit: `test_ask_csp_policy.py` (schema id must equal the consuming bit id — that is what links the answered Config to the bit) and 6 new allowlist tests in `test_check_csp_policy.py` (no-config unchanged, enforcement, wildcard-entry matching, keyword/nonce/scheme exemption, scheme/port/path stripping + case, wildcard left to the wildcard check). All 25 CSP tests green in the container; enforcement test verified to fail on pre-change code.
- Live E2E on the dev stack: after `bits/recalculate` the `/bit/check-csp-policy` Question appears on `Network|internet`; declaring a CSP header with `https://cdn.example.com` + `https://fonts.evil.example` and a Config with `allowed_hosts=cdn.example.com` produced exactly `CSP source host(s) not in the configured allowlist: fonts.evil.example.` — the allowlisted host is accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)