### PR TITLE
Use new findings table layout in crisis room (#4372)

### DIFF
--- a/rocky/reports/templates/partials/report_findings_table.html
+++ b/rocky/reports/templates/partials/report_findings_table.html
@@ -57,18 +57,38 @@
                     {% if not is_crisis_room %}
                         <tr class="expando-row">
                             <td colspan="5">
-                                <h5>{% translate "Description" %}</h5>
-                                <p>{{ info.finding_type.description }}</p>
-                                <h5>{% translate "Source" %}</h5>
-                                {% if info.finding_type.source %}
-                                    <a class="nowrap" href="{{ info.finding_type.source }}">{{ info.finding_type.source }}</a>
-                                {% else %}
-                                    <p>{{ info.finding_type.source }}</p>
-                                {% endif %}
-                                <h5>{% translate "Impact" %}</h5>
-                                <p>{{ info.finding_type.impact }}</p>
-                                <h5>{% translate "Recommendation" %}</h5>
-                                <p>{{ info.finding_type.recommendation }}</p>
+                                <div>
+                                    <dl>
+                                        <div>
+                                            <dt>{% translate "Description" %}</dt>
+                                            <dd>
+                                                {{ info.finding_type.description }}
+                                            </dd>
+                                        </div>
+                                        <div>
+                                            <dt>{% translate "Source" %}</dt>
+                                            <dd>
+                                                {% if info.finding_type.source %}
+                                                    <a class="nowrap" href="{{ info.finding_type.source }}">{{ info.finding_type.source }}</a>
+                                                {% else %}
+                                                    {{ info.finding_type.source }}
+                                                {% endif %}
+                                            </dd>
+                                        </div>
+                                        <div>
+                                            <dt>{% translate "Impact" %}</dt>
+                                            <dd>
+                                                {{ info.finding_type.impact }}
+                                            </dd>
+                                        </div>
+                                        <div>
+                                            <dt>{% translate "Recommendation" %}</dt>
+                                            <dd>
+                                                {{ info.finding_type.recommendation }}
+                                            </dd>
+                                        </div>
+                                    </dl>
+                                </div>
                                 <div>
                                     <h5>{% translate "Findings" %}</h5>
                                 </div>


### PR DESCRIPTION
## Summary
- The crisis room findings dashboard uses `report_findings_table.html` for its expandable rows, which still used the old `<h5>`+`<p>` layout (#4372).
- #4172 introduced a new `<dl>`+`<dt>`+`<dd>` layout for the findings list page. This PR applies the same structure to `report_findings_table.html`'s expandable rows (Description, Source, Impact, Recommendation).
- The sub-table of individual occurrences (Finding + First known occurrence) is kept unchanged.
- The crisis room overview (`is_crisis_room="yes"`) is unaffected — it doesn't show expandable rows.

## Test plan
- [x] All 112 dashboard + report tests pass.
- [x] pre-commit green (djLint formatting + linting, codespell).

Closes #4372.

Generated with [Devin](https://devin.ai)