### PR TITLE
Cache Bytes clients to reduce redundant token requests

### DIFF
--- a/boefjes/boefjes/api.py
+++ b/boefjes/boefjes/api.py
@@ -1,6 +1,7 @@
 import multiprocessing
 import uuid
 from datetime import datetime, timezone
+from functools import lru_cache
 from multiprocessing.context import ForkContext, ForkProcess
 from typing import Any
 from uuid import UUID
@@ -52,6 +53,7 @@ def get_scheduler_client(plugin_service=Depends(get_plugin_service)):
     return SchedulerAPIClient(plugin_service, str(settings.scheduler_api))
 
 
+@lru_cache(maxsize=1)
 def get_bytes_client():
     return BytesAPIClient(str(settings.bytes_api), username=settings.bytes_username, password=settings.bytes_password)
 

--- a/rocky/rocky/bytes_client.py
+++ b/rocky/rocky/bytes_client.py
@@ -3,7 +3,7 @@ import uuid
 from base64 import b64decode, b64encode
 from collections.abc import Generator, Sequence, Set
 from datetime import datetime, timezone
-from functools import cached_property
+from functools import cache, cached_property
 from typing import Any
 
 import httpx
@@ -242,5 +242,6 @@ class BytesClient:
         return response.json()["access_token"]
 
 
+@cache
 def get_bytes_client(organization: str | None) -> BytesClient:
     return BytesClient(settings.BYTES_API, settings.BYTES_USERNAME, settings.BYTES_PASSWORD, organization)

--- a/rocky/tests/conftest.py
+++ b/rocky/tests/conftest.py
@@ -335,6 +335,16 @@ def mock_models_katalogus(mocker):
     return mocker.patch("katalogus.client.get_katalogus_client")
 
 
+@pytest.fixture(autouse=True)
+def _clear_bytes_client_cache():
+    """Clear the lru_cache on get_bytes_client so tests don't leak cached clients into each other."""
+    from rocky.bytes_client import get_bytes_client
+
+    get_bytes_client.cache_clear()
+    yield
+    get_bytes_client.cache_clear()
+
+
 @pytest.fixture
 def mock_bytes_client(mocker):
     return mocker.patch("rocky.bytes_client.BytesClient")


### PR DESCRIPTION
## Summary

- `get_bytes_client()` in both Rocky and Boefjes created a new Bytes client on every call, causing a fresh token fetch per HTTP request even though the stateless JWT token is valid until expiry
- Wrapped both `get_bytes_client` factories with `lru_cache` so the client (and its cached token) is reused across requests — one token per process per organization instead of one per request
- Added an autouse test fixture to clear the `lru_cache` between tests so mocks don't leak across test cases

Closes #4442

#### Root cause

As noted in the issue discussion by @dekkers: the tokens are stateless signed JWTs that can only expire, not be invalidated. The excessive token requests were caused by client reinstantiation — each new `BytesClient`/`BytesAPIClient` instance fetches a new token. PR #5133 already improved the Rocky client with `TokenAuth` + `@cached_property` for the token, but the client itself was still recreated per request. This PR caches the client instance so the token is reused.

#### Test plan

- [x] Rocky tests: `test_upload_raw`, `test_boefjes_tasks`, `test_report_overview`, `reports/`, `test_upload_csv`, `test_organization`, `test_objects_edit` — all pass
- [x] Boefjes tests: `test_api`, `test_app` — pass (1 pre-existing docker failure unrelated)
- [x] Verified caching logic with standalone assertion (same org → same instance, different org → different instance)

Generated with [Devin](https://devin.ai)