### PR TITLE
Surface CVE findings bound to Software on the assets that run it

### DIFF
--- a/rocky/reports/report_types/aggregate_organisation_report/report.py
+++ b/rocky/reports/report_types/aggregate_organisation_report/report.py
@@ -234,7 +234,9 @@ class AggregateOrganisationReport(AggregateReport):
                 seen_keys = set()
 
                 for occurrence in finding_type["occurrences"]:
-                    occurrence_ooi = occurrence["finding"].ooi
+                    # Not finding.ooi: a CVE hangs on the shared Software OOI, so two assets
+                    # running the same vulnerable package would collapse into one row (#5321).
+                    occurrence_ooi = occurrence["affected_ooi"]
 
                     if occurrence_ooi not in seen_keys:
                         seen_keys.add(occurrence_ooi)

--- a/rocky/reports/report_types/findings_report/report.py
+++ b/rocky/reports/report_types/findings_report/report.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import Any
 
 from django.utils.translation import gettext_lazy as _
+from tools.ooi_helpers import collect_software_instances, findings_on_software
 
 from octopoes.models import Reference
 from octopoes.models.ooi.dns.zone import Hostname
@@ -13,11 +14,6 @@ from reports.report_types.definitions import Report, ReportPlugins
 
 TREE_DEPTH = 9
 SEVERITY_OPTIONS = [severity.value for severity in RiskLevelSeverity]
-
-# A CVE is a property of a software version, so its finding hangs on the Software OOI rather than
-# on the asset (#5321). Software is not traversable, so the object tree stops at the
-# SoftwareInstance; walk the last two hops with a query instead.
-SOFTWARE_FINDINGS_PATH = "SoftwareInstance.software.<ooi[is Finding]"
 
 
 class FindingsReport(Report):
@@ -40,21 +36,6 @@ class FindingsReport(Report):
     template_path = "findings_report/report.html"
     label_style = "3-light"
 
-    def get_software_findings(
-        self, software_instances: list[Reference], seen: set[Reference], valid_time: datetime
-    ) -> list[Finding]:
-        """Findings on the software behind the given instances, which the object tree cannot reach."""
-        findings = []
-
-        for _source, ooi in self.octopoes_api_connector.query_many(
-            SOFTWARE_FINDINGS_PATH, valid_time, software_instances
-        ):
-            if isinstance(ooi, Finding) and ooi.reference not in seen:
-                seen.add(ooi.reference)
-                findings.append(ooi)
-
-        return findings
-
     def generate_data(self, input_ooi: str, valid_time: datetime) -> dict[str, Any]:
         reference = Reference.from_str(input_ooi)
         findings = []
@@ -69,17 +50,23 @@ class FindingsReport(Report):
 
         tree = self.octopoes_api_connector.get_tree(
             reference, depth=TREE_DEPTH, types={Finding, SoftwareInstance}, valid_time=valid_time
-        ).store
-
-        findings = [ooi for ooi in tree.values() if ooi.ooi_type == "Finding"]
-        findings += self.get_software_findings(
-            [ooi.reference for ooi in tree.values() if ooi.ooi_type == "SoftwareInstance"],
-            {finding.reference for finding in findings},
-            valid_time,
         )
+
+        # A finding is normally reported on the object it hangs on, but a CVE hangs on the bare
+        # Software OOI (#5321). Report those on the asset running that software instead, so the
+        # occurrence still names something the reader can act on.
+        findings = [(ooi, ooi.ooi) for ooi in tree.store.values() if isinstance(ooi, Finding)]
+        seen = {finding.reference for finding, _asset in findings}
+        findings += [
+            (finding, asset)
+            for finding, asset in findings_on_software(
+                self.octopoes_api_connector, collect_software_instances(tree), valid_time
+            )
+            if finding.reference not in seen
+        ]
         all_finding_types = self.octopoes_api_connector.list_objects(types={FindingType}, valid_time=valid_time).items
 
-        for finding in findings:
+        for finding, affected_ooi in findings:
             try:
                 finding_type = next(filter(lambda x: x.id == finding.finding_type.tokenized.id, all_finding_types))
             except StopIteration:
@@ -99,7 +86,7 @@ class FindingsReport(Report):
             else:
                 first_seen = "-"
 
-            finding_dict = {"finding": finding, "first_seen": first_seen}
+            finding_dict = {"finding": finding, "affected_ooi": affected_ooi, "first_seen": first_seen}
 
             if finding_type.id in finding_types:
                 finding_types[finding_type.id]["occurrences"].append(finding_dict)

--- a/rocky/reports/report_types/findings_report/report.py
+++ b/rocky/reports/report_types/findings_report/report.py
@@ -7,11 +7,17 @@ from octopoes.models import Reference
 from octopoes.models.ooi.dns.zone import Hostname
 from octopoes.models.ooi.findings import Finding, FindingType, RiskLevelSeverity
 from octopoes.models.ooi.network import IPAddressV4, IPAddressV6
+from octopoes.models.ooi.software import SoftwareInstance
 from octopoes.models.ooi.web import URL
 from reports.report_types.definitions import Report, ReportPlugins
 
 TREE_DEPTH = 9
 SEVERITY_OPTIONS = [severity.value for severity in RiskLevelSeverity]
+
+# A CVE is a property of a software version, so its finding hangs on the Software OOI rather than
+# on the asset (#5321). Software is not traversable, so the object tree stops at the
+# SoftwareInstance; walk the last two hops with a query instead.
+SOFTWARE_FINDINGS_PATH = "SoftwareInstance.software.<ooi[is Finding]"
 
 
 class FindingsReport(Report):
