### PR TITLE
Strip boefje environment secrets from raw meta downloads (#4508)

### DIFF
--- a/rocky/rocky/views/bytes_raw.py
+++ b/rocky/rocky/views/bytes_raw.py
@@ -17,12 +17,27 @@ logger = structlog.get_logger(__name__)
 
 RAW_FILE_LIMIT = 1024 * 1024
 
+# Fields in boefje_meta that may contain secrets and must not be exposed in
+# downloads. See #4508.
+SENSITIVE_BOEFJE_META_FIELDS = ("environment",)
+
+
+def _strip_sensitive_fields(raw_metas: list[dict]) -> None:
+    """Remove sensitive fields (e.g. environment with secrets) from boefje_meta
+    in-place, so they are not leaked via raw meta downloads (#4508)."""
+    for raw_meta in raw_metas:
+        boefje_meta = raw_meta.get("boefje_meta")
+        if isinstance(boefje_meta, dict):
+            for field in SENSITIVE_BOEFJE_META_FIELDS:
+                boefje_meta.pop(field, None)
+
 
 class BytesRawView(OrganizationView):
     def get(self, request, **kwargs):
         boefje_meta_id = kwargs["boefje_meta_id"]
         try:
             raw_metas = self.bytes_client.get_raw_metas(boefje_meta_id, self.organization.code)
+            _strip_sensitive_fields(raw_metas)
             is_json_format = request.GET.get("format") == "json"
             if is_json_format:
                 size_limit = int(request.GET.get("size_limit", RAW_FILE_LIMIT))

--- a/rocky/rocky/views/bytes_raw.py
+++ b/rocky/rocky/views/bytes_raw.py
@@ -17,19 +17,44 @@ logger = structlog.get_logger(__name__)
 
 RAW_FILE_LIMIT = 1024 * 1024
 
-# Fields in boefje_meta that may contain secrets and must not be exposed in
-# downloads. See #4508.
-SENSITIVE_BOEFJE_META_FIELDS = ("environment",)
+_HASH_NOTE = (
+    "Secret fields have been removed from the boefje metadata in this download.\n"
+    "As a result, the hash of the metadata JSON will not match the hash stored\n"
+    "in Bytes. The raw file data itself is unmodified and its hash is intact.\n"
+)
 
 
-def _strip_sensitive_fields(raw_metas: list[dict]) -> None:
-    """Remove sensitive fields (e.g. environment with secrets) from boefje_meta
-    in-place, so they are not leaked via raw meta downloads (#4508)."""
+def _strip_secret_fields(raw_metas: list[dict], katalogus_client) -> None:
+    """Remove secret fields from boefje_meta.environment using the boefje
+    schema's ``secret`` list, so they are not leaked via raw meta downloads
+    (#4508). Falls back to removing the entire environment if the schema
+    cannot be fetched — fail-closed for security."""
+    schema_cache: dict[str, set[str] | None] = {}
+
     for raw_meta in raw_metas:
         boefje_meta = raw_meta.get("boefje_meta")
-        if isinstance(boefje_meta, dict):
-            for field in SENSITIVE_BOEFJE_META_FIELDS:
-                boefje_meta.pop(field, None)
+        if not isinstance(boefje_meta, dict):
+            continue
+        environment = boefje_meta.get("environment")
+        if not isinstance(environment, dict) or not environment:
+            continue
+
+        boefje_id = boefje_meta.get("boefje", {}).get("id", "")
+        if boefje_id not in schema_cache:
+            try:
+                plugin = katalogus_client.get_plugin(boefje_id)
+                schema = getattr(plugin, "boefje_schema", None) or {}
+                schema_cache[boefje_id] = set(schema.get("secret", []))
+            except Exception:
+                logger.exception("Failed to fetch boefje schema, stripping entire environment")
+                schema_cache[boefje_id] = None  # fail closed
+
+        secrets = schema_cache[boefje_id]
+        if secrets is None:
+            boefje_meta.pop("environment", None)
+        else:
+            for key in secrets:
+                environment.pop(key, None)
 
 
 class BytesRawView(OrganizationView):
@@ -37,7 +62,7 @@ class BytesRawView(OrganizationView):
         boefje_meta_id = kwargs["boefje_meta_id"]
         try:
             raw_metas = self.bytes_client.get_raw_metas(boefje_meta_id, self.organization.code)
-            _strip_sensitive_fields(raw_metas)
+            _strip_secret_fields(raw_metas, self.katalogus_client)
             is_json_format = request.GET.get("format") == "json"
             if is_json_format:
                 size_limit = int(request.GET.get("size_limit", RAW_FILE_LIMIT))
@@ -78,6 +103,7 @@ def zip_data(raws: dict[str, bytes], raw_metas: list[dict]) -> BytesIO:
     zf_buffer = BytesIO()
 
     with zipfile.ZipFile(zf_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("NOTE.txt", _HASH_NOTE)
         for raw_meta in raw_metas:
             zf.writestr(raw_meta["id"], raws[raw_meta["id"]])
             zf.writestr(f"raw_meta_{raw_meta['id']}.json", json.dumps(raw_meta))

--- a/rocky/tests/test_boefjes_tasks.py
+++ b/rocky/tests/test_boefjes_tasks.py
@@ -126,14 +126,68 @@ def test_download_task_no_raw(rf, client_member, mock_bytes_client, bytes_raw_me
     assert list(request._messages)[0].message == "The task does not have any raw data."
 
 
-def test_download_task_strips_environment_from_meta(
-    rf, client_member, mock_bytes_client, bytes_raw_metas, bytes_get_raw
+def test_download_task_strips_secret_fields_from_meta(
+    rf, client_member, mock_bytes_client, mock_mixins_katalogus, bytes_raw_metas, bytes_get_raw, plugin_details
 ):
-    """The raw meta download must not leak boefje environment secrets (#4508)."""
+    """The raw meta download must not leak boefje secret fields (#4508)."""
+    raw_metas = bytes_raw_metas
+    raw_metas[0]["boefje_meta"]["environment"] = {"SECRET_KEY": "super-secret-value", "NON_SECRET": "ok"}
+    mock_bytes_client().get_raw.return_value = bytes_get_raw
+    mock_bytes_client().get_raw_metas.return_value = raw_metas
+
+    plugin_details.boefje_schema = {"secret": ["SECRET_KEY"]}
+    mock_mixins_katalogus.get_plugin.return_value = plugin_details
+
+    request = setup_request(rf.get("bytes_raw"), client_member.user)
+    response = BytesRawView.as_view()(
+        request, organization_code=client_member.organization.code, boefje_meta_id=raw_metas[0]["id"]
+    )
+
+    assert response.status_code == 200
+    zf = zipfile.ZipFile(io.BytesIO(b"".join(response.streaming_content)))
+    meta_json = json.loads(zf.read(f"raw_meta_{raw_metas[0]['id']}.json"))
+    env = meta_json["boefje_meta"]["environment"]
+    assert "SECRET_KEY" not in env
+    assert env["NON_SECRET"] == "ok"
+    # NOTE.txt should explain the hash mismatch
+    assert b"hash" in zf.read("NOTE.txt")
+
+
+def test_download_task_json_format_strips_secret_fields(
+    rf, client_member, mock_bytes_client, mock_mixins_katalogus, bytes_raw_metas, bytes_get_raw, plugin_details
+):
+    """The JSON format response must also not leak boefje secret fields (#4508)."""
+    raw_metas = bytes_raw_metas
+    raw_metas[0]["boefje_meta"]["environment"] = {"SECRET_KEY": "super-secret-value", "NON_SECRET": "ok"}
+    mock_bytes_client().get_raw.return_value = bytes_get_raw
+    mock_bytes_client().get_raw_metas.return_value = raw_metas
+
+    plugin_details.boefje_schema = {"secret": ["SECRET_KEY"]}
+    mock_mixins_katalogus.get_plugin.return_value = plugin_details
+
+    request = setup_request(rf.get("/bytes?format=json"), client_member.user)
+    response = BytesRawView.as_view()(
+        request, organization_code=client_member.organization.code, boefje_meta_id=raw_metas[0]["id"]
+    )
+
+    assert response.status_code == 200
+    data = json.loads(response.content)
+    env = data[0]["boefje_meta"]["environment"]
+    assert "SECRET_KEY" not in env
+    assert env["NON_SECRET"] == "ok"
+
+
+def test_download_task_strips_entire_environment_on_schema_fetch_failure(
+    rf, client_member, mock_bytes_client, mock_mixins_katalogus, bytes_raw_metas, bytes_get_raw
+):
+    """If the boefje schema cannot be fetched, the entire environment is
+    stripped — fail-closed for security (#4508)."""
     raw_metas = bytes_raw_metas
     raw_metas[0]["boefje_meta"]["environment"] = {"SECRET_KEY": "super-secret-value"}
     mock_bytes_client().get_raw.return_value = bytes_get_raw
     mock_bytes_client().get_raw_metas.return_value = raw_metas
+
+    mock_mixins_katalogus.get_plugin.side_effect = Exception("katalogus down")
 
     request = setup_request(rf.get("bytes_raw"), client_member.user)
     response = BytesRawView.as_view()(
@@ -146,20 +200,25 @@ def test_download_task_strips_environment_from_meta(
     assert "environment" not in meta_json["boefje_meta"]
 
 
-def test_download_task_json_format_strips_environment(
-    rf, client_member, mock_bytes_client, bytes_raw_metas, bytes_get_raw
+def test_download_task_keeps_environment_when_no_secrets_in_schema(
+    rf, client_member, mock_bytes_client, mock_mixins_katalogus, bytes_raw_metas, bytes_get_raw, plugin_details
 ):
-    """The JSON format response must also not leak boefje environment secrets (#4508)."""
+    """If the boefje schema defines no secret fields, the environment is
+    kept intact (#4508)."""
     raw_metas = bytes_raw_metas
-    raw_metas[0]["boefje_meta"]["environment"] = {"SECRET_KEY": "super-secret-value"}
+    raw_metas[0]["boefje_meta"]["environment"] = {"API_KEY": "not-secret"}
     mock_bytes_client().get_raw.return_value = bytes_get_raw
     mock_bytes_client().get_raw_metas.return_value = raw_metas
 
-    request = setup_request(rf.get("/bytes?format=json"), client_member.user)
+    plugin_details.boefje_schema = {"secret": []}
+    mock_mixins_katalogus.get_plugin.return_value = plugin_details
+
+    request = setup_request(rf.get("bytes_raw"), client_member.user)
     response = BytesRawView.as_view()(
         request, organization_code=client_member.organization.code, boefje_meta_id=raw_metas[0]["id"]
     )
 
     assert response.status_code == 200
-    data = json.loads(response.content)
-    assert "environment" not in data[0]["boefje_meta"]
+    zf = zipfile.ZipFile(io.BytesIO(b"".join(response.streaming_content)))
+    meta_json = json.loads(zf.read(f"raw_meta_{raw_metas[0]['id']}.json"))
+    assert meta_json["boefje_meta"]["environment"] == {"API_KEY": "not-secret"}

--- a/rocky/tests/test_boefjes_tasks.py
+++ b/rocky/tests/test_boefjes_tasks.py
@@ -1,3 +1,7 @@
+import io
+import json
+import zipfile
+
 import pytest
 from django.http import Http404
 from pytest_django.asserts import assertContains
@@ -120,3 +124,42 @@ def test_download_task_no_raw(rf, client_member, mock_bytes_client, bytes_raw_me
 
     assert response.status_code == 302
     assert list(request._messages)[0].message == "The task does not have any raw data."
+
+
+def test_download_task_strips_environment_from_meta(
+    rf, client_member, mock_bytes_client, bytes_raw_metas, bytes_get_raw
+):
+    """The raw meta download must not leak boefje environment secrets (#4508)."""
+    raw_metas = bytes_raw_metas
+    raw_metas[0]["boefje_meta"]["environment"] = {"SECRET_KEY": "super-secret-value"}
+    mock_bytes_client().get_raw.return_value = bytes_get_raw
+    mock_bytes_client().get_raw_metas.return_value = raw_metas
+
+    request = setup_request(rf.get("bytes_raw"), client_member.user)
+    response = BytesRawView.as_view()(
+        request, organization_code=client_member.organization.code, boefje_meta_id=raw_metas[0]["id"]
+    )
+
+    assert response.status_code == 200
+    zf = zipfile.ZipFile(io.BytesIO(b"".join(response.streaming_content)))
+    meta_json = json.loads(zf.read(f"raw_meta_{raw_metas[0]['id']}.json"))
+    assert "environment" not in meta_json["boefje_meta"]
+
+
+def test_download_task_json_format_strips_environment(
+    rf, client_member, mock_bytes_client, bytes_raw_metas, bytes_get_raw
+):
+    """The JSON format response must also not leak boefje environment secrets (#4508)."""
+    raw_metas = bytes_raw_metas
+    raw_metas[0]["boefje_meta"]["environment"] = {"SECRET_KEY": "super-secret-value"}
+    mock_bytes_client().get_raw.return_value = bytes_get_raw
+    mock_bytes_client().get_raw_metas.return_value = raw_metas
+
+    request = setup_request(rf.get("/bytes?format=json"), client_member.user)
+    response = BytesRawView.as_view()(
+        request, organization_code=client_member.organization.code, boefje_meta_id=raw_metas[0]["id"]
+    )
+
+    assert response.status_code == 200
+    data = json.loads(response.content)
+    assert "environment" not in data[0]["boefje_meta"]


### PR DESCRIPTION
## Summary
- The raw meta download (`BytesRawView`) exposed the `boefje_meta.environment` field, which can contain secrets, to any user who can access the task list (#4508).
- Added `_strip_sensitive_fields()` that removes the `environment` key from `boefje_meta` in each raw meta, in-place, before the data is returned — both in the zip download and the JSON format response.
- The `DownloadTaskDetail` view (scheduler task data) is not affected: the Rocky `BoefjeTask` model does not include an `environment` field, so pydantic already discards it.

## Test plan
- [x] Added `test_download_task_strips_environment_from_meta` — verifies `environment` is absent from the zip's raw meta JSON.
- [x] Added `test_download_task_json_format_strips_environment` — verifies `environment` is absent from the JSON format response.
- [x] All 11 existing + new boefje tasks / zip tests pass.
- [x] pre-commit green (ruff, ruff-format, mypy, vulture, etc.).

Closes #4508.

Generated with [Devin](https://devin.ai)