### PR TITLE
Add non-org-scoped /api/v1/health endpoint (#4231)

### DIFF
--- a/rocky/rocky/templates/footer.html
+++ b/rocky/rocky/templates/footer.html
@@ -17,6 +17,10 @@
                 <li>
                     <a href="{% url "health_beautified" organization_code=organization.code %}">{% translate "Health" %}</a>
                 </li>
+            {% else %}
+                <li>
+                    <a href="{% url "global_health_beautified" %}">{% translate "Health" %}</a>
+                </li>
             {% endif %}
         </ul>
     </nav>

--- a/rocky/rocky/templates/footer.html
+++ b/rocky/rocky/templates/footer.html
@@ -17,7 +17,7 @@
                 <li>
                     <a href="{% url "health_beautified" organization_code=organization.code %}">{% translate "Health" %}</a>
                 </li>
-            {% else %}
+            {% elif request.user.is_authenticated %}
                 <li>
                     <a href="{% url "global_health_beautified" %}">{% translate "Health" %}</a>
                 </li>

--- a/rocky/rocky/templates/footer.html
+++ b/rocky/rocky/templates/footer.html
@@ -17,7 +17,7 @@
                 <li>
                     <a href="{% url "health_beautified" organization_code=organization.code %}">{% translate "Health" %}</a>
                 </li>
-            {% elif request.user.is_authenticated %}
+            {% elif request.user.is_superuser %}
                 <li>
                     <a href="{% url "global_health_beautified" %}">{% translate "Health" %}</a>
                 </li>

--- a/rocky/rocky/urls.py
+++ b/rocky/rocky/urls.py
@@ -11,7 +11,7 @@ from rocky.views.bytes_raw import BytesRawView
 from rocky.views.finding_add import FindingAddView
 from rocky.views.finding_list import FindingListView
 from rocky.views.finding_type_add import FindingTypeAddView
-from rocky.views.health import Health, HealthChecks
+from rocky.views.health import GlobalHealthView, Health, HealthChecks
 from rocky.views.indemnification_add import IndemnificationAddView
 from rocky.views.landing_page import LandingPageView
 from rocky.views.ooi_add import OOIAddTypeSelectView, OOIAddView
@@ -62,6 +62,7 @@ router.register(r"report-recipe", ReportRecipeViewSet, basename="report-recipe")
 urlpatterns = [
     path("i18n/", include("django.conf.urls.i18n")),
     path("api/v1/", include(router.urls)),
+    path("api/v1/health", GlobalHealthView.as_view(), name="global_health"),
     path("<organization_code>/health/", Health.as_view(), name="health"),
     path("", include(tf_urls)),
     path("robots.txt", TemplateView.as_view(template_name="robots.txt", content_type="text/plain")),

--- a/rocky/rocky/urls.py
+++ b/rocky/rocky/urls.py
@@ -63,6 +63,7 @@ urlpatterns = [
     path("i18n/", include("django.conf.urls.i18n")),
     path("api/v1/", include(router.urls)),
     path("api/v1/health", GlobalHealthView.as_view(), name="global_health"),
+    path("api/v1/health/", GlobalHealthView.as_view()),
     path("<organization_code>/health/", Health.as_view(), name="health"),
     path("", include(tf_urls)),
     path("robots.txt", TemplateView.as_view(template_name="robots.txt", content_type="text/plain")),

--- a/rocky/rocky/urls.py
+++ b/rocky/rocky/urls.py
@@ -11,7 +11,7 @@ from rocky.views.bytes_raw import BytesRawView
 from rocky.views.finding_add import FindingAddView
 from rocky.views.finding_list import FindingListView
 from rocky.views.finding_type_add import FindingTypeAddView
-from rocky.views.health import GlobalHealthView, Health, HealthChecks
+from rocky.views.health import GlobalHealthChecks, GlobalHealthView, Health, HealthChecks
 from rocky.views.indemnification_add import IndemnificationAddView
 from rocky.views.landing_page import LandingPageView
 from rocky.views.ooi_add import OOIAddTypeSelectView, OOIAddView
@@ -75,6 +75,7 @@ urlpatterns += i18n_patterns(
     path("crisis-room/", include("crisis_room.urls"), name="crisis_room"),
     path("<organization_code>/crisis-room/", include("crisis_room.urls_org"), name="crisis_room_org"),
     path("privacy-statement/", PrivacyStatementView.as_view(), name="privacy_statement"),
+    path("health/v1/", GlobalHealthChecks.as_view(), name="global_health_beautified"),
     path("tasks/", AllBoefjesTaskListView.as_view(), name="all_task_list"),
     path("tasks/boefjes", AllBoefjesTaskListView.as_view(), name="all_boefjes_task_list"),
     path("tasks/normalizers", AllNormalizersTaskListView.as_view(), name="all_normalizers_task_list"),

--- a/rocky/rocky/views/health.py
+++ b/rocky/rocky/views/health.py
@@ -2,6 +2,7 @@ from typing import Any
 
 import structlog
 from account.mixins import OrganizationView
+from django.conf import settings
 from django.http import HttpRequest, JsonResponse
 from django.urls.base import reverse
 from django.utils.translation import gettext_lazy as _
@@ -22,6 +23,19 @@ class Health(OrganizationView, View):
     def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> JsonResponse:
         octopoes_connector = self.octopoes_api_connector
         rocky_health = get_rocky_health(self.organization.code, octopoes_connector)
+        return JsonResponse(rocky_health.model_dump())
+
+
+class GlobalHealthView(View):
+    """Non-org-scoped health endpoint for monitoring and load balancers (#4231).
+
+    Checks all backing services without requiring an organization context.
+    Octopoes is checked via its root health endpoint, which does not need
+    a specific organization.
+    """
+
+    def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> JsonResponse:
+        rocky_health = get_rocky_health_global()
         return JsonResponse(rocky_health.model_dump())
 
 
@@ -48,7 +62,19 @@ def get_octopoes_health(octopoes_api_connector: OctopoesAPIConnector) -> Service
     return octopoes_health
 
 
-def get_scheduler_health(organization_code: str) -> ServiceHealth:
+def get_octopoes_root_health() -> ServiceHealth:
+    try:
+        connector = OctopoesAPIConnector(settings.OCTOPOES_API, "", timeout=settings.ROCKY_OUTGOING_REQUEST_TIMEOUT)
+        octopoes_health = ServiceHealth.model_validate(connector.root_health().model_dump())
+    except HTTPError:
+        logger.exception("Error while retrieving Octopoes root health state")
+        octopoes_health = ServiceHealth(
+            service="octopoes", healthy=False, additional="Could not connect to Octopoes. Service is possibly down"
+        )
+    return octopoes_health
+
+
+def get_scheduler_health(organization_code: str | None = None) -> ServiceHealth:
     try:
         scheduler_health = scheduler_client(organization_code).health()
     except SchedulerError:
@@ -75,6 +101,18 @@ def get_rocky_health(organization_code: str, octopoes_api_connector: OctopoesAPI
         service="rocky", healthy=services_healthy, version=__version__, results=services, additional=additional
     )
     return rocky_health
+
+
+def get_rocky_health_global() -> ServiceHealth:
+    services = [get_octopoes_root_health(), get_katalogus_health(), get_scheduler_health(), get_bytes_health()]
+
+    services_healthy = all(service.healthy for service in services)
+    additional = None
+    if not services_healthy:
+        additional = "Rocky will not function properly. Not all services are healthy."
+    return ServiceHealth(
+        service="rocky", healthy=services_healthy, version=__version__, results=services, additional=additional
+    )
 
 
 def flatten_health(health_: ServiceHealth) -> list[ServiceHealth]:

--- a/rocky/rocky/views/health.py
+++ b/rocky/rocky/views/health.py
@@ -123,6 +123,26 @@ def flatten_health(health_: ServiceHealth) -> list[ServiceHealth]:
     return results
 
 
+class GlobalHealthChecks(TemplateView):
+    """Non-org-scoped human-readable health page (#4231).
+
+    Renders the same template as the org-scoped HealthChecks view but
+    uses get_rocky_health_global() so it works without an organization.
+    """
+
+    template_name = "health.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["breadcrumbs"] = [
+            {"url": reverse("global_health"), "text": _("Health")},
+            {"url": reverse("global_health_beautified"), "text": _("Beautified")},
+        ]
+        rocky_health = get_rocky_health_global()
+        context["health_checks"] = flatten_health(rocky_health)
+        return context
+
+
 class HealthChecks(OrganizationView, TemplateView):
     template_name = "health.html"
 

--- a/rocky/rocky/views/health.py
+++ b/rocky/rocky/views/health.py
@@ -1,15 +1,23 @@
+from collections.abc import Callable
 from typing import Any
 
 import structlog
 from account.mixins import OrganizationView
 from django.conf import settings
+from django.contrib.auth.mixins import UserPassesTestMixin
 from django.http import HttpRequest, JsonResponse
 from django.urls.base import reverse
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import TemplateView, View
 from httpx import HTTPError
 from katalogus.health import get_katalogus_health
+from pydantic import ValidationError
+from rest_framework import status
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
+from octopoes.connector import ConnectorException
 from octopoes.connector.octopoes import OctopoesAPIConnector
 from rocky.bytes_client import get_bytes_client
 from rocky.health import ServiceHealth
@@ -26,17 +34,23 @@ class Health(OrganizationView, View):
         return JsonResponse(rocky_health.model_dump())
 
 
-class GlobalHealthView(View):
+class GlobalHealthView(APIView):
     """Non-org-scoped health endpoint for monitoring and load balancers (#4231).
 
-    Checks all backing services without requiring an organization context.
-    Octopoes is checked via its root health endpoint, which does not need
-    a specific organization.
+    Public endpoint: checks all backing services without requiring an
+    organization context. Returns 503 when any service is unhealthy so load
+    balancers can take the instance out of rotation. Version numbers are
+    stripped from the response to avoid fingerprinting.
     """
 
-    def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> JsonResponse:
+    permission_classes = [AllowAny]
+    authentication_classes: list = []
+
+    def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> Response:
         rocky_health = get_rocky_health_global()
-        return JsonResponse(rocky_health.model_dump())
+        _strip_versions(rocky_health)
+        http_status = status.HTTP_200_OK if rocky_health.healthy else status.HTTP_503_SERVICE_UNAVAILABLE
+        return Response(rocky_health.model_dump(), status=http_status)
 
 
 def get_bytes_health() -> ServiceHealth:
@@ -50,28 +64,25 @@ def get_bytes_health() -> ServiceHealth:
     return bytes_health
 
 
-def get_octopoes_health(octopoes_api_connector: OctopoesAPIConnector) -> ServiceHealth:
+def _get_octopoes_health(probe: Callable[[], ServiceHealth]) -> ServiceHealth:
+    """Call an Octopoes connector health method and convert errors to unhealthy."""
     try:
-        # we need to make sure we're using Rocky's ServiceHealth model, not Octopoes' model
-        octopoes_health = ServiceHealth.model_validate(octopoes_api_connector.health().model_dump())
-    except HTTPError:
+        return ServiceHealth.model_validate(probe().model_dump())
+    except (HTTPError, ConnectorException, ValidationError):
         logger.exception("Error while retrieving Octopoes health state")
-        octopoes_health = ServiceHealth(
+        return ServiceHealth(
             service="octopoes", healthy=False, additional="Could not connect to Octopoes. Service is possibly down"
         )
-    return octopoes_health
 
 
-def get_octopoes_root_health() -> ServiceHealth:
-    try:
-        connector = OctopoesAPIConnector(settings.OCTOPOES_API, "", timeout=settings.ROCKY_OUTGOING_REQUEST_TIMEOUT)
-        octopoes_health = ServiceHealth.model_validate(connector.root_health().model_dump())
-    except HTTPError:
-        logger.exception("Error while retrieving Octopoes root health state")
-        octopoes_health = ServiceHealth(
-            service="octopoes", healthy=False, additional="Could not connect to Octopoes. Service is possibly down"
-        )
-    return octopoes_health
+def get_octopoes_health(octopoes_api_connector: OctopoesAPIConnector) -> ServiceHealth:
+    return _get_octopoes_health(octopoes_api_connector.health)
+
+
+def get_octopoes_organizations_health() -> ServiceHealth:
+    """Probe Octopoes via /health/organizations — actually checks XTDB per node (#4231)."""
+    connector = OctopoesAPIConnector(settings.OCTOPOES_API, "", timeout=settings.ROCKY_OUTGOING_REQUEST_TIMEOUT)
+    return _get_octopoes_health(connector.organizations_health)
 
 
 def get_scheduler_health(organization_code: str | None = None) -> ServiceHealth:
@@ -85,27 +96,7 @@ def get_scheduler_health(organization_code: str | None = None) -> ServiceHealth:
     return scheduler_health
 
 
-def get_rocky_health(organization_code: str, octopoes_api_connector: OctopoesAPIConnector) -> ServiceHealth:
-    services = [
-        get_octopoes_health(octopoes_api_connector),
-        get_katalogus_health(),
-        get_scheduler_health(organization_code),
-        get_bytes_health(),
-    ]
-
-    services_healthy = all(service.healthy for service in services)
-    additional = None
-    if not services_healthy:
-        additional = "Rocky will not function properly. Not all services are healthy."
-    rocky_health = ServiceHealth(
-        service="rocky", healthy=services_healthy, version=__version__, results=services, additional=additional
-    )
-    return rocky_health
-
-
-def get_rocky_health_global() -> ServiceHealth:
-    services = [get_octopoes_root_health(), get_katalogus_health(), get_scheduler_health(), get_bytes_health()]
-
+def _aggregate(services: list[ServiceHealth]) -> ServiceHealth:
     services_healthy = all(service.healthy for service in services)
     additional = None
     if not services_healthy:
@@ -113,6 +104,30 @@ def get_rocky_health_global() -> ServiceHealth:
     return ServiceHealth(
         service="rocky", healthy=services_healthy, version=__version__, results=services, additional=additional
     )
+
+
+def get_rocky_health(organization_code: str, octopoes_api_connector: OctopoesAPIConnector) -> ServiceHealth:
+    return _aggregate(
+        [
+            get_octopoes_health(octopoes_api_connector),
+            get_katalogus_health(),
+            get_scheduler_health(organization_code),
+            get_bytes_health(),
+        ]
+    )
+
+
+def get_rocky_health_global() -> ServiceHealth:
+    return _aggregate(
+        [get_octopoes_organizations_health(), get_katalogus_health(), get_scheduler_health(), get_bytes_health()]
+    )
+
+
+def _strip_versions(health_: ServiceHealth) -> None:
+    """Remove version numbers from a ServiceHealth tree (public endpoint anti-fingerprinting)."""
+    health_.version = None
+    for sub_result in health_.results:
+        _strip_versions(sub_result)
 
 
 def flatten_health(health_: ServiceHealth) -> list[ServiceHealth]:
@@ -123,14 +138,17 @@ def flatten_health(health_: ServiceHealth) -> list[ServiceHealth]:
     return results
 
 
-class GlobalHealthChecks(TemplateView):
+class GlobalHealthChecks(UserPassesTestMixin, TemplateView):
     """Non-org-scoped human-readable health page (#4231).
 
-    Renders the same template as the org-scoped HealthChecks view but
-    uses get_rocky_health_global() so it works without an organization.
+    Restricted to superusers, matching the documented access policy for the
+    health page (see docs/source/installation-and-deployment/debugging-troubleshooting.rst).
     """
 
     template_name = "health.html"
+
+    def test_func(self) -> bool:
+        return self.request.user.is_superuser
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/rocky/rocky/views/health.py
+++ b/rocky/rocky/views/health.py
@@ -39,8 +39,9 @@ class GlobalHealthView(APIView):
 
     Public endpoint: checks all backing services without requiring an
     organization context. Returns 503 when any service is unhealthy so load
-    balancers can take the instance out of rotation. Version numbers are
-    stripped from the response to avoid fingerprinting.
+    balancers can take the instance out of rotation. The response is redacted
+    to service + healthy only — no versions, additional, or per-org details
+    that could fingerprint the installation.
     """
 
     permission_classes = [AllowAny]
@@ -48,7 +49,7 @@ class GlobalHealthView(APIView):
 
     def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> Response:
         rocky_health = get_rocky_health_global()
-        _strip_versions(rocky_health)
+        _redact_for_public(rocky_health)
         http_status = status.HTTP_200_OK if rocky_health.healthy else status.HTTP_503_SERVICE_UNAVAILABLE
         return Response(rocky_health.model_dump(), status=http_status)
 
@@ -79,10 +80,18 @@ def get_octopoes_health(octopoes_api_connector: OctopoesAPIConnector) -> Service
     return _get_octopoes_health(octopoes_api_connector.health)
 
 
-def get_octopoes_organizations_health() -> ServiceHealth:
-    """Probe Octopoes via /health/organizations — actually checks XTDB per node (#4231)."""
+def get_octopoes_root_health() -> ServiceHealth:
+    """Probe Octopoes reachability via /health — thin verdict, no per-org XTDB probe (#4231).
+
+    Does not check per-organization XTDB health: an installation with hundreds of
+    orgs would otherwise drive hundreds of XTDB probes per request. The global
+    health page explains this thin verdict to operators.
+    """
     connector = OctopoesAPIConnector(settings.OCTOPOES_API, "", timeout=settings.ROCKY_OUTGOING_REQUEST_TIMEOUT)
-    return _get_octopoes_health(connector.organizations_health)
+    health = _get_octopoes_health(connector.root_health)
+    if health.healthy:
+        health.additional = "Reachability check only — does not probe per-organization XTDB health."
+    return health
 
 
 def get_scheduler_health(organization_code: str | None = None) -> ServiceHealth:
@@ -118,16 +127,16 @@ def get_rocky_health(organization_code: str, octopoes_api_connector: OctopoesAPI
 
 
 def get_rocky_health_global() -> ServiceHealth:
-    return _aggregate(
-        [get_octopoes_organizations_health(), get_katalogus_health(), get_scheduler_health(), get_bytes_health()]
-    )
+    return _aggregate([get_octopoes_root_health(), get_katalogus_health(), get_scheduler_health(), get_bytes_health()])
 
 
-def _strip_versions(health_: ServiceHealth) -> None:
-    """Remove version numbers from a ServiceHealth tree (public endpoint anti-fingerprinting)."""
+def _redact_for_public(health_: ServiceHealth) -> None:
+    """Public endpoint: keep service + healthy, drop everything that fingerprints (#4231)."""
     health_.version = None
     for sub_result in health_.results:
-        _strip_versions(sub_result)
+        sub_result.version = None
+        sub_result.additional = None
+        sub_result.results = []
 
 
 def flatten_health(health_: ServiceHealth) -> list[ServiceHealth]:

--- a/rocky/tests/test_health.py
+++ b/rocky/tests/test_health.py
@@ -1,5 +1,9 @@
+import json
+from unittest.mock import patch
+
 from rocky.health import ServiceHealth
-from rocky.views.health import flatten_health
+from rocky.views.health import GlobalHealthView, flatten_health
+from tests.conftest import setup_request
 
 
 def test_flatten_health_simple():
@@ -18,3 +22,27 @@ def test_flatten_health_recursive():
         ServiceHealth(service="service1", healthy=True, version="1.1.1"),
         ServiceHealth(service="service2", healthy=False, version="2.2.2"),
     ]
+
+
+def test_global_health_endpoint(rf, client_member):
+    """The non-org-scoped health endpoint returns service health without requiring an organization (#4231)."""
+    mock_services = [
+        ServiceHealth(service="octopoes", healthy=True, version="1.0"),
+        ServiceHealth(service="katalogus", healthy=True, version="1.0"),
+        ServiceHealth(service="scheduler", healthy=True, version="1.0"),
+        ServiceHealth(service="bytes", healthy=True, version="1.0"),
+    ]
+    with (
+        patch("rocky.views.health.get_octopoes_root_health", return_value=mock_services[0]),
+        patch("rocky.views.health.get_katalogus_health", return_value=mock_services[1]),
+        patch("rocky.views.health.get_scheduler_health", return_value=mock_services[2]),
+        patch("rocky.views.health.get_bytes_health", return_value=mock_services[3]),
+    ):
+        request = setup_request(rf.get("global_health"), client_member.user)
+        response = GlobalHealthView.as_view()(request)
+
+    assert response.status_code == 200
+    data = json.loads(response.content)
+    assert data["service"] == "rocky"
+    assert data["healthy"] is True
+    assert {s["service"] for s in data["results"]} == {"octopoes", "katalogus", "scheduler", "bytes"}

--- a/rocky/tests/test_health.py
+++ b/rocky/tests/test_health.py
@@ -2,7 +2,7 @@ import json
 from unittest.mock import patch
 
 from rocky.health import ServiceHealth
-from rocky.views.health import GlobalHealthView, flatten_health
+from rocky.views.health import GlobalHealthChecks, GlobalHealthView, flatten_health
 from tests.conftest import setup_request
 
 
@@ -46,3 +46,24 @@ def test_global_health_endpoint(rf, client_member):
     assert data["service"] == "rocky"
     assert data["healthy"] is True
     assert {s["service"] for s in data["results"]} == {"octopoes", "katalogus", "scheduler", "bytes"}
+
+
+def test_global_health_beautified(rf, client_member):
+    """The non-org-scoped beautified health page renders without an organization (#4231)."""
+    mock_services = [
+        ServiceHealth(service="octopoes", healthy=True, version="1.0"),
+        ServiceHealth(service="katalogus", healthy=True, version="1.0"),
+        ServiceHealth(service="scheduler", healthy=True, version="1.0"),
+        ServiceHealth(service="bytes", healthy=True, version="1.0"),
+    ]
+    with (
+        patch("rocky.views.health.get_octopoes_root_health", return_value=mock_services[0]),
+        patch("rocky.views.health.get_katalogus_health", return_value=mock_services[1]),
+        patch("rocky.views.health.get_scheduler_health", return_value=mock_services[2]),
+        patch("rocky.views.health.get_bytes_health", return_value=mock_services[3]),
+    ):
+        request = setup_request(rf.get("global_health_beautified"), client_member.user)
+        response = GlobalHealthChecks.as_view()(request)
+
+    assert response.status_code == 200
+    assert b"Health Checks" in response.content

--- a/rocky/tests/test_health.py
+++ b/rocky/tests/test_health.py
@@ -1,6 +1,8 @@
 import json
 from unittest.mock import patch
 
+import pytest
+from django.core.exceptions import PermissionDenied
 from django.test import Client
 
 from rocky.health import ServiceHealth
@@ -35,7 +37,7 @@ def test_global_health_endpoint_healthy(rf, client_member):
         ServiceHealth(service="bytes", healthy=True, version="1.0"),
     ]
     with (
-        patch("rocky.views.health.get_octopoes_organizations_health", return_value=mock_services[0]),
+        patch("rocky.views.health.get_octopoes_root_health", return_value=mock_services[0]),
         patch("rocky.views.health.get_katalogus_health", return_value=mock_services[1]),
         patch("rocky.views.health.get_scheduler_health", return_value=mock_services[2]),
         patch("rocky.views.health.get_bytes_health", return_value=mock_services[3]),
@@ -62,7 +64,7 @@ def test_global_health_endpoint_unhealthy_returns_503(rf, client_member):
         ServiceHealth(service="bytes", healthy=True),
     ]
     with (
-        patch("rocky.views.health.get_octopoes_organizations_health", return_value=mock_services[0]),
+        patch("rocky.views.health.get_octopoes_root_health", return_value=mock_services[0]),
         patch("rocky.views.health.get_katalogus_health", return_value=mock_services[1]),
         patch("rocky.views.health.get_scheduler_health", return_value=mock_services[2]),
         patch("rocky.views.health.get_bytes_health", return_value=mock_services[3]),
@@ -80,8 +82,7 @@ def test_global_health_endpoint_anonymous_via_url(db):
     """The endpoint is reachable anonymously through the real URL — pins routing, auth, and trailing slash (#4231)."""
     with (
         patch(
-            "rocky.views.health.get_octopoes_organizations_health",
-            return_value=ServiceHealth(service="octopoes", healthy=True),
+            "rocky.views.health.get_octopoes_root_health", return_value=ServiceHealth(service="octopoes", healthy=True)
         ),
         patch("rocky.views.health.get_katalogus_health", return_value=ServiceHealth(service="katalogus", healthy=True)),
         patch("rocky.views.health.get_scheduler_health", return_value=ServiceHealth(service="scheduler", healthy=True)),
@@ -94,14 +95,16 @@ def test_global_health_endpoint_anonymous_via_url(db):
     assert data["service"] == "rocky"
     assert data["healthy"] is True
     assert data["version"] is None
+    # Finding A: public endpoint must not leak additional/results that fingerprint
+    assert all(s["additional"] is None for s in data["results"])
+    assert all(s["results"] == [] for s in data["results"])
 
 
 def test_global_health_endpoint_trailing_slash(db):
     """Both /api/v1/health and /api/v1/health/ resolve — no 404 on the slashed form (#4231)."""
     with (
         patch(
-            "rocky.views.health.get_octopoes_organizations_health",
-            return_value=ServiceHealth(service="octopoes", healthy=True),
+            "rocky.views.health.get_octopoes_root_health", return_value=ServiceHealth(service="octopoes", healthy=True)
         ),
         patch("rocky.views.health.get_katalogus_health", return_value=ServiceHealth(service="katalogus", healthy=True)),
         patch("rocky.views.health.get_scheduler_health", return_value=ServiceHealth(service="scheduler", healthy=True)),
@@ -116,7 +119,7 @@ def test_global_health_endpoint_unhealthy_via_url(db):
     """The real URL returns 503 when Octopoes is down — pins finding #2 through routing (#4231)."""
     with (
         patch(
-            "rocky.views.health.get_octopoes_organizations_health",
+            "rocky.views.health.get_octopoes_root_health",
             return_value=ServiceHealth(service="octopoes", healthy=False, additional="down"),
         ),
         patch("rocky.views.health.get_katalogus_health", return_value=ServiceHealth(service="katalogus", healthy=True)),
@@ -138,7 +141,7 @@ def test_global_health_beautified(rf, superuser):
         ServiceHealth(service="bytes", healthy=True, version="1.0"),
     ]
     with (
-        patch("rocky.views.health.get_octopoes_organizations_health", return_value=mock_services[0]),
+        patch("rocky.views.health.get_octopoes_root_health", return_value=mock_services[0]),
         patch("rocky.views.health.get_katalogus_health", return_value=mock_services[1]),
         patch("rocky.views.health.get_scheduler_health", return_value=mock_services[2]),
         patch("rocky.views.health.get_bytes_health", return_value=mock_services[3]),
@@ -149,3 +152,11 @@ def test_global_health_beautified(rf, superuser):
 
     assert response.status_code == 200
     assert b"Health Checks" in response.content
+
+
+def test_global_health_beautified_denied_for_non_superuser(rf, client_member):
+    """The beautified page is superuser-only (#4231) — a plain member must not reach it."""
+    request = setup_request(rf.get("global_health_beautified"), client_member.user)
+
+    with pytest.raises(PermissionDenied):
+        GlobalHealthChecks.as_view()(request)

--- a/rocky/tests/test_health.py
+++ b/rocky/tests/test_health.py
@@ -64,6 +64,7 @@ def test_global_health_beautified(rf, client_member):
     ):
         request = setup_request(rf.get("global_health_beautified"), client_member.user)
         response = GlobalHealthChecks.as_view()(request)
+        response.render()
 
     assert response.status_code == 200
     assert b"Health Checks" in response.content

--- a/rocky/tests/test_health.py
+++ b/rocky/tests/test_health.py
@@ -1,6 +1,8 @@
 import json
 from unittest.mock import patch
 
+from django.test import Client
+
 from rocky.health import ServiceHealth
 from rocky.views.health import GlobalHealthChecks, GlobalHealthView, flatten_health
 from tests.conftest import setup_request
@@ -24,8 +26,8 @@ def test_flatten_health_recursive():
     ]
 
 
-def test_global_health_endpoint(rf, client_member):
-    """The non-org-scoped health endpoint returns service health without requiring an organization (#4231)."""
+def test_global_health_endpoint_healthy(rf, client_member):
+    """The non-org-scoped health endpoint returns 200 with service health when all services are up (#4231)."""
     mock_services = [
         ServiceHealth(service="octopoes", healthy=True, version="1.0"),
         ServiceHealth(service="katalogus", healthy=True, version="1.0"),
@@ -33,23 +35,102 @@ def test_global_health_endpoint(rf, client_member):
         ServiceHealth(service="bytes", healthy=True, version="1.0"),
     ]
     with (
-        patch("rocky.views.health.get_octopoes_root_health", return_value=mock_services[0]),
+        patch("rocky.views.health.get_octopoes_organizations_health", return_value=mock_services[0]),
         patch("rocky.views.health.get_katalogus_health", return_value=mock_services[1]),
         patch("rocky.views.health.get_scheduler_health", return_value=mock_services[2]),
         patch("rocky.views.health.get_bytes_health", return_value=mock_services[3]),
     ):
         request = setup_request(rf.get("global_health"), client_member.user)
         response = GlobalHealthView.as_view()(request)
+        response.render()
 
     assert response.status_code == 200
     data = json.loads(response.content)
     assert data["service"] == "rocky"
     assert data["healthy"] is True
+    assert data["version"] is None  # version stripped from public endpoint
     assert {s["service"] for s in data["results"]} == {"octopoes", "katalogus", "scheduler", "bytes"}
+    assert all(s["version"] is None for s in data["results"])
 
 
-def test_global_health_beautified(rf, client_member):
-    """The non-org-scoped beautified health page renders without an organization (#4231)."""
+def test_global_health_endpoint_unhealthy_returns_503(rf, client_member):
+    """The endpoint returns 503 when a backing service is down so LBs can act on the status code (#4231)."""
+    mock_services = [
+        ServiceHealth(service="octopoes", healthy=False, additional="down"),
+        ServiceHealth(service="katalogus", healthy=True),
+        ServiceHealth(service="scheduler", healthy=True),
+        ServiceHealth(service="bytes", healthy=True),
+    ]
+    with (
+        patch("rocky.views.health.get_octopoes_organizations_health", return_value=mock_services[0]),
+        patch("rocky.views.health.get_katalogus_health", return_value=mock_services[1]),
+        patch("rocky.views.health.get_scheduler_health", return_value=mock_services[2]),
+        patch("rocky.views.health.get_bytes_health", return_value=mock_services[3]),
+    ):
+        request = setup_request(rf.get("global_health"), client_member.user)
+        response = GlobalHealthView.as_view()(request)
+        response.render()
+
+    assert response.status_code == 503
+    data = json.loads(response.content)
+    assert data["healthy"] is False
+
+
+def test_global_health_endpoint_anonymous_via_url(db):
+    """The endpoint is reachable anonymously through the real URL — pins routing, auth, and trailing slash (#4231)."""
+    with (
+        patch(
+            "rocky.views.health.get_octopoes_organizations_health",
+            return_value=ServiceHealth(service="octopoes", healthy=True),
+        ),
+        patch("rocky.views.health.get_katalogus_health", return_value=ServiceHealth(service="katalogus", healthy=True)),
+        patch("rocky.views.health.get_scheduler_health", return_value=ServiceHealth(service="scheduler", healthy=True)),
+        patch("rocky.views.health.get_bytes_health", return_value=ServiceHealth(service="bytes", healthy=True)),
+    ):
+        response = Client(SERVER_NAME="localhost").get("/api/v1/health")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["service"] == "rocky"
+    assert data["healthy"] is True
+    assert data["version"] is None
+
+
+def test_global_health_endpoint_trailing_slash(db):
+    """Both /api/v1/health and /api/v1/health/ resolve — no 404 on the slashed form (#4231)."""
+    with (
+        patch(
+            "rocky.views.health.get_octopoes_organizations_health",
+            return_value=ServiceHealth(service="octopoes", healthy=True),
+        ),
+        patch("rocky.views.health.get_katalogus_health", return_value=ServiceHealth(service="katalogus", healthy=True)),
+        patch("rocky.views.health.get_scheduler_health", return_value=ServiceHealth(service="scheduler", healthy=True)),
+        patch("rocky.views.health.get_bytes_health", return_value=ServiceHealth(service="bytes", healthy=True)),
+    ):
+        response = Client(SERVER_NAME="localhost").get("/api/v1/health/")
+
+    assert response.status_code == 200
+
+
+def test_global_health_endpoint_unhealthy_via_url(db):
+    """The real URL returns 503 when Octopoes is down — pins finding #2 through routing (#4231)."""
+    with (
+        patch(
+            "rocky.views.health.get_octopoes_organizations_health",
+            return_value=ServiceHealth(service="octopoes", healthy=False, additional="down"),
+        ),
+        patch("rocky.views.health.get_katalogus_health", return_value=ServiceHealth(service="katalogus", healthy=True)),
+        patch("rocky.views.health.get_scheduler_health", return_value=ServiceHealth(service="scheduler", healthy=True)),
+        patch("rocky.views.health.get_bytes_health", return_value=ServiceHealth(service="bytes", healthy=True)),
+    ):
+        response = Client(SERVER_NAME="localhost").get("/api/v1/health")
+
+    assert response.status_code == 503
+    assert response.json()["healthy"] is False
+
+
+def test_global_health_beautified(rf, superuser):
+    """The non-org-scoped beautified health page renders for superusers (#4231)."""
     mock_services = [
         ServiceHealth(service="octopoes", healthy=True, version="1.0"),
         ServiceHealth(service="katalogus", healthy=True, version="1.0"),
@@ -57,12 +138,12 @@ def test_global_health_beautified(rf, client_member):
         ServiceHealth(service="bytes", healthy=True, version="1.0"),
     ]
     with (
-        patch("rocky.views.health.get_octopoes_root_health", return_value=mock_services[0]),
+        patch("rocky.views.health.get_octopoes_organizations_health", return_value=mock_services[0]),
         patch("rocky.views.health.get_katalogus_health", return_value=mock_services[1]),
         patch("rocky.views.health.get_scheduler_health", return_value=mock_services[2]),
         patch("rocky.views.health.get_bytes_health", return_value=mock_services[3]),
     ):
-        request = setup_request(rf.get("global_health_beautified"), client_member.user)
+        request = setup_request(rf.get("global_health_beautified"), superuser)
         response = GlobalHealthChecks.as_view()(request)
         response.render()
 


### PR DESCRIPTION
## Summary
- The existing health endpoint requires an organization context (`<organization_code>/health/`), making it unsuitable for load balancers and monitoring that need to check Rocky's overall status without knowing a specific organization (#4231).
- Added `GlobalHealthView` at `/api/v1/health` that checks all backing services:
  - **Octopoes**: via `root_health()` endpoint (no organization needed)
  - **KATalogus**: already non-org-scoped
  - **Scheduler**: already supports `organization_code=None`
  - **Bytes**: already non-org-scoped
- The org-scoped `<organization_code>/health/` endpoint is unchanged.

## Test plan
- [x] Added `test_global_health_endpoint` — mocks all 4 backing services, asserts 200 response with `service=rocky`, `healthy=true`, and all 4 sub-services present.
- [x] Existing health tests still pass.
- [x] pre-commit green (ruff, ruff-format, mypy, vulture, etc.).

Closes #4231.

Generated with [Devin](https://devin.ai)