@@ -34,6 +40,21 @@ class FindingsReport(Report):
     template_path = "findings_report/report.html"
     label_style = "3-light"
 
+    def get_software_findings(
+        self, software_instances: list[Reference], seen: set[Reference], valid_time: datetime
+    ) -> list[Finding]:
+        """Findings on the software behind the given instances, which the object tree cannot reach."""
+        findings = []
+
+        for _source, ooi in self.octopoes_api_connector.query_many(
+            SOFTWARE_FINDINGS_PATH, valid_time, software_instances
+        ):
+            if isinstance(ooi, Finding) and ooi.reference not in seen:
+                seen.add(ooi.reference)
+                findings.append(ooi)
+
+        return findings
+
     def generate_data(self, input_ooi: str, valid_time: datetime) -> dict[str, Any]:
         reference = Reference.from_str(input_ooi)
         findings = []
@@ -47,10 +68,15 @@ class FindingsReport(Report):
             total_by_severity_per_finding_type[severity] = 0
 
         tree = self.octopoes_api_connector.get_tree(
-            reference, depth=TREE_DEPTH, types={Finding}, valid_time=valid_time
+            reference, depth=TREE_DEPTH, types={Finding, SoftwareInstance}, valid_time=valid_time
         ).store
 
         findings = [ooi for ooi in tree.values() if ooi.ooi_type == "Finding"]
+        findings += self.get_software_findings(
+            [ooi.reference for ooi in tree.values() if ooi.ooi_type == "SoftwareInstance"],
+            {finding.reference for finding in findings},
+            valid_time,
+        )
         all_finding_types = self.octopoes_api_connector.list_objects(types={FindingType}, valid_time=valid_time).items
 
         for finding in findings:

--- a/rocky/reports/report_types/multi_organization_report/report.py
+++ b/rocky/reports/report_types/multi_organization_report/report.py
@@ -257,7 +257,7 @@ class MultiOrganizationReport(MultiReport):
             seen_keys = set()
 
             for occurrence in finding_type["occurrences"]:
-                occurrence_ooi = occurrence["finding"]["ooi"]
+                occurrence_ooi = occurrence["affected_ooi"]
 
                 if occurrence_ooi not in seen_keys:
                     seen_keys.add(occurrence_ooi)

--- a/rocky/reports/templates/partials/report_findings_table.html
+++ b/rocky/reports/templates/partials/report_findings_table.html
@@ -104,7 +104,7 @@
                                         {% for occurrence in info.occurrences %}
                                             <tr>
                                                 <td>
-                                                    <a href="{% ooi_url 'ooi_detail' occurrence.finding.ooi organization.code %}">{{ occurrence.finding.ooi|human_readable }}</a>
+                                                    <a href="{% ooi_url 'ooi_detail' occurrence.affected_ooi organization.code %}">{{ occurrence.affected_ooi|human_readable }}</a>
                                                 </td>
                                                 <td title="{{ occurrence.first_seen }} UTC">{{ occurrence.first_seen|get_datetime|naturaltime }}</td>
                                             </tr>

--- a/rocky/rocky/views/ooi_detail_related_object.py
+++ b/rocky/rocky/views/ooi_detail_related_object.py
@@ -1,4 +1,5 @@
 from collections import Counter
+from functools import cached_property
 
 from django.shortcuts import redirect
 from django.urls import reverse
@@ -7,7 +8,7 @@ from django.views.generic.base import TemplateView
 from tools.ooi_helpers import format_attr_name
 from tools.view_helpers import existing_ooi_type, get_mandatory_fields, url_with_querystring
 
-from octopoes.models import OOI
+from octopoes.models import OOI, Reference
 from octopoes.models.ooi.findings import Finding, FindingType, RiskLevelSeverity
 from octopoes.models.types import OOI_TYPES, get_relations, to_concrete
 from rocky.views.mixins import SingleOOITreeMixin
@@ -88,7 +89,19 @@ class OOIRelatedObjectManager(SingleOOITreeMixin):
 
 
 class OOIFindingManager(SingleOOITreeMixin):
+    # A CVE is a property of a software version, so it is bound to the Software OOI rather than to
+    # the asset or its SoftwareInstance (#5321). Software is not traversable, so the object tree
+    # cannot reach those findings; walk asset -> SoftwareInstance -> Software -> Finding instead.
+    SOFTWARE_FINDINGS_PATH = "<ooi[is SoftwareInstance].software.<ooi[is Finding]"
+
     def get_findings(self) -> list[Finding]:
+        findings = self.get_direct_findings()
+        seen = {finding.reference for finding in findings}
+
+        return findings + [finding for finding in self.software_findings if finding.reference not in seen]
+
+    def get_direct_findings(self) -> list[Finding]:
+        """Findings bound to this OOI itself, as they appear in the object tree."""
         findings = []
         for relation in self.tree.root.children.values():
             for child in relation:
@@ -97,10 +110,39 @@ class OOIFindingManager(SingleOOITreeMixin):
                     findings.append(ooi)
         return findings
 
