### PR TITLE
Fix boefje/normalizer manual run tools and docs (#4057)

### DIFF
--- a/boefjes/tools/run_boefje.py
+++ b/boefjes/tools/run_boefje.py
@@ -5,6 +5,7 @@ import logging
 import pdb
 import sys
 import uuid
+from datetime import datetime, timezone
 from pathlib import Path
 
 import click
@@ -20,6 +21,7 @@ from boefjes.worker.boefje_handler import LocalBoefjeHandler
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from boefjes.job_handler import bytes_api_client
+from boefjes.worker.interfaces import Task, TaskStatus
 from boefjes.worker.job_models import Boefje, BoefjeMeta
 from boefjes.worker.repository import get_local_repository
 
@@ -43,8 +45,22 @@ def run_boefje(start_pdb, organization_code, boefje_id, input_ooi):
     meta = SchedulerAPIClient(plugin_service, "/dev/null")._hydrate_boefje_meta(meta)
 
     handler = LocalBoefjeHandler(local_repository, bytes_api_client)
+    task = Task(
+        id=meta.id,
+        scheduler_id="manual",
+        schedule_id=None,
+        organisation=organization_code,
+        priority=1,
+        status=TaskStatus.RUNNING,
+        type="boefje",
+        data=meta,
+        created_at=meta.started_at or datetime.now(timezone.utc),
+        modified_at=meta.started_at or datetime.now(timezone.utc),
+    )
     try:
-        handler.handle(meta)
+        result = handler.handle(task)
+        if result and result[1].files:
+            logging.info("Raw file IDs: %s", ", ".join(f.name for f in result[1].files))
     except Exception:
         if start_pdb:
             pdb.post_mortem()

--- a/boefjes/tools/run_normalizer.py
+++ b/boefjes/tools/run_normalizer.py
@@ -12,8 +12,9 @@ import click
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from boefjes.config import settings
-from boefjes.job_handler import NormalizerHandler, bytes_api_client
+from boefjes.job_handler import LocalNormalizerHandler, bytes_api_client
 from boefjes.local.runner import LocalNormalizerJobRunner
+from boefjes.worker.interfaces import Task, TaskStatus
 from boefjes.worker.job_models import Normalizer, NormalizerMeta
 from boefjes.worker.repository import get_local_repository
 
@@ -34,11 +35,23 @@ def run_normalizer(start_pdb, normalizer_id, raw_id):
 
     local_repository = get_local_repository()
 
-    handler = NormalizerHandler(
+    handler = LocalNormalizerHandler(
         LocalNormalizerJobRunner(local_repository), bytes_api_client, settings.scan_profile_whitelist
     )
+    task = Task(
+        id=meta.id,
+        scheduler_id="manual",
+        schedule_id=None,
+        organisation=raw.boefje_meta.organization,
+        priority=1,
+        status=TaskStatus.RUNNING,
+        type="normalizer",
+        data=meta,
+        created_at=raw.boefje_meta.started_at,
+        modified_at=raw.boefje_meta.started_at,
+    )
     try:
-        handler.handle(meta)
+        handler.handle(task)
     except Exception:
         if start_pdb:
             pdb.post_mortem()

--- a/docs/source/developer-documentation/boefjes.md
+++ b/docs/source/developer-documentation/boefjes.md
@@ -229,6 +229,12 @@ Both `run_boefje.py` and `run_normalizer.py` support the `--pdb` option to enter
 the standard Python Debugger when an exceptions happens or breakpoint is
 triggered.
 
+> **Note:** These tools require the Bytes, KATalogus, and Octopoes services to
+> be running. The input OOI must already exist in Octopoes for the organization.
+> `run_boefje.py` uses the KATalogus to hydrate the boefje metadata (e.g. OCI
+> image, environment variables), and `run_normalizer.py` fetches the raw data
+> from Bytes.
+
 If you are using the standard docker compose developer setup, you can use
 `docker compose exec` to execute the commands in the container. The boefje and
 normalizer containers use the same images and settings, so you can use both:


### PR DESCRIPTION
## Summary

- `run_normalizer.py` imported the abstract `NormalizerHandler` instead of `LocalNormalizerHandler`, causing instantiation to fail.
- Both `run_boefje.py` and `run_normalizer.py` passed a bare meta object to `handle()` instead of a `Task` wrapper. The handlers expect `task.data`, so both scripts crashed with `AttributeError`.
- Fix: import `LocalNormalizerHandler`, wrap meta in a `Task` with dummy scheduler fields, and log the raw file IDs after running a boefje so the user can feed them to `show_raw.py`.
- Added a note to the docs that Bytes, KATalogus, and Octopoes must be running.

Closes #4057

#### Test plan

- [x] `make check` (pre-commit) green
- [ ] Manual: `docker compose exec boefje ./tools/run_boefje.py <org> dns-records "Hostname|internet|example.com"` should run and log raw file IDs

Generated with [Devin](https://devin.ai)