### PR TITLE
Cache Bytes API token across client instances (#4442)

### DIFF
--- a/boefjes/boefjes/api.py
+++ b/boefjes/boefjes/api.py
@@ -15,6 +15,7 @@ from boefjes.clients.bytes_client import BytesAPIClient
 from boefjes.clients.scheduler_client import SchedulerAPIClient
 from boefjes.config import settings
 from boefjes.dependencies.plugins import get_plugin_service
+from boefjes.job_handler import bytes_api_client
 from boefjes.worker.interfaces import BoefjeInput, BoefjeOutput, StatusEnum, Task, TaskStatus, WorkerManager
 from boefjes.worker.repository import _default_mime_types
 
@@ -53,7 +54,7 @@ def get_scheduler_client(plugin_service=Depends(get_plugin_service)):
 
 
 def get_bytes_client():
-    return BytesAPIClient(str(settings.bytes_api), username=settings.bytes_username, password=settings.bytes_password)
+    return bytes_api_client
 
 
 @app.get("/healthz")

--- a/rocky/rocky/bytes_client.py
+++ b/rocky/rocky/bytes_client.py
@@ -3,7 +3,6 @@ import uuid
 from base64 import b64decode, b64encode
 from collections.abc import Generator, Sequence, Set
 from datetime import datetime, timezone
-from functools import cached_property
 from typing import Any
 
 import httpx
@@ -15,6 +14,10 @@ from rocky.health import ServiceHealth
 from rocky.scheduler import Boefje, BoefjeMeta, Normalizer, NormalizerMeta, RawData
 
 logger = structlog.get_logger("bytes_client")
+
+# Module-level token cache keyed by username so that token is reused across
+# BytesClient instances instead of being fetched on every request. See #4442.
+_token_cache: dict[str, str] = {}
 
 
 class NoAuth(httpx.Auth):
@@ -222,13 +225,17 @@ class BytesClient:
 
         return response.json()
 
-    @cached_property
+    @property
     def token(self) -> str:
-        return self._get_token()
+        username = self.credentials["username"]
+        if cached := _token_cache.get(username):
+            return cached
+        token = self._get_token()
+        _token_cache[username] = token
+        return token
 
     def _invalidate_token(self):
-        if "token" in self.__dict__:
-            del self.__dict__["token"]
+        _token_cache.pop(self.credentials["username"], None)
 
     def _get_token(self) -> str:
         # this request should not try to use the auth provider, as that would cause a loop

--- a/rocky/tests/test_bytes_client.py
+++ b/rocky/tests/test_bytes_client.py
@@ -1,0 +1,41 @@
+import rocky.bytes_client
+from rocky.bytes_client import BytesClient
+
+
+def test_token_cached_across_instances(mocker):
+    """Two BytesClient instances with the same credentials share one token (#4442)."""
+    rocky.bytes_client._token_cache.clear()
+    mocker.patch.object(BytesClient, "_get_token", return_value="token-a")
+
+    client1 = BytesClient("http://bytes", "user", "pass", "org")
+    client2 = BytesClient("http://bytes", "user", "pass", "org")
+
+    assert client1.token == "token-a"
+    assert client2.token == "token-a"
+    assert BytesClient._get_token.call_count == 1
+
+
+def test_token_invalidation_refetches(mocker):
+    """After invalidation the next access fetches a fresh token."""
+    rocky.bytes_client._token_cache.clear()
+    mocker.patch.object(BytesClient, "_get_token", side_effect=["token-a", "token-b"])
+
+    client1 = BytesClient("http://bytes", "user", "pass", "org")
+    client2 = BytesClient("http://bytes", "user", "pass", "org")
+
+    assert client1.token == "token-a"
+    client1._invalidate_token()
+    assert client2.token == "token-b"
+    assert BytesClient._get_token.call_count == 2
+
+
+def test_different_users_cached_separately(mocker):
+    rocky.bytes_client._token_cache.clear()
+    mocker.patch.object(BytesClient, "_get_token", side_effect=["token-a", "token-b"])
+
+    client_a = BytesClient("http://bytes", "user-a", "pass", "org")
+    client_b = BytesClient("http://bytes", "user-b", "pass", "org")
+
+    assert client_a.token == "token-a"
+    assert client_b.token == "token-b"
+    assert BytesClient._get_token.call_count == 2


### PR DESCRIPTION
## Summary

- **Root cause**: every `get_bytes_client()` call constructed a new `BytesClient`/`BytesAPIClient` that fetched a fresh token on first use, causing a token request per HTTP request even though tokens are valid for 15 minutes (#4442).
- **Rocky fix**: cache the token at module level (`_token_cache` dict keyed by username) so it is reused across `BytesClient` instances. The existing `TokenAuth` 401-retry invalidates the cache and fetches a new token when needed.
- **Boefjes fix**: `get_bytes_client()` in `api.py` now returns the existing `bytes_api_client` singleton from `job_handler` instead of constructing a new instance per request.

Closes #4442

#### Test plan

- [x] 3 new unit tests in `rocky/tests/test_bytes_client.py` (token cached across instances, invalidation refetches, different users cached separately)
- [x] All 26 existing bytes/upload tests pass
- [x] `make check` (pre-commit) green

Generated with [Devin](https://devin.ai)