### PR TITLE
Treat already-deleted Octopoes node as success (#4723)

### DIFF
--- a/rocky/tests/test_api_organization.py
+++ b/rocky/tests/test_api_organization.py
@@ -243,6 +243,32 @@ class TestOrganizationViewSet(ViewSetTest):
             }
             assert json == expected
 
+    class TestDestroyNodeAlreadyDeleted(UsesDeleteMethod, UsesDetailEndpoint, Returns204):
+        """Deleting an organization whose Octopoes node is already gone should
+        succeed, not show a failure notification (#4723)."""
+
+        initial_ids = precondition_fixture(
+            lambda mock_models_katalogus, mock_models_octopoes, organizations: set(
+                Organization.objects.values_list("id", flat=True)
+            ),
+            async_=False,
+        )
+
+        @pytest.fixture(autouse=True)
+        def mock_services(self, mocker):
+            from octopoes.models.exception import ObjectNotFoundException
+
+            mocker.patch("katalogus.client.KATalogusClient")
+            mocker.patch("rocky.signals.OctopoesAPIConnector.root_health")
+            mocker.patch(
+                "rocky.signals.OctopoesAPIConnector.delete_node", side_effect=ObjectNotFoundException("Node not found")
+            )
+
+        def test_it_deletes_organization(self, initial_ids, organization):
+            expected = initial_ids - {organization.id}
+            actual = set(Organization.objects.values_list("id", flat=True))
+            assert actual == expected
+
     class TestListNoPermission(UsesGetMethod, UsesListEndpoint, Returns403):
         client = lambda_fixture("drf_redteam_client")
 

--- a/rocky/tools/viewsets.py
+++ b/rocky/tools/viewsets.py
@@ -8,6 +8,7 @@ from rest_framework.response import Response
 from structlog import get_logger
 
 from octopoes.connector.octopoes import OctopoesAPIConnector
+from octopoes.models.exception import ObjectNotFoundException
 from rocky.exceptions import OctopoesException
 from rocky.signals import _get_healthy_katalogus, _get_healthy_octopoes
 from tools.models import Indemnification, Organization
@@ -42,6 +43,11 @@ class OrganizationViewSet(viewsets.ModelViewSet):
 
         try:
             octopoes_client.delete_node()
+        except ObjectNotFoundException as e:
+            if e.value == "Node not found":
+                logger.info("Octopoes node already deleted, continuing", organization_code=instance.code)
+            else:
+                raise OctopoesException("Failed deleting organization in Octopoes") from e
         except Exception as e:
             raise OctopoesException("Failed deleting organization in Octopoes") from e
 


### PR DESCRIPTION
## Summary
- When deleting an organization, if the Octopoes node was already removed (e.g. by a previous delete attempt or a race condition), the Octopoes API returns a 404 "Node not found" which the connector raises as `ObjectNotFoundException` (#4723).
- This was caught as a generic error and shown to the user as "Failed deleting organization in Octopoes", even though the node was already gone and the delete was effectively successful.
- Now `ObjectNotFoundException` with value "Node not found" is treated as success — the organization deletion continues to the Katalogus step and completes normally (204).

## Root cause
The `destroy` method in `OrganizationViewSet` caught all exceptions from `octopoes_client.delete_node()` as failures. But a 404 "Node not found" means the desired state (node deleted) is already achieved — not that the delete failed.

## Test plan
- [x] Added `TestDestroyNodeAlreadyDeleted` — mocks `delete_node` to raise `ObjectNotFoundException("Node not found")`, asserts the organization is still deleted successfully (204).
- [x] All 44 existing organization API tests still pass.
- [x] pre-commit green (ruff, ruff-format, mypy, vulture, etc.).

Closes #4723.

Generated with [Devin](https://devin.ai)