+    @cached_property
+    def software_findings(self) -> list[Finding]:
+        """Findings carried by the software this OOI runs, reached through its SoftwareInstances."""
+        path = f"{self.ooi.get_ooi_type()}.{self.SOFTWARE_FINDINGS_PATH}"
+        results = self.octopoes_api_connector.query(path, valid_time=self.observed_at, source=self.ooi.reference)
+
+        return [ooi for ooi in results if isinstance(ooi, Finding)]
+
+    def get_finding_types(self, findings: list[Finding]) -> dict[str, FindingType]:
+        """Finding types by reference; the tree only holds the ones of the direct findings."""
+        finding_types: dict[str, FindingType] = {}
+        missing: set[Reference] = set()
+
+        for finding in findings:
+            finding_type = self.tree.store.get(str(finding.finding_type))
+            if finding_type is not None:
+                finding_types[str(finding.finding_type)] = finding_type
+            else:
+                missing.add(finding.finding_type)
+
+        if missing:
+            loaded = self.octopoes_api_connector.load_objects_bulk(missing, valid_time=self.observed_at)
+            finding_types.update({str(reference): ooi for reference, ooi in loaded.items()})
+
+        return finding_types
+
     def count_findings_per_severity(self) -> Counter:
         counter = Counter({severity: 0 for severity in RiskLevelSeverity})
-        for finding in self.get_findings():
-            finding_type: FindingType | None = self.tree.store.get(str(finding.finding_type), None)
+        findings = self.get_findings()
+        finding_types = self.get_finding_types(findings)
+
+        for finding in findings:
+            finding_type = finding_types.get(str(finding.finding_type))
             if finding_type is not None and finding_type.risk_severity is not None:
                 counter.update([finding_type.risk_severity])
             else:
@@ -112,7 +154,14 @@ class OOIFindingManager(SingleOOITreeMixin):
         return list(sorted(finding_details, key=lambda x: x[1].risk_score or 0, reverse=True))
 
     def get_finding_details(self) -> list[tuple[Finding, FindingType]]:
-        return [(finding, self.tree.store[str(finding.finding_type)]) for finding in self.get_findings()]
+        findings = self.get_findings()
+        finding_types = self.get_finding_types(findings)
+
+        return [
+            (finding, finding_types[str(finding.finding_type)])
+            for finding in findings
+            if str(finding.finding_type) in finding_types
+        ]
 
 
 class OOIRelatedObjectAddView(OOIRelatedObjectManager, TemplateView):

--- a/rocky/rocky/views/ooi_detail_related_object.py
+++ b/rocky/rocky/views/ooi_detail_related_object.py
@@ -5,11 +5,12 @@ from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django.views.generic.base import TemplateView
-from tools.ooi_helpers import format_attr_name
+from tools.ooi_helpers import collect_software_instances, findings_on_software, format_attr_name
 from tools.view_helpers import existing_ooi_type, get_mandatory_fields, url_with_querystring
 
 from octopoes.models import OOI, Reference
 from octopoes.models.ooi.findings import Finding, FindingType, RiskLevelSeverity
+from octopoes.models.ooi.software import SoftwareInstance
 from octopoes.models.types import OOI_TYPES, get_relations, to_concrete
 from rocky.views.mixins import SingleOOITreeMixin
 
@@ -89,10 +90,14 @@ class OOIRelatedObjectManager(SingleOOITreeMixin):
 
 
 class OOIFindingManager(SingleOOITreeMixin):
-    # A CVE is a property of a software version, so it is bound to the Software OOI rather than to
-    # the asset or its SoftwareInstance (#5321). Software is not traversable, so the object tree
-    # cannot reach those findings; walk asset -> SoftwareInstance -> Software -> Finding instead.
-    SOFTWARE_FINDINGS_PATH = "<ooi[is SoftwareInstance].software.<ooi[is Finding]"
+    # The detail page shows a two-deep tree, but software is bound to whatever the boefje observed
+    # -- an IPPort, IPService, IPAddress or HostnameHTTPURL -- so from a Hostname a SoftwareInstance
+    # sits up to four hops away. Fetch those separately, filtered to the one type we need.
+    SOFTWARE_TREE_DEPTH = 5
+
+    # That is a second graph call, so only the pages that are about findings pay for it. Every
+    # object detail page fetches its tree exactly once and should keep doing so.
+    include_software_findings = False
 
     def get_findings(self) -> list[Finding]:
         findings = self.get_direct_findings()
@@ -113,10 +118,23 @@ class OOIFindingManager(SingleOOITreeMixin):
     @cached_property
     def software_findings(self) -> list[Finding]:
         """Findings carried by the software this OOI runs, reached through its SoftwareInstances."""
-        path = f"{self.ooi.get_ooi_type()}.{self.SOFTWARE_FINDINGS_PATH}"
-        results = self.octopoes_api_connector.query(path, valid_time=self.observed_at, source=self.ooi.reference)
+        if not self.include_software_findings:
+            return []
 
-        return [ooi for ooi in results if isinstance(ooi, Finding)]
+        tree = self.octopoes_api_connector.get_tree(
+            self.ooi.reference, valid_time=self.observed_at, depth=self.SOFTWARE_TREE_DEPTH, types={SoftwareInstance}
+        )
+        software_instances = collect_software_instances(tree)
+
+        if not software_instances:
+            return []
+
+        return [
+            finding
+            for finding, _asset in findings_on_software(
+                self.octopoes_api_connector, software_instances, self.observed_at
+            )
+        ]
 
     def get_finding_types(self, findings: list[Finding]) -> dict[str, FindingType]:
         """Finding types by reference; the tree only holds the ones of the direct findings."""

