### PR TITLE
Fix report JSON export crash on organization tags (#4332)

### DIFF
--- a/rocky/reports/views/base.py
+++ b/rocky/reports/views/base.py
@@ -562,7 +562,7 @@ class ViewReportView(ObservedAtMixin, OrganizationView, TemplateView, AddDashboa
             response = {
                 "organization_code": self.organization.code,
                 "organization_name": self.organization.name,
-                "organization_tags": list(self.organization.tags.all()),
+                "organization_tags": [tag.name for tag in self.organization.tags.all()],
                 "data": self.report_data,
             }
 

--- a/rocky/reports/views/mixins.py
+++ b/rocky/reports/views/mixins.py
@@ -109,7 +109,7 @@ class SaveMultiReportMixin(BaseReportView):
             template=report_type.template_path,
             organization_code=self.organization.code,
             organization_name=self.organization.name,
-            organization_tags=set(self.organization.tags.all()),
+            organization_tags={tag.name for tag in self.organization.tags.all()},
             data_raw_id=report_data_raw_id,
             date_generated=now,
             reference_date=observed_at,  # TODO: https://github.com/minvws/nl-kat-coordination/issues/4014

--- a/rocky/tests/reports/test_aggregate_report_flow.py
+++ b/rocky/tests/reports/test_aggregate_report_flow.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import patch
 
 from pytest_django.asserts import assertContains
 from reports.views.aggregate_report import (
@@ -361,8 +362,9 @@ def test_json_download_aggregate_report_with_organization_tags(
     which raised TypeError. Tags should be serialized as their names, matching
     the form the report runner itself uses.
     """
-    client_member.organization.tags = ["tag-a", "tag-b"]
-    client_member.organization.save()
+    with patch("katalogus.client.KATalogusClient"), patch("rocky.signals.OctopoesAPIConnector"):
+        client_member.organization.tags = ["tag-a", "tag-b"]
+        client_member.organization.save()
 
     mock_organization_view_octopoes().get_report.return_value = get_aggregate_report_ooi
     mock_bytes_client().get_raws.return_value = [

--- a/rocky/tests/reports/test_aggregate_report_flow.py
+++ b/rocky/tests/reports/test_aggregate_report_flow.py
@@ -344,3 +344,38 @@ def test_json_download_aggregate_report(
     json_compare_data = json.dumps(get_aggregate_report_data())
 
     assert json_response_data == json_compare_data
+
+
+def test_json_download_aggregate_report_with_organization_tags(
+    rf,
+    client_member,
+    get_aggregate_report_ooi,
+    get_aggregate_report_from_bytes,
+    mock_organization_view_octopoes,
+    mock_bytes_client,
+    mock_katalogus_client,
+):
+    """Regression guard for #4332: organization tags must be JSON serializable.
+
+    The JSON export passed OrganizationTag model instances to JsonResponse,
+    which raised TypeError. Tags should be serialized as their names, matching
+    the form the report runner itself uses.
+    """
+    client_member.organization.tags = ["tag-a", "tag-b"]
+    client_member.organization.save()
+
+    mock_organization_view_octopoes().get_report.return_value = get_aggregate_report_ooi
+    mock_bytes_client().get_raws.return_value = [
+        ("7b305f0d-c0a7-4ad5-af1e-31f81fc229c2", get_aggregate_report_from_bytes)
+    ]
+
+    request = setup_request(
+        rf.get("view_report_json", {"json": "true", "report_id": f"{get_aggregate_report_ooi.primary_key}"}),
+        client_member.user,
+    )
+
+    json_response = ViewReportView.as_view()(request, organization_code=client_member.organization.code)
+
+    assert json_response.status_code == 200
+    data = json.loads(json_response.content)
+    assert data["organization_tags"] == ["tag-a", "tag-b"]


### PR DESCRIPTION
## Summary
- The report JSON export (`?json=true`) crashed with `TypeError: Object of type OrganizationTag is not JSON serializable` when the organization had tags (#4332).
- Root cause: `ViewReportView.get` passed `list(self.organization.tags.all())` — `OrganizationTag` model instances — to `JsonResponse`, whose encoder only handles `OOI`s and dataclasses.
- Fix: serialize tags as their names (`[tag.name for tag in ...]`), matching the form the report runner itself already uses (`reports/runner/report_runner.py`).

## Test plan
- [x] Added `test_json_download_aggregate_report_with_organization_tags` — sets tags on the org, hits the JSON export, asserts `organization_tags == ["tag-a", "tag-b"]` and status 200.
- [x] Existing `test_json_download_aggregate_report` (no tags) still passes.
- [x] pre-commit green (ruff, ruff-format, mypy, vulture, etc.).

Closes #4332.

Generated with [Devin](https://devin.ai)