### PR TITLE
Increase onboarding report delay to 5 minutes (#4060)

### DIFF
--- a/rocky/onboarding/views.py
+++ b/rocky/onboarding/views.py
@@ -386,7 +386,7 @@ class OnboardingCreateReportRecipe(
         parent_report_type = self.get_parent_report_type()
         report_recipe = self.create_report_recipe(report_name_format, parent_report_type, None)
 
-        self.create_report_schedule(report_recipe, datetime.now(timezone.utc) + timedelta(minutes=2))
+        self.create_report_schedule(report_recipe, datetime.now(timezone.utc) + timedelta(minutes=5))
         run_findings_dashboard(self.organization)
 
         return redirect(
@@ -431,7 +431,7 @@ class OnboardingReportView(
         messages.success(
             self.request,
             _(
-                "Your report is scheduled for generation in about 3 minutes, "
+                "Your report is scheduled for generation in a few minutes, "
                 "as we are waiting for Boefjes to complete. "
                 "In the meantime get familiar with OpenKAT and visit the Reports History tab later."
             ),

--- a/rocky/rocky/locale/de/LC_MESSAGES/django.po
+++ b/rocky/rocky/locale/de/LC_MESSAGES/django.po
@@ -2597,7 +2597,7 @@ msgstr ""
 
 #: onboarding/views.py
 msgid ""
-"Your report is scheduled for generation in about 3 minutes, as we are "
+"Your report is scheduled for generation in a few minutes, as we are "
 "waiting for Boefjes to complete. In the meantime get familiar with OpenKAT "
 "and visit the Reports History tab later."
 msgstr ""

--- a/rocky/rocky/locale/django.pot
+++ b/rocky/rocky/locale/django.pot
@@ -2559,7 +2559,7 @@ msgstr ""
 
 #: onboarding/views.py
 msgid ""
-"Your report is scheduled for generation in about 3 minutes, as we are "
+"Your report is scheduled for generation in a few minutes, as we are "
 "waiting for Boefjes to complete. In the meantime get familiar with OpenKAT "
 "and visit the Reports History tab later."
 msgstr ""

--- a/rocky/rocky/locale/en@pirate/LC_MESSAGES/django.po
+++ b/rocky/rocky/locale/en@pirate/LC_MESSAGES/django.po
@@ -2558,7 +2558,7 @@ msgstr ""
 
 #: onboarding/views.py
 msgid ""
-"Your report is scheduled for generation in about 3 minutes, as we are "
+"Your report is scheduled for generation in a few minutes, as we are "
 "waiting for Boefjes to complete. In the meantime get familiar with OpenKAT "
 "and visit the Reports History tab later."
 msgstr ""

--- a/rocky/rocky/locale/es/LC_MESSAGES/django.po
+++ b/rocky/rocky/locale/es/LC_MESSAGES/django.po
@@ -2557,7 +2557,7 @@ msgstr ""
 
 #: onboarding/views.py
 msgid ""
-"Your report is scheduled for generation in about 3 minutes, as we are "
+"Your report is scheduled for generation in a few minutes, as we are "
 "waiting for Boefjes to complete. In the meantime get familiar with OpenKAT "
 "and visit the Reports History tab later."
 msgstr ""

--- a/rocky/rocky/locale/fr/LC_MESSAGES/django.po
+++ b/rocky/rocky/locale/fr/LC_MESSAGES/django.po
@@ -2557,7 +2557,7 @@ msgstr ""
 
 #: onboarding/views.py
 msgid ""
-"Your report is scheduled for generation in about 3 minutes, as we are "
+"Your report is scheduled for generation in a few minutes, as we are "
 "waiting for Boefjes to complete. In the meantime get familiar with OpenKAT "
 "and visit the Reports History tab later."
 msgstr ""

--- a/rocky/rocky/locale/fy/LC_MESSAGES/django.po
+++ b/rocky/rocky/locale/fy/LC_MESSAGES/django.po
@@ -2657,7 +2657,7 @@ msgstr ""
 
 #: onboarding/views.py
 msgid ""
-"Your report is scheduled for generation in about 3 minutes, as we are "
+"Your report is scheduled for generation in a few minutes, as we are "
 "waiting for Boefjes to complete. In the meantime get familiar with OpenKAT "
 "and visit the Reports History tab later."
 msgstr ""

--- a/rocky/rocky/locale/it/LC_MESSAGES/django.po
+++ b/rocky/rocky/locale/it/LC_MESSAGES/django.po
@@ -2643,7 +2643,7 @@ msgstr ""
 
 #: onboarding/views.py
 msgid ""
-"Your report is scheduled for generation in about 3 minutes, as we are "
+"Your report is scheduled for generation in a few minutes, as we are "
 "waiting for Boefjes to complete. In the meantime get familiar with OpenKAT "
 "and visit the Reports History tab later."
 msgstr ""

--- a/rocky/rocky/locale/nl/LC_MESSAGES/django.po
+++ b/rocky/rocky/locale/nl/LC_MESSAGES/django.po
@@ -2905,7 +2905,7 @@ msgstr "Web URL niet gevonden."
 
 #: onboarding/views.py
 msgid ""
-"Your report is scheduled for generation in about 3 minutes, as we are "
+"Your report is scheduled for generation in a few minutes, as we are "
 "waiting for Boefjes to complete. In the meantime get familiar with OpenKAT "
 "and visit the Reports History tab later."
 msgstr ""

--- a/rocky/rocky/locale/pap/LC_MESSAGES/django.po
+++ b/rocky/rocky/locale/pap/LC_MESSAGES/django.po
@@ -2617,7 +2617,7 @@ msgstr ""
 
 #: onboarding/views.py
 msgid ""
-"Your report is scheduled for generation in about 3 minutes, as we are "
+"Your report is scheduled for generation in a few minutes, as we are "
 "waiting for Boefjes to complete. In the meantime get familiar with OpenKAT "
 "and visit the Reports History tab later."
 msgstr ""

--- a/rocky/rocky/locale/ta/LC_MESSAGES/django.po
+++ b/rocky/rocky/locale/ta/LC_MESSAGES/django.po
@@ -2666,7 +2666,7 @@ msgstr ""
 
 #: onboarding/views.py
 msgid ""
-"Your report is scheduled for generation in about 3 minutes, as we are "
+"Your report is scheduled for generation in a few minutes, as we are "
 "waiting for Boefjes to complete. In the meantime get familiar with OpenKAT "
 "and visit the Reports History tab later."
 msgstr ""


### PR DESCRIPTION
## Summary

- The onboarding report was scheduled with a fixed 2-minute delay, but DNS boefjes often had not finished by then, causing the DNS records section to be empty in the report (race condition).
- Increase the delay to 5 minutes to give boefjes more time to complete and produce `DNSRecord` OOIs before the report runner snapshots Octopoes.
- Update the user-facing message from "about 3 minutes" to "a few minutes" to avoid being misleading.

This is a pragmatic fix. A proper solution would wait for boefje completion before generating the report, but that requires a larger architectural change.

Closes #4060

#### Test plan

- [x] `make check` (pre-commit) green
- [ ] Manual: `make reset`, go through onboarding, verify DNS records section appears in the report

Generated with [Devin](https://devin.ai)