### PR TITLE
Translate task status labels in task list rows (#4234)

### DIFF
--- a/rocky/rocky/scheduler.py
+++ b/rocky/rocky/scheduler.py
@@ -117,6 +117,21 @@ class TaskStatus(Enum):
     # Task has been cancelled
     CANCELLED = "cancelled"
 
+    @property
+    def label(self) -> str:
+        return _TASK_STATUS_LABELS[self.value]
+
+
+_TASK_STATUS_LABELS = {
+    "pending": _("Pending"),
+    "queued": _("Queued"),
+    "dispatched": _("Dispatched"),
+    "running": _("Running"),
+    "completed": _("Completed"),
+    "failed": _("Failed"),
+    "cancelled": _("Cancelled"),
+}
+
 
 class Task(BaseModel):
     model_config = ConfigDict(from_attributes=True)

--- a/rocky/rocky/templates/tasks/boefjes.html
+++ b/rocky/rocky/templates/tasks/boefjes.html
@@ -62,7 +62,7 @@
                                     <td>
                                         <i class="icon {{ task.status.value }}"></i>
                                         <a href="{{ request.path }}?status={{ task.status.value }}"
-                                           title="{% translate "Filter on this status" %}">{{ task.status.value|capfirst }}</a>
+                                           title="{% translate "Filter on this status" %}">{{ task.status.label }}</a>
                                         <a href="{{ request.path }}{% querystring status=task.status.value %}"
                                            title="{% translate "Add filter on this status" %}"><i class="icon filteradd"></i></a>
                                     </td>

--- a/rocky/rocky/templates/tasks/normalizers.html
+++ b/rocky/rocky/templates/tasks/normalizers.html
@@ -61,7 +61,7 @@
                                         <a href="{% url "normalizer_detail" task.data.raw_data.boefje_meta.organization task.data.normalizer.id %}">{{ task.data.normalizer.id }}</a>
                                     </td>
                                     <td class="nowrap">
-                                        <i class="icon {{ task.status.value }}"></i>&nbsp;<a href="{{ request.path }}?status={{ task.status.value }}">{{ task.status.value|capfirst }}</a>
+                                        <i class="icon {{ task.status.value }}"></i>&nbsp;<a href="{{ request.path }}?status={{ task.status.value }}">{{ task.status.label }}</a>
                                     </td>
                                     <td>{{ task.created_at }}</td>
                                     <td>{{ task.modified_at }}</td>

--- a/rocky/rocky/templates/tasks/ooi_detail_task_list.html
+++ b/rocky/rocky/templates/tasks/ooi_detail_task_list.html
@@ -32,7 +32,7 @@
                             {% endif %}
                         </td>
                         <td class="nowrap">
-                            <i class="icon {{ task.status.value }}"></i>&nbsp;{{ task.status.value|capfirst }}
+                            <i class="icon {{ task.status.value }}"></i>&nbsp;{{ task.status.label }}
                         </td>
                         <td class="nowrap">{{ task.created_at }}</td>
                         <td class="actions">

--- a/rocky/rocky/templates/tasks/plugin_detail_task_list.html
+++ b/rocky/rocky/templates/tasks/plugin_detail_task_list.html
@@ -23,7 +23,7 @@
                         data-task-type="{{ task.type }}"
                         data-task-status="{{ task.status.value }}">
                         <td class="nowrap">
-                            <i class="icon {{ task.status.value }}"></i>&nbsp;{{ task.status.value|capfirst }}
+                            <i class="icon {{ task.status.value }}"></i>&nbsp;{{ task.status.label }}
                         </td>
                         <td>{{ task.created_at }}</td>
                         <td>

--- a/rocky/rocky/templates/tasks/reports.html
+++ b/rocky/rocky/templates/tasks/reports.html
@@ -49,7 +49,7 @@
                                                 </td>
                                             {% endif %}
                                             <td>
-                                                <i class="icon {{ report_task.status.value }}"></i>{{ report_task.status.value|capfirst }}
+                                                <i class="icon {{ report_task.status.value }}"></i>{{ report_task.status.label }}
                                             </td>
                                             <td>
                                                 <a href="{% ooi_url "ooi_detail" recipe_pk report_task.data.organisation_id query=ooi.mandatory_fields observed_at=report_task.created_at|date:'c' %}">{{ report_task.data.report_recipe_id }}</a>

--- a/rocky/tests/conftest.py
+++ b/rocky/tests/conftest.py
@@ -25,6 +25,10 @@ from django_otp import DEVICE_ID_SESSION_KEY
 from django_otp.middleware import OTPMiddleware
 from httpx import Response
 from katalogus.client import Boefje, parse_plugin
+from reports.report_types.findings_report.report import FindingsReport
+from tools.enums import SCAN_LEVEL
+from tools.models import GROUP_ADMIN, GROUP_CLIENT, GROUP_REDTEAM, Indemnification, Organization, OrganizationMember
+
 from octopoes.config.settings import (
     DEFAULT_LIMIT,
     DEFAULT_OFFSET,
@@ -44,11 +48,8 @@ from octopoes.models.pagination import Paginated
 from octopoes.models.transaction import TransactionRecord
 from octopoes.models.tree import ReferenceTree
 from octopoes.models.types import OOIType
-from reports.report_types.findings_report.report import FindingsReport
 from rocky.health import ServiceHealth
 from rocky.scheduler import PaginatedTasksResponse, ReportTask, ScheduleResponse, Task, TaskStatus
-from tools.enums import SCAN_LEVEL
-from tools.models import GROUP_ADMIN, GROUP_CLIENT, GROUP_REDTEAM, Indemnification, Organization, OrganizationMember
 
 LANG_LIST = [code for code, _ in settings.LANGUAGES]
 

--- a/rocky/tests/conftest.py
+++ b/rocky/tests/conftest.py
@@ -27,6 +27,22 @@ from reports.report_types.findings_report.report import FindingsReport
 from tools.enums import SCAN_LEVEL
 from tools.models import GROUP_ADMIN, GROUP_CLIENT, GROUP_REDTEAM, Indemnification, Organization, OrganizationMember
 
+
+@pytest.fixture(scope="session", autouse=True)
+def _compile_translations():
+    """Compile .mo files so translation tests work in CI.
+
+    The CI volume mount (..:/app/rocky) overwrites .mo files from the
+    Docker build because .mo files are gitignored. Without recompiling,
+    gettext_lazy strings render as English even inside override("nl").
+    """
+    try:
+        from django.core.management import call_command
+
+        call_command("compilemessages", verbosity=0)
+    except Exception:
+        pass  # gettext not installed — translation tests will fail
+
 from octopoes.config.settings import (
     DEFAULT_LIMIT,
     DEFAULT_OFFSET,

--- a/rocky/tests/conftest.py
+++ b/rocky/tests/conftest.py
@@ -1,4 +1,5 @@
 import binascii
+import contextlib
 import json
 import logging
 import uuid
@@ -18,31 +19,12 @@ from django.conf import settings
 from django.contrib.auth.models import Group, Permission
 from django.contrib.messages.middleware import MessageMiddleware
 from django.contrib.sessions.middleware import SessionMiddleware
+from django.core.management import call_command
 from django.utils.translation import activate, deactivate
 from django_otp import DEVICE_ID_SESSION_KEY
 from django_otp.middleware import OTPMiddleware
 from httpx import Response
 from katalogus.client import Boefje, parse_plugin
-from reports.report_types.findings_report.report import FindingsReport
-from tools.enums import SCAN_LEVEL
-from tools.models import GROUP_ADMIN, GROUP_CLIENT, GROUP_REDTEAM, Indemnification, Organization, OrganizationMember
-
-
-@pytest.fixture(scope="session", autouse=True)
-def _compile_translations():
-    """Compile .mo files so translation tests work in CI.
-
-    The CI volume mount (..:/app/rocky) overwrites .mo files from the
-    Docker build because .mo files are gitignored. Without recompiling,
-    gettext_lazy strings render as English even inside override("nl").
-    """
-    try:
-        from django.core.management import call_command
-
-        call_command("compilemessages", verbosity=0)
-    except Exception:
-        pass  # gettext not installed — translation tests will fail
-
 from octopoes.config.settings import (
     DEFAULT_LIMIT,
     DEFAULT_OFFSET,
@@ -62,13 +44,28 @@ from octopoes.models.pagination import Paginated
 from octopoes.models.transaction import TransactionRecord
 from octopoes.models.tree import ReferenceTree
 from octopoes.models.types import OOIType
+from reports.report_types.findings_report.report import FindingsReport
 from rocky.health import ServiceHealth
 from rocky.scheduler import PaginatedTasksResponse, ReportTask, ScheduleResponse, Task, TaskStatus
+from tools.enums import SCAN_LEVEL
+from tools.models import GROUP_ADMIN, GROUP_CLIENT, GROUP_REDTEAM, Indemnification, Organization, OrganizationMember
 
 LANG_LIST = [code for code, _ in settings.LANGUAGES]
 
 # Quiet faker locale messages down in tests.
 logging.getLogger("faker").setLevel(logging.INFO)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _compile_translations():
+    """Compile .mo files so translation tests work in CI.
+
+    The CI volume mount (..:/app/rocky) overwrites .mo files from the
+    Docker build because .mo files are gitignored. Without recompiling,
+    gettext_lazy strings render as English even inside override("nl").
+    """
+    with contextlib.suppress(Exception):  # gettext not installed, translation tests will fail
+        call_command("compilemessages", verbosity=0)
 
 
 # Copied from https://www.structlog.org/en/stable/testing.html

--- a/rocky/tests/test_boefjes_tasks.py
+++ b/rocky/tests/test_boefjes_tasks.py
@@ -1,6 +1,7 @@
 import pytest
 from django.http import Http404
-from pytest_django.asserts import assertContains
+from django.utils.translation import override
+from pytest_django.asserts import assertContains, assertNotContains
 
 from rocky.scheduler import SchedulerTooManyRequestError
 from rocky.views.bytes_raw import BytesRawView
@@ -29,6 +30,17 @@ def test_tasks_view_simple(rf, client_member, mock_scheduler, mock_scheduler_cli
     response = BoefjesTaskListView.as_view()(request, organization_code=client_member.organization.code)
 
     assertContains(response, "Completed")
+
+
+def test_tasks_view_status_translated(rf, client_member, mock_scheduler, mock_scheduler_client_task_list):
+    """#4234: the status label in the task list rows must follow the active language,
+    matching the status filter dropdown (which is translated via ChoiceField labels)."""
+    request = setup_request(rf.get("boefjes_task_list"), client_member.user)
+    response = BoefjesTaskListView.as_view()(request, organization_code=client_member.organization.code)
+
+    with override("nl"):
+        assertContains(response, "Voltooid")
+        assertNotContains(response, ">Completed<")
 
 
 def test_reschedule_task(rf, client_member, mock_scheduler, task):

--- a/rocky/tests/test_boefjes_tasks.py
+++ b/rocky/tests/test_boefjes_tasks.py
@@ -35,10 +35,9 @@ def test_tasks_view_simple(rf, client_member, mock_scheduler, mock_scheduler_cli
 def test_tasks_view_status_translated(rf, client_member, mock_scheduler, mock_scheduler_client_task_list):
     """#4234: the status label in the task list rows must follow the active language,
     matching the status filter dropdown (which is translated via ChoiceField labels)."""
-    request = setup_request(rf.get("boefjes_task_list"), client_member.user)
-    response = BoefjesTaskListView.as_view()(request, organization_code=client_member.organization.code)
-
     with override("nl"):
+        request = setup_request(rf.get("boefjes_task_list"), client_member.user)
+        response = BoefjesTaskListView.as_view()(request, organization_code=client_member.organization.code)
         assertContains(response, "Voltooid")
         assertNotContains(response, ">Completed<")
 


### PR DESCRIPTION
## Summary
- The status filter dropdown in the task list uses translated `ChoiceField` labels (`_("Completed")` etc.), but the task list rows rendered the raw English enum value via `{{ task.status.value|capfirst }}`. After a language switch the dropdown was Dutch while the row statuses stayed English (#4234).
- Added a translated `label` property to `TaskStatus` (reuses the existing translation keys already present for the filter form and stats table) and use `{{ task.status.label }}` in the five task list templates.
- URL query params (`?status=...`), CSS icon classes (`icon {{ status.value }}`) and `data-task-status` attributes keep using the raw value so filtering/styling keep working.

#### Test plan
- [x] `test_tasks_view_status_translated` renders the boefjes task list under `override("nl")` and asserts `Voltooid` is present while `>Completed<` is not.
- [x] Existing `test_tasks_view_simple` / `test_report_task_list` still pass (English default renders `Completed`/`Failed`).
- [x] pre-commit (ruff, ruff-format, djLint, mypy) green.
- [ ] CI (makelang + tests across Python versions).

Generated with [Devin](https://devin.ai)