### PR TITLE
Make crisis room findings drilling consistent (#5362)

### DIFF
--- a/rocky/crisis_room/templates/partials/crisis_room_findings_table.html
+++ b/rocky/crisis_room/templates/partials/crisis_room_findings_table.html
@@ -82,7 +82,7 @@
                                         {% endblocktranslate %}
                                     </p>
                                 </div>
-                                {% include "partials/report_findings_table.html" with finding_types=findings.finding_types report=dashboard_item.report is_crisis_room="yes" %}
+                                {% include "partials/report_findings_table.html" with finding_types=findings.finding_types report=dashboard_item.report organization=dashboard_item.item.dashboard.organization is_dashboard_item="yes" %}
 
                             {% else %}
                                 <p>{% translate "No findings have been identified. Check report for more details." %}</p>


### PR DESCRIPTION
## Summary
- The all-organisations crisis room used `is_crisis_room="yes"` which showed an "Open in report" link instead of expandable detail rows (#5362).
- The per-organisation crisis room showed expandable rows with full finding details (description, source, impact, recommendation, occurrences).
- This inconsistency was confusing — the same finding type showed different information depending on which crisis room view you came from.
- Now both views use the same expandable-row layout. The organisation code is passed per-row (`organization=dashboard_item.item.dashboard.organization`) so OOI links in the detail rows point to the correct organisation.
- The "View findings report" button below the table already provides access to the full report, so the per-row "Open in report" link is not needed.
- `is_dashboard_item="yes"` is passed instead of `is_crisis_room="yes"` to preserve the "No critical and high findings" message when there are no findings.

## Test plan
- [x] All 141 dashboard, organization, and report tests pass.
- [x] pre-commit green (djLint formatting + linting, codespell).

Closes #5362.

Generated with [Devin](https://devin.ai)