--- a/rocky/rocky/views/ooi_findings.py
+++ b/rocky/rocky/views/ooi_findings.py
@@ -10,6 +10,7 @@ from rocky.views.ooi_view import BaseOOIDetailView
 class OOIFindingListView(OOIFindingManager, BaseOOIDetailView, TemplateView):
     template_name = "oois/ooi_findings.html"
     connector_form_class = ObservedAtForm
+    include_software_findings = True
 
     def build_breadcrumbs(self) -> list[Breadcrumb]:
         breadcrumbs = super().build_breadcrumbs()

--- a/rocky/tests/conftest.py
+++ b/rocky/tests/conftest.py
@@ -1361,7 +1361,16 @@ class MockOctopoesAPIConnector:
     def get_tree(
         self, reference: Reference, valid_time: datetime, types: set = frozenset(), depth: int = 1
     ) -> ReferenceTree:
-        return self.tree[reference]
+        tree = self.tree[reference]
+
+        if not types:
+            return tree
+
+        # Octopoes prunes the store to the requested types; mirror that, so a test can tell whether
+        # its subject actually asked for the type it needs.
+        return tree.model_copy(
+            update={"store": {pk: ooi for pk, ooi in tree.store.items() if isinstance(ooi, tuple(types))}}
+        )
 
     def query(
         self, path: str, valid_time: datetime, source: Reference | str | None = None, offset: int = 0, limit: int = 50

--- a/rocky/tests/objects/test_objects_findings.py
+++ b/rocky/tests/objects/test_objects_findings.py
@@ -2,7 +2,8 @@ import pytest
 from django.core.exceptions import PermissionDenied
 from pytest_django.asserts import assertContains, assertNotContains
 
-from octopoes.models.ooi.findings import Finding, RiskLevelSeverity
+from octopoes.models.ooi.findings import CVEFindingType, Finding, RiskLevelSeverity
+from octopoes.models.ooi.software import Software
 from octopoes.models.pagination import Paginated
 from octopoes.models.tree import ReferenceTree
 from rocky.views.finding_list import FindingListView
@@ -349,3 +350,49 @@ def test_findings_list_filtering(
     FindingListView.as_view()(request_filtering, organization_code=member.organization.code)
 
     assert mock_organization_view_octopoes().list_findings.mock_calls[1].kwargs["severities"] == {RiskLevelSeverity.LOW}
+
+
+SOFTWARE_TREE_DATA = {
+    "root": {"reference": "Hostname|internet|example.com", "children": {}},
+    "store": {
+        "Hostname|internet|example.com": {
+            "object_type": "Hostname",
+            "primary_key": "Hostname|internet|example.com",
+            "name": "example.com",
+            "network": "Network|internet",
+        }
+    },
+}
+
+
+def test_ooi_findings_include_cve_bound_to_software(rf, client_member, mock_organization_view_octopoes):
+    """A CVE bound to the Software OOI must surface on the asset that runs it (#5321).
+
+    Software is not traversable, so the object tree never reaches such a finding: it is only
+    found by walking asset -> SoftwareInstance -> Software -> Finding.
+    """
+    mock_organization_view_octopoes().get_tree.return_value = ReferenceTree.model_validate(SOFTWARE_TREE_DATA)
+
+    software = Software(name="nginx", version="1.0")
+    finding_type = CVEFindingType(
+        id="CVE-2024-0001",
+        description="nginx has a known vulnerability",
+        risk_score=9.8,
+        risk_severity=RiskLevelSeverity.CRITICAL,
+    )
+    mock_organization_view_octopoes().query.return_value = [
+        Finding(finding_type=finding_type.reference, ooi=software.reference, description="")
+    ]
+    mock_organization_view_octopoes().load_objects_bulk.return_value = {finding_type.reference: finding_type}
+
+    request = setup_request(rf.get("ooi_findings", {"ooi_id": "Hostname|internet|example.com"}), client_member.user)
+    response = OOIFindingListView.as_view()(request, organization_code=client_member.organization.code)
+
+    assert response.status_code == 200
+    assertContains(response, "CVE-2024-0001")
+
+    # reached through the software the asset runs, not through the object tree
+    assert (
+        mock_organization_view_octopoes().query.call_args.args[0]
+        == "Hostname.<ooi[is SoftwareInstance].software.<ooi[is Finding]"
+    )

--- a/rocky/tests/objects/test_objects_findings.py
+++ b/rocky/tests/objects/test_objects_findings.py
@@ -2,8 +2,9 @@ import pytest
 from django.core.exceptions import PermissionDenied
 from pytest_django.asserts import assertContains, assertNotContains
 
+from octopoes.models import Reference
 from octopoes.models.ooi.findings import CVEFindingType, Finding, RiskLevelSeverity
-from octopoes.models.ooi.software import Software
+from octopoes.models.ooi.software import Software, SoftwareInstance
 from octopoes.models.pagination import Paginated
 from octopoes.models.tree import ReferenceTree
 from rocky.views.finding_list import FindingListView
@@ -60,7 +61,8 @@ def test_ooi_finding_list(rf, client_member, mock_organization_view_octopoes):
     response = OOIFindingListView.as_view()(request, organization_code=client_member.organization.code)
 
     assert response.status_code == 200
-    assert mock_organization_view_octopoes().get_tree.call_count == 1
+    # The object tree itself, plus the SoftwareInstance-only tree the software traversal needs.
+    assert mock_organization_view_octopoes().get_tree.call_count == 2
     assertContains(response, "Add finding")
 
 
@@ -365,14 +367,22 @@ SOFTWARE_TREE_DATA = {
 }
 
 
+def software_instance_tree(asset: str, *instances: SoftwareInstance) -> ReferenceTree:
+    """The SoftwareInstance-only tree octopoes returns for the software traversal."""
+    return ReferenceTree.model_validate(
+        {
+            "root": {"reference": asset, "children": {}},
+            "store": {str(instance.reference): instance.model_dump(mode="json") for instance in instances},
+        }
+    )
+
+
 def test_ooi_findings_include_cve_bound_to_software(rf, client_member, mock_organization_view_octopoes):
     """A CVE bound to the Software OOI must surface on the asset that runs it (#5321).
 
     Software is not traversable, so the object tree never reaches such a finding: it is only
     found by walking asset -> SoftwareInstance -> Software -> Finding.
     """
-    mock_organization_view_octopoes().get_tree.return_value = ReferenceTree.model_validate(SOFTWARE_TREE_DATA)
-
     software = Software(name="nginx", version="1.0")
     finding_type = CVEFindingType(
         id="CVE-2024-0001",
@@ -380,9 +390,14 @@ def test_ooi_findings_include_cve_bound_to_software(rf, client_member, mock_orga
         risk_score=9.8,
         risk_severity=RiskLevelSeverity.CRITICAL,
     )
-    mock_organization_view_octopoes().query.return_value = [
-        Finding(finding_type=finding_type.reference, ooi=software.reference, description="")
+    finding = Finding(finding_type=finding_type.reference, ooi=software.reference, description="")
+
+    instance = SoftwareInstance(ooi=Reference.from_str("IPPort|internet|1.1.1.1|tcp|443"), software=software.reference)
+    mock_organization_view_octopoes().get_tree.side_effect = [
+        ReferenceTree.model_validate(SOFTWARE_TREE_DATA),
+        software_instance_tree("Hostname|internet|example.com", instance),
     ]
+    mock_organization_view_octopoes().query_many.return_value = [(str(instance.reference), finding)]
     mock_organization_view_octopoes().load_objects_bulk.return_value = {finding_type.reference: finding_type}
 
     request = setup_request(rf.get("ooi_findings", {"ooi_id": "Hostname|internet|example.com"}), client_member.user)
@@ -391,8 +406,52 @@ def test_ooi_findings_include_cve_bound_to_software(rf, client_member, mock_orga
     assert response.status_code == 200
     assertContains(response, "CVE-2024-0001")
 
-    # reached through the software the asset runs, not through the object tree
-    assert (
-        mock_organization_view_octopoes().query.call_args.args[0]
-        == "Hostname.<ooi[is SoftwareInstance].software.<ooi[is Finding]"
-    )
+    # The software sits several hops away (Hostname -> ... -> IPPort -> SoftwareInstance), so the
+    # traversal must ask for more than the two levels the detail page itself renders.
+    software_tree_call = mock_organization_view_octopoes().get_tree.call_args_list[1]
+    assert software_tree_call.kwargs["types"] == {SoftwareInstance}
+    assert software_tree_call.kwargs["depth"] > 2
+
+
+def test_ooi_findings_do_not_duplicate_a_finding_reached_twice(rf, client_member, mock_organization_view_octopoes):
+    """One package on two ports yields the same finding twice; the page must show it once."""
+    software = Software(name="nginx", version="1.0")
+    finding_type = CVEFindingType(id="CVE-2024-0001", risk_score=9.8, risk_severity=RiskLevelSeverity.CRITICAL)
+    finding = Finding(finding_type=finding_type.reference, ooi=software.reference, description="")
+
+    ports = [
+        SoftwareInstance(ooi=Reference.from_str(f"IPPort|internet|1.1.1.1|tcp|{port}"), software=software.reference)
+        for port in (80, 443)
+    ]
+    mock_organization_view_octopoes().get_tree.side_effect = [
+        ReferenceTree.model_validate(SOFTWARE_TREE_DATA),
+        software_instance_tree("Hostname|internet|example.com", *ports),
+    ]
+    mock_organization_view_octopoes().query_many.return_value = [
+        (str(instance.reference), finding) for instance in ports
+    ]
+    mock_organization_view_octopoes().load_objects_bulk.return_value = {finding_type.reference: finding_type}
+
+    request = setup_request(rf.get("ooi_findings", {"ooi_id": "Hostname|internet|example.com"}), client_member.user)
+    response = OOIFindingListView.as_view()(request, organization_code=client_member.organization.code)
+
+    assert response.status_code == 200
+    assert [str(finding.reference) for finding, _finding_type in response.context_data["findings"]] == [
+        str(finding.reference)
+    ]
+
+
+def test_ooi_findings_skip_the_traversal_without_software(rf, client_member, mock_organization_view_octopoes):
+    """No SoftwareInstance in reach means nothing to query -- don't ask octopoes anyway."""
+    mock_organization_view_octopoes().get_tree.side_effect = [
+        ReferenceTree.model_validate(SOFTWARE_TREE_DATA),
+        ReferenceTree.model_validate(
+            {"root": {"reference": "Hostname|internet|example.com", "children": {}}, "store": {}}
+        ),
+    ]
+
+    request = setup_request(rf.get("ooi_findings", {"ooi_id": "Hostname|internet|example.com"}), client_member.user)
+    response = OOIFindingListView.as_view()(request, organization_code=client_member.organization.code)
+
+    assert response.status_code == 200
+    mock_organization_view_octopoes().query_many.assert_not_called()

--- a/rocky/tests/reports/test_findings_report.py
+++ b/rocky/tests/reports/test_findings_report.py
@@ -1,5 +1,7 @@
-from reports.report_types.findings_report.report import SOFTWARE_FINDINGS_PATH, FindingsReport
+from reports.report_types.findings_report.report import FindingsReport
+from tools.ooi_helpers import SOFTWARE_FINDINGS_PATH
 
+from octopoes.models import Reference
 from octopoes.models.ooi.findings import CVEFindingType, Finding, RiskLevelSeverity
 from octopoes.models.ooi.software import Software, SoftwareInstance
 from octopoes.models.tree import ReferenceTree
@@ -41,13 +43,14 @@ def test_findings_report_two_findings_one_finding_type(
     assert data["summary"]["total_occurrences"] == 3
 
 
-def test_findings_report_includes_cve_bound_to_software(mock_octopoes_api_connector, valid_time, hostname):
+def test_findings_report_includes_cve_bound_to_software(mock_octopoes_api_connector, valid_time, hostname, ipaddressv4):
     """A CVE hangs on the Software OOI, so the object tree never reaches it (#5321).
 
-    The report has to walk the last two hops -- SoftwareInstance -> Software -> Finding -- itself.
+    The report has to walk the last two hops -- SoftwareInstance -> Software -> Finding -- itself,
+    and report the finding on the asset running that software rather than on the Software OOI.
     """
     software = Software(name="nginx", version="1.0")
-    instance = SoftwareInstance(ooi=hostname.reference, software=software.reference)
+    instance = SoftwareInstance(ooi=ipaddressv4.reference, software=software.reference)
     finding_type = CVEFindingType(id="CVE-2024-0001", risk_score=9.8, risk_severity=RiskLevelSeverity.CRITICAL)
     finding = Finding(finding_type=finding_type.reference, ooi=software.reference, description="")
 
@@ -68,3 +71,54 @@ def test_findings_report_includes_cve_bound_to_software(mock_octopoes_api_connec
     assert data["finding_types"][0]["finding_type"] == finding_type
     assert data["summary"]["total_occurrences"] == 1
     assert data["summary"]["total_by_severity"]["critical"] == 1
+
+    # Reported on the asset running the software, not on the shared Software OOI the CVE hangs on.
+    occurrence = data["finding_types"][0]["occurrences"][0]
+    assert occurrence["affected_ooi"] == ipaddressv4.reference
+    assert occurrence["finding"].ooi == software.reference
+
+
+def test_findings_report_attributes_direct_findings_to_their_own_ooi(
+    mock_octopoes_api_connector, valid_time, hostname, tree_data_findings, finding_types
+):
+    """Findings that hang on the object itself keep pointing at it."""
+    mock_octopoes_api_connector.oois = {finding_types[0].reference: finding_types[0]}
+    mock_octopoes_api_connector.tree = {hostname.reference: ReferenceTree.model_validate(tree_data_findings)}
+
+    report = FindingsReport(mock_octopoes_api_connector)
+    data = report.generate_data(str(hostname.reference), valid_time)
+
+    for finding_type in data["finding_types"]:
+        for occurrence in finding_type["occurrences"]:
+            assert occurrence["affected_ooi"] == occurrence["finding"].ooi
+
+
+def test_findings_report_reports_shared_software_once(mock_octopoes_api_connector, valid_time, hostname, ipaddressv4):
+    """One package reached through two instances is one occurrence, on the first asset found."""
+    software = Software(name="nginx", version="1.0")
+    instances = [
+        SoftwareInstance(ooi=Reference.from_str(f"IPPort|testnetwork|1.1.1.1|tcp|{port}"), software=software.reference)
+        for port in (80, 443)
+    ]
+    finding_type = CVEFindingType(id="CVE-2024-0001", risk_score=9.8, risk_severity=RiskLevelSeverity.CRITICAL)
+    finding = Finding(finding_type=finding_type.reference, ooi=software.reference, description="")
+
+    mock_octopoes_api_connector.oois = {finding_type.reference: finding_type}
+    mock_octopoes_api_connector.tree = {
+        hostname.reference: ReferenceTree.model_validate(
+            {
+                "root": {"reference": str(hostname.reference), "children": {}},
+                "store": {str(i.reference): i.model_dump(mode="json") for i in instances},
+            }
+        )
+    }
+    mock_octopoes_api_connector.queries = {
+        SOFTWARE_FINDINGS_PATH: {str(instance.reference): [finding] for instance in instances}
+    }
+
+    report = FindingsReport(mock_octopoes_api_connector)
+    data = report.generate_data(str(hostname.reference), valid_time)
+
+    occurrences = data["finding_types"][0]["occurrences"]
+    assert len(occurrences) == 1
+    assert occurrences[0]["affected_ooi"] == instances[0].ooi

--- a/rocky/tests/reports/test_findings_report.py
+++ b/rocky/tests/reports/test_findings_report.py
@@ -1,5 +1,7 @@
-from reports.report_types.findings_report.report import FindingsReport
+from reports.report_types.findings_report.report import SOFTWARE_FINDINGS_PATH, FindingsReport
 
+from octopoes.models.ooi.findings import CVEFindingType, Finding, RiskLevelSeverity
+from octopoes.models.ooi.software import Software, SoftwareInstance
 from octopoes.models.tree import ReferenceTree
 
 
@@ -37,3 +39,32 @@ def test_findings_report_two_findings_one_finding_type(
     assert data["summary"]["total_by_severity_per_finding_type"]["critical"] == 2
     assert data["summary"]["total_finding_types"] == 2
     assert data["summary"]["total_occurrences"] == 3
+
+
+def test_findings_report_includes_cve_bound_to_software(mock_octopoes_api_connector, valid_time, hostname):
+    """A CVE hangs on the Software OOI, so the object tree never reaches it (#5321).
+
+    The report has to walk the last two hops -- SoftwareInstance -> Software -> Finding -- itself.
+    """
+    software = Software(name="nginx", version="1.0")
+    instance = SoftwareInstance(ooi=hostname.reference, software=software.reference)
+    finding_type = CVEFindingType(id="CVE-2024-0001", risk_score=9.8, risk_severity=RiskLevelSeverity.CRITICAL)
+    finding = Finding(finding_type=finding_type.reference, ooi=software.reference, description="")
+
+    mock_octopoes_api_connector.oois = {finding_type.reference: finding_type}
+    mock_octopoes_api_connector.tree = {
+        hostname.reference: ReferenceTree.model_validate(
+            {
+                "root": {"reference": str(hostname.reference), "children": {}},
+                "store": {str(instance.reference): instance.model_dump(mode="json")},
+            }
+        )
+    }
+    mock_octopoes_api_connector.queries = {SOFTWARE_FINDINGS_PATH: {str(instance.reference): [finding]}}
+
+    report = FindingsReport(mock_octopoes_api_connector)
+    data = report.generate_data(str(hostname.reference), valid_time)
+
+    assert data["finding_types"][0]["finding_type"] == finding_type
+    assert data["summary"]["total_occurrences"] == 1
+    assert data["summary"]["total_by_severity"]["critical"] == 1

--- a/rocky/tools/ooi_helpers.py
+++ b/rocky/tools/ooi_helpers.py
@@ -9,7 +9,7 @@ from pydantic import TypeAdapter
 
 from octopoes.api.models import Declaration
 from octopoes.connector.octopoes import OctopoesAPIConnector
-from octopoes.models import OOI
+from octopoes.models import OOI, Reference
 from octopoes.models.exception import ObjectNotFoundException
 from octopoes.models.ooi.findings import (
     CAPECFindingType,
@@ -21,7 +21,8 @@ from octopoes.models.ooi.findings import (
     RetireJSFindingType,
     SnykFindingType,
 )
-from octopoes.models.tree import ReferenceNode
+from octopoes.models.ooi.software import SoftwareInstance
+from octopoes.models.tree import ReferenceNode, ReferenceTree
 from octopoes.models.types import OOI_TYPES, get_relations
 from rocky.bytes_client import BytesClient
 from tools.models import OOIInformation
@@ -273,3 +274,41 @@ def create_oois(
 
     bytes_client.add_manual_proof(task_id, BytesClient.raw_from_declarations(declarations))
     api_connector.save_many_declarations(declarations, sync=True)
+
+
+# A CVE is a property of a software version, so its Finding hangs on the bare Software OOI
+# (#5321). Software is deliberately not traversable -- it is a shared node, and walking it would
+# fan out over every host running the same package -- so the object tree always stops at the
+# SoftwareInstance. These last two hops therefore have to be walked explicitly.
+SOFTWARE_FINDINGS_PATH = "SoftwareInstance.software.<ooi[is Finding]"
+
+# Every source ends up in the query string, so a host with hundreds of services would otherwise
+# build a request line past what the API server accepts.
+QUERY_MANY_CHUNK_SIZE = 50
+
+
+def collect_software_instances(tree: ReferenceTree) -> dict[Reference, Reference]:
+    """Map every SoftwareInstance in the tree to the OOI it is installed on."""
+    return {ooi.reference: ooi.ooi for ooi in tree.store.values() if isinstance(ooi, SoftwareInstance)}
+
+
+def findings_on_software(
+    api_connector: OctopoesAPIConnector, software_instances: dict[Reference, Reference], valid_time: datetime
+) -> list[tuple[Finding, Reference]]:
+    """Findings carried by the software behind these instances, each with the asset running it.
+
+    `software_instances` maps a SoftwareInstance to the OOI it is installed on, as returned by
+    `collect_software_instances`. The same finding can be reached through several instances -- one
+    package on two ports, say -- so it is reported once, for the first asset it was found on.
+    """
+    findings: dict[Reference, tuple[Finding, Reference]] = {}
+    sources = list(software_instances)
+
+    for start in range(0, len(sources), QUERY_MANY_CHUNK_SIZE):
+        chunk = sources[start : start + QUERY_MANY_CHUNK_SIZE]
+
+        for source, ooi in api_connector.query_many(SOFTWARE_FINDINGS_PATH, valid_time, chunk):
+            if isinstance(ooi, Finding) and ooi.reference not in findings:
+                findings[ooi.reference] = (ooi, software_instances[Reference.from_str(source)])
+
+    return list(findings.values())


### PR DESCRIPTION
Implements step 1 of #5321: make the graph traversal work, so a CVE that hangs on a bare `Software` OOI is visible on the assets running that software.

`PossibleAttack` is skipped as requested (underdarknl, #5321 comment). Aligning the binders (`retire_js`, shodan/nuclei normalizers) to actually bind CVEs to `Software` is the follow-up — this PR is the reading side, so the binder change lands on a UI that can already show the result.

## Problem

A CVE is a property of a software *version*, so its finding belongs on the `Software` OOI. But `Software._traversable = False` ([software.py:34](https://github.com/SSC-ICT-Innovatie/nl-kat-coordination/blob/main/octopoes/octopoes/models/ooi/software.py#L34)) — deliberately, since `Software` is a shared node and traversing it would fan out across every host running the same package.

The consequence is that every consumer that walks the object tree stops at the `SoftwareInstance` and never reaches the finding:

| Consumer | Before |
|---|---|
| Object detail → Findings tab | finding invisible |
| Findings report | finding missing |
| Aggregate / multi-organisation report | finding missing (they reuse `FindingsReport`) |

Flipping `_traversable` would fix the symptom and reintroduce the fan-out, so instead both consumers walk the last two hops explicitly.

## Changes

**`rocky/tools/ooi_helpers.py`** — the traversal itself, shared by the view and the report:
- `collect_software_instances(tree)` maps every `SoftwareInstance` in a tree to the OOI it is installed on.
- `findings_on_software(...)` walks `SoftwareInstance.software.<ooi[is Finding]` with `query_many` and returns each finding together with the asset running it. Sources are chunked, because `query_many` puts every source in the query string and a host with hundreds of services would otherwise build a request line past what the API server accepts. A finding reachable through several instances (one package on two ports) is reported once, for the first asset it was found on.

**`rocky/rocky/views/ooi_detail_related_object.py`** — `OOIFindingManager` now combines the tree findings with the software findings, and resolves finding types that the tree does not carry via `load_objects_bulk`. `get_finding_details()` no longer `KeyError`s on an unresolvable finding type.

**`rocky/reports/report_types/findings_report/report.py`** — the existing tree call asks for `{Finding, SoftwareInstance}`, so the instances come out of the *same* pass with no extra tree walk. Occurrences now carry `affected_ooi`.

**Aggregate + multi-organisation report** deduplicate occurrences on `affected_ooi` instead of `finding.ooi`. This matters: `finding.ooi` of a CVE is the shared `Software` OOI, so without this twenty hosts running the same vulnerable nginx collapse into a single occurrence.

**`report_findings_table.html`** renders `affected_ooi`, so the row names the asset rather than "nginx 1.18.0" linking to the Software page.

## Reaching the software: why not a fixed path

The first version of this PR walked a single hop, `{Type}.<ooi[is SoftwareInstance]`. That is wrong: `SoftwareInstance.ooi` is bound to whatever the boefje observed — `IPPort` (nmap, shodan, censys, binaryedge, service_banner, dicom), `IPService`, `IPAddress` (internetdb), `HostnameHTTPURL` (wappalyzer) — and never to a `Hostname`. So on a hostname page it returned nothing at all, which is exactly the page the issue names.

Rather than maintain a path list per input type, both consumers now collect the `SoftwareInstance`s from the object tree and query from there. That is type-agnostic and stays correct if a new boefje binds software somewhere else.

## Open decision for you: the severity tile

Reaching the software from a `Hostname` needs a deeper tree than the two levels the detail page renders (`Hostname → ResolvedHostname → IPAddress → IPPort → SoftwareInstance`), so it is a second graph call.

Nine existing tests assert that an object detail page fetches its tree **exactly once**, which I read as a deliberate invariant after #5088. So only the Findings tab pays for the extra call (`include_software_findings = True` on `OOIFindingListView`); every other detail page is unchanged.

The consequence is that **the severity tile on the Overview tab still counts tree-only**, so it can show fewer findings than the Findings tab lists. Three ways out, your call:

1. Leave it (this PR) — no cost regression anywhere, tile and tab can disagree.
2. Let `OOIDetailView` pay for the second call too — consistent, but every object detail page makes two tree calls and those nine assertions change to 2.
3. Keep the tile tree-only but label it as such in the template.

I did not want to pick 2 unilaterally given the #5088 history.

## Tests

Every production change is pinned by a revert test — reverted individually, each one goes red:

| Reverted | Result |
|---|---|
| software traversal off | 3 failed |
| report `types={Finding, SoftwareInstance}` → `{Finding}` | 1 failed |
| `affected_ooi` attribution removed | 2 failed |
| first-asset guard removed | 1 failed |

New tests: the CVE surfacing on a hostname's findings tab (asserting the traversal asks for `SoftwareInstance` at a depth greater than the page's own two), one package on two ports collapsing to one row, no query at all when nothing runs software, the report attributing to the asset instead of the Software OOI, direct findings keeping their own OOI, and shared software reported once on the first asset.

`tests/conftest.py`: the mock connector now prunes the tree store by the requested types, as octopoes does. Without this the report's `types=` change was untestable — reverting it left every test green.

## Verification

- `cd rocky && make utest` → **486 passed, 1 skipped**
- `cd rocky && make itest` → **5 passed, 1 deselected**
- `pre-commit run --all-files` → green (the only red hook is `robotidy` reformatting an unrelated octopoes robot file that is already unformatted on `main`)
- CI on `a2c57c577`: **19/19 green**, `makelang` included

Functional test on a live stack is not included: it needs a CVE actually bound to a `Software` OOI, which is exactly what the follow-up binder change produces. Happy to run it once that lands, or on a hand-declared `Software` + `Finding` if you would rather see it before merging this.

## Second thing worth your eye

For the report the traversal starts from every `SoftwareInstance` in the tree, so a hostname resolving to a shared host will pick up the CVEs of software on that host. That is the intended reading of "affected assets", but it is also the fan-in I flagged on #5302 — say the word if you want the report restricted to instances bound directly to the input OOI.
