### PR TITLE
Align crisis room URL structure with standard org-scope pattern (#4633)

### DIFF
--- a/rocky/crisis_room/urls.py
+++ b/rocky/crisis_room/urls.py
@@ -2,17 +2,5 @@ from django.urls import path
 
 from . import views
 
-# Crisis room overview urls
-urlpatterns = [
-    path("", views.CrisisRoomView.as_view(), name="crisis_room"),
-    path("<organization_code>/<int:id>/", views.OrganizationsCrisisRoomView.as_view(), name="organization_crisis_room"),
-    path(
-        "<organization_code>/",
-        views.OrganizationsCrisisRoomLandingView.as_view(),
-        name="organization_crisis_room_landing",
-    ),
-    path("<organization_code>/add/", views.AddDashboardView.as_view(), name="add_dashboard"),
-    path("<organization_code>/update-item/", views.UpdateDashboardItemView.as_view(), name="update_dashboard_item"),
-    path("<organization_code>/delete/", views.DeleteDashboardView.as_view(), name="delete_dashboard"),
-    path("<organization_code>/delete-item/", views.DeleteDashboardItemView.as_view(), name="delete_dashboard_item"),
-]
+# Crisis room overview (non-org-scope) url
+urlpatterns = [path("", views.CrisisRoomView.as_view(), name="crisis_room")]

--- a/rocky/crisis_room/urls_org.py
+++ b/rocky/crisis_room/urls_org.py
@@ -1,0 +1,15 @@
+from django.urls import path
+
+from . import views
+
+# Crisis room urls scoped to an organization. Included under
+# <organization_code>/crisis-room/ in rocky/urls.py, so organization_code
+# is provided by the mount point and does not need to be captured here.
+urlpatterns = [
+    path("", views.OrganizationsCrisisRoomLandingView.as_view(), name="organization_crisis_room_landing"),
+    path("<int:id>/", views.OrganizationsCrisisRoomView.as_view(), name="organization_crisis_room"),
+    path("add/", views.AddDashboardView.as_view(), name="add_dashboard"),
+    path("update-item/", views.UpdateDashboardItemView.as_view(), name="update_dashboard_item"),
+    path("delete/", views.DeleteDashboardView.as_view(), name="delete_dashboard"),
+    path("delete-item/", views.DeleteDashboardItemView.as_view(), name="delete_dashboard_item"),
+]

--- a/rocky/rocky/urls.py
+++ b/rocky/rocky/urls.py
@@ -72,6 +72,7 @@ urlpatterns += i18n_patterns(
     path("", LandingPageView.as_view(), name="landing_page"),
     path("onboarding/", include("onboarding.urls"), name="onboarding"),
     path("crisis-room/", include("crisis_room.urls"), name="crisis_room"),
+    path("<organization_code>/crisis-room/", include("crisis_room.urls_org"), name="crisis_room_org"),
     path("privacy-statement/", PrivacyStatementView.as_view(), name="privacy_statement"),
     path("tasks/", AllBoefjesTaskListView.as_view(), name="all_task_list"),
     path("tasks/boefjes", AllBoefjesTaskListView.as_view(), name="all_boefjes_task_list"),

--- a/rocky/tests/test_dashboard.py
+++ b/rocky/tests/test_dashboard.py
@@ -60,11 +60,11 @@ def test_expected_findings_results_dashboard(rf, mocker, client_member, expected
     assertContains(response, "<h2>Findings per organization</h2>", html=True)
     assertContains(response, '<caption class="visually-hidden">Findings per organization overview</caption>', html=True)
 
-    assertContains(response, f'<td><a href="/en/crisis-room/{org_code_a}/">{org_name_a}</a></td>', html=True)
+    assertContains(response, f'<td><a href="/en/{org_code_a}/crisis-room/">{org_name_a}</a></td>', html=True)
     assertContains(response, "<h5>Findings overview</h5>", html=True)
     assertContains(response, '<td>Total</td><td class="number">4</td><td class="number">7</td>', html=True)
 
-    assertContains(response, f'<td><a href="/en/crisis-room/{org_code_b}/">{org_name_b}</a></td>', html=True)
+    assertContains(response, f'<td><a href="/en/{org_code_b}/crisis-room/">{org_name_b}</a></td>', html=True)
 
     assertContains(
         response,


### PR DESCRIPTION
## Summary
- The crisis room org-scope URLs used `/en/crisis-room/<org>/...` instead of the standard `/en/<org>/...` pattern used everywhere else in Rocky (#4633).
- Split `crisis_room/urls.py` into:
  - `crisis_room/urls.py` — non-org-scope overview only (`crisis-room/`)
  - `crisis_room/urls_org.py` — org-scope URLs, included under `<organization_code>/crisis-room/` in `rocky/urls.py`, matching how katalogus (`<organization_code>/kat-alogus/`) and reports (`<organization_code>/reports/`) are already mounted.
- URL **names** are unchanged, so all `reverse()` and `{% url %}` references work without modification. Only the URL **paths** change.

### Before
```
/en/crisis-room/                         ← overview (unchanged)
/en/crisis-room/<org>/                   ← org landing
/en/crisis-room/<org>/<id>/              ← org dashboard
/en/crisis-room/<org>/add/               ← add dashboard
```

### After
```
/en/crisis-room/                         ← overview (unchanged)
/en/<org>/crisis-room/                   ← org landing
/en/<org>/crisis-room/<id>/              ← org dashboard
/en/<org>/crisis-room/add/               ← add dashboard
```

## Test plan
- [x] Updated 2 hardcoded URL assertions in `tests/test_dashboard.py` (lines 63, 67).
- [x] All 25 dashboard tests pass.
- [x] All 259 related tests pass (dashboard, crisis, organization, landing, onboarding, report).
- [x] pre-commit green (ruff, ruff-format, mypy, vulture, etc.).

Closes #4633.

Generated with [Devin](https://devin.ai)