### PR TITLE
Deduplicate origins with missing source_method in OOI detail view (#4035)

### DIFF
--- a/octopoes/octopoes/models/origin.py
+++ b/octopoes/octopoes/models/origin.py
@@ -19,7 +19,7 @@ class Origin(BaseModel):
     origin_type: OriginType
     method: str
     source: Reference
-    source_method: str | None = None  # None for bits and normalizers
+    source_method: str | None = None  # None for bits/inferences; boefje id for observations
     result: list[Reference] = Field(default_factory=list)
     task_id: UUID | None = None
 

--- a/rocky/rocky/views/mixins.py
+++ b/rocky/rocky/views/mixins.py
@@ -181,6 +181,7 @@ class OctopoesView(ObservedAtMixin, OrganizationView):
         plugins = {}
         normalizer_datas = {}
         bytes_origins = []
+        seen_observation_keys: set[tuple[str, str]] = set()
         for origin in origins:
             origin = OriginData(origin=origin)
             if origin.origin.origin_type != OriginType.OBSERVATION or not origin.origin.task_id:
@@ -189,6 +190,15 @@ class OctopoesView(ObservedAtMixin, OrganizationView):
                 elif origin.origin.origin_type == OriginType.INFERENCE:
                     inferences.append(origin)
                 continue
+
+            # Deduplicate observations: when both an old origin (source_method=None)
+            # and a new origin (source_method=<boefje-id>) exist for the same
+            # (method, source), only keep the one with source_method set.
+            obs_key = (origin.origin.method, str(origin.origin.source))
+            if origin.origin.source_method is None and obs_key in seen_observation_keys:
+                continue
+            seen_observation_keys.add(obs_key)
+
             bytes_origins.append(origin.origin.task_id)
             observations.append(origin)
 


### PR DESCRIPTION
## Summary

- The `Origin.id` property is conditional on `source_method`: when None, the boefje id is omitted from the key.
- Old observations (before `source_method` was added) and new observations for the same `(method, source)` end up as two separate XTDB entities, both shown in the OOI origin list.
- Fix: add deduplication in `get_origins()` — when both an old origin (`source_method=None`) and a new origin (`source_method=<boefje-id>`) exist for the same `(method, source)`, only keep the one with `source_method` set.
- Also fix the misleading comment on `Origin.source_method`: normalizers do set `source_method` to the boefje id, it is only None for bits/inferences.

Existing old data should be cleaned up by running the migration at `POST /origins/migrate` or `boefjes/tools/upgrade_v1_17_0.py`.

Closes #4035

#### Test plan

- [x] `make check` (pre-commit) green
- [x] All 12 existing OOI detail tests pass
- [ ] Manual: verify OOI origin list no longer shows duplicate origins

Generated with [Devin](https://devin.ai)