### PR TITLE
Strip SPF macros from all mechanisms, not only exists: (#4158)

### DIFF
--- a/octopoes/bits/spf_discovery/spf_discovery.py
+++ b/octopoes/bits/spf_discovery/spf_discovery.py
@@ -20,8 +20,9 @@ def run(input_ooi: DNSTXTRecord, additional_oois: list, config: dict[str, Any]) 
     if input_ooi.value.lower().startswith("v=spf1 ") or input_ooi.value.lower() == "v=spf1":
         spf_value = input_ooi.value.replace("%{d}", input_ooi.hostname.tokenized.name)
 
-        # remove exists:%i mechanisms
-        spf_value = re.sub(r"exists:%{[^\s]+", "", spf_value)
+        # remove mechanisms that still contain macros we cannot resolve without a
+        # mail session (only %{d} is resolvable, and was substituted above)
+        spf_value = re.sub(r"\S*%\{[^}]*\}\S*", "", spf_value)
 
         parsed = parse(spf_value)
         # check if spf record passes the internet.nl parser

--- a/octopoes/tests/test_bit_spf_discovery.py
+++ b/octopoes/tests/test_bit_spf_discovery.py
@@ -68,3 +68,21 @@ def test_spf_discovery_with_identifier():
     results = list(run(dnstxt_record, [], {}))
 
     assert len(results) == 10
+
+
+def test_spf_discovery_multiple_macros_in_mechanism():
+    """#4158: a single mechanism may contain multiple macros, and macros may
+    appear in mechanisms other than exists: (include, a, redirect). All
+    unresolvable macros must be stripped, not only those in exists:."""
+    dnstxt_record = DNSTXTRecord(
+        hostname=Reference.from_str("Hostname|internet|example.com"),
+        value="v=spf1 exists:%{ir}.%{v}.arpa._spf.example.com include:%{l}.%{d}.example.com ~all",
+    )
+    results = list(run(dnstxt_record, [], {}))
+
+    # both macro-bearing mechanisms are dropped; only the ~all record remains
+    spf_records = [r for r in results if isinstance(r, DNSSPFRecord)]
+    assert len(spf_records) == 1
+    assert spf_records[0].all == "~"
+    # no bogus hostnames with macro syntax leaked through
+    assert not any("%{" in str(getattr(r, "name", "")) for r in results)


### PR DESCRIPTION
## Summary
- #4145 only removed `exists:` mechanisms containing `%{...}` macros. Macros in `include:`, `a:`, `mx:`, `redirect=` etc. were left in and produced bogus hostnames (e.g. `%{l}.example.com`).
- Replaced the `exists:`-only regex with `\S*%\{[^}]*\}\S*`, which drops any whitespace-delimited mechanism that still contains a `%{...}` macro after `%{d}` substitution. `%{d}` is the only macro resolvable without a mail session; all others (`%{i}`, `%{l}`, `%{s}`, `%{v}`, …) cannot be expanded, so the whole mechanism is removed — consistent with underdarknl's note that we strip macros rather than resolve them.

#### Test plan
- [x] `test_spf_discovery_multiple_macros_in_mechanism`: record with two macros in one `exists:` mechanism plus a macro in `include:` → both dropped, only `~all` remains, no `%{` hostnames leak.
- [x] Existing `test_spf_discovery_with_identifier` (10 results) and `test_spf_discovery_intermediate_success` (12 results) still pass.
- [x] pre-commit (ruff, ruff-format, mypy) green.

Generated with [Devin](https://devin.ai)