### PR TITLE
Close all dropdown types when one opens (#4055)

### DIFF
--- a/rocky/assets/js/dropdown.js
+++ b/rocky/assets/js/dropdown.js
@@ -1,29 +1,33 @@
+const OPEN_SELECTOR =
+  '.dropdown-button[aria-expanded="true"], .collapsible-toggle[aria-expanded="true"]';
+
+function closeAllDropdowns(except) {
+  document.querySelectorAll(OPEN_SELECTOR).forEach((button) => {
+    if (button !== except) {
+      button.setAttribute("aria-expanded", "false");
+    }
+  });
+}
+
 function toggleAriaExpanded(event) {
   const currentButton = event.target;
   const isExpanded = currentButton.getAttribute("aria-expanded") === "true";
-  const activeButton = document.querySelector(
-    ".dropdown-button[aria-expanded='true']",
-  );
-
-  if (activeButton && currentButton !== activeButton) {
-    activeButton.setAttribute("aria-expanded", "false");
-  }
-
+  closeAllDropdowns(currentButton);
   currentButton.setAttribute("aria-expanded", !isExpanded);
 }
 
 document.addEventListener("click", (event) => {
   const isDropdownButtonClicked =
     event.target.classList.contains("dropdown-button");
+  const isCollapsibleToggleClicked =
+    event.target.classList.contains("collapsible-toggle");
 
   if (isDropdownButtonClicked) {
     toggleAriaExpanded(event);
+  } else if (isCollapsibleToggleClicked) {
+    // Manon's collapsible.js handles its own toggle; just close dropdown buttons
+    closeAllDropdowns(event.target);
   } else {
-    activeButton = document.querySelector(
-      ".dropdown-button[aria-expanded='true']",
-    );
-    if (activeButton) {
-      activeButton.setAttribute("aria-expanded", "false");
-    }
+    closeAllDropdowns(null);
   }
 });


### PR DESCRIPTION
## Summary
- The language switcher (`.dropdown-button`) and user profile menu (`.collapsible-toggle`) used independent toggle mechanisms that didn't know about each other, causing overlapping dropdowns when switching between them (#4055).
- Generalized `dropdown.js` to close both `.dropdown-button` and `.collapsible-toggle` elements when any dropdown-like button is toggled, or when clicking outside.
- Manon's `collapsible.js` still handles its own toggle; we only close `.dropdown-button` elements when a `.collapsible-toggle` is clicked (and vice versa).

#### Test plan
- [x] pre-commit green (prettier, codespell).
- [ ] Manual: open user profile dropdown, then click language switcher — only one should be open at a time.
- [ ] Manual: open language switcher, then click user profile — only one should be open at a time.
- [ ] Manual: click outside both — both should close.

Closes #4055.

Generated with [Devin](https://devin.ai)