### PR TITLE
Delete origins of removed bits during recalculate

### DIFF
--- a/octopoes/octopoes/core/service.py
+++ b/octopoes/octopoes/core/service.py
@@ -707,11 +707,15 @@ class OctopoesService:
                         param = OriginParameter(origin_id=bit_instance.id, reference=param_ooi.reference)
                         self.origin_parameter_repository.save(param, valid_time)
 
-        # TODO: remove all Origins and Origin Parameters, which are no longer in use
-
-        # rerun all existing bits
+        # rerun all existing bits; origins of bits that no longer exist are deleted (with their
+        # parameters), so their results are garbage collected instead of lingering forever
         origins = self.origin_repository.list_origins(valid_time, origin_type=OriginType.INFERENCE)
         for origin in origins:
+            if origin.method not in bit_definitions:
+                for origin_parameter in self.origin_parameter_repository.list_by_origin({origin.id}, valid_time):
+                    self.origin_parameter_repository.delete(origin_parameter, valid_time)
+                self.origin_repository.delete(origin, valid_time)
+                continue
             self._run_inference(origin, valid_time)
             bit_counter.update({origin.method})
         return sum(bit_counter.values())

--- a/octopoes/tests/test_octopoes_service.py
+++ b/octopoes/tests/test_octopoes_service.py
@@ -128,3 +128,33 @@ def test_on_create_scan_profile(octopoes_service, new_data, old_data, bit_runner
     assert octopoes_service.ooi_repository.save.call_count == 2
     octopoes_service.ooi_repository.save.assert_any_call(mock_oois[0], valid_time=valid_time, end_valid_time=None)
     octopoes_service.ooi_repository.save.assert_any_call(mock_oois[1], valid_time=valid_time, end_valid_time=None)
+
+
+@patch("octopoes.core.service.get_bit_definitions", mocked_bit_definitions)
+def test_recalculate_bits_deletes_origins_of_removed_bits(octopoes_service, valid_time):
+    network = Network(name="internet")
+    hostname = Hostname(network=network.reference, name="example.com")
+    removed_origin = Origin(origin_type=OriginType.INFERENCE, method="removed-bit", source=network.reference)
+    kept_origin = Origin(origin_type=OriginType.INFERENCE, method="fake-hostname-bit", source=hostname.reference)
+    stale_parameter = Mock(origin_id=removed_origin.id)
+
+    octopoes_service.ooi_repository.list_oois_by_object_types = MagicMock(return_value=[])
+    octopoes_service.origin_repository.list_origins = MagicMock(return_value=[removed_origin, kept_origin])
+    octopoes_service.origin_repository.delete = MagicMock()
+    octopoes_service.origin_parameter_repository.list_by_origin = MagicMock(return_value=[stale_parameter])
+    octopoes_service.origin_parameter_repository.delete = MagicMock()
+    octopoes_service._run_inference = MagicMock()
+
+    octopoes_service.recalculate_bits()
+
+    # the origin of the bit that no longer exists is deleted, together with its parameters,
+    # so _on_delete_origin garbage-collects its results
+    deleted_origins = [call.args[0] for call in octopoes_service.origin_repository.delete.call_args_list]
+    assert deleted_origins == [removed_origin]
+    octopoes_service.origin_parameter_repository.list_by_origin.assert_called_once()
+    octopoes_service.origin_parameter_repository.delete.assert_called_once()
+    assert octopoes_service.origin_parameter_repository.delete.call_args.args[0] is stale_parameter
+
+    # the origin of the still-existing bit is rerun, not deleted
+    rerun_origins = [call.args[0] for call in octopoes_service._run_inference.call_args_list]
+    assert rerun_origins == [kept_origin]


### PR DESCRIPTION
### Changes

Follow-up 2 of 2 on @underdarknl's post-merge comment on #5351 ("we moeten iets met het verwijderen van objecten die door de nu verwijderde bits voor altijd blijven bestaan, al kan dat zo veel zijn als een 'rerun all bits' na een upgrade").

Current behaviour when a bit is removed from the codebase (like `check-csp-header` in #5351): its inference origins stay behind forever. `_run_inference` already empties their results when something triggers a rerun of that specific origin, but nothing ever deletes the origins themselves, and results only empty once the source OOI happens to be touched — this was the standing `TODO: remove all Origins and Origin Parameters, which are no longer in use` in `recalculate_bits`.

This PR resolves that TODO for the removed-bit case: during `recalculate_bits`, an inference origin whose `method` has no bit definition anymore is **deleted** (together with its origin parameters) instead of rerun. Origin deletion goes through the existing `_on_delete_origin` event handling, so the bit's results are garbage-collected by the normal origin bookkeeping — nothing new is invented for the cleanup itself. Disabled bits are unaffected: they keep their origins with empty results, exactly as before, so re-enabling them keeps working.

With this, "rerun all bits after an upgrade" (Rocky's *Recalculate bits*) becomes precisely the cleanup step you described.

### Issue link

Follow-up on #5351 (comment thread); resolves the `recalculate_bits` TODO for removed bits.

### QA notes

- Unit: `test_recalculate_bits_deletes_origins_of_removed_bits` — a `removed-bit` origin is deleted with its parameter while a still-defined bit's origin is rerun, not deleted. Verified to fail on pre-change code (nothing calls delete there). Full octopoes suite (minus the `test_api.py` modules that need the CI environment): 209 passed, 6 skipped in the container.
- Live E2E on the dev stack, on the real-world case this is about: the stack had **18 orphaned `check-csp-header` origins** left behind by #5351's bit removal. After this change, `POST /{org}/bits/recalculate` deleted all 18 (plus their emptied results via `_on_delete_origin`); a follow-up scan of the origins shows **zero** inference origins without a bit definition, and all still-defined bits reran normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)